### PR TITLE
Add missing FK to experiments.category + items.category

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -31,7 +31,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 81;
+    private const REQUIRED_SCHEMA = 82;
 
     private Db $Db;
 

--- a/src/sql/schema82.sql
+++ b/src/sql/schema82.sql
@@ -1,11 +1,17 @@
 -- Schema 82
--- add FK and constraints to experiments.category
+-- add missing FK and constraints
 START TRANSACTION;
     ALTER TABLE `experiments`
       ADD KEY `fk_experiments_status_id` (`category`);
     ALTER TABLE `experiments`
       ADD CONSTRAINT `fk_experiments_status_id`
         FOREIGN KEY (`category`) REFERENCES `status` (`id`)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+    ALTER TABLE `items`
+      ADD KEY `fk_items_items_types_id` (`category`);
+    ALTER TABLE `items`
+      ADD CONSTRAINT `fk_items_items_types_id`
+        FOREIGN KEY (`category`) REFERENCES `items_types` (`id`)
         ON DELETE CASCADE ON UPDATE CASCADE;
     UPDATE config SET conf_value = 82 WHERE conf_name = 'schema';
 COMMIT;

--- a/src/sql/schema82.sql
+++ b/src/sql/schema82.sql
@@ -1,0 +1,11 @@
+-- Schema 82
+-- add FK and constraints to experiments.category
+START TRANSACTION;
+    ALTER TABLE `experiments`
+      ADD KEY `fk_experiments_status_id` (`category`);
+    ALTER TABLE `experiments`
+      ADD CONSTRAINT `fk_experiments_status_id`
+        FOREIGN KEY (`category`) REFERENCES `status` (`id`)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+    UPDATE config SET conf_value = 82 WHERE conf_name = 'schema';
+COMMIT;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -113,6 +113,8 @@ CREATE TABLE `experiments` (
 -- RELATIONSHIPS FOR TABLE `experiments`:
 --   `userid`
 --       `users` -> `userid`
+--   `category`
+--       `status` -> `id`
 --
 
 -- --------------------------------------------------------
@@ -819,7 +821,8 @@ ALTER TABLE `api_keys`
 --
 ALTER TABLE `experiments`
   ADD KEY `fk_experiments_users_userid` (`userid`),
-  ADD KEY `idx_experiments_state` (`state`);
+  ADD KEY `idx_experiments_state` (`state`),
+  ADD KEY `fk_experiments_status_id` (`category`);
 
 --
 -- Indexes for table `experiments_comments`
@@ -941,7 +944,8 @@ ALTER TABLE `api_keys`
 -- Constraints for table `experiments`
 --
 ALTER TABLE `experiments`
-  ADD CONSTRAINT `fk_experiments_users_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
+  ADD CONSTRAINT `fk_experiments_users_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_experiments_status_id` FOREIGN KEY (`category`) REFERENCES `status` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `experiments_comments`

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -364,6 +364,8 @@ CREATE TABLE `items` (
 -- RELATIONSHIPS FOR TABLE `items`:
 --   `team`
 --       `teams` -> `id`
+--   `category`
+--       `items_types` -> `id`
 --
 
 -- --------------------------------------------------------
@@ -863,7 +865,8 @@ ALTER TABLE `favtags2users`
 --
 ALTER TABLE `items`
   ADD KEY `fk_items_teams_id` (`team`),
-  ADD KEY `idx_items_state` (`state`);
+  ADD KEY `idx_items_state` (`state`),
+  ADD KEY `fk_items_items_types_id` (`category`);
 
 --
 -- Indexes for table `items_comments`
@@ -998,7 +1001,8 @@ ALTER TABLE `favtags2users`
 -- Constraints for table `items`
 --
 ALTER TABLE `items`
-  ADD CONSTRAINT `fk_items_teams_id` FOREIGN KEY (`team`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+  ADD CONSTRAINT `fk_items_teams_id` FOREIGN KEY (`team`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_items_items_types_id` FOREIGN KEY (`category`) REFERENCES `items_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `items_comments`

--- a/tests/unit/models/StatusTest.php
+++ b/tests/unit/models/StatusTest.php
@@ -31,13 +31,11 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testRead(): void
     {
-        $all = $this->Status->read(new ContentParams());
-        $this->assertTrue(is_array($all));
+        $this->assertIsArray($this->Status->read(new ContentParams()));
     }
 
     public function testUpdate(): void
     {
-        $params = new StatusParams('Yep', '#29AEB9', false, true);
         $id = $this->Status->create(new StatusParams('Yep', '#29AEB9', false, true));
         $Status = new Status(1, $id);
         $Status->update(new StatusParams('Updated', '#121212', true, false));
@@ -46,10 +44,18 @@ class StatusTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('121212', $status['color']);
         $this->assertTrue((bool) $status['is_timestampable']);
         $this->assertFalse((bool) $status['is_default']);
+        $Status->update(new StatusParams('Updated', '#121212', true, true));
+        $status = $Status->read(new ContentParams());
+        $this->assertTrue((bool) $status['is_default']);
+        // undo changes so that MakeTimestampTest.php:testNonTimestampableExperiment works
+        $Status->update(new StatusParams('Updated', '#121212', false, true));
     }
 
     public function testDestroy(): void
     {
+        $id = $this->Status->create(new StatusParams('Yep1', '#29AEB9', false, false));
+        $Status = new Status(1, $id);
+        $this->assertTrue($Status->destroy());
         $this->expectException(ImproperActionException::class);
         $this->Status->destroy();
     }


### PR DESCRIPTION
Hi Nico,
I'm not sure if there is a reason behind the missing fk/constraints on experiments.category and items.category but it seems logical to me to have it to support the JOINs.
experiments.category and items.category should never be anything else than what is listed in the status / items_types table, right? So there is no need to check data integrity here.