### PR TITLE
fix metadata not saving changes on admin panel

### DIFF
--- a/src/classes/AbstractProcessor.php
+++ b/src/classes/AbstractProcessor.php
@@ -117,7 +117,7 @@ abstract class AbstractProcessor implements ProcessorInterface
         } elseif ($type === 'template') {
             return new Templates($this->Users, $itemId);
         } elseif ($type === 'itemtype') {
-            return new ItemsTypes($this->Users->team, $itemId);
+            return new ItemsTypes($this->Users, $itemId);
         }
         return new Items($this->Users, $itemId);
     }

--- a/src/classes/Permissions.php
+++ b/src/classes/Permissions.php
@@ -98,6 +98,17 @@ class Permissions
     }
 
     /**
+     * For ItemType write permission check for metadata
+     */
+    public function forItemType(): array
+    {
+        if ($this->Users->userData['is_admin'] && ((int) $this->item['team'] === $this->Users->userData['team'])) {
+            return array('read' => true, 'write' => true);
+        }
+        return array('read' => false, 'write' => false);
+    }
+
+    /**
      * Get the write permission for an exp/item
      */
     private function getWrite(): bool

--- a/src/commands/PopulateDatabase.php
+++ b/src/commands/PopulateDatabase.php
@@ -124,7 +124,9 @@ class PopulateDatabase extends Command
 
         // add more items types
         foreach ($yaml['items_types'] as $items_types) {
-            $ItemsTypes = new ItemsTypes((int) $items_types['team']);
+            $user = new Users();
+            $user->team = (int) $items_types['team'];
+            $ItemsTypes = new ItemsTypes($user);
             $extra = array(
                 'color' => $items_types['color'],
                 'body' => $items_types['template'],

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -249,7 +249,7 @@ class ApiController implements ControllerInterface
         } elseif ($this->endpoint === 'templates') {
             $this->Entity = new Templates($this->Users, $this->id);
         } elseif ($this->endpoint === 'items_types') {
-            $this->Category = new ItemsTypes($this->Users->team);
+            $this->Category = new ItemsTypes($this->Users);
         } elseif ($this->endpoint === 'status') {
             $this->Category = new Status($this->Users->team);
         } elseif ($this->endpoint === 'events') {
@@ -777,7 +777,7 @@ class ApiController implements ControllerInterface
     private function createItem(): Response
     {
         // check that the id we have is a valid item type from our team
-        $ItemsTypes = new ItemsTypes($this->Users->team);
+        $ItemsTypes = new ItemsTypes($this->Users);
         $itemsTypesArr = $ItemsTypes->readAll();
         $validIds = array();
         foreach ($itemsTypesArr as $itemsTypes) {

--- a/src/controllers/DatabaseController.php
+++ b/src/controllers/DatabaseController.php
@@ -24,7 +24,7 @@ class DatabaseController extends AbstractEntityController
     {
         parent::__construct($app, $entity);
 
-        $Category = new ItemsTypes($this->App->Users->team);
+        $Category = new ItemsTypes($this->App->Users);
         $this->categoryArr = $Category->readAll();
     }
 

--- a/src/controllers/SearchController.php
+++ b/src/controllers/SearchController.php
@@ -30,7 +30,7 @@ class SearchController extends AbstractEntityController
         if ($this->App->Request->query->get('type') === 'experiments') {
             $Category = new Status($this->App->Users->team);
         } else {
-            $Category = new ItemsTypes($this->App->Users->team);
+            $Category = new ItemsTypes($this->App->Users);
         }
         $this->categoryArr = $Category->read(new ContentParams('', 'all'));
     }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -469,6 +469,9 @@ abstract class AbstractEntity implements CrudInterface
         if ($this instanceof Experiments || $this instanceof Items || $this instanceof Templates) {
             return $Permissions->forEntity();
         }
+        if ($this instanceof ItemsTypes) {
+            return $Permissions->forItemType();
+        }
 
         return array('read' => false, 'write' => false);
     }

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -33,7 +33,7 @@ class Items extends AbstractEntity
     public function create(EntityParamsInterface $params): int
     {
         $category = (int) $params->getContent();
-        $ItemsTypes = new ItemsTypes($this->Users->team, $category);
+        $ItemsTypes = new ItemsTypes($this->Users, $category);
         $itemsTypesArr = $ItemsTypes->read(new ContentParams());
 
         // SQL for create DB item

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -24,9 +24,12 @@ class ItemsTypes extends AbstractEntity
 {
     use SortableTrait;
 
-    public function __construct(private int $team, ?int $id = null)
+    private int $team;
+
+    public function __construct(public Users $Users, ?int $id = null)
     {
         $this->Db = Db::getConnection();
+        $this->team = $this->Users->team;
         $this->type = 'items_types';
         if ($id !== null) {
             $this->setId($id);
@@ -59,7 +62,7 @@ class ItemsTypes extends AbstractEntity
             return $this->readAll();
         }
 
-        $sql = 'SELECT template, canread, canwrite, metadata FROM items_types WHERE id = :id AND team = :team';
+        $sql = 'SELECT team, template, canread, canwrite, metadata FROM items_types WHERE id = :id AND team = :team';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);

--- a/src/models/Teams.php
+++ b/src/models/Teams.php
@@ -152,7 +152,9 @@ class Teams implements ReadableInterface, DestroyableInterface
         $Status->createDefault();
 
         // create default item type
-        $ItemsTypes = new ItemsTypes($newId);
+        $user = new Users();
+        $user->team = $newId;
+        $ItemsTypes = new ItemsTypes($user);
         $extra = array(
             'color' => '#32a100',
             'body' => '<p>Go to the admin panel to edit/add more items types!</p>',

--- a/src/services/Populate.php
+++ b/src/services/Populate.php
@@ -52,7 +52,7 @@ class Populate
             $Category = new Status($Entity->Users->team);
             $tpl = 0;
         } else {
-            $Category = new ItemsTypes($Entity->Users->team);
+            $Category = new ItemsTypes($Entity->Users);
             $tpl = (int) $Category->readAll()[0]['category_id'];
         }
         $categories = $Category->readAll();

--- a/tests/unit/models/ItemsTypesTest.php
+++ b/tests/unit/models/ItemsTypesTest.php
@@ -18,7 +18,7 @@ class ItemsTypesTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->ItemsTypes= new ItemsTypes(1);
+        $this->ItemsTypes= new ItemsTypes(new Users(1, 1));
     }
 
     public function testCreateUpdateDestroy(): void

--- a/web/admin.php
+++ b/web/admin.php
@@ -41,7 +41,7 @@ try {
         throw new IllegalActionException('Non admin user tried to access admin controller.');
     }
 
-    $ItemsTypes = new ItemsTypes($App->Users->team);
+    $ItemsTypes = new ItemsTypes($App->Users);
     $Status = new Status($App->Users->team);
     $Tags = new Tags(new Experiments($App->Users));
     $TeamGroups = new TeamGroups($App->Users);

--- a/web/app/controllers/EntityAjaxController.php
+++ b/web/app/controllers/EntityAjaxController.php
@@ -187,7 +187,7 @@ try {
         if ($Entity instanceof Experiments) {
             $Category = new Status($App->Users->team);
         } else {
-            $Category = new ItemsTypes($App->Users->team);
+            $Category = new ItemsTypes($App->Users);
         }
         $Response->setData(array(
             'res' => true,

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -42,7 +42,7 @@ try {
             if (!$App->Session->get('is_admin')) {
                 throw new IllegalActionException('Non admin user tried to access admin controller.');
             }
-            $Entity = new ItemsTypes($App->Users->team);
+            $Entity = new ItemsTypes($App->Users);
             break;
         case 'status':
             if (!$App->Session->get('is_admin')) {

--- a/web/search.php
+++ b/web/search.php
@@ -38,7 +38,7 @@ $Database = new Items($App->Users);
 $Tags = new Tags($Experiments);
 $tagsArr = $Tags->readAll();
 
-$itemsTypesArr = (new ItemsTypes($App->Users->team))->read(new ContentParams('', 'all'));
+$itemsTypesArr = (new ItemsTypes($App->Users))->read(new ContentParams('', 'all'));
 $categoryArr = $statusArr = (new Status($App->Users->team))->read(new ContentParams());
 if ($Request->query->get('type') !== 'experiments') {
     $categoryArr = $itemsTypesArr;


### PR DESCRIPTION
fix #2832

So what I did is mostly revert init of the ItemsTypes object with a full Users instead of just the team. This was not so much a big change as most `new` calls where just taking the team from the existing Users object.

@MarcelBolten it would be great if you could review this ;)