### PR TITLE
Add tag in search. Fix issue #63

### DIFF
--- a/search.php
+++ b/search.php
@@ -36,15 +36,21 @@ require_once 'inc/info_box.php';
 <menu class='border'><a href='experiments.php?mode=show'><img src='img/arrow-left-blue.png' class='bot5px' alt='' /> <?php echo _('Back to experiments listing'); ?></a></menu>
 <section class='searchform box'>
     <form name="search" method="get" action="search.php">
-
         <div class='row'>
             <!-- SEARCH IN-->
-            <div class='col-md-4'>
+            <?php
+            if (isset($_GET['type']) && $_GET['type'] == 'database') {
+                $seldb = " selected='selected'";
+            } else {
+                $seldb = "";
+            }
+            ?>
+            <div class='col-md-3'>
                 <label for='searchin'><?php echo _('Search in'); ?></label>
-                <select name='type' id='searchin'>
+                <select name='type' id='searchin' onchange='toggleTag();'>
                     <option value='experiments'><?php echo ngettext('Experiment', 'Experiments', 2); ?></option>
                     <option disabled>----------------</option>
-                    <option disabled><?php echo ngettext('Database', '', 1); ?></option>
+                    <option value='database' <?php echo $seldb; ?>><?php echo ngettext('Database', '', 1); ?></option>
                     <?php // Database items types
                     $sql = "SELECT * FROM items_types WHERE team = :team ORDER BY name ASC";
                     $req = $pdo->prepare($sql);
@@ -54,7 +60,7 @@ require_once 'inc/info_box.php';
                     while ($items_types = $req->fetch()) {
                         echo "<option value='" . $items_types['id'] . "'";
                         // item get selected if it is in the search url
-                        if (isset($_GET['type']) && ($items_types['id'] == $_GET['type'])) {
+                        if (isset($_GET['type']) && $items_types['id'] == $_GET['type']) {
                             echo " selected='selected'";
                         }
                         echo "> - " . $items_types['name'] . "</option>";
@@ -63,9 +69,71 @@ require_once 'inc/info_box.php';
                 </select>
             </div>
             <!-- END SEARCH IN -->
+            <!-- SEARCH WITH TAG -->
+            <div class='col-md-3' id='tag_exp'>
+                <label for='tag_exp'><?php echo _('With the Tag'); ?></label>
+                <select name='tag_exp'>
+                    <option value=''><?php echo ngettext('Select a Tag', '', 1); ?></option>
+                    <?php // Database items types
+                    $sql = "SELECT tag, COUNT(id) as nbtag FROM experiments_tags GROUP BY tag ORDER BY tag ASC";
+                    $req = $pdo->prepare($sql);
+                    $req->execute(array(
+                        'team' => $_SESSION['team_id']
+                    ));
+                    while ($items_types = $req->fetch()) {
+                        echo "<option value='" . $items_types['tag'] . "'";
+                        // item get selected if it is in the search url
+                        if (isset($_GET['tag_exp']) && ($items_types['tag'] == $_GET['tag_exp'])) {
+                            echo " selected='selected'";
+                        }
+                        echo ">" . $items_types['tag'] . " (" . $items_types['nbtag'] . ")</option>";
+                    }
+                    ?>
+                </select>
+            </div>
+            <div class='col-md-3' id='tag_db'>
+                <label for='tag_db'><?php echo _('With the Tag'); ?></label>
+                <select name='tag_db'>
+                    <option value=''><?php echo ngettext('Select a Tag', '', 1); ?></option>
+                    <?php // Database items types
+                    $sql = "SELECT tag, COUNT(id) as nbtag FROM items_tags GROUP BY tag ORDER BY tag ASC";
+                    $req = $pdo->prepare($sql);
+                    $req->execute(array(
+                        'team' => $_SESSION['team_id']
+                    ));
+                    while ($items_types = $req->fetch()) {
+                        echo "<option value='" . $items_types['tag'] . "'";
+                        // item get selected if it is in the search url
+                        if (isset($_GET['tag_db']) && ($items_types['tag'] == $_GET['tag_db'])) {
+                            echo " selected='selected'";
+                        }
+                        echo ">" . $items_types['tag'] . " (" . $items_types['nbtag'] . ")</option>";
+                    }
+                    ?>
+                </select>
+            </div>
+            <script>
+                <?php
+                if (isset($_GET['type']) && $_GET['type'] == 'experiments') {
+                    echo '$("#tag_db").hide();';
+                } else {
+                    echo '$("#tag_exp").hide();';
+                }
+                ?>
 
+                $('#searchin').on('change', function() {
+                    if(this.value == 'experiments'){
+                        $("#tag_exp").show();
+                        $("#tag_db").hide();
+                    }else{
+                        $("#tag_exp").hide();
+                        $("#tag_db").show();
+                    }
+                });
+            </script>
+            <!-- END SEARCH WITH TAG -->
             <!-- SEARCH ONLY -->
-            <div class='col-md-8'>
+            <div class='col-md-6'>
                 <label for'searchonly'><?php echo _('Search only in experiments owned by:'); ?> </label><br>
                 <select id='searchonly' name='owner'>
                     <option value=''><?php echo _('Yourself'); ?></option>
@@ -87,12 +155,12 @@ require_once 'inc/info_box.php';
                     ?>
                 </select><br>
                 <!-- search everyone box -->
-                <label for='all_experiments_chkbx'>(<?php echo _("search in everyone's experiments"); ?> </label>
                 <input name="all" id='all_experiments_chkbx' value="y" type="checkbox" <?php
                     // keep the box checked if it was checked
                     if (isset($_GET['all'])) {
                         echo "checked=checked";
-                    }?>>)
+                    }?>>
+                <label for='all_experiments_chkbx'><?php echo _("search in everyone's experiments"); ?> </label>
             </div>
             <!-- END _('Search') ONLY -->
         </div>
@@ -246,8 +314,10 @@ if (isset($_GET)) {
     }
 
     // TAGS
-    if (isset($_GET['tags']) && !empty($_GET['tags'])) {
-        $tags = filter_var($_GET['tags'], FILTER_SANITIZE_STRING);
+    if (isset($_GET['tag_exp']) && !empty($_GET['tag_exp']) && isset($_GET['type']) && $_GET['type'] === 'experiments') {
+        $tags = filter_var($_GET['tag_exp'], FILTER_SANITIZE_STRING);
+    } elseif (isset($_GET['tag_db']) && !empty($_GET['tag_db']) && isset($_GET['type']) && !empty($_GET['type']) && $_GET['type'] !== 'experiments') {
+        $tags = filter_var($_GET['tag_db'], FILTER_SANITIZE_STRING);
     } else {
         $tags = '';
     }
@@ -280,16 +350,26 @@ if (isset($_GET)) {
     }
 
     // PREPARE SQL query
+    if (isset($_GET['type']) && $_GET['type'] === 'experiments') {
+        $tb = 'exp';
+        $tbt = 'exptag';
+    } else {
+        $tb = 'i';
+        $tbt = 'itag';
+    }
+
+    $sqlGroup = " GROUP BY $tb.id";
+
     // Title search
     if (!empty($title)) {
-        $sqlTitle = " AND title LIKE '%$title%'";
+        $sqlTitle = " AND $tb.title LIKE '%$title%'";
     } elseif (isset($title_arr)) {
         $sqlTitle = " AND (";
         foreach ($title_arr as $key => $value) {
             if ($key != 0) {
                 $sqlTitle .= " OR ";
             }
-            $sqlTitle .= "title LIKE '%$value%'";
+            $sqlTitle .= "$tb.title LIKE '%$value%'";
         }
         $sqlTitle .= ")";
     } else {
@@ -298,41 +378,48 @@ if (isset($_GET)) {
 
     // Body search
     if (!empty($body)) {
-        $sqlBody = " AND body LIKE '%$title%'";
+        $sqlBody = " AND $tb.body LIKE '%$title%'";
     } elseif (isset($body_arr)) {
         $sqlBody = " AND (";
         foreach ($body_arr as $key => $value) {
             if ($key != 0) {
                 $sqlBody .= " OR ";
             }
-            $sqlBody .= "body LIKE '%$value%'";
+            $sqlBody .= "$tb.body LIKE '%$value%'";
         }
         $sqlBody .= ")";
     } else {
         $sqlBody = "";
     }
 
+    // Tag search
+    if (!empty($tags)) {
+        $sqlTag = " AND $tb.id = $tbt.item_id AND $tbt.tag = '$tags'";
+    } else {
+        $sqlTag = "";
+    }
+
     // Status search
     if (!empty($status)) {
-        $sqlStatus = " AND status LIKE '$status'";
+        $sqlStatus = " AND $tb.status LIKE '$status'";
     } else {
         $sqlStatus = "";
     }
 
     // Rating search
     if (!empty($rating)) {
-        $sqlRating = " AND rating LIKE '$rating'";
+        $sqlRating = " AND $tb.rating LIKE '$rating'";
     } else {
         $sqlRating = "";
     }
 
     // Date search
     if (!empty($from) && !empty($to)) {
-        $sqlDate = " AND date BETWEEN '$from' AND '$to'";
+        $sqlDate = " AND $tb.date BETWEEN '$from' AND '$to'";
     } elseif (!empty($from) && empty($to)) {
-        $sqlDate = " AND date BETWEEN '$from' AND '99991212'";
+        $sqlDate = " AND $tb.date BETWEEN '$from' AND '99991212'";
     } elseif (empty($from) && !empty($to)) {
-        $sqlDate = " AND date BETWEEN '00000101' AND '$to'";
+        $sqlDate = " AND $tb.date BETWEEN '00000101' AND '$to'";
     } else {
         $sqlDate = "";
     }
@@ -342,13 +429,12 @@ if (isset($_GET)) {
         if ($_GET['type'] === 'experiments') {
 
             if (isset($_GET['all']) && !empty($_GET['all'])) {
-                $sqlFirst = " team = " . $_SESSION['team_id'];
+                $sqlFirst = " $tb.team = " . $_SESSION['team_id'];
             } else {
-                $sqlFirst = " userid = :userid";
+                $sqlFirst = " $tb.userid = :userid";
             }
 
-            $sql = "SELECT * FROM experiments WHERE" . $sqlFirst . $sqlTitle .  $sqlBody . $sqlStatus . $sqlDate;
-            echo $sql;
+            $sql = "SELECT exp.* FROM experiments as exp, experiments_tags as exptag WHERE" . $sqlFirst . $sqlTitle .  $sqlBody . $sqlTag . $sqlStatus . $sqlDate . $sqlGroup;
             $req = $pdo->prepare($sql);
             // if there is a selection on 'owned by', we use the owner id as parameter
             if ($owner_search) {
@@ -398,15 +484,26 @@ if (isset($_GET)) {
                 display_message('error_nocross', _("Sorry. I couldn't find anything :("));
             }
 
-    // DATABASE SEARCH
-        } elseif (is_pos_int($_GET['type'])) {
+        // DATABASE SEARCH
+        } elseif (is_pos_int($_GET['type']) || $_GET['type'] === 'database') {
 
-            $sqlFirst = " type = :type";
-            $sql = "SELECT * FROM items WHERE" . $sqlFirst . $sqlTitle .  $sqlBody . $sqlRating . $sqlDate;
+            if($_GET['type'] === 'database' && empty($title) && empty($body) && empty($tags) && empty($status) && empty($rating) && empty($from) && empty($to)){
+                $sqlFirst = "SELECT i.* FROM items as i, items_tags as itag WHERE i.id > 0";
+            } elseif($_GET['type'] === 'database'){
+                $sqlFirst = "SELECT i.* FROM items as i, items_tags as itag WHERE i.id > 0";
+            } else {
+                $sqlFirst = "SELECT i.* FROM items as i, items_tags as itag WHERE type = :type";
+            }
+            $sql = $sqlFirst . $sqlTitle .  $sqlBody . $sqlTag . $sqlRating . $sqlDate . $sqlGroup;
             $req = $pdo->prepare($sql);
-            $req->execute(array(
-                'type' => $_GET['type']
-            ));
+            if($_GET['type'] === 'database'){
+                $req->execute();
+            } else {
+                $req->execute(array(
+                    'type' => $_GET['type']
+                ));
+            }
+
             $count = $req->rowCount();
             if ($count > 0) {
                 // make array of results id

--- a/search.php
+++ b/search.php
@@ -47,7 +47,7 @@ require_once 'inc/info_box.php';
             ?>
             <div class='col-md-3'>
                 <label for='searchin'><?php echo _('Search in'); ?></label>
-                <select name='type' id='searchin' onchange='toggleTag();'>
+                <select name='type' id='searchin'>
                     <option value='experiments'><?php echo ngettext('Experiment', 'Experiments', 2); ?></option>
                     <option disabled>----------------</option>
                     <option value='database' <?php echo $seldb; ?>><?php echo ngettext('Database', '', 1); ?></option>


### PR DESCRIPTION
- add 2 select with tags, 1 for experiments & 1 for database. 
- Toggle hide/show the right select in JS (experiments tag OR database tag). 
- Item counter for each tag in select ( myTag (n) )
- Allow full database search (not only a type)
- Search in team check box cosmetic