### PR TITLE
Updated link to user guide

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -122,7 +122,7 @@
       <div class='modal-body' data-wait='{{ 'Please wait…' }}'>
         <ul>
             <li class='tip'>
-                {{ 'There is a manual available %shere%s.'|trans|format("<a href='https://doc.elabftw.net/manual.html'>", "</a>")|raw }}
+                {{ 'There is a manual available %shere%s.'|trans|format("<a href='https://doc.elabftw.net/user-guide.html'>", "</a>")|raw }}
             </li>
             <li class='tip'>
                 {{ "You can use a TODOlist by pressing '%s'."|trans|format(App.Users.userData.sc_todo) }}


### PR DESCRIPTION
The link to the manual in the Help menu points to a no longer existing file (`manual.html`). This PR updates this link to the user guide, which I would guess is the intended target.

This is the only occurrence of this link.
