### PR TITLE
remove PDO fetchAll wrapper Db::fetchAll

### DIFF
--- a/src/classes/Db.php
+++ b/src/classes/Db.php
@@ -143,19 +143,6 @@ final class Db
     }
 
     /**
-     * Force fetchAll() to return an array or throw exception if result is false
-     * because this is hard to test
-     */
-    public function fetchAll(PDOStatement $req): array
-    {
-        $res = $req->fetchAll();
-        if ($res === false) {
-            throw new DatabaseErrorException();
-        }
-        return $res;
-    }
-
-    /**
      * Make a simple query
      *
      * @param string $sql The SQL query

--- a/src/classes/TagCloud.php
+++ b/src/classes/TagCloud.php
@@ -70,7 +70,7 @@ class TagCloud
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -260,10 +260,9 @@ abstract class AbstractEntity implements CrudInterface
         }
 
         $this->bindExtendedValues($req);
-
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     public function read(ContentParamsInterface $params): array
@@ -335,9 +334,8 @@ abstract class AbstractEntity implements CrudInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':type', $this->type);
         $this->Db->execute($req);
-        $res = $this->Db->fetchAll($req);
         $allTags = array();
-        foreach ($res as $tags) {
+        foreach ($req->fetchAll() as $tags) {
             $allTags[$tags['item_id']][] = $tags;
         }
         return $allTags;
@@ -588,7 +586,7 @@ abstract class AbstractEntity implements CrudInterface
         $req->bindParam(':to', $to);
         $this->Db->execute($req);
 
-        return array_column($this->Db->fetchAll($req), 'id');
+        return array_column($req->fetchAll(), 'id');
     }
 
     /**
@@ -648,8 +646,8 @@ abstract class AbstractEntity implements CrudInterface
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
         $req->bindParam(':category', $category);
         $req->execute();
-        $res = $this->Db->fetchAll($req);
-        return array_column($res, 'id');
+
+        return array_column($req->fetchAll(), 'id');
     }
 
     public function addToExtendedFilter(string $extendedFilter, array $bindExtendedValues = array()): void

--- a/src/models/ApiKeys.php
+++ b/src/models/ApiKeys.php
@@ -83,7 +83,8 @@ class ApiKeys implements CrudInterface
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     /**
@@ -94,8 +95,7 @@ class ApiKeys implements CrudInterface
         $sql = 'SELECT hash, userid, can_write, team FROM api_keys';
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
-        $keysArr = $this->Db->fetchAll($req);
-        foreach ($keysArr as $key) {
+        foreach ($req->fetchAll() as $key) {
             if (password_verify($apiKey, $key['hash'])) {
                 return array('userid' => $key['userid'], 'canWrite' => $key['can_write'], 'team' => $key['team']);
             }

--- a/src/models/Comments.php
+++ b/src/models/Comments.php
@@ -46,6 +46,7 @@ class Comments implements CrudInterface
         if ($this->Entity instanceof Experiments) {
             $this->createNotification();
         }
+
         return $this->Db->lastInsertId();
     }
 
@@ -59,7 +60,8 @@ class Comments implements CrudInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     public function update(ContentParamsInterface $params): bool
@@ -73,6 +75,7 @@ class Comments implements CrudInterface
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
+
         return $this->Db->execute($req);
     }
 

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -14,7 +14,6 @@ use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Key;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\Update;
-use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Interfaces\ContentParamsInterface;
 use PDO;
 use const SECRET_KEY;
@@ -82,9 +81,7 @@ final class Config
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
         $config = $req->fetchAll(PDO::FETCH_COLUMN | PDO::FETCH_GROUP);
-        if ($config === false) {
-            throw new DatabaseErrorException();
-        }
+
         return array_map(function ($v) {
             return $v[0];
         }, $config);

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -187,7 +187,8 @@ class Experiments extends AbstractEntity
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/FavTags.php
+++ b/src/models/FavTags.php
@@ -61,7 +61,8 @@ class FavTags implements CrudInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     public function update(ContentParamsInterface $params): bool

--- a/src/models/Idps.php
+++ b/src/models/Idps.php
@@ -72,7 +72,8 @@ class Idps implements DestroyableInterface
         $sql = 'SELECT * FROM idps';
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -124,7 +124,7 @@ class ItemsTypes extends AbstractEntity
         $req->bindValue(':state', self::STATE_NORMAL, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Links.php
+++ b/src/models/Links.php
@@ -79,7 +79,7 @@ class Links implements CrudInterface
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Notifications.php
+++ b/src/models/Notifications.php
@@ -87,7 +87,7 @@ class Notifications implements CrudInterface
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $notifs = $this->Db->fetchAll($req);
+        $notifs = $req->fetchAll();
         foreach ($notifs as &$notif) {
             $notif['body'] = json_decode($notif['body'], true, 512, JSON_THROW_ON_ERROR);
         }

--- a/src/models/Pins.php
+++ b/src/models/Pins.php
@@ -61,11 +61,10 @@ class Pins
 
         $this->Db->execute($req);
 
-        $ids = $this->Db->fetchAll($req);
         $entity = clone $this->Entity;
 
         $pinArr = array();
-        foreach ($ids as $id) {
+        foreach ($req->fetchAll() as $id) {
             $entity->setId((int) $id['entity_id']);
             $pinArr[] = $entity->read(new ContentParams());
         }

--- a/src/models/Revisions.php
+++ b/src/models/Revisions.php
@@ -88,7 +88,7 @@ class Revisions implements DestroyableInterface
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Scheduler.php
+++ b/src/models/Scheduler.php
@@ -91,7 +91,7 @@ class Scheduler
         $req->bindParam(':end', $end);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**
@@ -120,7 +120,7 @@ class Scheduler
         $req->bindParam(':end', $end);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Status.php
+++ b/src/models/Status.php
@@ -86,7 +86,7 @@ class Status extends AbstractCategory
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Steps.php
+++ b/src/models/Steps.php
@@ -82,7 +82,7 @@ class Steps implements CrudInterface
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Tags.php
+++ b/src/models/Tags.php
@@ -110,11 +110,7 @@ class Tags implements CrudInterface
         $req->bindParam(':team', $this->Entity->Users->userData['team'], PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $res = $req->fetchAll();
-        if ($res === false) {
-            return array();
-        }
-        return $res;
+        return $req->fetchAll();
     }
 
     /**
@@ -187,7 +183,7 @@ class Tags implements CrudInterface
         $req->bindParam(':team', $this->Entity->Users->userData['team'], PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $idsToDelete = $this->Db->fetchAll($req);
+        $idsToDelete = $req->fetchAll();
         // loop on each tag that needs to be deduplicated and do the work
         foreach ($idsToDelete as $idsList) {
             $this->deduplicateFromIdsList($idsList['id_list']);
@@ -262,11 +258,7 @@ class Tags implements CrudInterface
         $req->bindParam(':type', $this->Entity->type, PDO::PARAM_STR);
         $req->bindValue(':count', count($tagIds), PDO::PARAM_INT);
         $req->execute();
-        $results = $req->fetchAll();
-        if ($results === false) {
-            return array();
-        }
-        foreach ($results as $res) {
+        foreach ($req->fetchAll() as $res) {
             $itemIds[] = (int) $res['item_id'];
         }
         return $itemIds;

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -66,7 +66,7 @@ class TeamGroups implements CrudInterface
         $this->Db->execute($req);
 
         $groups = $req->fetchAll();
-        if ($groups === false) {
+        if (empty($groups)) {
             return $fullGroups;
         }
 
@@ -223,7 +223,7 @@ class TeamGroups implements CrudInterface
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Teams.php
+++ b/src/models/Teams.php
@@ -191,7 +191,7 @@ class Teams implements CrudInterface
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     public function update(ContentParamsInterface $params): bool

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -187,7 +187,7 @@ class Templates extends AbstractEntity
         $req->bindValue(':state', self::STATE_NORMAL, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/models/Todolist.php
+++ b/src/models/Todolist.php
@@ -54,7 +54,7 @@ class Todolist implements CrudInterface
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     public function update(ContentParamsInterface $params): bool

--- a/src/models/UnfinishedSteps.php
+++ b/src/models/UnfinishedSteps.php
@@ -52,9 +52,7 @@ class UnfinishedSteps extends Steps
         }
         $this->Db->execute($req);
 
-        $res = $this->Db->fetchAll($req);
-
-        return $this->cleanUpResult($res);
+        return $this->cleanUpResult($req->fetchAll());
     }
 
     /*

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -188,7 +188,7 @@ class Uploads implements CrudInterface
         $req->bindParam(':type', $this->Entity->type);
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     public function readAllNormal(): array

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -197,7 +197,7 @@ class Users
         }
         $this->Db->execute($req);
 
-        return $this->Db->fetchAll($req);
+        return $req->fetchAll();
     }
 
     /**

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -134,9 +134,8 @@ class Email
         }
         $Db->execute($req);
 
-        $users = $Db->fetchAll($req);
         $emails = array();
-        foreach ($users as $user) {
+        foreach ($req->fetchAll() as $user) {
             $emails[] = new Address($user['email'], $user['fullname']);
         }
         return $emails;

--- a/src/services/EmailNotifications.php
+++ b/src/services/EmailNotifications.php
@@ -72,7 +72,8 @@ class EmailNotifications
         $sql = 'SELECT id, userid, category, body FROM notifications WHERE send_email = 1 AND email_sent = 0';
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 
     /**

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -60,7 +60,7 @@ class TeamsHelper
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        return array_column($this->Db->fetchAll($req), 'userid');
+        return array_column($req->fetchAll(), 'userid');
     }
 
     /**

--- a/src/services/UploadsMigrator.php
+++ b/src/services/UploadsMigrator.php
@@ -50,6 +50,7 @@ class UploadsMigrator
         $req = $this->Db->prepare($sql);
         $req->bindValue(':storage', StorageFactory::LOCAL);
         $this->Db->execute($req);
-        return $this->Db->fetchAll($req);
+
+        return $req->fetchAll();
     }
 }

--- a/src/services/UploadsPruner.php
+++ b/src/services/UploadsPruner.php
@@ -36,7 +36,7 @@ class UploadsPruner implements CleanerInterface
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', Uploads::STATE_DELETED, PDO::PARAM_INT);
         $this->Db->execute($req);
-        foreach ($this->Db->fetchAll($req) as $upload) {
+        foreach ($req->fetchAll() as $upload) {
             $storageFs = (new StorageFactory((int) $upload['storage']))->getStorage()->getFs();
             $storageFs->delete($upload['long_name']);
             // also delete an hypothetical thumbnail
@@ -44,6 +44,7 @@ class UploadsPruner implements CleanerInterface
             $storageFs->delete($upload['long_name'] . '_th.jpg');
         }
         $this->deleteFromDb();
+
         return $req->rowCount();
     }
 

--- a/src/services/UsersHelper.php
+++ b/src/services/UsersHelper.php
@@ -71,7 +71,7 @@ class UsersHelper
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $res = $this->Db->fetchAll($req);
+        $res = $req->fetchAll();
         if (empty($res)) {
             throw new ImproperActionException('Could not find a team for this user!');
         }


### PR DESCRIPTION
As of php 8.0 [PDO fetchAll() always returns an array](https://www.php.net/manual/en/pdostatement.fetchall.php#refsect1-pdostatement.fetchall-changelog); no more false.
This makes the Db::fetchAll() wrapper obsolete and it can be remove.