### PR TITLE
4.3.0 fixes 2

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -56,6 +56,9 @@ document.addEventListener('DOMContentLoaded', () => {
     },
   });
 
+  const AjaxC = new Ajax();
+
+
   // set the language for js translated strings
   i18next.changeLanguage(document.getElementById('user-prefs').dataset.lang);
 
@@ -139,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
           content: value,
           notif: true,
         };
-        (new Ajax()).send(payload)
+        AjaxC.send(payload)
           .then(json => notif(json))
           .then(() => {
             if (el.dataset.reload) {
@@ -207,7 +210,6 @@ document.addEventListener('DOMContentLoaded', () => {
         action: Action.Read,
         model: Model.PrivacyPolicy,
       };
-      const AjaxC = new Ajax();
       AjaxC.send(payload).then(json => {
         let policy = json.value as string;
         if (!policy) {
@@ -299,7 +301,6 @@ document.addEventListener('DOMContentLoaded', () => {
         target: Target.Finished,
         id: parseInt(el.dataset.id, 10),
       };
-      const AjaxC = new Ajax();
       if (el.parentElement.dataset.ack === '0') {
         AjaxC.send(payload).then(() => {
           if (el.dataset.href) {
@@ -321,7 +322,6 @@ document.addEventListener('DOMContentLoaded', () => {
         action: Action.Destroy,
         model: Model.Notification,
       };
-      const AjaxC = new Ajax();
       AjaxC.send(payload).then(() => {
         document.querySelectorAll('.notification').forEach(el => el.remove());
       });

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -58,7 +58,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const AjaxC = new Ajax();
 
-
   // set the language for js translated strings
   i18next.changeLanguage(document.getElementById('user-prefs').dataset.lang);
 
@@ -314,7 +313,7 @@ document.addEventListener('DOMContentLoaded', () => {
           window.location.href = el.dataset.href;
         }
       }
-      
+
     // DESTROY (clear all) NOTIF
     } else if (el.matches('[data-action="destroy-notif"]')) {
       const payload: Payload = {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -300,14 +300,20 @@ document.addEventListener('DOMContentLoaded', () => {
         id: parseInt(el.dataset.id, 10),
       };
       const AjaxC = new Ajax();
-      AjaxC.send(payload).then(() => {
+      if (el.parentElement.dataset.ack === '0') {
+        AjaxC.send(payload).then(() => {
+          if (el.dataset.href) {
+            window.location.href = el.dataset.href;
+          } else {
+            reloadElement('navbarNotifDiv');
+          }
+        });
+      } else {
         if (el.dataset.href) {
           window.location.href = el.dataset.href;
-        } else {
-          reloadElement('navbarNotifDiv');
         }
-      });
-
+      }
+      
     // DESTROY (clear all) NOTIF
     } else if (el.matches('[data-action="destroy-notif"]')) {
       const payload: Payload = {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -303,6 +303,8 @@ document.addEventListener('DOMContentLoaded', () => {
       AjaxC.send(payload).then(() => {
         if (el.dataset.href) {
           window.location.href = el.dataset.href;
+        } else {
+          reloadElement('navbarNotifDiv');
         }
       });
 


### PR DESCRIPTION
* Instantiate Ajax object only once
* Don't repeatedly send ajax request if notification is already acknowledged
* Reload navbarNotifDiv of current page if no data-href attribute is set (before the notification without href would stay highlited until the next page reload)

This adds some ugly else's. Maybe you have a better solution?