### PR TITLE
make ove work with S3 file storage

### DIFF
--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -21,6 +21,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
   Array.from(document.getElementsByClassName('viewer-ove')).forEach(el => {
     const oveDivDataset = (el as HTMLDivElement).dataset;
     const viewerID = el.id;
+    const isSnapGeneFile = (new URL(oveDivDataset.href, window.location.origin)).searchParams.get('f').slice(-4) === '.dna';
     const filename = oveDivDataset.href;
     const realName = oveDivDataset.realName;
 
@@ -240,7 +241,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
     }
 
     // load DNA data either as File (.dna files Snapgene) or as String
-    if (filename.slice(-4) === '.dna') {
+    if (isSnapGeneFile) {
       const xhr = new XMLHttpRequest();
       xhr.open('GET', filename, true);
       xhr.responseType = 'blob';


### PR DESCRIPTION
The addition of support for S3 file storage (#3281) [950c4a7be] requires to parse the download uri to see if a file is a SnapGene file (.dna extension)