### PR TITLE
Refactor SSRF protection to use Mpdf:s settings.

### DIFF
--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -241,10 +241,6 @@ class MakePdf extends AbstractMake implements FileMakerInterface
         );
 
         $html = $this->getTwig(Config::getConfig())->render('pdf.html', $renderArr);
-
-        // now remove any img src pointing to outside world
-        // prevent blind ssrf (thwarted by CSP on webpage, but not in pdf)
-        return preg_replace('/img src=("|\')(ht|f|)tp/i', 'nope', $html);
     }
 
     /**

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -27,7 +27,6 @@ use Elabftw\Traits\TwigTrait;
 use Elabftw\Traits\UploadTrait;
 use function implode;
 use Mpdf\Mpdf;
-use function preg_replace;
 use setasign\Fpdi\FpdiException;
 use const SITE_URL;
 use function str_replace;

--- a/src/services/MpdfProvider.php
+++ b/src/services/MpdfProvider.php
@@ -45,6 +45,7 @@ class MpdfProvider implements MpdfProviderInterface
                 ),
             ),
             'default_font' => 'lato',
+            'whitelistStreamWrappers' => [ 'file' ],
         ));
 
         // make sure we can read the pdf in a long time

--- a/src/services/MpdfProvider.php
+++ b/src/services/MpdfProvider.php
@@ -45,7 +45,7 @@ class MpdfProvider implements MpdfProviderInterface
                 ),
             ),
             'default_font' => 'lato',
-            'whitelistStreamWrappers' => [ 'file' ],
+            'whitelistStreamWrappers' => ['file'],
         ));
 
         // make sure we can read the pdf in a long time


### PR DESCRIPTION
The Mpdf library provides an allowlist for stream wrappers. By default this contains file, http and https, where only the first one is useful. Using the library's own code is neater, and seems to provide protection from the kind of external "images" the regex should deal with.