### PR TITLE
add uploads:prune to bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -30,5 +30,6 @@ $Application->add(new PruneRevisions());
 $Application->add(new MfaCode());
 $Application->add(new AddMissingLinks());
 $Application->add(new SendNotifications());
+$Application->add(new PruneUploads());
 
 $Application->run();

--- a/src/commands/PruneUploads.php
+++ b/src/commands/PruneUploads.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Commands;
+
+use Elabftw\Services\UploadsPruner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * To remove deleted files completely
+ */
+class PruneUploads extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'uploads:prune';
+
+    protected function configure(): void
+    {
+        $this
+            // the short description shown while running "php bin/console list"
+            ->setDescription('Remove deleted uploaded files')
+
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp('Remove uploaded files marked as deleted from the filesystem and from the database');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($output->isVerbose()) {
+            $output->writeln(array(
+                'Pruning uploads',
+                '===============',
+            ));
+        }
+        $Cleaner = new UploadsPruner();
+        $cleanedNumber = $Cleaner->cleanup();
+        if ($output->isVerbose()) {
+            $output->writeln(sprintf('Removed %d uploads', $cleanedNumber));
+        }
+        return 0;
+    }
+}

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -42,14 +42,14 @@ class Uploads implements CrudInterface
     use UploadTrait;
     use SetIdTrait;
 
+    public const STATE_DELETED = 3;
+
     /** @var int BIG_FILE_THRESHOLD size of a file in bytes above which we don't process it (50 Mb) */
     private const BIG_FILE_THRESHOLD = 50000000;
 
     private const STATE_NORMAL = 1;
 
     private const STATE_ARCHIVED = 2;
-
-    private const STATE_DELETED = 3;
 
     protected Db $Db;
 

--- a/src/services/UploadsPruner.php
+++ b/src/services/UploadsPruner.php
@@ -39,6 +39,9 @@ class UploadsPruner implements CleanerInterface
         foreach ($this->Db->fetchAll($req) as $upload) {
             $storageFs = (new StorageFactory((int) $upload['storage']))->getStorage()->getFs();
             $storageFs->delete($upload['long_name']);
+            // also delete an hypothetical thumbnail
+            // this won't throw any error if the file doesn't exist
+            $storageFs->delete($upload['long_name'] . '_th.jpg');
         }
         $this->deleteFromDb();
         return $req->rowCount();

--- a/src/services/UploadsPruner.php
+++ b/src/services/UploadsPruner.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Interfaces\CleanerInterface;
+use Elabftw\Models\Uploads;
+use PDO;
+
+/**
+ * Remove deleted uploads
+ */
+class UploadsPruner implements CleanerInterface
+{
+    private Db $Db;
+
+    public function __construct()
+    {
+        $this->Db = Db::getConnection();
+    }
+
+    /**
+     * Remove uploads with deleted state from database and filesystem
+     * This is a global function and should only be called by uploads:prune command
+     */
+    public function cleanup(): int
+    {
+        $sql = 'SELECT id, long_name, storage FROM uploads WHERE state = :state';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', Uploads::STATE_DELETED, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        foreach ($this->Db->fetchAll($req) as $upload) {
+            $storageFs = (new StorageFactory((int) $upload['storage']))->getStorage()->getFs();
+            $storageFs->delete($upload['long_name']);
+        }
+        $this->deleteFromDb();
+        return $req->rowCount();
+    }
+
+    private function deleteFromDb(): bool
+    {
+        $sql = 'DELETE FROM uploads WHERE state = :state';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', Uploads::STATE_DELETED, PDO::PARAM_INT);
+        return $this->Db->execute($req);
+    }
+}

--- a/tests/unit/services/UploadsPrunerTest.php
+++ b/tests/unit/services/UploadsPrunerTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Elabftw\CreateUpload;
+use Elabftw\Models\Experiments;
+use Elabftw\Models\Users;
+
+class UploadsPrunerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCleanup(): void
+    {
+        // create an upload that we will delete
+        $Experiments = new Experiments(new Users(1, 1), 1);
+        $uploadId = $Experiments->Uploads->create(new CreateUpload('to_delete.sql', dirname(__DIR__, 2) . '/_data/dummy.sql'));
+        $Experiments->Uploads->setId($uploadId);
+        $Experiments->Uploads->destroy();
+
+        $Cleaner = new UploadsPruner();
+        $this->assertEquals(1, $Cleaner->cleanup());
+    }
+}


### PR DESCRIPTION
will remove deleted files from db and filesystem

Now that uploads are not deleted from db and filesystem on user request, a sysadmin needs to be able to do it from the `bin/console`.