### PR TITLE
Remove unnecessary MakePdf::getFileContent() call

### DIFF
--- a/src/services/AbstractMakeZip.php
+++ b/src/services/AbstractMakeZip.php
@@ -75,7 +75,6 @@ abstract class AbstractMakeZip extends AbstractMake
             (bool) $userData['pdfa'],
         );
         $MakePdf = new MakePdf($MpdfProvider, $this->Entity);
-        $MakePdf->getFileContent();
         $this->Zip->addFile($this->folder . '/' . $MakePdf->getFileName(), $MakePdf->getFileContent());
     }
 }


### PR DESCRIPTION
While working on #3283 I noticed notifications were shown twice.
Here is the fix that will remove the unnecessary call to getFileContent() of MakePdf.
Cheers