### PR TITLE
Support user authentication by the web server

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -30,7 +30,7 @@ use PDO;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 52;
+    private const REQUIRED_SCHEMA = 53;
 
     /** @var Config $Config instance of Config */
     public $Config;

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -220,6 +220,12 @@ class Config
             ('saml_lowercaseurlencoding', 0),
             ('email_domain', NULL),
             ('saml_sync_teams', 0),
+            ('extauth_remote_user', ''),
+            ('extauth_first_name', ''),
+            ('extauth_family_name', ''),
+            ('extauth_email', ''),
+            ('extauth_teams', ''),
+
             ('deletable_xp', 1);";
 
         $req = $this->Db->prepare($sql);

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -49,6 +49,7 @@ MySQL database structure version: {{ App.Config.configArr.schema }}</p>
         <li class='tabhandle' id='tab6'>{{ 'Email'|trans }}</li>
         <li class='tabhandle' id='tab7'>{{ 'SAML'|trans }}</li>
         <li class='tabhandle' id='tab8'>{{ 'Privacy policy'|trans }}</li>
+        <li class='tabhandle' id='tab9'>{{ 'External auth'|trans }}</li>
     </ul>
 </menu>
 
@@ -656,6 +657,39 @@ MySQL database structure version: {{ App.Config.configArr.schema }}</p>
         </form>
     </div>
 </div>
+
+<!-- TAB 9 EXTERNAL AUTH -->
+<div class='divhandle box' id='tab9div'>
+    <form method='post' action='app/controllers/SysconfigController.php'>
+      <div class='form-group'>
+        <h3>{{ 'External authentication mapping'|trans }}</h3>
+        <hr>
+        <input type='hidden' name='updateConfig' value='true' />
+
+          <p class='smallgray'>{{ 'If the server manages authentication, then you can provide here the environment variables names for user information.'|trans }}</p>
+
+        <label for='extauth_remote_user'>{{ 'Remote user:'|trans }}</label>                            
+        <input class='form-control col-md-4' type='text' placeholder='REMOTE_USER' value='{{ App.Config.configArr.extauth_remote_user }}' name='extauth_remote_user' id='extauth_remote_user' />                     
+        
+        <label for='extauth_first_name'>{{ 'First name:'|trans }}</label> 
+        <input class='form-control col-md-4' type='text' placeholder='MELLON_givenName' value='{{ App.Config.configArr.extauth_first_name }}' name='extauth_first_name' id='extauth_first_name' />   
+
+        <label for='extauth_family_name'>{{ 'Family name:'|trans }}</label> 
+        <input class='form-control col-md-4' type='text' placeholder='MELLON_sn' value='{{ App.Config.configArr.extauth_family_name }}' name='extauth_family_name' id='extauth_family_name' />   
+
+        <label for='extauth_email'>{{ 'E-mail address:'|trans }}</label> 
+        <input class='form-control col-md-4' type='text' placeholder='MELLON_mail' value='{{ App.Config.configArr.extauth_email }}' name='extauth_email' id='extauth_email' />   
+
+        <label for='extauth_teams'>{{ 'Teams:'|trans }}</label> 
+        <input class='form-control col-md-4' type='text' placeholder='MELLON_ou' value='{{ App.Config.configArr.extauth_teams }}' name='extauth_teams' id='extauth_teams' />   
+
+        <div class='submitButtonDiv'>
+            <button type='submit' name='Submit' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
+            <button class='button btn btn-danger' type='submit' name='clear_policy'>{{ 'Clear'|trans }}</button>
+        </div>
+    </form>
+</div>
+
 
 <script src='app/js/sysconfig.bundle.js'></script>
 {% endblock body %}

--- a/web/app/controllers/SysconfigController.php
+++ b/web/app/controllers/SysconfigController.php
@@ -54,6 +54,16 @@ try {
         }
     }
 
+    // EXTERNAL AUTH
+    if ($Request->request->has('extauth_remote_user')) {
+        $tab = '9';
+        $App->Config->update(array('extauth_remote_user' => $Request->request->get('extauth_remote_user')));
+        $App->Config->update(array('extauth_first_name' => $Request->request->get('extauth_first_name')));
+        $App->Config->update(array('extauth_family_name' => $Request->request->get('extauth_family_name')));
+        $App->Config->update(array('extauth_email' => $Request->request->get('extauth_email')));
+        $App->Config->update(array('extauth_teams' => $Request->request->get('extauth_teams')));
+    }
+
     // TAB 1 and 4 to 7
     if ($Request->request->has('updateConfig')) {
         if ($Request->request->has('lang')) {

--- a/web/login.php
+++ b/web/login.php
@@ -40,6 +40,27 @@ try {
         exit;
     }
 
+    // Check for external authentication by web server
+    if (isset($_SERVER[$App->Config->configArr['extauth_remote_user']])) {
+	$Teams = new Teams($App->Users);
+
+	$fname = $_SERVER[$App->Config->configArr['extauth_first_name']];
+	$lname = $_SERVER[$App->Config->configArr['extauth_family_name']];
+        $email = $_SERVER[$App->Config->configArr['extauth_email']];
+	$pwd = '********'; /* unused password */
+	$teams = array($_SERVER[$App->Config->configArr['extauth_teams']]);
+	if (sizeof($Teams->validateTeams($teams)) == 0)
+		$teams = array("1"); /* Default teams */
+
+        if (($userid = $Auth->getUseridFromEmail($email)) == 0) {
+            $App->Users->create($email, $teams, $fname, $lname, $pwd);
+            $App->Log->info('New user autocreated');
+            $userid = $Auth->getUseridFromEmail($email);
+        }
+        $Session->set('email', $email);
+        $Auth->login($userid);
+    }
+
     $BannedUsers = new BannedUsers($App->Config);
 
     // if we are not in https, die saying we work only in https


### PR DESCRIPTION
The change lets eLabFTW use authenticated user information provided
by the web server in environment variables. A new tab is added
in sysconfig panel so that variable names can be configured.