### PR TITLE
Generate a single PDF file with all selected items

### DIFF
--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -22,6 +22,7 @@ use Elabftw\Services\MakeMultiPdf;
 use Elabftw\Services\MakePdf;
 use Elabftw\Services\MakeReport;
 use Elabftw\Services\MakeStreamZip;
+use function substr_count;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -66,7 +67,7 @@ class MakeController implements ControllerInterface
                 return $this->makePdf();
 
             case 'multiPdf':
-                if (\substr_count($this->App->Request->query->get('id'), ' ') === 0) {
+                if (substr_count($this->App->Request->query->get('id'), ' ') === 0) {
                     return $this->makePdf();
                 }
                 return $this->makeMultiPdf();

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -18,6 +18,7 @@ use Elabftw\Models\Database;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Teams;
 use Elabftw\Services\MakeCsv;
+use Elabftw\Services\MakeMultiPdf;
 use Elabftw\Services\MakePdf;
 use Elabftw\Services\MakeReport;
 use Elabftw\Services\MakeStreamZip;
@@ -64,6 +65,12 @@ class MakeController implements ControllerInterface
             case 'pdf':
                 return $this->makePdf();
 
+            case 'multiPdf':
+                if (\substr_count($this->App->Request->query->get('id'), ' ') === 0) {
+                    return $this->makePdf();
+                }
+                return $this->makeMultiPdf();
+
             case 'report':
                 return $this->makeReport();
 
@@ -108,6 +115,26 @@ class MakeController implements ControllerInterface
         $Make = new MakePdf($this->Entity);
         return new Response(
             $Make->getPdf(),
+            200,
+            array(
+                'Content-Type' => 'application/pdf',
+                'Content-disposition' => 'inline; filename="' . $Make->getFileName() . '"',
+                'Cache-Control' => 'no-store',
+                'Last-Modified' => gmdate('D, d M Y H:i:s') . ' GMT',
+            )
+        );
+    }
+
+    /**
+     * Create a multi entity PDF export
+     *
+     * @return Response
+     */
+    private function makeMultiPdf(): Response
+    {
+        $Make = new MakeMultiPdf($this->Entity, $this->App->Request->query->get('id'));
+        return new Response(
+            $Make->getMultiPdf(),
             200,
             array(
                 'Content-Type' => 'application/pdf',

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -220,7 +220,8 @@ class Config
             ('saml_lowercaseurlencoding', 0),
             ('email_domain', NULL),
             ('saml_sync_teams', 0),
-            ('deletable_xp', 1);";
+            ('deletable_xp', 1),
+            ('max_revisions', 10);";
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':schema', $schema);

--- a/src/services/MakeMultiPdf.php
+++ b/src/services/MakeMultiPdf.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 namespace Elabftw\Services;
 
 use Elabftw\Models\AbstractEntity;
-use Elabftw\Models\Experiments;
-use Mpdf\Mpdf;
 
 /**
  * Make a PDF from several experiments or db items
@@ -38,13 +36,7 @@ class MakeMultiPdf extends AbstractMake
 
         $this->idArr = explode(' ', $idList);
 
-        // suppress the "A non-numeric value encountered" error from mpdf
-        // see https://github.com/baselbers/mpdf/commit
-        // 5cbaff4303604247f698afc6b13a51987a58f5bc#commitcomment-23217652
-        error_reporting(E_ERROR);
-
         $makePdf = new MakePdf($this->Entity, true);
-
         $this->mpdf = $makePdf->initializeMpdf(true);
     }
 

--- a/src/services/MakeMultiPdf.php
+++ b/src/services/MakeMultiPdf.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2012 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+declare(strict_types=1);
+
+namespace Elabftw\Services;
+
+use Elabftw\Exceptions\FilesystemErrorException;
+use Elabftw\Models\AbstractEntity;
+use Elabftw\Models\Experiments;
+use Mpdf\Mpdf;
+
+/**
+ * Make a PDF from several experiments or db items
+ */
+class MakeMultiPdf extends AbstractMake
+{
+    /** @var array $idArr the input ids but in an array */
+    private $idArr = array();
+
+    /** @var Mpdf $mpdf The mpdf object which contains all information for the multi entiy PDF file */
+    private $mpdf;
+
+    /**
+     * Give me an id list and a type, I make multi entity PDF for you
+     *
+     * @param AbstractEntity $entity
+     * @param string $idList 1+3+5+8
+     * @return void
+     */
+    public function __construct(AbstractEntity $entity, string $idList)
+    {
+        parent::__construct($entity);
+
+        $this->idArr = explode(' ', $idList);
+
+        $this->initializeMpdf();
+
+        // suppress the "A non-numeric value encountered" error from mpdf
+        // see https://github.com/baselbers/mpdf/commit
+        // 5cbaff4303604247f698afc6b13a51987a58f5bc#commitcomment-23217652
+        error_reporting(E_ERROR);
+    }
+
+    /**
+     * Get the name of the generated file
+     *
+     * @return string
+     */
+    public function getFileName(): string
+    {
+        return 'multientries.elabftw.pdf';
+    }
+
+    /**
+     * Loop over each id and add it to the PDF
+     * This could be called the main function.
+     *
+     * @return string
+     */
+    public function getMultiPdf(): string
+    {
+        foreach ($this->idArr as $key => $id) {
+            $this->addToPdf((int) $id);
+
+            if ($key !== count($this->idArr) -1) {
+                $this->mpdf->WriteHTML('<pagebreak resetpagenum="1" />');
+            }
+        }
+
+        if ($this->Entity->Users->userData['pdfa']) {
+            // make sure we can read the pdf in a long time
+            // will embed the font and make the pdf bigger
+            $this->mpdf->PDFA = true;
+        }
+
+        return $this->mpdf->Output('', 'S');
+    }
+
+    /**
+     * Initialize Mpdf
+     *
+     * @return void
+     */
+    private function initializeMpdf(): void
+    {
+        $format = $this->Entity->Users->userData['pdf_format'];
+
+        // we use a custom tmp dir, not the same as Twig because its content gets deleted after pdf is generated
+        $tmpDir = \dirname(__DIR__, 2) . '/cache/mpdf/';
+        if (!is_dir($tmpDir) && !mkdir($tmpDir, 0700, true) && !is_dir($tmpDir)) {
+            throw new FilesystemErrorException("Could not create the $tmpDir directory! Please check permissions on this folder.");
+        }
+
+        // create the pdf
+        $this->mpdf = new Mpdf(array(
+            'format' => $format,
+            'tempDir' => $tmpDir,
+            'mode' => 'utf-8',
+        ));
+
+        // make sure header and footer are not overlapping the body text
+        $this->mpdf->setAutoTopMargin = 'stretch';
+        $this->mpdf->setAutoBottomMargin = 'stretch';
+
+        // set metadata
+        $this->mpdf->SetAuthor($this->Entity->Users->userData['fullname']);
+        $this->mpdf->SetTitle('Multi Entity elabftw pdf');
+        $this->mpdf->SetSubject('eLabFTW pdf');
+        //$this->mpdf->SetKeywords(\str_replace('|', ' ', $this->Entity->entityData['tags']));
+        $this->mpdf->SetCreator('www.elabftw.net');
+    }
+    
+    /**
+     * This is where the magic happens
+     *
+     * @param int $id The id of the current item
+     * @return void
+     */
+    private function addToPdf(int $id): void
+    {
+        $this->Entity->setId($id);
+        $CurrentEntity = new MakePdf($this->Entity, true);
+        $permissions = $this->Entity->getPermissions();
+        if ($permissions['read']) {
+            $this->mpdf->WriteHTML($CurrentEntity->getContent());
+        }
+    }
+}

--- a/src/services/MakeMultiPdf.php
+++ b/src/services/MakeMultiPdf.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Elabftw\Services;
 
-use Elabftw\Exceptions\FilesystemErrorException;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Experiments;
 use Mpdf\Mpdf;

--- a/src/services/MakeMultiPdf.php
+++ b/src/services/MakeMultiPdf.php
@@ -39,12 +39,14 @@ class MakeMultiPdf extends AbstractMake
 
         $this->idArr = explode(' ', $idList);
 
-        $this->initializeMpdf();
-
         // suppress the "A non-numeric value encountered" error from mpdf
         // see https://github.com/baselbers/mpdf/commit
         // 5cbaff4303604247f698afc6b13a51987a58f5bc#commitcomment-23217652
         error_reporting(E_ERROR);
+
+        $makePdf = new MakePdf($this->Entity, true);
+
+        $this->mpdf = $makePdf->initializeMpdf(true);
     }
 
     /**
@@ -82,40 +84,6 @@ class MakeMultiPdf extends AbstractMake
         return $this->mpdf->Output('', 'S');
     }
 
-    /**
-     * Initialize Mpdf
-     *
-     * @return void
-     */
-    private function initializeMpdf(): void
-    {
-        $format = $this->Entity->Users->userData['pdf_format'];
-
-        // we use a custom tmp dir, not the same as Twig because its content gets deleted after pdf is generated
-        $tmpDir = \dirname(__DIR__, 2) . '/cache/mpdf/';
-        if (!is_dir($tmpDir) && !mkdir($tmpDir, 0700, true) && !is_dir($tmpDir)) {
-            throw new FilesystemErrorException("Could not create the $tmpDir directory! Please check permissions on this folder.");
-        }
-
-        // create the pdf
-        $this->mpdf = new Mpdf(array(
-            'format' => $format,
-            'tempDir' => $tmpDir,
-            'mode' => 'utf-8',
-        ));
-
-        // make sure header and footer are not overlapping the body text
-        $this->mpdf->setAutoTopMargin = 'stretch';
-        $this->mpdf->setAutoBottomMargin = 'stretch';
-
-        // set metadata
-        $this->mpdf->SetAuthor($this->Entity->Users->userData['fullname']);
-        $this->mpdf->SetTitle('Multi Entity elabftw pdf');
-        $this->mpdf->SetSubject('eLabFTW pdf');
-        //$this->mpdf->SetKeywords(\str_replace('|', ' ', $this->Entity->entityData['tags']));
-        $this->mpdf->SetCreator('www.elabftw.net');
-    }
-    
     /**
      * This is where the magic happens
      *

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -16,6 +16,7 @@ use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Users;
 use Mpdf\Mpdf;
+use fuction str_replace;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -138,7 +139,7 @@ class MakePdf extends AbstractMake
         if (!$multiEntity) {
             $mpdf->SetAuthor($this->Entity->entityData['fullname']);
             $mpdf->SetTitle($this->Entity->entityData['title']);
-            $mpdf->SetKeywords(\str_replace('|', ' ', $this->Entity->entityData['tags']));
+            $mpdf->SetKeywords(str_replace('|', ' ', $this->Entity->entityData['tags']));
         }
 
         return $mpdf;

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -81,7 +81,6 @@ class MakePdf extends AbstractMake
 
         return $content;
     }
-}
 
     /**
      * Generate pdf and return it as string
@@ -444,3 +443,4 @@ Witness' signature:<br><br>
 <sethtmlpagefooter name="footer" value="on" />
 ';
     }
+}

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -443,7 +443,7 @@ Witness' signature:<br><br>
         <p style="float:left; width:90%;">
             <strong>Date:</strong> ' . $date->format('Y-m-d') . '<br />
             <strong>Tags:</strong> <em>' .
-                \str_replace('|', ' ', $this->Entity->entityData['tags']) . '</em> <br />
+                str_replace('|', ' ', $this->Entity->entityData['tags']) . '</em> <br />
             <strong>Created by:</strong> ' . $this->Entity->entityData['fullname'] . '
         </p>
         <p style="float:right; width:10%;"><br /><br />

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -16,7 +16,7 @@ use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Users;
 use Mpdf\Mpdf;
-use fuction str_replace;
+use function str_replace;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -108,7 +108,7 @@ class MakePdf extends AbstractMake
      *
      * @return Mpdf
      */
-    public function initializeMpdf($multiEntity = false): void
+    public function initializeMpdf($multiEntity = false): Mpdf
     {
         $format = $this->Entity->Users->userData['pdf_format'];
 

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -104,11 +104,11 @@ class MakePdf extends AbstractMake
     }
 
     /**
-     * Build the pdf
+     * Initialize Mpdf
      *
      * @return Mpdf
      */
-    private function generate(): Mpdf
+    public function initializeMpdf($multiEntity = false): void
     {
         $format = $this->Entity->Users->userData['pdf_format'];
 
@@ -130,11 +130,28 @@ class MakePdf extends AbstractMake
         $mpdf->setAutoBottomMargin = 'stretch';
 
         // set metadata
-        $mpdf->SetAuthor($this->Entity->entityData['fullname']);
-        $mpdf->SetTitle($this->Entity->entityData['title']);
+        $mpdf->SetAuthor($this->Entity->Users->userData['fullname']);
+        $mpdf->SetTitle('eLabFTW pdf');
         $mpdf->SetSubject('eLabFTW pdf');
-        $mpdf->SetKeywords(\str_replace('|', ' ', $this->Entity->entityData['tags']));
         $mpdf->SetCreator('www.elabftw.net');
+
+        if (!$multiEntity) {
+            $mpdf->SetAuthor($this->Entity->entityData['fullname']);
+            $mpdf->SetTitle($this->Entity->entityData['title']);
+            $mpdf->SetKeywords(\str_replace('|', ' ', $this->Entity->entityData['tags']));
+        }
+
+        return $mpdf;
+    }
+
+    /**
+     * Build the pdf
+     *
+     * @return Mpdf
+     */
+    private function generate(): Mpdf
+    {
+        $mpdf = $this->initializeMpdf();
 
         // write content
         $mpdf->WriteHTML($this->getContent());

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -65,6 +65,25 @@ class MakePdf extends AbstractMake
     }
 
     /**
+     * Build HTML content that will be fed to mpdf->WriteHTML()
+     *
+     * @return string
+     */
+    public function getContent(): string
+    {
+        $content = $this->buildHeader();
+        $content .= $this->buildBody();
+        $content .= $this->addLinkedItems();
+        $content .= $this->addSteps();
+        $content .= $this->addAttachedFiles();
+        $content .= $this->addComments();
+        $content .= $this->buildInfoBlock();
+
+        return $content;
+    }
+}
+
+    /**
      * Generate pdf and return it as string
      *
      * @return string
@@ -421,24 +440,7 @@ Witness' signature:<br><br>
         <p style="font-size:6pt;">File generated on {DATE d-m-Y} at {DATE H:m}</p>
     </div>
 </htmlpagefooter>
+<sethtmlpageheader name="header" value="on" show-this-page="1" />
+<sethtmlpagefooter name="footer" value="on" />
 ';
     }
-
-    /**
-     * Build HTML content that will be fed to mpdf->WriteHTML()
-     *
-     * @return string
-     */
-    private function getContent(): string
-    {
-        $content = $this->buildHeader();
-        $content .= $this->buildBody();
-        $content .= $this->addLinkedItems();
-        $content .= $this->addSteps();
-        $content .= $this->addAttachedFiles();
-        $content .= $this->addComments();
-        $content .= $this->buildInfoBlock();
-
-        return $content;
-    }
-}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -122,8 +122,9 @@
         </select>
 
     {% endif %}
-        <button data-what = 'zip' class='button btn btn-primary csvzip'>{{ 'Make Zip'|trans }}</button>
+        <button data-what='zip' class='button btn btn-primary csvzip'>{{ 'Make Zip'|trans }}</button>
         <button data-what='csv' class='button btn btn-primary csvzip'>{{ 'Make Csv'|trans }}</button>
+        <button data-what='multiPdf' class='button btn btn-primary csvzip'>{{ 'Make PDF|trans' }}</button>
         <button id='deleteChecked' class='button btn btn-danger'>{{ 'Delete'|trans }}</button>
     </p>
     <div class='row display-flex'>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -124,7 +124,7 @@
     {% endif %}
         <button data-what='zip' class='button btn btn-primary csvzip'>{{ 'Make Zip'|trans }}</button>
         <button data-what='csv' class='button btn btn-primary csvzip'>{{ 'Make Csv'|trans }}</button>
-        <button data-what='multiPdf' class='button btn btn-primary csvzip'>{{ 'Make PDF|trans' }}</button>
+        <button data-what='multiPdf' class='button btn btn-primary csvzip'>{{ 'Make PDF'|trans }}</button>
         <button id='deleteChecked' class='button btn btn-danger'>{{ 'Delete'|trans }}</button>
     </p>
     <div class='row display-flex'>


### PR DESCRIPTION
Hi Nicolas,

This feature was requested some time ago (#434) and I think it is an important one that is currently missing.
The code basically uses the already existing PDF functionality and loops over every selected item.
If you like it you propably want to come up with a better file name for the generated PDF. Currently it is _[multientries.elabftw.pdf](https://github.com/elabftw/elabftw/commit/67cf314de00245e28a2f4aa8afbbdc527aee868a#diff-951f2362b469fa572511b408d74b11fbR55-R58)_.

Cheers,
Marcel