### PR TITLE
Ove button css, only minified ove.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "full": "yarn phpcs && yarn jslint && yarn csslint && yarn psalm && yarn phpstan && yarn test unit",
     "jslint": "eslint --ext .ts src/ts",
     "jslint-ci": "eslint --ext .ts --quiet src/ts",
-    "ove": "mkdir -p web/assets/ove/ && cp node_modules/@deltablot/open-vector-editor-umd/* web/assets/ove/",
+    "ove": "mkdir -p web/assets/ove/ && cp node_modules/@deltablot/open-vector-editor-umd/* web/assets/ove/ && rm -f web/assets/ove/open-vector-editor.js*",
     "phan": "phan --allow-polyfill-parser -k src/tools/phan-config.php",
     "phpcs": "./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --using-cache=no",
     "phpcs-dry": "./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --stop-on-violation --using-cache=no",

--- a/src/scss/_ove.scss
+++ b/src/scss/_ove.scss
@@ -6,6 +6,33 @@
  * @package elabftw
  */
 
-.bp3-intent-primary {
-    background-color: $elabblue !important;
+.preview-mode-container {
+    .bp3-button.bp3-intent-primary {
+        background-color: $elabblue !important;
+        border: 1px solid transparent !important;
+        border-radius: 5px !important;
+        box-shadow: none !important;
+    }
+
+    .bp3-button.bp3-intent-primary:hover {
+        background-color: #22919a !important;
+        border-color: #20878f !important;
+        box-shadow: none !important;
+    }
+
+    .bp3-button.bp3-intent-primary:focus {
+        box-shadow: 0 0 0 0.2rem rgba(73, 186, 196, 0.5) !important;
+    }
+
+    .bp3-button-group.preview-mode-view-fullscreen:hover {
+        background: none !important;
+    }
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.veToolbar {
+    .bp3-button[class*='bp3-intent-'] .bp3-icon {
+        //$elabblue does not look as great here IMHO, it's to light
+        color: #20878f !important;
+    }
 }


### PR DESCRIPTION
There are some side effects to the tool bar icons with the current css.
before:
![image](https://user-images.githubusercontent.com/65481677/126436755-802349d4-b888-451c-b27e-470fd75a6c70.png)

after:
![image](https://user-images.githubusercontent.com/65481677/126437317-26ebf0b0-1f51-4413-8cb6-adb260a5d048.png)

Also, only keep minified ove.js, speed up brotli and zopfli.
