### PR TITLE
use SITE_URL config value

### DIFF
--- a/src/classes/Tools.php
+++ b/src/classes/Tools.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -6,12 +6,10 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
 use function array_map;
-use Elabftw\Models\Config;
 use function filter_var;
 use function implode;
 use function json_decode;
@@ -19,7 +17,6 @@ use League\CommonMark\Exception\UnexpectedEncodingException;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use function mb_strlen;
 use function pathinfo;
-use function rtrim;
 use Symfony\Component\HttpFoundation\Request;
 use function trim;
 
@@ -262,25 +259,6 @@ class Tools
         $gray = "<i style='color:gray' class='fas fa-star' title='☺'></i>";
 
         return str_repeat($green, $rating) . str_repeat($gray, 5 - $rating);
-    }
-
-    /**
-     * Return a full URL of the elabftw install.
-     * Will first check for config value of 'url' or try to guess from Request
-     */
-    public static function getUrl(): string
-    {
-        $Config = Config::getConfig();
-
-        // this might not be set yet
-        if ($Config->configArr['url']) {
-            $url = $Config->configArr['url'];
-        } else {
-            $Request = Request::createFromGlobals();
-            // this is only used as fallback because with proxies it can get stuff wrong
-            $url = $Request->getScheme() . '://' . $Request->getHost() . ':' . (string) $Request->getPort();
-        }
-        return rtrim($url, '/');
     }
 
     public static function getIdFilterSql(array $idArr): string

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -31,7 +31,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 73;
+    private const REQUIRED_SCHEMA = 74;
 
     private Db $Db;
 

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -6,7 +6,6 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-declare(strict_types=1);
 
 namespace Elabftw\Models;
 
@@ -204,7 +203,6 @@ final class Config
             ('local_register', '1'),
             ('admins_create_users', '1'),
             ('anon_users', '0'),
-            ('url', NULL),
             ('schema', :schema),
             ('open_science', '0'),
             ('open_team', NULL),

--- a/src/services/AbstractMake.php
+++ b/src/services/AbstractMake.php
@@ -13,9 +13,9 @@ namespace Elabftw\Services;
 use function dirname;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\FsTools;
-use Elabftw\Elabftw\Tools;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Traits\UploadTrait;
+use const SITE_URL;
 
 /**
  * Mother class of the Make* services
@@ -61,7 +61,7 @@ abstract class AbstractMake
     {
         return sprintf(
             '%s/%s.php?mode=view&id=%d',
-            Tools::getUrl(),
+            SITE_URL,
             $this->Entity->page,
             $entityId ?? $this->Entity->id,
         );

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -13,13 +13,13 @@ use function count;
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Key;
 use Elabftw\Elabftw\Db;
-use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Config;
 use Elabftw\Models\Users;
 use Monolog\Logger;
 use PDO;
 use const SECRET_KEY;
+use const SITE_URL;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
@@ -144,7 +144,7 @@ class Email
 
     private function makeFooter(): string
     {
-        return sprintf("\n\n~~~\n%s %s\n", _('Sent from eLabFTW'), Tools::getUrl());
+        return sprintf("\n\n~~~\n%s %s\n", _('Sent from eLabFTW'), SITE_URL);
     }
 
     /**

--- a/src/services/EmailNotifications.php
+++ b/src/services/EmailNotifications.php
@@ -11,12 +11,12 @@ namespace Elabftw\Services;
 
 use function count;
 use Elabftw\Elabftw\Db;
-use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Notifications;
 use Elabftw\Models\Users;
 use function json_decode;
 use PDO;
+use const SITE_URL;
 use Symfony\Component\Mime\Address;
 
 /**
@@ -86,7 +86,7 @@ class EmailNotifications
             case Notifications::COMMENT_CREATED:
                 $subject .= _('New comment posted');
                 $commenter = new Users((int) $notifBody['commenter_userid']);
-                $url = Tools::getUrl() . '/experiments.php?mode=view&id=' . $notifBody['experiment_id'];
+                $url = SITE_URL . '/experiments.php?mode=view&id=' . $notifBody['experiment_id'];
 
                 $body = sprintf(
                     _('Hi. %s left a comment on your experiment. Have a look: %s'),
@@ -111,7 +111,7 @@ class EmailNotifications
                     $user->userData['fullname'],
                     $user->userData['email'],
                 );
-                $url = Tools::getUrl() . '/admin.php';
+                $url = SITE_URL . '/admin.php';
                 $body = $base . sprintf(_('Head to the admin panel to validate the account: %s'), $url);
                 break;
             case Notifications::SELF_NEED_VALIDATION:
@@ -120,7 +120,7 @@ class EmailNotifications
                 break;
             case Notifications::SELF_IS_VALIDATED:
                 $subject .= _('Account validated');
-                $url = Tools::getUrl() . '/login.php';
+                $url = SITE_URL . '/login.php';
                 $body = _('Hello. Your account on eLabFTW was validated by an admin. Follow this link to login: ') . $url;
                 break;
             default:

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -29,6 +29,7 @@ use function implode;
 use Mpdf\Mpdf;
 use function preg_replace;
 use setasign\Fpdi\FpdiException;
+use const SITE_URL;
 use function str_replace;
 use function strtolower;
 use Symfony\Component\HttpFoundation\Request;
@@ -198,8 +199,8 @@ class MakePdf extends AbstractMake implements FileMakerInterface
             'title' => $this->Entity->entityData['title'],
             'uploadsArr' => $this->Entity->Uploads->readAll(),
             'uploadsFolder' => dirname(__DIR__, 2) . '/uploads/',
-            'url' => $this->getUrl(),
-            'linkBaseUrl' => Tools::getUrl() . '/database.php',
+            'url' => SITE_URL,
+            'linkBaseUrl' => SITE_URL . '/database.php',
             'useCjk' => $this->Entity->Users->userData['cjk_fonts'],
         );
 

--- a/src/sql/schema74.sql
+++ b/src/sql/schema74.sql
@@ -1,0 +1,5 @@
+-- Schema 74
+START TRANSACTION;
+    DELETE FROM `config` WHERE `conf_name` = 'url';
+    UPDATE config SET conf_value = 74 WHERE conf_name = 'schema';
+COMMIT;

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -11,11 +11,6 @@
     {{ 'Please finalize install: %slink to documentation%s.'|trans|format("<a href='https://doc.elabftw.net/sysadmin-guide.html#setting-up-email'>", "</a>")|msg('ko') }}
 {% endif %}
 
-<!-- show error if the instance url is not configured -->
-{% if not App.Config.configArr.url %}
-    {{ 'Make sure to set the Installation URL in the Server Settings.'|msg('ko') }}
-{% endif %}
-
 <p>Docker image version: {{ elabimgVersion }}<br />
 MySQL database structure version: {{ App.Config.configArr.schema }}</p>
 
@@ -92,10 +87,6 @@ MySQL database structure version: {{ App.Config.configArr.schema }}</p>
               {% endfor %}
           </select>
           <p class='smallgray'>{{ 'The default language of this instance. It can be overridden by each users.' }}</p>
-
-          <label for='proxy'>{{ 'Installation URL:'|trans }}</label>
-          <input class='form-control col-md-4' type='url' value='{{ App.Config.configArr.url }}' name='url' id='url' />
-          <p class='smallgray'>{{ 'The canonical address of the eLabFTW installation. If this value is empty, eLabFTW will try to guess it, but in some instances, it might not be correct so you should fill this setting. Example: https://elabftw.example.org'|trans }}</p>
 
           <label for='proxy'>{{ 'Address of the Proxy:'|trans }}</label>
           <input class='form-control col-md-4' type='text' value='{{ App.Config.configArr.proxy }}' name='proxy' id='proxy' />

--- a/tests/config-ci.php
+++ b/tests/config-ci.php
@@ -4,5 +4,6 @@ define('DB_NAME', 'phpunit');
 define('DB_USER', 'phpunit');
 define('DB_PASSWORD', 'phpunit');
 define('SECRET_KEY', 'def00000f236867588a2b27e58196fc45c7d740b2a54685a63adc5820f23a8b08f0992749a910788421870ec4c638592a32fa929d7d6271a30d890b8055b35948edd43e1');
+define('SITE_URL', 'https://elab.local:3148');
 define('ELAB_AWS_ACCESS_KEY', 'yep');
 define('ELAB_AWS_SECRET_KEY', 'yop');

--- a/tests/config-home.php
+++ b/tests/config-home.php
@@ -4,5 +4,6 @@ define('DB_NAME', 'phpunit');
 define('DB_USER', 'phpunit');
 define('DB_PASSWORD', 'phpunit');
 define('SECRET_KEY', 'def00000f236867588a2b27e58196fc45c7d740b2a54685a63adc5820f23a8b08f0992749a910788421870ec4c638592a32fa929d7d6271a30d890b8055b35948edd43e1');
+define('SITE_URL', 'https://elab.local:3148');
 define('ELAB_AWS_ACCESS_KEY', 'yep');
 define('ELAB_AWS_SECRET_KEY', 'yop');

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -40,6 +40,7 @@ services:
             - USE_REDIS=false
             - ENABLE_IPV6=true
             - DEV_MODE=true
+            - SITE_URL=https://elab.local:3148
             - ELAB_AWS_ACCESS_KEY=yep
             - ELAB_AWS_SECRET_KEY=yop
         volumes:

--- a/web/app/controllers/EntityAjaxController.php
+++ b/web/app/controllers/EntityAjaxController.php
@@ -35,6 +35,7 @@ use Exception;
 use GuzzleHttp\Client;
 use function mb_convert_encoding;
 use PDOException;
+use const SITE_URL;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -128,7 +129,7 @@ try {
             throw new IllegalActionException('Can only share experiments or items.');
         }
         $Entity->canOrExplode('read');
-        $link = Tools::getUrl() . '/' . $Entity->page . '.php?mode=view&id=' . $Entity->id . '&elabid=' . $Entity->entityData['elabid'];
+        $link = SITE_URL . '/' . $Entity->page . '.php?mode=view&id=' . $Entity->id . '&elabid=' . $Entity->entityData['elabid'];
         $Response->setData(array(
             'res' => true,
             'msg' => $link,

--- a/web/app/controllers/ResetPasswordController.php
+++ b/web/app/controllers/ResetPasswordController.php
@@ -24,6 +24,7 @@ use Exception;
 use function nl2br;
 use function random_int;
 use const SECRET_KEY;
+use const SITE_URL;
 use function sleep;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Mime\Address;
@@ -67,7 +68,7 @@ try {
         $key = $ResetPasswordKey->generate($Users->userData['email']);
 
         // build the reset link
-        $resetLink = Tools::getUrl() . '/change-pass.php';
+        $resetLink = SITE_URL . '/change-pass.php';
         // not pretty but gets the job done
         $resetLink = str_replace('app/controllers/', '', $resetLink);
         $resetLink .= '?key=' . $key;

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -24,6 +24,7 @@ use function is_readable;
 use Monolog\Logger;
 use PDOException;
 use function setcookie;
+use const SITE_URL;
 use function stripos;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -145,15 +146,7 @@ try {
     header('X-Elab-Need-Auth: 1');
     // don't send a GET app/logout.php if it's an ajax call because it messes up the jquery ajax
     if ($Request->headers->get('X-Requested-With') !== 'XMLHttpRequest') {
-        // Note: we assume https here, this will cause an issue if you try to access it in http, but anyway this should never be done so I guess it's okay.
-        // don't use the Config from App here as it might not exist yet
-        $Config = Config::getConfig();
-        if ($Config->configArr['url']) {
-            $url = $Config->configArr['url'];
-        } else {
-            $url = 'https://' . $Request->getHost() . ':' . $Request->getPort();
-        }
-        $url .= '/app/logout.php?keep_redirect=1';
+        $url = SITE_URL . '/app/logout.php?keep_redirect=1';
         header('Location: ' . $url);
     }
     exit;

--- a/web/login.php
+++ b/web/login.php
@@ -36,8 +36,8 @@ $Response->prepare($Request);
 try {
     // if we are not in https, die saying we work only in https
     if (!$Request->isSecure() && !$Request->server->has('HTTP_X_FORWARDED_PROTO')) {
-        // get the url to display a link to click (without the port)
-        $url = Tools::getUrl();
+        // get the url to display a link to click
+        $url = SITE_URL;
         $message = "eLabFTW works only in HTTPS. Please enable HTTPS on your server. Or click this link : <a href='" .
             $url . "'>$url</a>";
         throw new ImproperActionException($message);


### PR DESCRIPTION
`SITE_URL` is now a mandatory env value that will endup in the `config.php` file, so the app knows what is the canonical URL without having to guess or do complicated gymnastics with ports and trusted proxies. Many apps have this setting (Discourse, Mattermost, ...) so it's not crazy to require it. We already have SERVER_NAME but this doesn't include the port, that could be custom, so having a complete URL is best.

`url` key from `Config` was not mandatory and could only be set after instance start, so it could sometimes not be reached. Also causes issues during site transfer, now it should be clear that this must be changed if a site is moved.

Works along https://github.com/elabftw/elabimg/commit/605e2b29c662336655534ea20b91ad02eb9a2b0f.

fix #3319