### PR TITLE
Improve items types admin panel interface

### DIFF
--- a/src/classes/Db.php
+++ b/src/classes/Db.php
@@ -17,6 +17,7 @@ use const DB_PASSWORD;
 use const DB_PORT;
 use const DB_USER;
 use Elabftw\Exceptions\DatabaseErrorException;
+use Elabftw\Exceptions\ResourceNotFoundException;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -127,7 +128,23 @@ final class Db
     }
 
     /**
-     * Force fetchAll to return an array or throw exception if result is false
+     * Force fetch() to return an array or throw exception if result is false
+     * because this is hard to test
+     */
+    public function fetch(PDOStatement $req): array
+    {
+        if ($req->rowCount() === 0) {
+            throw new ResourceNotFoundException();
+        }
+        $res = $req->fetch();
+        if ($res === false || $res === null) {
+            return array();
+        }
+        return $res;
+    }
+
+    /**
+     * Force fetchAll() to return an array or throw exception if result is false
      * because this is hard to test
      */
     public function fetchAll(PDOStatement $req): array

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -35,7 +35,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 67;
+    private const REQUIRED_SCHEMA = 68;
 
     private Db $Db;
 

--- a/src/classes/UserStats.php
+++ b/src/classes/UserStats.php
@@ -43,7 +43,7 @@ class UserStats
 
         // get all status name and id
         $Status = new Status($this->Users->team);
-        $statusAll = $Status->read(new ContentParams());
+        $statusAll = $Status->readAll();
 
         // populate arrays
         foreach ($statusAll as $status) {

--- a/src/controllers/ExperimentsController.php
+++ b/src/controllers/ExperimentsController.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace Elabftw\Controllers;
 
 use Elabftw\Elabftw\App;
-use Elabftw\Elabftw\ContentParams;
 use Elabftw\Elabftw\DisplayParams;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Status;
@@ -29,7 +28,7 @@ class ExperimentsController extends AbstractEntityController
         parent::__construct($app, $entity);
 
         $Category = new Status($this->App->Users->team);
-        $this->categoryArr = $Category->read(new ContentParams());
+        $this->categoryArr = $Category->readAll();
     }
 
     /**

--- a/src/models/AbstractCategory.php
+++ b/src/models/AbstractCategory.php
@@ -28,11 +28,6 @@ abstract class AbstractCategory implements CrudInterface
     protected int $team;
 
     /**
-     * Get the color of an item type
-     */
-    abstract public function readColor(int $id): string;
-
-    /**
      * Get all the things
      */
     abstract public function readAll(): array;

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -18,7 +18,6 @@ use Elabftw\Elabftw\Permissions;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\ContentParamsInterface;
 use Elabftw\Interfaces\CrudInterface;
 use Elabftw\Interfaces\EntityParamsInterface;
@@ -289,9 +288,6 @@ abstract class AbstractEntity implements CrudInterface
         $this->Db->execute($req);
 
         $item = $req->fetch();
-        if ($item === false) {
-            throw new ResourceNotFoundException();
-        }
 
         $permissions = $this->getPermissions($item);
         if ($permissions['read'] === false) {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -125,7 +125,7 @@ abstract class AbstractEntity implements CrudInterface
      */
     public function toggleLock(): bool
     {
-        $permissions = $this->getPermissions();
+        $this->getPermissions();
         if (!$this->Users->userData['can_lock'] && $this->entityData['userid'] !== $this->Users->userData['userid']) {
             throw new ImproperActionException(_("You don't have the rights to lock/unlock this."));
         }

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -6,7 +6,6 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-declare(strict_types=1);
 
 namespace Elabftw\Models;
 
@@ -37,9 +36,8 @@ class Items extends AbstractEntity
     {
         $category = (int) $params->getContent();
         $ItemsTypes = new ItemsTypes($this->Users, $category);
-        $itemsTypesArr = $ItemsTypes->read(new ContentParams());
+        $itemTemplate = $ItemsTypes->read(new ContentParams());
 
-        // SQL for create DB item
         $sql = 'INSERT INTO items(team, title, date, body, userid, category, elabid, canread, canwrite, metadata)
             VALUES(:team, :title, :date, :body, :userid, :category, :elabid, :canread, :canwrite, :metadata)';
         $req = $this->Db->prepare($sql);
@@ -48,26 +46,23 @@ class Items extends AbstractEntity
             'title' => _('Untitled'),
             'date' => Filter::kdate(),
             'elabid' => $this->generateElabid(),
-            'body' => $itemsTypesArr['template'],
+            'body' => $itemTemplate['body'],
             'userid' => $this->Users->userData['userid'],
             'category' => $category,
-            'canread' => $itemsTypesArr['canread'],
-            'canwrite' => $itemsTypesArr['canwrite'],
-            'metadata' => $itemsTypesArr['metadata'],
+            'canread' => $itemTemplate['canread'],
+            'canwrite' => $itemTemplate['canwrite'],
+            'metadata' => $itemTemplate['metadata'],
         ));
 
         $newId = $this->Db->lastInsertId();
 
         $this->insertTags($params->getTags(), $newId);
+        $this->Links->duplicate((int) $itemTemplate['id'], $newId, true);
+        $this->Steps->duplicate((int) $itemTemplate['id'], $newId, true);
 
         return $newId;
     }
 
-    /**
-     * Duplicate an item
-     *
-     * @return int The id of the newly created item
-     */
     public function duplicate(): int
     {
         $this->canOrExplode('read');

--- a/src/models/Links.php
+++ b/src/models/Links.php
@@ -159,7 +159,7 @@ class Links implements CrudInterface
     {
         $table = $this->Entity->type;
         if ($fromTpl) {
-            $table = 'experiments_templates';
+            $table = $this->Entity instanceof Experiments ? 'experiments_templates' : 'items_types';
         }
         $linksql = 'SELECT link_id FROM ' . $table . '_links WHERE item_id = :id';
         $linkreq = $this->Db->prepare($linksql);

--- a/src/models/Scheduler.php
+++ b/src/models/Scheduler.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -6,7 +6,6 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-declare(strict_types=1);
 
 namespace Elabftw\Models;
 
@@ -15,7 +14,6 @@ use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\EntityTrait;
 use PDO;
@@ -131,13 +129,7 @@ class Scheduler
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
-
-        $res = $req->fetch();
-        if ($res === false) {
-            throw new ResourceNotFoundException();
-        }
-
-        return $res;
+        return $this->Db->fetch($req);
     }
 
     /**

--- a/src/models/Status.php
+++ b/src/models/Status.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
-use Elabftw\Elabftw\ContentParams;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\StatusParams;
 use Elabftw\Exceptions\ImproperActionException;
@@ -61,15 +60,21 @@ class Status extends AbstractCategory
         );
     }
 
-    public function readAll(): array
+    public function read(ContentParamsInterface $params): array
     {
-        return $this->read(new ContentParams());
+        $sql = 'SELECT id as category_id, name as category, color, is_timestampable, is_default
+            FROM status WHERE team = :team AND id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':team', $this->team, PDO::PARAM_INT);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $this->Db->fetch($req);
     }
 
     /**
      * SQL to get all status from team
      */
-    public function read(ContentParamsInterface $params): array
+    public function readAll(): array
     {
         $sql = 'SELECT status.id AS category_id,
             status.name AS category,
@@ -82,25 +87,6 @@ class Status extends AbstractCategory
         $this->Db->execute($req);
 
         return $this->Db->fetchAll($req);
-    }
-
-    /**
-     * Get the color of a status
-     *
-     * @param int $id ID of the category
-     */
-    public function readColor(int $id): string
-    {
-        $sql = 'SELECT color FROM status WHERE id = :id';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':id', $id, PDO::PARAM_INT);
-        $this->Db->execute($req);
-
-        $res = $req->fetchColumn();
-        if ($res === false || $res === null) {
-            return '00FF00';
-        }
-        return (string) $res;
     }
 
     /**

--- a/src/models/Steps.php
+++ b/src/models/Steps.php
@@ -96,7 +96,7 @@ class Steps implements CrudInterface
     {
         $table = $this->Entity->type;
         if ($fromTpl) {
-            $table = 'experiments_templates';
+            $table = $this->Entity instanceof Experiments ? 'experiments_templates' : 'items_types';
         }
         $stepsql = 'SELECT body, ordering FROM ' . $table . '_steps WHERE item_id = :id';
         $stepreq = $this->Db->prepare($stepsql);

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -18,7 +18,6 @@ use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\FilesystemErrorException;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\ContentParamsInterface;
 use Elabftw\Interfaces\CreateUploadParamsInterface;
 use Elabftw\Interfaces\CrudInterface;
@@ -170,11 +169,7 @@ class Uploads implements CrudInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
-        $res = $req->fetch();
-        if ($res === false) {
-            throw new ResourceNotFoundException();
-        }
-        return $res;
+        return $this->Db->fetch($req);
     }
 
     /**

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -12,7 +12,6 @@ namespace Elabftw\Models;
 
 use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\ContentParamsInterface;
 use Elabftw\Services\Check;
 use Elabftw\Services\Email;
@@ -433,12 +432,7 @@ class Users
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $this->Db->execute($req);
-        $res = $req->fetch();
-        if ($res === false) {
-            throw new ResourceNotFoundException();
-        }
-
-        return $res;
+        return $this->Db->fetch($req);
     }
 
     private function checkEmail(string $email): void

--- a/src/sql/schema68.sql
+++ b/src/sql/schema68.sql
@@ -1,0 +1,27 @@
+-- Schema 68
+START TRANSACTION;
+    ALTER TABLE `items_types` CHANGE `template` `body` TEXT NULL DEFAULT NULL;
+    ALTER TABLE `items_types` CHANGE `color` `color` VARCHAR(6) NOT NULL DEFAULT '29aeb9';
+    CREATE TABLE `items_types_steps` (
+        `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+        `item_id` int(10) unsigned NOT NULL,
+        `body` text NOT NULL,
+        `ordering` int(10) unsigned DEFAULT NULL,
+        `finished` tinyint(1) NOT NULL DEFAULT '0',
+        `finished_time` datetime DEFAULT NULL,
+        PRIMARY KEY (`id`),
+        KEY `fk_items_types_steps_items_id` (`item_id`),
+        CONSTRAINT `fk_items_types_steps_items_id` FOREIGN KEY (`item_id`) REFERENCES `items_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+    CREATE TABLE `items_types_links` (
+        `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+        `item_id` int(10) unsigned NOT NULL,
+        `link_id` int(10) unsigned NOT NULL,
+        PRIMARY KEY (`id`),
+        KEY `fk_items_types_links_items_id` (`item_id`),
+        KEY `fk_items_types_links_items_id2` (`link_id`),
+        CONSTRAINT `fk_items_types_links_items_types_id` FOREIGN KEY (`item_id`) REFERENCES `items_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT `fk_items_types_links_items_id` FOREIGN KEY (`link_id`) REFERENCES `items` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+    UPDATE config SET conf_value = 68 WHERE conf_name = 'schema';
+COMMIT;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -408,8 +408,8 @@ CREATE TABLE `items_types` (
   `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `team` int(10) UNSIGNED NOT NULL,
   `name` varchar(255) NOT NULL,
-  `color` varchar(6) DEFAULT '000000',
-  `template` text,
+  `color` varchar(6) DEFAULT '29aeb9',
+  `body` text NULL DEFAULT NULL,
   `ordering` int(10) UNSIGNED DEFAULT NULL,
   `bookable` tinyint(1) UNSIGNED DEFAULT '0',
   `canread` varchar(255) NOT NULL DEFAULT 'team',
@@ -425,6 +425,33 @@ CREATE TABLE `items_types` (
 --   `team`
 --       `teams` -> `id`
 --
+
+--
+-- Table structure for table `items_types_links`
+--
+
+CREATE TABLE `items_types_links` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `item_id` int UNSIGNED NOT NULL,
+  `link_id` int UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `items_types_steps`
+--
+
+CREATE TABLE `items_types_steps` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `item_id` int UNSIGNED NOT NULL,
+  `body` text NOT NULL,
+  `ordering` int UNSIGNED DEFAULT NULL,
+  `finished` tinyint(1) NOT NULL DEFAULT '0',
+  `finished_time` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
 --
@@ -799,6 +826,18 @@ ALTER TABLE `items_types`
   ADD KEY `fk_items_types_teams_id` (`team`);
 
 --
+-- Indexes for table `items_types_links`
+--
+ALTER TABLE `items_types_links`
+  ADD KEY `fk_items_types_links_items_id` (`item_id`),
+  ADD KEY `fk_items_types_links_items_id2` (`link_id`);
+
+--
+-- Indexes for table `items_types_steps`
+--
+ALTER TABLE `items_types_steps`
+  ADD KEY `fk_items_types_steps_items_id` (`item_id`);
+--
 -- Indexes for table `status`
 --
 ALTER TABLE `status`
@@ -918,6 +957,19 @@ ALTER TABLE `items_revisions`
 --
 ALTER TABLE `items_types`
   ADD CONSTRAINT `fk_items_types_teams_id` FOREIGN KEY (`team`) REFERENCES `teams`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `items_types_links`
+--
+ALTER TABLE `items_types_links`
+  ADD CONSTRAINT `fk_items_types_links_items_id` FOREIGN KEY (`link_id`) REFERENCES `items` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_items_types_links_items_types_id` FOREIGN KEY (`item_id`) REFERENCES `items_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `items_types_steps`
+--
+ALTER TABLE `items_types_steps`
+  ADD CONSTRAINT `fk_items_types_steps_items_id` FOREIGN KEY (`item_id`) REFERENCES `items_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `status`

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -240,130 +240,101 @@
 
 <!-- TAB 5 ITEMS TYPES-->
 <div data-tabcontent='5' hidden>
-  <div class='box'>
-    <h3>{{ 'Add a new type of item'|trans }}</h3>
-    <hr>
-    <div class='form-row align-items-center mb-2'>
-      <div class='col-auto'>
-        <label for='itemsTypesName'>{{ 'Name'|trans }}</label>
-        <input class='form-control' type='text' id='itemsTypesName' />
-      </div>
-
-      <div class='col-1'>
-        <label for='itemsTypesColor'>{{ 'Color'|trans }}</label>
-        <input class='form-control randomColor' type='color' id='itemsTypesColor' />
-      </div>
-
-      <div class='col-auto'>
-        <div class='form-check mt-4'>
-          <input class='form-check-input' type='checkbox' id='itemsTypesBookable' />
-          <label class='form-check-label' for='itemsTypesBookable'>{{ 'Bookable'|trans }} {{ 'in the %sscheduler%s'|trans|format("<a href='team.php'>", "</a>")|raw }}</label>
-        </div>
-      </div>
-    </div>
-
-    <textarea class='mceditable' id='itemsTypesTemplate'></textarea>
-
+  <div class='box' style='min-height: 600px;'>
     <div class='row'>
-      <div class='col-md-3'>
-        <!-- CAN READ -->
-        <i class='fas fa-eye' title='Visibility'></i>
-        <label for='canread_select'>{{ 'Visibility'|trans }}</label>
-        <select id='canread_select' class='form-control'>
-          {% for key, value in visibilityArr %}
-            <option value='{{ key }}'
-            {{ key == 'team' ? ' selected' }}
-            >{{ value|trans }}</option>
+      <div class='col'>
+        <h3>{{ 'Database Items Types'|trans }}</h3>
+      </div>
+      <!-- CREATE NEW BUTTON -->
+      <div class='col text-right'>
+        <button type='button' class='btn btn-primary' data-action='itemstypes-create'>{{ 'Create'|trans }}</button>
+      </div>
+    </div>
+
+    <form class='row'>
+      <div class='col-md-10'>
+        <input type='hidden' name='tab' value='5' />
+        <select class='form-control selectpicker' name='templateid' required data-show-subtext='true' data-live-search='true'>
+          {% for template in itemsCategoryArr %}
+            <option value='{{ template.category_id }}'{{ App.Request.query.get('templateid') == template.category_id ? ' selected' }}>{{ template.category|raw }}</option>
           {% endfor %}
         </select>
       </div>
 
-      <div class='col-md-3'>
-        <!-- CAN WRITE -->
-        <i class='fas fa-pencil-alt' title='Can write'></i>
-        <label for='canwrite_select'>{{ 'Can write'|trans }}</label>
-        <select id='canwrite_select' class='form-control'>
-          {% for key, value in visibilityArr %}
-            <option value='{{ key }}'
-            {{ key == 'team' ? ' selected' }}
-            >{{ value|trans }}</option>
-          {% endfor %}
-        </select>
+      <div class='col-md-2'>
+        <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
       </div>
-    </div>
 
-    <div class='mt-4 text-center'>
-      <button id='itemsTypesCreate' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
-    </div>
+    </form>
+    <hr>
+
+    <!-- templateData will be loaded with content from an item type if templateid is present is url -->
+    {% if templateData %}
+      <ul class='list-inline'>
+        <li class='list-inline-item'>
+          <label for='itemsTypesName'>{{ 'Name'|trans }}</label>
+          <input type='text' class='form-control' id='itemsTypesName' value='{{ templateData.name|raw }}' />
+        </li>
+
+        <li class='list-inline-item col-1 align-top'>
+          <label for='itemsTypesColor'>{{ 'Color'|trans }}</label>
+          <input class='form-control' type='color' id='itemsTypesColor' value='#{{ templateData.color }}' />
+        </li>
+
+        <li class='list-inline-item'>
+          <input id='itemsTypesBookable' type='checkbox' {{ templateData.bookable ? " checked" }} />
+          <label for='itemsTypesBookable'>{{ 'Bookable'|trans }}</label>
+        </li>
+
+        <li class='list-inline-item'>
+          <label for='itemsTypesCanread'>{{ 'Visibility'|trans }}</label>
+          <select id='itemsTypesCanread' class='form-control'>
+            {% for key, value in visibilityArr %}
+              <option value='{{ key }}'
+              {{ key == templateData.canread ? ' selected' }}
+              >{{ value|trans }}</option>
+            {% endfor %}
+          </select>
+        </li>
+
+        <li class='list-inline-item'>
+          <label for='itemsTypesCanwrite'>{{ 'Can write'|trans }}</label>
+          <select id='itemsTypesCanwrite' class='form-control'>
+            {% for key, value in visibilityArr %}
+              <option value='{{ key }}'
+              {{ key == templateData.canwrite ? ' selected' }}
+              >{{ value|trans }}</option>
+            {% endfor %}
+          </select>
+        </li>
+      </ul>
+
+      <textarea class='mceditable' id='itemsTypesBody'>{{ templateData.body }}</textarea>
+
+      {% set mode = 'edit-template' %}
+      {% include('steps-links-edit.html') %}
+      <!-- METADATA editor for items types -->
+      {{ include('json-editor.html') }}
+
+      <div class='text-center'>
+        <button class='button btn btn-primary' data-id='{{ templateData.id }}' data-action='itemstypes-update'>{{ 'Save'|trans }}</button>
+        <button class='button btn btn-danger' data-id='{{ templateData.id }}' data-action='itemstypes-destroy'>{{ 'Delete'|trans }}</button>
+      </div>
+    {% endif %}
+
   </div>
 
-
+  <!-- SORT ITEMS TYPES -->
   <div class='box'>
-    <h3>{{ 'Database Items Types'|trans }}</h3>
+    <h3>{{ 'Sort items types'|trans }}</h3>
     <hr>
     <ul class='list-group form-group sortable' data-axis='y' data-table='items_types'>
-      {% for itemType in itemsTypesArr %}
-        <li id='itemstypes_{{ itemType.category_id }}' class='list-group-item'>
-          <ul class='list-inline'>
-            <li class='list-inline-item'><span class='sortableHandle draggable float-right'><i class='fas fa-sort fa-2x'></i></span></li>
-            <li class='list-inline-item'>
-              <label for='itemsTypesName_{{ itemType.category_id }}'>{{ 'Name'|trans }}</label>
-              <input type='text' class='form-control' id='itemsTypesName_{{ itemType.category_id }}' value='{{ itemType.category|raw }}' />
-            </li>
-
-            <li class='list-inline-item col-1 align-top'>
-              <label for='itemsTypesColor_{{ itemType.category_id }}'>{{ 'Color'|trans }}</label>
-              <input class='form-control' type='color' id='itemsTypesColor_{{ itemType.category_id }}' value='#{{ itemType.color }}' />
-            </li>
-            <li class='list-inline-item'>
-              <input id='itemsTypesBookable_{{ itemType.category_id }}' type='checkbox' {{ itemType.bookable ? " checked" }} />
-              <label for='itemsTypesBookable_{{ itemType.category_id }}'>{{ 'Bookable'|trans }}</label>
-            </li>
-            <li class='list-inline-item'>
-              <button data-id='{{ itemType.category_id }}' class='button btn btn-neutral itemsTypesShowEditor'>{{ 'Edit the template'|trans }}</button>
-            </li>
-            <li class='list-inline-item'>
-              <button data-id='{{ itemType.category_id }}' data-type='items_types' data-action='json-load-metadata-from-id' class='button btn btn-neutral'>{{ 'Edit metadata'|trans }}</button>
-            </li>
-            <li class='list-inline-item'>
-              <label for='itemsTypesSelectCanread_{{ itemType.category_id }}'>{{ 'Visibility'|trans }}</label>
-              <select id='itemsTypesSelectCanread_{{ itemType.category_id }}' data-id='{{ itemType.category_id }}' class='itemsTypesSelectCanread form-control'>
-                {% for key, value in visibilityArr %}
-                  <option value='{{ key }}'
-                  {{ key == itemType.canread ? ' selected' }}
-                  >{{ value|trans }}</option>
-                {% endfor %}
-              </select>
-            </li>
-
-            <li class='list-inline-item itemsTypesCanwrite'>
-              <label for='itemsTypesSelectCanwrite_{{ itemType.category_id }}'>{{ 'Can write'|trans }}</label>
-              <select id='itemsTypesSelectCanwrite_{{ itemType.category_id }}' data-id='{{ itemType.category_id }}' class='itemsTypesSelectCanwrite form-control'>
-                {% for key, value in visibilityArr %}
-                  <option value='{{ key }}'
-                  {{ key == itemType.canwrite ? ' selected' }}
-                  >{{ value|trans }}</option>
-                {% endfor %}
-              </select>
-            </li>
-            <li class='list-inline-item'>
-              <button data-id='{{ itemType.category_id }}' class='button btn btn-primary itemsTypesUpdate'>{{ 'Save'|trans }}</button>
-            </li>
-            <li class='list-inline-item'>
-              <button data-id='{{ itemType.category_id }}' class='button btn btn-danger itemsTypesDestroy'>{{ 'Delete'|trans }}</button>
-            </li>
-            <li class='list-inline-item mt-2 itemsTypesEditor' id='itemsTypesEditor_{{ itemType.category_id }}'>
-              <textarea class='' id='itemsTypesTemplate_{{ itemType.category_id }}'>{{ itemType.template }}</textarea>
-            </li>
-          </ul>
-        </li>
+      {% for itemType in itemsCategoryArr %}
+      <li class='box' id='itemstypes_{{ itemType.category_id }}' style='color: #{{ itemType.color }}'><span class='sortableHandle draggable mr-2'><i class='fas fa-sort fa-2x'></i></span>{{ itemType.category | raw }}</li>
       {% endfor %}
     </ul>
   </div>
 
-  <!-- METADATA editor for items types -->
-  {% set mode = 'edit-template' %}
-  {{ include('json-editor.html') }}
 </div>
 
 <!-- TAB 6 IMPORT -->
@@ -379,7 +350,7 @@
       <label for='target_csv'>{{ '1. Select a type of item to import to:'|trans }}</label>
       <select class='form-control col-md-4' id='target_csv' autocomplete='off' name='target'>
         <option selected disabled>--------</option>
-        {% for itemsType in itemsTypesArr %}
+        {% for itemsType in itemsCategoryArr %}
         <option value='{{ itemsType.category_id }}'>{{ itemsType.category }}</option>
         {% endfor %}
       </select>
@@ -422,7 +393,7 @@
       <select class='form-control col-md-4' id='target_zip' autocomplete='off' name='target'>
         <option selected disabled>-------</option>
         <option disabled>{{ 'Import in database'|trans }}</option>
-        {% for itemsType in itemsTypesArr %}
+        {% for itemsType in itemsCategoryArr %}
           <option value='{{ itemsType.category_id }}'>{{ itemsType.category }}</option>
         {% endfor %}
         <option disabled>{{ 'Import in experiments'|trans }}</option>
@@ -494,6 +465,6 @@
   </div>
 </div>
 
-<div id='info' data-page='template-edit' data-type='items_types'></div>
+<div id='info' data-page='template-edit' data-type='items_types' data-id='{{ App.Request.query.get('templateid') }}'></div>
 
 {% endblock body %}

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -1,4 +1,5 @@
 <!-- JSON EDITOR -->
+<!-- json metadata is preloaded for templates -->
 <section class='box' id='json-editor'>
   <i class='fas fa-list mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'JSON Editor'|trans }}</h3>
   <button class='button btn btn-primary plusMinusButton jsonEditorPlusMinusButton' data-toggle='collapse' data-target='#jsonEditorDiv' aria-expanded='false' aria-controls='jsonEditorDiv'>+</button>
@@ -7,7 +8,7 @@
   {% endif %}
   <div id='jsonEditorDiv' class='collapse mt-2'>
     <h6 id='jsonEditorTitle'></h6>
-    <div id='jsonEditorContainer' data-what=''></div>
+    <div id='jsonEditorContainer' {{ mode == 'edit-template' ? 'data-preload-json="1"' : '' }}></div>
     {% if mode == 'edit' %}
       <div class='mt-4 text-center'>
         <div class='btn-group'>
@@ -27,7 +28,7 @@
     {% endif %}
     {% if mode == 'edit-template' %}
       <div class='mt-4 text-center'>
-        <button type='button' id='templateJsonSave' data-action='json-save-metadata-from-id' data-id='' class='btn btn-primary'>{{ 'Save as metadata'|trans }}</button>
+        <button type='button' id='templateJsonSave' data-action='json-save-metadata-from-id' data-id='{{ templateData.id }}' class='btn btn-primary'>{{ 'Save as metadata'|trans }}</button>
         <button type='button' data-action='json-clear' class='btn btn-danger float-right'>{{ 'Clear'|trans }}</button>
       </div>
     {% endif %}

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,4 +1,4 @@
-{% if Entity.type == 'experiments_templates' %}
+{% if mode == 'edit-template' %}
   {% set Entity_id = templateData.id %}
 {% else %}
   {% set Entity_id = Entity.id %}
@@ -9,7 +9,7 @@
     <section class='col-md-6'>
         <i class='fas fa-check-square mr-1 align-baseline'></i><h5 class='d-inline'>{{ 'Steps'|trans }}</h5>
         <br>
-        <div class='mt-2 sortable' id='steps_div_{{ Entity_id }}' data-axis='y' data-table='{{ Entity.type }}_steps'>
+        <div class='mt-2 sortable' id='steps_div_{{ Entity_id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types'}}_steps'>
           {% for step in stepsArr %}
 
             <div class='input-group mb-2' id='step_{{ step.id }}'>
@@ -29,7 +29,7 @@
               </div>
               <div class='input-group-prepend'>
                 <div class='input-group-text'>
-                  <input aria-label='{{ 'Toggle completion'|trans }}' type='checkbox' {{ Entity.type == 'experiments_templates' ? 'disabled' }} {{ step.finished ? 'checked' }} data-stepid='{{ step.id }}' data-id='{{ Entity_id }}' class='stepbox'>
+                  <input aria-label='{{ 'Toggle completion'|trans }}' type='checkbox' {{ mode == 'edit-template' ? 'disabled' }} {{ step.finished ? 'checked' }} data-stepid='{{ step.id }}' data-id='{{ Entity_id }}' class='stepbox'>
                 </div>
               </div>
               <div class='pl-2 step-static form-control-plaintext {{ step.finished ? 'finished' }}'>
@@ -68,7 +68,7 @@
                     <span class='item-category' style='color:#{{ link.color|raw }}'>{{ link.name|raw }}</span> - <a href='database.php?mode=view&id={{ link.itemid }}'>
                   {{ link.title|raw }}</a>
                   <div class='float-right'>
-                    {% if Entity.type != 'experiments_templates' %}
+                    {% if mode != 'edit-template' %}
                       <a data-action='import-link' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}'>
                         <i class='fas fa-lg fa-file-import'></i>
                       </a>

--- a/src/templates/templates-edit.html
+++ b/src/templates/templates-edit.html
@@ -55,6 +55,6 @@
 <div class='text-center'>
   <button data-action='update-template' data-id='{{ templateData.id }}' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
 </div>
-{% include('steps-links-edit.html') %}
 {% set mode = 'edit-template' %}
+{% include('steps-links-edit.html') %}
 {{ include('json-editor.html') }}

--- a/src/ts/ItemType.class.ts
+++ b/src/ts/ItemType.class.ts
@@ -7,8 +7,6 @@
  */
 import { Payload, Method, Entity, Action, EntityType, ResponseMsg } from './interfaces';
 import { Ajax } from './Ajax.class';
-import { getTinymceBaseConfig } from './tinymce';
-import tinymce from 'tinymce/tinymce';
 
 
 export default class ItemType {
@@ -21,7 +19,7 @@ export default class ItemType {
     this.sender = new Ajax();
   }
 
-  create(content: string, color: string, bookable: number, body: string, canread: string, canwrite: string): Promise<ResponseMsg> {
+  create(content: string): Promise<ResponseMsg> {
     const payload: Payload = {
       method: Method.POST,
       action: Action.Create,
@@ -31,21 +29,8 @@ export default class ItemType {
         id: null,
       },
       content: content,
-      extraParams: {
-        color: color,
-        bookable: bookable,
-        body: body,
-        canread: canread,
-        canwrite: canwrite,
-      },
     };
     return this.sender.send(payload);
-  }
-
-  showEditor(id): void {
-    $('#itemsTypesTemplate_' + id).addClass('mceditable');
-    tinymce.init(getTinymceBaseConfig('items_types'));
-    $('#itemsTypesEditor_' + id).toggle();
   }
 
   update(id: number, content: string, color: string, bookable: number, body: string, canread: string, canwrite: string): Promise<ResponseMsg> {

--- a/src/ts/JsonEditorHelper.class.ts
+++ b/src/ts/JsonEditorHelper.class.ts
@@ -50,9 +50,12 @@ export default class JsonEditorHelper {
     if (editable) {
       this.editor.setMode('tree');
     }
+    if (this.editorDiv.dataset.preloadJson === '1') {
+      this.loadMetadata();
+    }
   }
 
-  load(json: Record<string, any>): void {
+  focus(): void {
     // show the editor (use jQuery selector here for collapse())
     ($('#jsonEditorDiv') as JQuery<HTMLDivElement>).collapse('show');
     // toggle the +/- button
@@ -62,8 +65,6 @@ export default class JsonEditorHelper {
       plusMinusButton.classList.add('btn-neutral');
       plusMinusButton.classList.remove('btn-primary');
     }
-    // load the json content into the editor
-    this.editor.set(json);
     // and scroll page into editor view
     document.getElementById('jsonEditorContainer').scrollIntoView();
   }
@@ -78,7 +79,10 @@ export default class JsonEditorHelper {
         }
         return response.json();
       })
-      .then(json => this.load(json))
+      .then(json => {
+        this.editor.set(json);
+        this.focus();
+      })
       .catch(e => {
         if (e instanceof SyntaxError) {
           notif({ 'res': false, 'msg': i18next.t('json-parse-error') });
@@ -95,13 +99,16 @@ export default class JsonEditorHelper {
   loadMetadata(): void {
     // set the title
     this.editorTitle.innerText = i18next.t('editing-metadata');
-    this.MetadataC.read().then(metadata => this.load(metadata));
+    this.MetadataC.read().then(metadata => this.editor.set(metadata));
     this.editorDiv.dataset.what = 'metadata';
   }
 
   loadMetadataFromId(entity: Entity): void {
     const MetadataC = new Metadata(entity);
-    MetadataC.read().then(metadata => this.load(metadata));
+    MetadataC.read().then(metadata => {
+      this.editor.set(metadata);
+      this.focus();
+    });
     this.editorDiv.dataset.what = 'metadata';
   }
 

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -178,9 +178,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // ITEMS TYPES
   const ItemTypeC = new ItemType();
 
-  // CREATE
-  $('.itemsTypesEditor').hide();
-  $(document).on('click', '#itemsTypesCreate', function() {
+  // UPDATE
+  function itemsTypesUpdate(id: number): void {
     const nameInput = (document.getElementById('itemsTypesName') as HTMLInputElement);
     const name = nameInput.value;
     if (name === '') {
@@ -195,50 +194,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (checkbox) {
       bookable = 1;
     }
-    const template = tinymce.get('itemsTypesTemplate').getContent();
 
-    const canread= (document.getElementById('canread_select') as HTMLSelectElement).value;
-    const canwrite= (document.getElementById('canwrite_select') as HTMLSelectElement).value;
-    // set the editor as non dirty so we can navigate out without a warning to clear
-    tinymce.activeEditor.setDirty(false);
-    // TODO don't reload the whole page, just what we need
-    ItemTypeC.create(name, color, bookable, template, canread, canwrite).then(() => window.location.replace('admin.php?tab=5'));
-  });
-
-  // TOGGLE BODY
-  $(document).on('click', '.itemsTypesShowEditor', function() {
-    ItemTypeC.showEditor($(this).data('id'));
-  });
-
-  // UPDATE
-  $(document).on('click', '.itemsTypesUpdate', function() {
-    const id = $(this).data('id');
-    const nameInput = (document.getElementById('itemsTypesName_' + id) as HTMLInputElement);
-    const name = nameInput.value;
-    if (name === '') {
-      notif({'res': false, 'msg': 'Name cannot be empty'});
-      nameInput.style.borderColor = 'red';
-      nameInput.focus();
-      return;
-    }
-    const color = (document.getElementById('itemsTypesColor_' + id) as HTMLInputElement).value;
-    const checkbox = $('#itemsTypesBookable_' + id).is(':checked');
-    let bookable = 0;
-    if (checkbox) {
-      bookable = 1;
-    }
-
-    const canread = (document.querySelector(`.itemsTypesSelectCanread[data-id="${id}"`) as HTMLSelectElement).value;
-    const canwrite = (document.querySelector(`.itemsTypesSelectCanwrite[data-id="${id}"`) as HTMLSelectElement).value;
-    // if tinymce is hidden, it'll fail to trigger
-    // so we toggle it quickly to grab the content
-    if ($('#itemsTypesTemplate_' + id).is(':hidden')) {
-      ItemTypeC.showEditor(id);
-    }
-    const template = tinymce.get('itemsTypesTemplate_' + id).getContent();
-    $('#itemsTypesEditor_' + id).toggle();
+    const canread = (document.getElementById('itemsTypesCanread') as HTMLSelectElement).value;
+    const canwrite = (document.getElementById('itemsTypesCanwrite') as HTMLSelectElement).value;
+    const template = tinymce.get('itemsTypesBody').getContent();
     ItemTypeC.update(id, name, color, bookable, template, canread, canwrite);
-  });
+  }
 
   // DESTROY
   $(document).on('click', '.itemsTypesDestroy', function() {
@@ -274,6 +235,18 @@ document.addEventListener('DOMContentLoaded', () => {
       AjaxC.send(payload).then(json => {
         notif(json);
       });
+    // UPDATE ITEMS TYPES
+    } else if (el.matches('[data-action="itemstypes-update"]')) {
+      itemsTypesUpdate(parseInt(el.dataset.id, 10));
+    // CREATE ITEMS TYPES
+    } else if (el.matches('[data-action="itemstypes-create"]')) {
+      const title = prompt(i18next.t('template-title'));
+      if (title) {
+        // no body on template creation
+        ItemTypeC.create(title).then(json => {
+          window.location.replace(`admin.php?tab=5&templateid=${json.value}`);
+        });
+      }
     }
   });
 });

--- a/tests/unit/models/ItemsTypesTest.php
+++ b/tests/unit/models/ItemsTypesTest.php
@@ -46,7 +46,7 @@ class ItemsTypesTest extends \PHPUnit\Framework\TestCase
         $this->ItemsTypes->updateAll(
             new ItemTypeParams('new', 'all', $extra)
         );
-        $this->assertEquals('newbody', $this->ItemsTypes->read(new ContentParams())['template']);
+        $this->assertEquals('newbody', $this->ItemsTypes->read(new ContentParams())['body']);
         $this->ItemsTypes->setId((int) $last['category_id']);
         $this->ItemsTypes->destroy();
     }

--- a/tests/unit/models/StatusTest.php
+++ b/tests/unit/models/StatusTest.php
@@ -41,19 +41,11 @@ class StatusTest extends \PHPUnit\Framework\TestCase
         $id = $this->Status->create(new StatusParams('Yep', '#29AEB9', false, true));
         $Status = new Status(1, $id);
         $Status->update(new StatusParams('Updated', '#121212', true, false));
-        $ourStatus = array_filter($Status->read(new ContentParams()), function ($s) use ($id) {
-            return ((int) $s['category_id']) === $id;
-        });
-        $status = array_pop($ourStatus);
+        $status = $Status->read(new ContentParams());
         $this->assertEquals('Updated', $status['category']);
         $this->assertEquals('121212', $status['color']);
         $this->assertTrue((bool) $status['is_timestampable']);
         $this->assertFalse((bool) $status['is_default']);
-    }
-
-    public function testReadColor(): void
-    {
-        $this->assertEquals('29aeb9', strtolower($this->Status->readColor(1)));
     }
 
     public function testDestroy(): void

--- a/web/admin.php
+++ b/web/admin.php
@@ -47,7 +47,20 @@ try {
     $TeamGroups = new TeamGroups($App->Users);
     $Teams = new Teams($App->Users);
 
-    $itemsTypesArr = $ItemsTypes->readAll();
+    $itemsCategoryArr = $ItemsTypes->readAll();
+    $templateData = array();
+    $stepsArr = array();
+    $linksArr = array();
+    if ($Request->query->has('templateid')) {
+        $ItemsTypes->setId((int) $App->Request->query->get('templateid'));
+        $templateData = $ItemsTypes->read(new ContentParams());
+        $permissions = $ItemsTypes->getPermissions($templateData);
+        if ($permissions['write'] === false) {
+            throw new IllegalActionException('User tried to access a template without write permissions');
+        }
+        $stepsArr = $ItemsTypes->Steps->read(new ContentParams());
+        $linksArr = $ItemsTypes->Links->read(new ContentParams());
+    }
     $statusArr = $Status->read(new ContentParams());
     $teamConfigArr = $Teams->read(new ContentParams());
     $teamGroupsArr = $TeamGroups->read(new ContentParams());
@@ -79,12 +92,15 @@ try {
         'tagsArr' => $tagsArr,
         'fromSysconfig' => false,
         'isSearching' => $isSearching,
-        'itemsTypesArr' => $itemsTypesArr,
+        'itemsCategoryArr' => $itemsCategoryArr,
         'statusArr' => $statusArr,
         'teamConfigArr' => $teamConfigArr,
         'teamGroupsArr' => $teamGroupsArr,
         'visibilityArr' => $TeamGroups->getVisibilityList(),
         'teamsArr' => $teamsArr,
+        'templateData' => $templateData,
+        'stepsArr' => $stepsArr,
+        'linksArr' => $linksArr,
         'unvalidatedUsersArr' => $unvalidatedUsersArr,
         'usersArr' => $usersArr,
     );

--- a/web/admin.php
+++ b/web/admin.php
@@ -61,7 +61,7 @@ try {
         $stepsArr = $ItemsTypes->Steps->read(new ContentParams());
         $linksArr = $ItemsTypes->Links->read(new ContentParams());
     }
-    $statusArr = $Status->read(new ContentParams());
+    $statusArr = $Status->readAll();
     $teamConfigArr = $Teams->read(new ContentParams());
     $teamGroupsArr = $TeamGroups->read(new ContentParams());
     $teamsArr = $Teams->readAll();

--- a/web/app/controllers/EntityAjaxController.php
+++ b/web/app/controllers/EntityAjaxController.php
@@ -226,17 +226,19 @@ try {
 
     // UPDATE CATEGORY (item type or status)
     if ($Request->request->has('updateCategory')) {
-        $Entity->updateCategory((int) $Request->request->get('categoryId'));
+        $id = (int) $Request->request->get('categoryId');
+        $Entity->updateCategory($id);
         // get the color of the status/item type for updating the css
         if ($Entity instanceof Experiments) {
-            $Category = new Status($App->Users->team);
+            $Category = new Status($App->Users->team, $id);
         } else {
-            $Category = new ItemsTypes($App->Users);
+            $Category = new ItemsTypes($App->Users, $id);
         }
+        $categoryArr = $Category->read(new ContentParams());
         $Response->setData(array(
             'res' => true,
             'msg' => _('Saved'),
-            'color' => $Category->readColor((int) $Request->request->get('categoryId')),
+            'color' => $categoryArr['color'],
         ));
     }
 } catch (ImproperActionException | UnauthorizedException | PDOException $e) {

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -68,6 +68,10 @@ try {
             $model = new Templates($App->Users);
             $Entity = $model->Steps;
             break;
+        case 'items_types_steps':
+            $model = new ItemsTypes($App->Users);
+            $Entity = $model->Steps;
+            break;
         default:
             throw new IllegalActionException('Bad table for updateOrdering.');
     }

--- a/web/search.php
+++ b/web/search.php
@@ -38,7 +38,7 @@ $Tags = new Tags($Experiments);
 $tagsArr = $Tags->readAll();
 
 $itemsTypesArr = (new ItemsTypes($App->Users))->read(new ContentParams('', 'all'));
-$categoryArr = $statusArr = (new Status($App->Users->team))->read(new ContentParams());
+$categoryArr = $statusArr = (new Status($App->Users->team))->readAll();
 if ($Request->query->get('type') !== 'experiments') {
     $categoryArr = $itemsTypesArr;
 }

--- a/web/team.php
+++ b/web/team.php
@@ -71,9 +71,6 @@ try {
             $allItems = false;
             // itemData is to display the name/category of the selected item
             $itemData = $Scheduler->Items->read(new ContentParams());
-            if (empty($itemData)) {
-                throw new ImproperActionException(_('Nothing to show with this id'));
-            }
         }
     }
 


### PR DESCRIPTION
The items types in the admin panel now looks similar to the experiments templates. Overall there is less code now with more features! (30 files changed, 288 insertions(+), 327 deletions(-)).

* introduce Db->fetch() which throws a ResourceNotFoundException if nothing is found, allowing for less ifs elsewhere in the code
* change the read/readall function in Status to align with the rest
* remove the readColor function
* rename the items_types template column to body
* add links and steps to items types
* add a default color to items types
* preload metadata in json editor (but don't focus/open it)
* fix #1495
