### PR TITLE
Fix #385 Searching on multiple tags is broken

### DIFF
--- a/search.php
+++ b/search.php
@@ -123,10 +123,10 @@ foreach ($itemsTypesArr as $items_types) {
             <!-- SEARCH WITH TAG -->
 <?php
 $tagsArr = array();
-if (isset($_GET['tag_exp'])) {
+if ($_GET['type'] === 'experiments' && isset($_GET['tag_exp'])) {
     $tagsArr = $_GET['tag_exp'];
 }
-if (isset($_GET['tag_db'])) {
+if ($_GET['type'] === 'database' && isset($_GET['tag_db'])) {
     $tagsArr = $_GET['tag_db'];
 }
 
@@ -290,7 +290,7 @@ if (isset($_GET)) {
     // assign variables from get
 
     $table = 'items';
-    $tableTag = 'items_tags';
+    $tagTable = 'items_tags';
     $status = '';
     $rating = '';
     $tags = '';
@@ -298,7 +298,7 @@ if (isset($_GET)) {
     // TABLE
     if (isset($_GET['type']) && $_GET['type'] === 'experiments') {
         $table = 'experiments';
-        $tableTag = 'items_tags';
+        $tagTable = 'experiments_tags';
     }
 
     // STATUS
@@ -357,7 +357,7 @@ if (isset($_GET)) {
     if (!empty($tagsArr)) {
         foreach ($tagsArr as $tag) {
             $tag = filter_var($tag, FILTER_SANITIZE_STRING);
-            $sqlTag .= " AND EXISTS (SELECT 1 FROM " . $tableTag . " tagt WHERE tagt.item_id = " . $table . ".id AND tagt.tag LIKE '%" . $tag . "%') ";
+            $sqlTag .= " AND EXISTS (SELECT 1 FROM " . $tagTable . " tagt WHERE tagt.item_id = " . $table . ".id AND tagt.tag LIKE '%" . $tag . "%') ";
         }
     }
 

--- a/search.php
+++ b/search.php
@@ -290,6 +290,7 @@ if (isset($_GET)) {
     // assign variables from get
 
     $table = 'items';
+    $tableTag = 'items_tags';
     $status = '';
     $rating = '';
     $tags = '';
@@ -297,6 +298,7 @@ if (isset($_GET)) {
     // TABLE
     if (isset($_GET['type']) && $_GET['type'] === 'experiments') {
         $table = 'experiments';
+        $tableTag = 'items_tags';
     }
 
     // STATUS
@@ -355,7 +357,7 @@ if (isset($_GET)) {
     if (!empty($tagsArr)) {
         foreach ($tagsArr as $tag) {
             $tag = filter_var($tag, FILTER_SANITIZE_STRING);
-            $sqlTag .= " AND tagt.tag LIKE '%" . $tag . "%' ";
+            $sqlTag .= " AND EXISTS (SELECT 1 FROM " . $tableTag . " tagt WHERE tagt.item_id = " . $table . ".id AND tagt.tag LIKE '%" . $tag . "%') ";
         }
     }
 


### PR DESCRIPTION
Added simple exists sql clause to find all experiments or database
entries that contains the tag or both of the chosen tags.

Still problems setting up my development environment. Now finally just one commit...