### PR TITLE
CSS mod : menu width, search icon...

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -199,15 +199,20 @@ nav .navleft a {
     font-size:90%;
     font-weight:bold;
     text-transform:uppercase;
-    margin:5px;
-    color: #5a5a5a;
+    margin:5px 8px;
+    color: #888;
     text-decoration: none;
 }
+
 #logonav {
     font-size:130%;
     color:white;
     margin-left: 45px;
     margin-right: 15px;
+}
+
+nav .navleft{
+    width:75%;
 }
 
 nav .navleft a.selected {
@@ -220,31 +225,31 @@ nav .navleft a.selected {
 
 nav .navleft a:hover {
     color:#29AEB9;
-    -moz-transition-duration: 1500ms;
-    -webkit-transition-duration: 1500ms;
-    -o-transition-duration: 1500ms;
-    -ms-transition-duration: 1500ms;
+    -moz-transition-duration: 500ms;
+    -webkit-transition-duration: 500ms;
+    -o-transition-duration: 500ms;
+    -ms-transition-duration: 500ms;
 }
 
 /* search bar in head.php ; nav */
 form#big_search {
-    width:40%;
+    width:25%;
     float:right;
     margin-right: 30px;
     text-align:right;
 }
 form#big_search input {
-    background:#555 url(../img/search.png) no-repeat scroll right center;
+    background:#555 url(../img/search.png) no-repeat scroll right 10px center;
     border: none;
     border-radius: 20px;
-    width:40%;
+    width:50%;
     height:2em;
     margin: 13px 10px 0 0;
     color: white;
     transition:width 1s;
 }
 form#big_search input:focus {
-    width:60%;
+    width:90%;
 }
 /*  MENU is below main nav */
 menu {


### PR DESCRIPTION
I have modified CSS properties of the nav, because in french menu width was too large for the span container. 
- So I fix this and adapt the search form to have more space for the menu translation (and custom "wiki" menu).
- I also have adjusted menu color to be more visible and margin between them.
- Magnifying glass icone of search input is now well aligned.
- Menu hover color-transition is more fast, because it wasn't really visible before...

![update_nav_css](https://cloud.githubusercontent.com/assets/2032715/6441088/7b9d1708-c0e4-11e4-912b-1c94c854a83a.jpg)