### PR TITLE
Update mathjax-config.js

### DIFF
--- a/web/app/js/src/mathjax-config.js
+++ b/web/app/js/src/mathjax-config.js
@@ -15,5 +15,7 @@ window.MathJax = {
     },
     'HTML-CSS': {
         fonts: ['TeX']
+    },
+    TeX: { extensions: ["autoload-all.js"] 
     }
 };


### PR DESCRIPTION
Automatically loads Mathjax extensions when required. 
Extensions were already present in repo, but not configured to load.
