### PR TITLE
restore admins possibility to disable 2FA

### DIFF
--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -269,7 +269,7 @@ class Users
         // NOTE: previously, the ORDER BY started with the team, but that didn't work
         // with the DISTINCT, so it was removed.
         $sql = "SELECT DISTINCT users.userid,
-            users.firstname, users.lastname, users.email,
+            users.firstname, users.lastname, users.email, users.mfa_secret,
             users.validated, users.usergroup, users.archived, users.last_login,
             CONCAT(users.firstname, ' ', users.lastname) AS fullname
             FROM users


### PR DESCRIPTION
I found another bug in the 2FA functionality.
This PR will restore the (sys)admins ability to deactivate 2FA for a user.

I also realized that if the user activates 2FA and the code is not verified a failed attempt is reported and counted. This should only be the case after 2FA activation was successful and the user tries to login with a wrong code. I will open another PR later to fix it.