### PR TITLE
#360 Fix cutting out text in Safari

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -111,6 +111,7 @@ input, select, textarea {
     border-radius: 4px;
     border: 1px #e3e3e3 solid;
     margin:5px 0;
+    line-height: 1;
 }
 .disabled-input{
     color:#989898;


### PR DESCRIPTION
Fixes #360 Search field does show text input in Safari 10.0.3 on Mac OS X 10.12.3