### PR TITLE
simplify tag unreference button

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -901,11 +901,6 @@ the form-control fails to do that so we do the border ourselves */
 
 }
 
-.tag-delete:hover {
-    color: $darkred !important;
-    transition: color 0.8s ease;
-}
-
 /* print only the main div */
 @media print {
     /* overwrite bootstrap defaults

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -177,9 +177,7 @@
         {% set tagsIdArr = Entity.entityData.tags_id|split(',') %}
         {% set tagsValueArr = Entity.entityData.tags|split('|') %}
         {% for tag in tagsValueArr %}
-          <span class='tag m-1 clickable' data-action='unreference-tag' data-tagid='{{ tagsIdArr[loop.index0] }}'>
-            <a class='tag-delete'>{{ tag|raw }}</a>
-          </span>
+          <a class='tag m-1 clickable tag-delete' data-action='unreference-tag' data-tagid='{{ tagsIdArr[loop.index0] }}'>{{ tag|raw }}</a>
         {% endfor %}
       {% endif %}
     </span>

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -177,7 +177,7 @@
         {% set tagsIdArr = Entity.entityData.tags_id|split(',') %}
         {% set tagsValueArr = Entity.entityData.tags|split('|') %}
         {% for tag in tagsValueArr %}
-          <a class='tag m-1 clickable tag-delete' data-action='unreference-tag' data-tagid='{{ tagsIdArr[loop.index0] }}'>{{ tag|raw }}</a>
+          <a class='tag m-1 clickable hover-danger' data-action='unreference-tag' data-tagid='{{ tagsIdArr[loop.index0] }}'>{{ tag|raw }}</a>
         {% endfor %}
       {% endif %}
     </span>


### PR DESCRIPTION
Currently the >tag unreference< button in edit mode is a bit wonky.
The text can be clicked to unreference a tag but the surrounding button does not work although a pointer cursor is shown.
![image](https://user-images.githubusercontent.com/65481677/152477108-6c1108ee-54b7-49c0-ae17-41ab9553ec69.png)
