### PR TITLE
Fix pdf after commit 63cb86c

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "tinymce": "cp node_modules/tinymce/skins/ui/oxide/fonts/tinymce-mobile.woff web/app/css/tinymce/fonts/tinymce-mobile.woff && cp node_modules/tinymce/skins/ui/oxide/*.min.css web/app/css/tinymce/",
     "unit": "tests/run.sh unit",
     "unit-ci": "php vendor/bin/codecept run unit",
-    "watchcss": "sass --quiet-deps --watch src/scss/main.scss:web/assets/elabftw.min.css",
+    "watchcss": "sass --quiet-deps --watch src/scss/main.scss:web/assets/elabftw.min.css src/scss/pdf.scss:web/assets/pdf.min.css",
     "watchjs": "webpack-cli --config builder.js --mode=development --watch --progress",
     "watchnode": "webpack-cli --config node-builder.js --mode=development --watch --progress"
   },

--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -150,20 +150,11 @@ img, /* <-- can be removed after PR https://github.com/mpdf/mpdf/pull/1405 is ac
 }
 
 /* BLOCKQUOTE */
-// FIXME quote not appearing in pdf
+// quote marks in pdf is not implemented by mpdf
+// https://github.com/mpdf/mpdf/blob/d3ef7689800c6356ab7df7604289f97c17f37c76/src/Tag/BlockQuote.php
 blockquote {
     background: #f9f9f9;
     border-left: 10px solid #ccc;
     margin: 1.5em 10px;
     padding: 0.5em 10px;
-    quotes: '\201C''\201D''\2018''\2019';
-}
-
-blockquote::before {
-    color: #ccc;
-    content: open-quote;
-    font-size: 4em;
-    line-height: 0.1em;
-    margin-right: 0.25em;
-    vertical-align: -0.4em;
 }

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <style>{{ css }}</style>
+    <style>{{ css|raw }}</style>
     {{ useCjk ? '<style>td { font-family:sun-extA; }</style>' }}
   </head>
   <body {{ useCjk ? " style='font-family:sun-extA;'" }}>
@@ -97,7 +97,7 @@
         {% set filePath = filePath ~ '_th.jpg' %}
       {% endif %}
       {% if ext in ['tiff', 'jpg', 'jpeg', 'png', 'gif'] %}
-        <br><img class='attached-image' src='{{ filePath }}' alt='{{ upload.comment }}' />
+        <br><img class='attached-image' src='{{ filePath|raw }}' alt='{{ upload.comment }}' />
       {% endif %}
       </p>
     {% endfor %}
@@ -121,14 +121,14 @@
 <table id='infoblock'>
   <tr>
     <td class='noborder'>
-      <barcode code='{{ url }}' type='QR' class='barcode' size='0.8' error='M' />
+      <barcode code='{{ url|raw }}' type='QR' class='barcode' size='0.8' error='M' />
     </td>
     <td class='noborder'>
       <p class='elabid'>{{ 'Unique eLabID:'|trans }} {{ elabid }}</p>
       {% if locked %}
         <p class='elabid'>Locked by {{ lockerName }} on {{ lockDate }}</p>
       {% endif %}
-      <p class='elabid'>Link: <a href='{{ url }}'>{{ url }}</a></p>
+      <p class='elabid'>Link: <a href='{{ url|raw }}'>{{ url }}</a></p>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
The pdf rendering is broken after commit 63cb86c402d6a87ce4ecb85dbe59aba919ebeed0
![image](https://user-images.githubusercontent.com/65481677/152666904-949a0bb6-1c0b-49f6-8a1e-1d1cea7570ab.png)
It is fixed by removing the quotes property.
Actually, this will never work because [mpdf does not implement this css property](https://github.com/mpdf/mpdf/blob/d3ef7689800c6356ab7df7604289f97c17f37c76/src/Tag/BlockQuote.php).

In addition, some twig variables must not use html escaping.