### PR TITLE
Fix not working UCP preferences

### DIFF
--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -94,8 +94,8 @@
         <option value='desc' {{ App.Users.userData.sort == 'desc' ? ' selected' }}>{{ 'DESC'|trans }}</option>
       </select>
 
-      <input id='layout' class='mt-2' type='checkbox' name='single_column_layout'
-          {{ App.Users.userData.single_column_layout == '1' ? " checked='checked'" }}
+      <input id='layout' class='mt-2' type='checkbox' name='single_column_layout' value='1'
+          {{ App.Users.userData.single_column_layout == '1' ? ' checked' }}
       />
       <label for='layout'>{{ 'Use single column layout'|trans }}</label>
     </section>
@@ -138,18 +138,20 @@
         </select>
         <br>
 
-        <input id='cjk_fonts' type='checkbox' name='cjk_fonts'
-          {{ App.Users.userData.cjk_fonts == '1' ? " checked='checked'" }}
+        <input id='cjk_fonts' type='checkbox' name='cjk_fonts' value='1'
+          {{ App.Users.userData.cjk_fonts == '1' ? ' checked' }}
         />
         <label for='cjk_fonts'>{{ 'Enable Chinese, Japanese and Korean fonts in PDF generation (WARNING: this will dramatically increase the file size unless you disable PDF/A)'|trans }}</label>
         <br>
-        <input id='pdfa' type='checkbox' name='pdfa'
-          {{ App.Users.userData.pdfa == '1' ? " checked='checked'" }}
+
+        <input id='pdfa' type='checkbox' name='pdfa' value='1'
+          {{ App.Users.userData.pdfa == '1' ? ' checked' }}
         />
         <label for='pdfa'>{{ 'Generate PDF/A compliant pdfs (will embed the fonts and make the file bigger)'|trans }}</label>
         <br>
-        <input id='inc_files_pdf' type='checkbox' name='inc_files_pdf'
-          {{ App.Users.userData.inc_files_pdf == '1' ? " checked='checked'" }}
+
+        <input id='inc_files_pdf' type='checkbox' name='inc_files_pdf' value='1'
+          {{ App.Users.userData.inc_files_pdf == '1' ? ' checked' }}
         />
         <label for='inc_files_pdf'>{{ 'Add attached files summary to the pdf'|trans }}</label>
         <br>
@@ -166,28 +168,28 @@
     <section class='box'>
         <h3>{{ 'Miscellaneous'|trans }}</h3>
         <p>
-        <input id='show_team' type='checkbox' name='show_team'
-          {{ App.Users.userData.show_team == '1' ? " checked='checked'" }}
+        <input id='show_team' type='checkbox' name='show_team' value='1'
+          {{ App.Users.userData.show_team == '1' ? ' checked' }}
         />
         <label for='show_team'>{{ 'Show experiments from the team on the Experiments page'|trans }}</label>
         <br>
-        <input id='show_team_templates' type='checkbox' name='show_team_templates'
-               {{ App.Users.userData.show_team_templates == '1' ? " checked='checked'" }}
+        <input id='show_team_templates' type='checkbox' name='show_team_templates' value='1'
+               {{ App.Users.userData.show_team_templates == '1' ? ' checked' }}
         />
         <label for='show_team_templates'>{{ 'Show templates from the team on the Templates page and in the menus'|trans }}</label>
         <br>
-        <input id='chem_editor' type='checkbox' name='chem_editor'
-          {{ App.Users.userData.chem_editor == '1' ? " checked='checked'" }}
+        <input id='chem_editor' type='checkbox' name='chem_editor' value='1'
+          {{ App.Users.userData.chem_editor == '1' ? ' checked' }}
         />
         <label for='chem_editor'>{{ 'Display the molecule editor in edit mode'|trans }}</label>
         <br>
-        <input id='json_editor' type='checkbox' name='json_editor'
-          {{ App.Users.userData.json_editor == '1' ? " checked='checked'" }}
+        <input id='json_editor' type='checkbox' name='json_editor' value='1'
+          {{ App.Users.userData.json_editor == '1' ? ' checked' }}
         />
         <label for='json_editor'>{{ 'Display the JSON editor in edit mode'|trans }}</label>
         <br>
-        <input id='use_markdown' type='checkbox' name='use_markdown'
-          {{ App.Users.userData.use_markdown == '1' ? " checked='checked'" }}
+        <input id='use_markdown' type='checkbox' name='use_markdown' value='1'
+          {{ App.Users.userData.use_markdown == '1' ? ' checked' }}
         />
         <label for='use_markdown'>{{ 'Disable the rich text editor and write Markdown directly'|trans }}</label>
         </p>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -143,13 +143,11 @@
         />
         <label for='cjk_fonts'>{{ 'Enable Chinese, Japanese and Korean fonts in PDF generation (WARNING: this will dramatically increase the file size unless you disable PDF/A)'|trans }}</label>
         <br>
-
         <input id='pdfa' type='checkbox' name='pdfa' value='1'
           {{ App.Users.userData.pdfa == '1' ? ' checked' }}
         />
         <label for='pdfa'>{{ 'Generate PDF/A compliant pdfs (will embed the fonts and make the file bigger)'|trans }}</label>
         <br>
-
         <input id='inc_files_pdf' type='checkbox' name='inc_files_pdf' value='1'
           {{ App.Users.userData.inc_files_pdf == '1' ? ' checked' }}
         />


### PR DESCRIPTION
There is a little bug due to the new Maps\UserPreferences.php. Users can only activate check boxes but not deactivate them anymore. This PR will fix it by the addition of the attribute `value='1'` to the `<input>` elements. It will also simplify the `checked` attribute.

Note: Maps\UserPreferences.php requires '1' as value not the default 'on' as it uses Services\Filter::toBinary() and not onToBinary().