### PR TITLE
Schema 84: check data integrity, remove duplicates

### DIFF
--- a/src/sql/schema84.sql
+++ b/src/sql/schema84.sql
@@ -1,12 +1,68 @@
 -- Schema 84
 -- improve primary key for links
 START TRANSACTION;
+    -- experiments_links remove duplicates, triplicates, ...
+    DELETE FROM experiments_links
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT MIN(t1.id) as id
+        FROM experiments_links AS t1
+        INNER JOIN experiments_links AS t2
+          ON (t1.item_id = t2.item_id
+            AND t1.link_id = t2.link_id
+            AND t1.id < t2.id
+          )
+        GROUP BY t1.id
+      ) tmp
+    );
     ALTER TABLE `experiments_links` DROP `id`;
     ALTER TABLE `experiments_links` ADD PRIMARY KEY(`item_id`, `link_id`);
+    -- experiments_templates_links remove duplicates, triplicates, ...
+    DELETE FROM experiments_templates_links
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT MIN(t1.id) as id
+        FROM experiments_templates_links AS t1
+        INNER JOIN experiments_templates_links AS t2
+          ON (t1.item_id = t2.item_id
+            AND t1.link_id = t2.link_id
+            AND t1.id < t2.id
+          )
+        GROUP BY t1.id
+      ) tmp
+    );
     ALTER TABLE `experiments_templates_links` DROP `id`;
     ALTER TABLE `experiments_templates_links` ADD PRIMARY KEY(`item_id`, `link_id`);
+    -- items_links remove duplicates, triplicates, ...
+    DELETE FROM items_links
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT MIN(t1.id) as id
+        FROM items_links AS t1
+        INNER JOIN items_links AS t2
+          ON (t1.item_id = t2.item_id
+            AND t1.link_id = t2.link_id
+            AND t1.id < t2.id
+          )
+        GROUP BY t1.id
+      ) tmp
+    );
     ALTER TABLE `items_links` DROP `id`;
     ALTER TABLE `items_links` ADD PRIMARY KEY(`item_id`, `link_id`);
+    -- items_types_links remove duplicates, triplicates, ...
+    DELETE FROM items_types_links
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT MIN(t1.id) as id
+        FROM items_types_links AS t1
+        INNER JOIN items_types_links AS t2
+          ON (t1.item_id = t2.item_id
+            AND t1.link_id = t2.link_id
+            AND t1.id < t2.id
+          )
+        GROUP BY t1.id
+      ) tmp
+    );
     ALTER TABLE `items_types_links` DROP `id`;
     ALTER TABLE `items_types_links` ADD PRIMARY KEY(`item_id`, `link_id`);
     UPDATE config SET conf_value = 84 WHERE conf_name = 'schema';


### PR DESCRIPTION
Not sure why but I had duplicates in my dev database. So maybe they can exist in some production database too?!
It should not hurt to check data integrity before changing the primary key.

Also, instead of using `START TRANSACTION` and `COMMIT;` in the sql file it would be better to use something like:

```SQL
/* Begin a transaction, turning off autocommit */
$db->beginTransaction();

/* Change the database schema */
$sth = $db->exec();

/* Recognize mistake and roll back changes */
$db->rollBack();

/* Database connection is now back in autocommit mode */
```
_copy-pasted from [php.net PDO::beginTransaction](https://www.php.net/manual/en/pdo.begintransaction.php#refsect1-pdo.begintransaction-examples)_

This will prevent the database from having an intermediate update state. If I recall correctly there were some issues related to interrupted db updates.