### PR TITLE
fix 2FA and broken redirect

### DIFF
--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -62,7 +62,7 @@ class LoginController implements ControllerInterface
                 );
 
                 // check the input code against the secret stored in session
-                if (!$MfaHelper->verifyCode($this->App->Request->get('mfa_code') ?? '')) {
+                if (!$MfaHelper->verifyCode($this->App->Request->request->get('mfa_code') ?? '')) {
                     throw new InvalidCredentialsException('The code you entered is not valid!');
                 }
 
@@ -78,8 +78,10 @@ class LoginController implements ControllerInterface
             $this->App->Session->remove('enable_mfa');
             $this->App->Session->remove('mfa_auth_required');
             $this->App->Session->remove('mfa_secret');
+            $location = $this->App->Session->get('mfa_redirect');
+            $this->App->Session->remove('mfa_redirect');
 
-            return new RedirectResponse('../../ucp.php?tab=2');
+            return new RedirectResponse($location);
         }
 
         // store the rememberme choice in session
@@ -189,7 +191,7 @@ class LoginController implements ControllerInterface
                         (int) $this->App->Session->get('auth_userid'),
                         $this->App->Session->get('mfa_secret'),
                     ),
-                    $this->App->Request->get('mfa_code') ?? '',
+                    $this->App->Request->request->get('mfa_code') ?? '',
                 );
 
             default:

--- a/src/services/MfaHelper.php
+++ b/src/services/MfaHelper.php
@@ -28,7 +28,7 @@ class MfaHelper
     private const DIGITS = 6;
 
     /** @var int PERIOD number of seconds a code will be valid */
-    private const PERIOD = 60;
+    private const PERIOD = 30;
 
     /** @var string ALGO algorithm used */
     private const ALGO = 'sha1';

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -94,6 +94,7 @@ try {
             if ($App->Request->headers->get('X-Requested-With') != 'XMLHttpRequest') {
                 // NO DON'T USE  THE FULL URL HERE BECAUSE IF SERVER IS HTTP it will fail badly
                 header('Location: app/logout.php?keep_redirect=1');
+                exit;
             }
             throw new UnauthorizedException(_('Your session expired.'));
         }


### PR DESCRIPTION
Hi Nicolas,

I found some bugs during my initial testing of elabFTW 3.6.0-beta.

- With a fresh installation I got an SQL error on `experiments.php`. This seems to be due to changes in `init.inc.php`. Adding the exit after the header solved the problem for me.
- The 2FA did not work with 2 apps that I tested due to the 60 sec period. In my first implementation it was set to 30 sec.
 Any particular reason you changed it?
- The saved session variable `mfa_redirect` was not used. This is not really a fix as it works without my changes in this PR. You could also remove this session variable from the [UcpController.php](https://github.com/elabftw/elabftw/blob/5ce4cd5e137670f2d4592f965633e06f2d0e7290/web/app/controllers/UcpController.php#L96)