### PR TITLE
generate and display thumbnails of svg images

### DIFF
--- a/app/models/Uploads.php
+++ b/app/models/Uploads.php
@@ -317,6 +317,7 @@ class Uploads extends Entity
                             'image/gif',
                             'image/tiff',
                             'image/x-eps',
+                            'image/svg+xml',
                             'application/pdf',
                             'application/postscript');
 

--- a/app/views/UploadsView.php
+++ b/app/views/UploadsView.php
@@ -138,7 +138,7 @@ class UploadsView extends EntityView
             }
 
             // only display the thumbnail if the file is here
-            if (file_exists($thumbpath) && preg_match('/(jpg|jpeg|png|gif|tif|tiff|pdf|eps)$/i', $ext)) {
+            if (file_exists($thumbpath) && preg_match('/(jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg)$/i', $ext)) {
                 // if it's a picture, we display it with fancybox
                 // see: http://fancyapps.com/fancybox/3/docs/
                 $fancybox = ' ';


### PR DESCRIPTION
This pull request adds the generation and display of thumbnails of attached SVG images.
~~Provides kind of a workaround for #346 as it is now possible to add the thumbnail (of limited resolution) to the experiment/database body.~~
Fixes #346, since it is already possible to add SVG images to the experiment body using the usual "Insert image" functionality of TinyMCE and providing the URL of the uploaded file.

![svg_thumb](https://cloud.githubusercontent.com/assets/552653/25717794/e887870e-3103-11e7-8564-8bd227b4f1cd.png)
