### PR TITLE
Fix spelling of "information"

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,9 +1,9 @@
 # Description of the problem
 
 DO NOT DELETE THE TEXT BELOW
-BUT FILL THE REQUESTED INFOS!!!!!!
+BUT FILL THE REQUESTED INFO!!!!!!
 
-# Informations
+# Information
 
 * Elabftw version (visible in Sysadmin panel) :
 * Installation method (git, docker or zip archive) :

--- a/paper.md
+++ b/paper.md
@@ -31,4 +31,4 @@ bibliography: paper.bib
 eLabFTW is a free and open source electronic laboratory notebook for researchers.
 Once installed on a server, it allows researchers to track their experiments, but
 also to manage their assets in the lab (antibodies, mouse, siRNAs, proteins, etc.).
-Experiments can be timestamp to any RFC 3161 Time Stamping Authority, allowing solid legal proof in case of issues about a patent. It also features a scheduler to book equipment. More informations can be found on the official website [@Elabweb] and in the documentation [@Elabdoc]. Moreover, an online demo is accessible [@Elabdemo] to try out the software without installing.
+Experiments can be timestamp to any RFC 3161 Time Stamping Authority, allowing solid legal proof in case of issues about a patent. It also features a scheduler to book equipment. More information can be found on the official website [@Elabweb] and in the documentation [@Elabdoc]. Moreover, an online demo is accessible [@Elabdemo] to try out the software without installing.

--- a/src/models/Idps.php
+++ b/src/models/Idps.php
@@ -15,7 +15,7 @@ namespace Elabftw\Elabftw;
 use PDO;
 
 /**
- * Store informations about different identity providers for auth with SAML
+ * Store information about different identity providers for auth with SAML
  */
 class Idps implements CrudInterface
 {

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -119,7 +119,7 @@
     </form>
 
     <div class='box'>
-        <h3>{{ 'Informations'|trans }}</h3>
+        <h3>{{ 'Information'|trans }}</h3>
         <hr>
         <ul class='clean-list'>
             <li><p>{{ 'Operating System'|trans }}: {{ phpInfos.0 }}</p></li>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -119,7 +119,7 @@
     </form>
 
     <div class='box'>
-        <h3>{{ 'Information'|trans }}</h3>
+        <h3>{{ 'System Information'|trans }}</h3>
         <hr>
         <ul class='clean-list'>
             <li><p>{{ 'Operating System'|trans }}: {{ phpInfos.0 }}</p></li>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -196,14 +196,14 @@
 
 </div>
 
-<!-- TAB 2 - USER INFORMATIONS -->
+<!-- TAB 2 - USER INFORMATION -->
 <div class='divhandle' id='tab2div'>
     <div class='box'>
 
     <form method="post" action="app/controllers/UcpController.php">
         <div class='row'>
             <div class='col-md-6'>
-                <h4>{{ 'Modify your personal informations'|trans }}</h4>
+                <h4>{{ 'Modify your personal information'|trans }}</h4>
                 <label class='block' for='currpass'>{{ 'Enter your password to edit infos.'|trans }}</label>
                 <input id='currpass' name='currpass' type='password' pattern='.{8,}' required />
                 <label class='block' for='email'>{{ 'Email'|trans }}</label>


### PR DESCRIPTION
Fixed various spelling errors in sys panels and such, but didn't touch .po files. Also tweaked the header in the default sysadmin page from "information" to "system information".