### PR TITLE
CLI AddMissingLinks - "manually" add links for locked/timestamped entities

### DIFF
--- a/src/commands/AddMissingLinks.php
+++ b/src/commands/AddMissingLinks.php
@@ -17,6 +17,7 @@ use Elabftw\Models\Items;
 use Elabftw\Models\Links;
 use Elabftw\Models\Templates;
 use Elabftw\Models\Users;
+use PDO;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,20 +50,20 @@ class AddMissingLinks extends Command
         $Db = Db::getConnection();
 
         $tables = array('experiments', 'experiments_templates', 'items');
-        $query = "SELECT `id`, `body`, `userid` FROM `table` WHERE `body` LIKE '%database.php?mode=view&amp;id=%';";
+        $query = "SELECT `id`, `body`, `userid`, `lockedby` FROM `table` WHERE `body` LIKE '%database.php?mode=view&amp;id=%';";
 
         foreach ($tables as $table) {
-            echo 'Searching in ' . $table . "\n";
+            echo 'Searching in ' . $table . PHP_EOL;
             $sql = str_replace('table', $table, $query);
             $req = $Db->prepare($sql);
             $req->execute();
             $res = $req->fetchAll();
 
             if (!empty($res)) {
-                echo 'Found ' . count($res) . " entries with ids:\n";
+                echo 'Found ' . count($res) . ' entries with ids:' . PHP_EOL;
                 $count = 0;
                 foreach ($res as $data) {
-                    echo '  ' . $data['id'] . "\n";
+                    echo '  ' . $data['id'] . PHP_EOL;
                     switch ($table) {
                         case 'experiments':
                             $entity = new Experiments(new Users((int) $data['userid']), (int) $data['id']);
@@ -80,7 +81,30 @@ class AddMissingLinks extends Command
                     preg_match_all('/database\.php\?mode=view&amp;id=([0-9]+)/', $data['body'], $matches);
                     foreach ($matches[1] as $match) {
                         try {
-                            $out = (new Links($entity))->create(new ContentParams($match));
+                            // locked/timestamped entities are a problem because of canOrExplode
+                            if ($data['lockedby']) {
+                                // manually create new link
+                                $sql = 'INSERT INTO ' . $table . '_links (item_id, link_id)';
+                                $sql .= ' SELECT ' . $data['id'] . ' item_id, ' . $match . ' link_id FROM DUAL';
+                                // if it does not exist
+                                $sql .= ' WHERE NOT EXISTS (';
+                                $sql .= 'SELECT 1 FROM ' . $table . '_links WHERE item_id = :item_id AND link_id = :link_id LIMIT 1';
+                                $sql .= ')';
+
+                                // https://stackoverflow.com/a/8534693
+                                // it would be better to add a UNIQUE KEY to (item_id, link_id) for all the link tables:
+                                // ALTER TABLE `x` ADD UNIQUE KEY `link_uniq_key` (item_id, link_id);
+                                // and than use "INSERT IGNORE INTO ' . $table . '_links (item_id, link_id) VALUES(:item_id, :link_id)";
+
+                                $req = $Db->prepare($sql);
+                                $req->bindParam(':item_id', $data['id'], PDO::PARAM_INT);
+                                $req->bindParam(':link_id', $match, PDO::PARAM_INT);
+                                $Db->execute($req);
+
+                                $out = $Db->lastInsertId();
+                            } else {
+                                $out = (new Links($entity))->create(new ContentParams($match));
+                            }
                             if ((int) $out !== 0) {
                                 $count++;
                             }
@@ -91,7 +115,7 @@ class AddMissingLinks extends Command
                         }
                     }
                 }
-                echo 'Added ' . $count . " links.\n\n";
+                echo 'Added ' . $count . ' links.' . PHP_EOL . PHP_EOL;
             }
         }
         return 0;


### PR DESCRIPTION
Hi Nico,

Following up on https://gitter.im/elabftw/elabftw?at=61b902088853d316404abe38
I added functionality to cover the locked/timestamped entities.
We should maybe add a unique key to columns (item_id, link_id) in tables experiments_links, experiments_templates_links, items_links, and items_types_links. See details on line 94 and following.
This will also make the [test for existing links obsolete](https://github.com/elabftw/elabftw/blob/f0343e733d9e2994c16150d63c3ad9270b26d0e9/src/models/Links.php#L45-L51) if I get it right.