### PR TITLE
Always feed body of experiments and items into md2html

### DIFF
--- a/app/tpl/view.html
+++ b/app/tpl/view.html
@@ -110,9 +110,7 @@
 <!--  BODY (show only if not empty) -->
 {% set body = Entity.entityData.body %}
 {% if body != '' %}
-    {% if Entity.Users.userData.use_markdown %}
-        {% set body = Entity.entityData.body|md2html %}
-    {% endif %}
+    {% set body = Entity.entityData.body|md2html %}
     <div id='body_view' class='txt'>{{ body|raw }}</div>
     <br>
 {% endif %}


### PR DESCRIPTION
This prevents markdown code to show up for users that have rich text
editing ("WYSIWYG") enabled. Fixes issue #489. 

Note that this only addresses viewing of markdown-styled content for users with enabled rich text editor. They still will be presented markdown syntax when trying to edit this content. I'm experimenting with including [html-to-markdown](https://github.com/thephpleague/html-to-markdown) to always store content as HTML. It looks promising though I still have to verify that the interconversion does not mess everything up.
