### PR TITLE
Fail silently if thumbnail generation does not work

### DIFF
--- a/app/models/Uploads.php
+++ b/app/models/Uploads.php
@@ -323,7 +323,7 @@ class Uploads extends Entity
         }
 
         // do some sane white-listing; in theory, gmagick handles almost all image formats,
-        // but the processing of rarely // used formats may be less tested/stable or may have security issues;
+        // but the processing of rarely used formats may be less tested/stable or may have security issues;
         // when adding new mime types take care of
         // ambiguities: e.g. image/eps may be a valid application/postscript; image/bmp may also be image/x-bmp or
         // image/x-ms-bmp
@@ -337,24 +337,28 @@ class Uploads extends Entity
                             'application/postscript');
 
         if (in_array($mime, $allowed_mime)) {
-        // if pdf or postscript, generate thumbnail using the first page (index 0) do the same for postscript files;
-        // sometimes eps images will be identified as application/postscript as well, but thumbnail generation still
-        // works in those cases
+            // if pdf or postscript, generate thumbnail using the first page (index 0) do the same for postscript files;
+            // sometimes eps images will be identified as application/postscript as well, but thumbnail generation still
+            // works in those cases
             if ($mime === 'application/pdf' || $mime === 'application/postscript') {
                 $src = $src . '[0]';
             }
+            // fail silently if thumbnail generation does not work to keep file upload field functional;
+            // originally introduced due to issue #415.
+            try {
                 $image = new Gmagick($src);
-
+            } catch (Exception $e) {
+                return false;
+            }
         } else {
-
             return false;
         }
-          // create thumbnail of width 100px; height is calculated automatically to keep the aspect ratio
-          $image->thumbnailimage(100, 0);
-          // create the physical thumbnail image to its destination (85% quality)
-          $image->setCompressionQuality(85);
-          $image->write($dest);
-          $image->clear();
+        // create thumbnail of width 100px; height is calculated automatically to keep the aspect ratio
+        $image->thumbnailimage(100, 0);
+        // create the physical thumbnail image to its destination (85% quality)
+        $image->setCompressionQuality(85);
+        $image->write($dest);
+        $image->clear();
     }
 
     /**


### PR DESCRIPTION
This is a workaround for issue #415 to keep the file upload field functional, even if thumbnail generation fails. 
