### PR TITLE
Fix disappearing 3D molecule after new upload or delete

### DIFF
--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -7,7 +7,7 @@
  */
 declare let key: any;
 declare let MathJax: any;
-import { addDateOnCursor, displayMolFiles, insertParamAndReload, notif, quickSave } from './misc';
+import { addDateOnCursor, displayMolFiles, display3DMolecules, insertParamAndReload, notif, quickSave } from './misc';
 import 'jquery-ui/ui/widgets/datepicker';
 import tinymce from 'tinymce/tinymce';
 import 'tinymce/icons/default';
@@ -89,6 +89,7 @@ $(document).ready(function() {
         if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
           $('#filesdiv').load('?mode=edit&id=' + $('#info').data('id') + ' #filesdiv', function() {
             displayMolFiles();
+            display3DMolecules(true);
             const dropZone = Dropzone.forElement('#elabftw-dropzone');
 
             // Check to make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -8,6 +8,7 @@
 declare let ChemDoodle: any;
 import tinymce from 'tinymce/tinymce';
 import 'jquery-ui/ui/widgets/sortable';
+import * as $3Dmol from '3dmol/build/3Dmol-nojquery.js';
 
 interface ResponseMsg {
   res: boolean;
@@ -69,6 +70,27 @@ export function displayMolFiles(): void {
     });
   });
 }
+
+// DISPLAY 3D MOL FILES 
+export function display3DMolecules(autoload = false): void {
+  if (autoload) {
+    $3Dmol.autoload();
+  }
+  // 3DMOL
+  // Top left menu to change the style of the displayed molecule
+  $('.dropdown-item').on('click', '.3dmol-style', function() {
+    const targetStyle = $(this).data('style');
+    let options = {};
+    const style = {};
+    if (targetStyle === 'cartoon') {
+      options = { color: 'spectrum' };
+    }
+    style[targetStyle] = options;
+
+    $3Dmol.viewers[$(this).data('divid')].setStyle(style).render();
+  });
+}
+
 // for editXP/DB, ctrl-shift-D will add the date
 export function addDateOnCursor(): void {
   const todayDate = new Date();

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -71,12 +71,11 @@ export function displayMolFiles(): void {
   });
 }
 
-// DISPLAY 3D MOL FILES 
+// DISPLAY 3D MOL FILES
 export function display3DMolecules(autoload = false): void {
   if (autoload) {
     $3Dmol.autoload();
   }
-  // 3DMOL
   // Top left menu to change the style of the displayed molecule
   $('.dropdown-item').on('click', '.3dmol-style', function() {
     const targetStyle = $(this).data('style');

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -8,8 +8,7 @@
 import $ from 'jquery';
 import 'jquery-jeditable/src/jquery.jeditable.js';
 import '@fancyapps/fancybox/dist/jquery.fancybox.js';
-import { notif, displayMolFiles } from './misc';
-import * as $3Dmol from '3dmol/build/3Dmol-nojquery.js';
+import { notif, displayMolFiles, display3DMolecules } from './misc';
 import i18next from 'i18next';
 
 $(document).ready(function() {
@@ -18,6 +17,7 @@ $(document).ready(function() {
     return;
   }
   displayMolFiles();
+  display3DMolecules();
 
   // REPLACE UPLOAD toggle form
   $(document).on('click', '.replaceUpload', function() {
@@ -86,6 +86,7 @@ $(document).ready(function() {
         if (json.res) {
           $('#filesdiv').load('?mode=edit&id=' + itemid + ' #filesdiv', function() {
             displayMolFiles();
+            display3DMolecules(true);
           });
         }
       });
@@ -94,18 +95,4 @@ $(document).ready(function() {
 
   // ACTIVATE FANCYBOX
   $('[data-fancybox]').fancybox();
-
-  // 3DMOL
-  // Top left menu to change the style of the displayed molecule
-  $('.dropdown-item').on('click', '.3dmol-style', function() {
-    const targetStyle = $(this).data('style');
-    let options = {};
-    const style = {};
-    if (targetStyle === 'cartoon') {
-      options = { color: 'spectrum' };
-    }
-    style[targetStyle] = options;
-
-    $3Dmol.viewers[$(this).data('divid')].setStyle(style).render();
-  });
 });


### PR DESCRIPTION
It seems like the `<canvas>` element disappears after an upload or a delete.
This fix uses the auto-initialization function of 3Dmol.js (https://github.com/3dmol/3Dmol.js/blob/master/3Dmol/autoload.js) which is running after a webpage is loaded ($(document).ready(function()) if 3Dmol.js is included and generates the `<canvas>` element.
We have to avoid that it runs a second time and generates a second `<canvas>` element (a copy), run it after AJAX is done.

For now the view and style settings will be reset with every call of `display3DMolecules()` but this can potentially be fixed aswell.
One needs to save the particular viewer from the viewers dictionary and reload it somehow.