### PR TITLE
Fix timestamp on generated PDF

### DIFF
--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -464,7 +464,7 @@ Witness' signature:<br><br>
 <htmlpagefooter name="footer">' . $pdfSig . '
     <div class="footer-block footer">
         PDF generated with <a href="https://www.elabftw.net">elabftw</a>, a free and open source lab notebook
-        <p style="font-size:6pt;">File generated on {DATE d-m-Y} at {DATE H:m}</p>
+        <p style="font-size:6pt;">File generated on {DATE d-m-Y} at {DATE H:i}</p>
     </div>
 </htmlpagefooter>
 <sethtmlpageheader name="header" value="on" show-this-page="1" />


### PR DESCRIPTION
Using "Minutes" instead of "Months" in the date part of the time stamp.
The output timestamp is of format "DD-MM-YYYY at hh:mm"
Eg. File generated on 01-10-2020 at 13:00
