### PR TITLE
Improve handling of uploaded structure files that are not macromolecules.

### DIFF
--- a/app/classes/MolViewer.php
+++ b/app/classes/MolViewer.php
@@ -56,7 +56,7 @@ class MolViewer
         // Check for proper use:
         // We always want either is_pdb to be true or a valid filepath!
         if ($filePath === "" && !$isPdb) {
-            throw new Exception('If $id is not a PDB ID ($isPdb=False) then a valid file path must be passed!');
+            throw new Exception('If $id is not a PDB ID ($isPdb=false) then a valid file path must be passed!');
         }
         $this->id = $id;
         $this->isPdb = $isPdb;
@@ -102,7 +102,7 @@ class MolViewer
     {
         // Array holding list of styles for the dropdown list.
         // Each item consists of its label als translatable string and a corresponding javascript function
-        // that is executet if the item is clicked.
+        // that is executed if the item is clicked.
         $styles = array(
             'cartoon' => array(_('Cartoon'), 'show_cartoon(\'' . $this->divId . '\');'),
             'stick' => array(_('Stick'), 'show_stick(\'' . $this->divId . '\');'),

--- a/app/views/UploadsView.php
+++ b/app/views/UploadsView.php
@@ -162,7 +162,13 @@ class UploadsView extends EntityView
 
             // if this is something 3Dmol.js can handle
             } elseif (in_array($ext, $molExtensions)) {
-                $molviewer = new MolViewer($upload['id'], $filepath);
+                // try to be clever and choose stick representation for
+                // all files that are not in pdb format
+                $style = 'stick';
+                if ($ext === 'pdb') {
+                  $style = 'cartoon:color=spectrum';
+                }
+                $molviewer = new MolViewer($upload['id'], $filepath, false, $style);
                 $html .= $molviewer->getViewerDiv();
 
             } else {


### PR DESCRIPTION
Cartoon representation is only used if the file is a PDB file. Otherwise, stick representation is used. Mol2 and sdf are most likely not macromolecules, but small compounds which will result in an empty rendering if cartoon representation is used.