### PR TITLE
replace callbacks with MutationObserver

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -9,7 +9,7 @@ import $ from 'jquery';
 import { Ajax } from './Ajax.class';
 import 'bootstrap-select';
 import 'bootstrap/js/src/modal.js';
-import { notif, relativeMoment, displayMolFiles, makeSortableGreatAgain } from './misc';
+import { notif, relativeMoment, makeSortableGreatAgain } from './misc';
 import i18next from 'i18next';
 import EntityClass from './Entity.class';
 import { EntityType, Payload, Method, Model, Action } from './interfaces';
@@ -55,7 +55,6 @@ $(document).ready(function() {
 
   makeSortableGreatAgain();
   relativeMoment();
-  displayMolFiles();
 
   // SHOW/HIDE THE DOODLE CANVAS/CHEM EDITOR/JSON EDITOR
   const plusMinusButton = document.getElementsByClassName('plusMinusButton');

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -7,8 +7,7 @@
  */
 declare let key: any;
 declare let MathJax: any;
-import { displayMolFiles, display3DMolecules, insertParamAndReload, notif } from './misc';
-import { displayPlasmidViewer } from './ove';
+import { insertParamAndReload, notif } from './misc';
 import { getTinymceBaseConfig, quickSave } from './tinymce';
 import { EntityType, Target, Upload, Payload, Method, Action } from './interfaces';
 import './doodle';
@@ -88,9 +87,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // reload the #filesdiv once the file is uploaded
         if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
           $('#filesdiv').load(`?mode=edit&id=${String(entity.id)} #filesdiv > *`, function() {
-            displayMolFiles();
-            display3DMolecules(true);
-            displayPlasmidViewer(about);
             const dropZone = Dropzone.forElement('#elabftw-dropzone');
             // Check to make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
             if (typeof dropZone.tinyImageSuccess !== 'undefined' && dropZone.tinyImageSuccess !== null) {

--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -129,9 +129,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
         generatePng: true,
         handleFullscreenClose: function(): void { // event could be used as parameter
           editor[viewerID].close();
-          $('#filesdiv').load('?mode=' + about.page + '&id=' + about.id + ' #filesdiv > *', function() {
-            displayPlasmidViewer(about);
-          });
+          $('#filesdiv').load('?mode=' + about.page + '&id=' + about.id + ' #filesdiv > *');
         },
         onCopy: function(event, copiedSequenceData, editorState): void {
           // the copiedSequenceData is the subset of the sequence that has been copied in the teselagen sequence format

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -134,9 +134,9 @@ $(document).ready(function() {
 
   // Create an observer instance linked to the callback function(mutationsList, observer)
   const filesDivObserver = new MutationObserver(() => {
-      displayMolFiles();
-      display3DMolecules(true);
-      displayPlasmidViewer(about);
+    displayMolFiles();
+    display3DMolecules(true);
+    displayPlasmidViewer(about);
   });
 
   // Start observing the target node for configured mutations

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -122,11 +122,7 @@ $(document).ready(function() {
       if (confirm(i18next.t('generic-delete-warning'))) {
         UploadC.destroy(uploadId).then(json => {
           if (json.res) {
-            $('#filesdiv').load('?mode=edit&id=' + entity.id + ' #filesdiv > *', function() {
-              displayMolFiles();
-              display3DMolecules(true);
-              displayPlasmidViewer(about);
-            });
+            $('#filesdiv').load('?mode=edit&id=' + entity.id + ' #filesdiv > *');
           }
         });
       }
@@ -135,4 +131,14 @@ $(document).ready(function() {
 
   // ACTIVATE FANCYBOX
   $('[data-fancybox]').fancybox();
+
+  // Create an observer instance linked to the callback function(mutationsList, observer)
+  const filesDivObserver = new MutationObserver(() => {
+      displayMolFiles();
+      display3DMolecules(true);
+      displayPlasmidViewer(about);
+  });
+
+  // Start observing the target node for configured mutations
+  filesDivObserver.observe(document.getElementById('filesdiv'), {childList: true});
 });


### PR DESCRIPTION
Hi Nico,

There are several callbacks to trigger after the upload area (filesdiv) is reloaded.
Those callbacks are somewhat distributed in the ts code base (and in chemdoodle-web-mini maybe more?).
In terms of maintenance it makes sense to me to concentrate them in one place.
This PR introduces a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) for the filesdiv element. This will hopefully help to avoid 'broken' rendering of plasmids, 3D- and 2D-mol files.

Cheers