### PR TITLE
Fix #433 - Problems with special characters in headers after upgrade …

### DIFF
--- a/app/classes/Db.php
+++ b/app/classes/Db.php
@@ -41,7 +41,7 @@ final class Db
             $pdo_options[PDO::ATTR_DEFAULT_FETCH_MODE] = PDO::FETCH_ASSOC;
             $this->connection = new \PDO(
                 'mysql:host=' . DB_HOST . ';dbname=' .
-                DB_NAME,
+                DB_NAME . ';charset=UTF8',
                 DB_USER,
                 DB_PASSWORD,
                 $pdo_options


### PR DESCRIPTION
…from 1.5.7 to 1.6.1

Added ';charset=UTF8' to the database connection url to fix problems with special characters