### PR TITLE
Jsonviewer

### DIFF
--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -101,9 +101,14 @@
                 id='filecomment_{{ upload.id }}'>{{ upload.comment}}</p>
             {% endif %}
 
-            {% if mode == 'edit' and ext matches '/(json)$/i' and App.Users.userData.json_editor %}
+            {% if ext matches '/(json)$/i' and App.Users.userData.json_editor %}
             <div class='jsonLoader clickable' data-type='{{ upload.type }}' data-link='{{ upload.long_name }}' data-id='{{ upload.item_id }}' data-uploadid='{{ upload.id }}'>
-                <i class='fas fa-pencil-alt mr-1'></i><p class='d-inline'>{{ 'Load into JSON Editor'|trans }}</p>
+              {% if mode == 'view' %}
+                <i class='fas fa-eye mr-1'>
+              {% elseif mode == 'edit' %}
+                <i class='fas fa-pencil-alt mr-1'>
+              {% endif %}
+                </i><p class='d-inline'>{{ 'Load into JSON Editor'|trans }}</p>
             </div>
             {% endif %}
 

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -101,7 +101,7 @@
                 id='filecomment_{{ upload.id }}'>{{ upload.comment}}</p>
             {% endif %}
 
-            {% if ext matches '/(json)$/i' and App.Users.userData.json_editor %}
+            {% if ext matches '/(json)$/i' %}
             <div class='jsonLoader clickable' data-type='{{ upload.type }}' data-link='{{ upload.long_name }}' data-id='{{ upload.item_id }}' data-uploadid='{{ upload.id }}'>
               {% if mode == 'view' %}
                 <i class='fas fa-eye mr-1'>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -216,6 +216,17 @@
 
 {{ include('uploads.html') }}
 
+{% if Entity.Users.userData.json_editor %}
+  <!-- JSON EDITOR -->
+  <section class='box' id='json-editor'>
+    <i class='fas fa-list mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'JSON Editor'|trans }}</h3>
+    <button class='button btn btn-primary plusMinusButton jsonEditorPlusMinusButton' data-toggle='collapse' data-target='#jsonEditorDiv' aria-expanded='false' aria-controls='jsonEditorDiv'>+</button>
+    <div id='jsonEditorDiv' class='collapse mt-2'>
+      <div id='jsonEditorContainer'></div>
+    </div>
+  </section>
+{% endif %}
+
 {% if App.Session.get('auth') %}
     <section id='comment_container'>
         <div id='comment' class='box'>
@@ -263,5 +274,8 @@
     data-create='{{ Entity.Users.userData.sc_create }}'
     data-edit='{{ Entity.Users.userData.sc_edit }}'>
 </div>
+
+<!-- Load the JSONEditor CSS -->
+<link href='app/css/jsoneditor/jsoneditor.min.css' rel='stylesheet' type='text/css'>
 
 {% endblock body %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -216,7 +216,6 @@
 
 {{ include('uploads.html') }}
 
-{% if Entity.Users.userData.json_editor %}
   <!-- JSON EDITOR -->
   <section class='box' id='json-editor'>
     <i class='fas fa-list mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'JSON Editor'|trans }}</h3>
@@ -225,7 +224,6 @@
       <div id='jsonEditorContainer'></div>
     </div>
   </section>
-{% endif %}
 
 {% if App.Session.get('auth') %}
     <section id='comment_container'>

--- a/src/ts/jsoneditor.ts
+++ b/src/ts/jsoneditor.ts
@@ -12,13 +12,13 @@ import JSONEditor from 'jsoneditor';
 
 // editor div
 $(document).ready(function() {
-  if ($('#info').data('page') !== 'edit') {
+  if (!($('#info').data('page') === 'edit' || $('#info').data('page') === 'view')) {
     return;
   }
   const container = document.getElementById('jsonEditorContainer');
 
   const options = {
-    modes: ['tree','code','view','form','text'],
+    modes: (($('#info').data('page') === 'edit') ? ['tree','code','view','form','text']:['view']),
     onModeChange: function(newMode) {
       if (newMode==='code' || newMode==='text'){
         $('#jsoneditor').height('800px');


### PR DESCRIPTION
Hi Nicolas,

We needed new functionality on the experiments page. And this PR is one of the few changes I think would be good for sharing experiments to non-registered users. We want to be able to let users view data we have uploaded on the experiment page rather then downloading it. We plan on hosting large datasets that won't be ideal to download every time. I am working on a different plugin for that. This is a stepping stone in getting that functionality added.

The idea with this PR is that when a user shares his/her experiment, the person on the receiving end can view the metadata/.json file within their browser. Currently, ElabFTW only supports these plugins in edit mode. So I have allowed the JSONviewer to be available in view mode as well. This is a little test to see how we can implement view mode plugins. Eventually, I will have that large dataset viewer implemented. 

I tried to keep the changes very minimal. Let me know what you think.

Cheers,
Sherjeel
