### PR TITLE
Fix visibility part of where clause

### DIFF
--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -292,6 +292,6 @@ class QueryBuilderVisitor implements Visitor
             );
         }
 
-        return new WhereCollector(implode(' OR ', $queryParts), $bindValues);
+        return new WhereCollector('(' . implode(' OR ', $queryParts) . ')', $bindValues);
     }
 }


### PR DESCRIPTION
Hi Nico,

There are some parentheses missing to avoid precedence confusion in the where clause of the visibility part.

Cheers,
Marcel