### PR TITLE
Database Tag fix & Issue #34

### DIFF
--- a/inc/showDB.php
+++ b/inc/showDB.php
@@ -65,16 +65,27 @@ $req->execute(array(
 if (isset($_GET['tag']) && !empty($_GET['tag'])) {
     $tag = filter_var($_GET['tag'], FILTER_SANITIZE_STRING);
     $results_arr = array();
-    $sql = "SELECT item_id, team_id FROM items_tags
-    WHERE tag LIKE :tag AND team_id = :team_id";
+    $sql = "SELECT item_id FROM items_tags
+    WHERE tag LIKE :tag";
     $req = $pdo->prepare($sql);
     $req->execute(array(
-        'tag' => $tag,
-        'team_id' => $_SESSION['team_id']
+        'tag' => $tag
     ));
     // put resulting ids in the results array
     while ($data = $req->fetch()) {
         $results_arr[] = $data['item_id'];
+    }
+    
+    // load time
+    $time = microtime();
+    $time = explode(' ', $time);
+    $time = $time[1] + $time[0];
+    $finish = $time;
+    $total_time = round(($finish - $start), 4);
+    $unit = 'seconds';
+    if ($total_time < 0.01) {
+        $total_time = $total_time * 1000;
+        $unit = 'milliseconds';
     }
 
     // show number of results found
@@ -99,6 +110,19 @@ if (isset($_GET['tag']) && !empty($_GET['tag'])) {
     $results_arr = search_item('db', $query, $_SESSION['userid']);
     // filter out duplicate ids and reverse the order; items should be sorted by date
     $results_arr = array_reverse(array_unique($results_arr));
+
+    // load time
+    $time = microtime();
+    $time = explode(' ', $time);
+    $time = $time[1] + $time[0];
+    $finish = $time;
+    $total_time = round(($finish - $start), 4);
+    $unit = 'seconds';
+    if ($total_time < 0.01) {
+        $total_time = $total_time * 1000;
+        $unit = 'milliseconds';
+    }
+    
     // show number of results found
     if (count($results_arr) == 0) {
         display_message('error_nocross', _("Sorry. I couldn't find anything :("));


### PR DESCRIPTION
**Fix issue #34 : space=AND for body & title // search query restructure**
I have Kicked the search code to have a good structure for the next issues on this functionality.
And I add multiple word search for title & body... 
And also a date 'from', to select only item from a date to the most recent.
("date BETWEEN '00000101' AND '$to'")

**Bug fix : Database click on tag > PDO error**
After click on a tag link in database, the page displaying a PDO error because there's not 'team_id' field in 'items_tags' table.
Now this page work !

And I copy your 'timer code' for the result... because he don't find it.

![update_tag_db](https://cloud.githubusercontent.com/assets/2032715/6461645/1a2694ea-c1a2-11e4-9166-d5dc3305abb7.jpg)