### PR TITLE
Drop non-Docker code

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -63,6 +63,7 @@ class Update
      */
     public function runUpdateScript(): array
     {
+        // at the end of the update, warnings can be displayed for important informations
         $warn = array();
 
         // do nothing if we're up to date
@@ -93,9 +94,6 @@ class Update
                 $warn[] = 'Change in the notification/email system: a cronjob is now REQUIRED for email notifications to be sent. Make sure to read the release notes!';
             }
         }
-
-        // remove cached twig templates (for non docker users)
-        FsTools::deleteCache();
 
         return $warn;
     }

--- a/src/commands/Install.php
+++ b/src/commands/Install.php
@@ -11,24 +11,18 @@ declare(strict_types=1);
 namespace Elabftw\Commands;
 
 use const DB_NAME;
-use Defuse\Crypto\Key;
 use function dirname;
 use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\FsTools;
 use Elabftw\Elabftw\Sql;
 use Elabftw\Services\DatabaseInstaller;
-use function is_writable;
-use League\Flysystem\Filesystem as Fs;
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Install the database when not in docker
+ * Import database structure
  */
 class Install extends Command
 {
@@ -49,12 +43,6 @@ class Install extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $fs = new Filesystem();
-        $elabRoot = dirname(__DIR__, 2);
-        $configFilePath = $elabRoot . '/config.php';
-        $cacheDir = $elabRoot . '/cache';
-        $uploadsDir = $elabRoot . '/uploads';
-
         $output->writeln(array(
             '',
             '      _          _     _____ _______        __',
@@ -66,98 +54,30 @@ class Install extends Command
             '',
         ));
 
-
         $output->writeln(array(
-            'Welcome to the install of eLabFTW!',
-            'This program will check if everything is good, create a config.php file and install the MySQL structure.',
-            'Before proceeding, make sure you have an empty MySQL database for eLabFTW with a user+password to access it.',
+            '<info>Welcome to the install of eLabFTW!</info>',
+            '<info>This program will install the MySQL structure.</info>',
+            '<info>Before proceeding, make sure you have an empty MySQL database for eLabFTW with a user+password to access it.</info>',
             '',
         ));
-        $output->writeln('=> Preliminary checks starting');
 
-        // check for config.php
-        if ($fs->exists($configFilePath)) {
-            $output->writeln('<info>✓ A config file is already present. It will be used to initialize the database.</info>');
-        } else {
-            $output->writeln('<info>✓ No config file present. One will be created.</info>');
-            // check if the folder is writable for saving the config file
-            if (!is_writable($elabRoot)) {
-                $msg = sprintf('The eLabFTW folder (%s) is not writable by the current user. Adjust permissions and try again.', $elabRoot);
-                $output->writeln('<error>ERROR: ' . $msg . '</error>');
-                return 1;
-            }
-            $output->writeln('<info>✓ Folder is writable by current user.</info>');
-        }
-
-        // Check for hash function
-        if (!function_exists('hash')) {
-            $message = "You don't have the hash function. On Freebsd it's in /usr/ports/security/php73-hash.";
-            $output->writeln('<error>ERROR: ' . $message . '</error>');
-            return 1;
-        }
-
-        $output->writeln('<info>✓ Hash function is present.</info>');
-
-        // same doc url for cache and uploads folder
-        $doc = 'https://doc.elabftw.net/faq.html#failed-creating-uploads-directory';
-        try {
-            $dirs = array($cacheDir, $uploadsDir);
-            $fs->mkdir($dirs);
-            $fs->chmod($dirs, 0777);
-        } catch (IOExceptionInterface $e) {
-            $output->writeln('<error>ERROR: ' . $e->getMessage() . '</error>');
-            $message = 'Documentation: ' . $doc;
-            $output->writeln($message);
-            return 1;
-        }
-
-        if (!$fs->exists($configFilePath)) {
-            $output->writeln('✓ All preliminary checks succeeded. Now asking information to produce the config.php file.');
-            $output->writeln('<comment>The value between brackets is the default value entered if you just press enter.</comment>');
-            // ask for authentication credentials
-            $helper = $this->getHelper('question');
-            $config = array();
-            $question = new Question('<question>MySQL hostname [localhost]:</question> ', 'localhost');
-            $config['dbHost'] = $helper->ask($input, $output, $question);
-            $question = new Question('<question>Database name [elabftw]:</question> ', 'elabftw');
-            $config['dbName'] = $helper->ask($input, $output, $question);
-            $question = new Question('<question>Database port [3306]:</question> ', '3306');
-            $config['dbPort'] = $helper->ask($input, $output, $question);
-            $question = new Question('<question>MySQL username [elabftw]:</question> ', 'elabftw');
-            $config['dbUser'] = $helper->ask($input, $output, $question);
-            $question = new Question('<question>MySQL password:</question> ', '');
-            $config['dbPass'] = $helper->ask($input, $output, $question);
-
-            // BUILD CONFIG FILE
-            $configFilePath = $elabRoot . '/config.php';
-
-            // make a new secret key
-            $key = Key::createNewRandomKey();
-
-            // what we will write in the file
-            $configContent = "<?php
-            define('DB_HOST', '" . $config['dbHost'] . "');
-            define('DB_PORT', '" . $config['dbPort'] . "');
-            define('DB_NAME', '" . $config['dbName'] . "');
-            define('DB_USER', '" . $config['dbUser'] . "');
-            define('DB_PASSWORD', '" . $config['dbPass'] . "');
-            define('SECRET_KEY', '" . $key->saveToAsciiSafeString() . "');";
-            $fs->dumpFile($configFilePath, $configContent);
-            $output->writeln('✓ Config file is now in place.');
-        }
-
-        $output->writeln('<info>=> Initializing MySQL database...</info>');
+        $output->writeln('<info>→ Reading file config.php...</info>');
         require_once dirname(__DIR__, 2) . '/config.php';
+
         if ($input->getOption('reset')) {
-            $output->writeln('<info>=> Resetting MySQL database...</info>');
+            $output->writeln('<info>→ Resetting MySQL database...</info>');
             $Db = Db::getConnection();
             $Db->q('DROP DATABASE ' . DB_NAME);
-            $Db->q('CREATE DATABASE ' . DB_NAME);
+            $Db->q('CREATE DATABASE ' . DB_NAME . ' CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci');
             $Db->q('USE ' . DB_NAME);
         }
-        $Installer = new DatabaseInstaller(new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql'))));
+
+        $output->writeln('<info>→ Initializing MySQL database...</info>');
+        $sqlFs = FsTools::getFs(dirname(__DIR__) . '/sql');
+        $Installer = new DatabaseInstaller(new Sql($sqlFs));
         $Installer->install();
         $output->writeln('<info>✓ Installation successful! You can now start using your eLabFTW instance.</info>');
+        $output->writeln('<info>→ Subscribe to the low volume newsletter to stay informed about new releases: http://eepurl.com/bTjcMj</info>');
         return 0;
     }
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -40,6 +40,7 @@ services:
             - USE_REDIS=false
             - ENABLE_IPV6=true
             - DEV_MODE=true
+            - SITE_URL=https://elab.local:3148
             - ELAB_AWS_ACCESS_KEY=yep
             - ELAB_AWS_SECRET_KEY=yop
         volumes:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,10 +20,10 @@ fi
 
 # make sure we tear down everything when script ends
 cleanup() {
-if (! $scrutinizer); then
-    $sudoCmd cp -v config.php.dev config.php
-    $sudoCmd chown 101:101 config.php
-fi
+    if (! $scrutinizer); then
+        $sudoCmd cp -v config.php.dev config.php
+        $sudoCmd chown 101:101 config.php
+    fi
 }
 trap cleanup EXIT
 
@@ -66,8 +66,7 @@ fi
 # install the database
 docker exec -it elabtmp bin/install start -r
 if ($scrutinizer); then
-    docker exec -it elabtmp yarn psalm
-    docker exec -it elabtmp yarn phpstan
+    docker exec -it elabtmp yarn static
 fi
 # populate the database
 docker exec -it elabtmp bin/console dev:populate tests/populate-config.yml


### PR DESCRIPTION
* Remove installation code related to non-docker install (basically creating interactively the config.php file).
* Don't delete cache files after update (useless as this will be empty for each new container run)