### PR TITLE
Fix UCP templates json editor

### DIFF
--- a/src/templates/templates-edit.html
+++ b/src/templates/templates-edit.html
@@ -57,4 +57,3 @@
 </div>
 {% include('steps-links-edit.html') %}
 {{ include('json-editor.html') }}
-<div id='info' data-type='experiments_templates' data-id='{{ templateData.id }}'></div>


### PR DESCRIPTION
Remove duplication of `<div id='info'>` in templates-edit.html, it is also present in show-templates-edit.html.

See [#2832](https://github.com/elabftw/elabftw/issues/2832#issuecomment-895253256)