### PR TITLE
Refactor TeamGroups::read() and TeamGroups::isInTeamGroup()

### DIFF
--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -190,16 +190,12 @@ class TeamGroups implements CrudInterface
      */
     public function isInTeamGroup(int $userid, int $groupid): bool
     {
-        $sql = 'SELECT DISTINCT userid FROM users2team_groups WHERE groupid = :groupid';
+        $sql = 'SELECT count(userid) FROM users2team_groups WHERE groupid = :groupid AND userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':groupid', $groupid, PDO::PARAM_INT);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $this->Db->execute($req);
-        $authUsersArr = array();
-        while ($authUsers = $req->fetch()) {
-            $authUsersArr[] = (int) $authUsers['userid'];
-        }
-
-        return in_array($userid, $authUsersArr, true);
+        return $req->fetchColumn() > '0';
     }
 
     /**

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -87,7 +87,7 @@ class TeamGroups implements CrudInterface
                                 'fullname' => $fullname,
                             );
                         },
-                        explode(',', $group['usersids']),
+                        explode(',', $group['userids']),
                         explode(',', $group['fullnames'])
                     )
                     : array(),

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -198,24 +198,6 @@ class TeamGroups implements CrudInterface
         return $req->fetchColumn() > '0';
     }
 
-    /**
-     * Check if both users are in the same group
-     *
-     * @param int $userid the other user
-     */
-    public function isUserInSameGroup(int $userid): bool
-    {
-        $sql = 'SELECT t1.groupid FROM users2team_groups AS t1
-            INNER JOIN users2team_groups AS t2
-            WHERE t1.userid = :userid AND t2.userid = :userid2';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
-        $req->bindParam(':userid2', $userid, PDO::PARAM_INT);
-        $this->Db->execute($req);
-        $req->fetch();
-        return $req->rowCount() > 0;
-    }
-
     public function readGroupsFromUser(): array
     {
         $sql = 'SELECT DISTINCT team_groups.id, team_groups.name

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use function array_combine;
+use function array_map;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Exceptions\IllegalActionException;
@@ -18,6 +19,7 @@ use Elabftw\Interfaces\ContentParamsInterface;
 use Elabftw\Interfaces\CrudInterface;
 use Elabftw\Interfaces\TeamGroupParamsInterface;
 use Elabftw\Traits\SetIdTrait;
+use function explode;
 use PDO;
 
 /**

--- a/tests/unit/models/TeamGroupsTest.php
+++ b/tests/unit/models/TeamGroupsTest.php
@@ -44,6 +44,10 @@ class TeamGroupsTest extends \PHPUnit\Framework\TestCase
 
     public function testRead(): void
     {
+        // without users
+        $this->assertTrue(is_array($this->TeamGroups->read(new ContentParams())));
+
+        // with users
         $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 1, 'group' => 1,'how' => 'add')));
         $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 2, 'group' => 1,'how' => 'add')));
         $this->assertTrue(is_array($this->TeamGroups->read(new ContentParams())));

--- a/tests/unit/models/TeamGroupsTest.php
+++ b/tests/unit/models/TeamGroupsTest.php
@@ -20,11 +20,6 @@ class TeamGroupsTest extends \PHPUnit\Framework\TestCase
         $this->TeamGroups->create(new ContentParams('Group Name'));
     }
 
-    public function testRead(): void
-    {
-        $this->assertTrue(is_array($this->TeamGroups->read(new ContentParams())));
-    }
-
     public function testReadName(): void
     {
         $id = $this->TeamGroups->create(new ContentParams('Group Name'));
@@ -45,6 +40,15 @@ class TeamGroupsTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->TeamGroups->isInTeamGroup(1, 1));
         $this->expectException(IllegalActionException::class);
         $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 1, 'group' => 1,'how' => 'yep')));
+    }
+
+    public function testRead(): void
+    {
+        $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 1, 'group' => 1,'how' => 'add')));
+        $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 2, 'group' => 1,'how' => 'add')));
+        $this->assertTrue(is_array($this->TeamGroups->read(new ContentParams())));
+        $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 1, 'group' => 1,'how' => 'rm')));
+        $this->TeamGroups->update(new TeamGroupParams('', 'member', array('userid' => 2, 'group' => 1,'how' => 'rm')));
     }
 
     public function testDestroy(): void


### PR DESCRIPTION
`isInTeamGroup()` should be faster.
I'm not so sure about `read()` but the queries in the loop are gone. However they are replaced with an `array_map()`.
This PR will benefit from the added FKs in #3431.