### PR TITLE
Search attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mathjax-full": "^3.2.0",
     "mini-css-extract-plugin": "^2.1.0",
     "peggy": "1.0.0",
-    "phpeggy": "1.0.0",
+    "phpeggy": "^1.0.0",
     "popper.js": "1.16.*",
     "prismjs": "^1.25.0",
     "sass": "^1.23.7",

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -86,7 +86,7 @@ abstract class AbstractEntity implements CrudInterface
     private string $extendedFilter = '';
 
     // inserted in sql
-    private array $bindExtendedValues = array();
+    private array $extendedValues = array();
 
     // start metadata stuff
     private bool $isMetadataSearch = false;
@@ -646,10 +646,10 @@ abstract class AbstractEntity implements CrudInterface
         return array_column($req->fetchAll(), 'id');
     }
 
-    public function addToExtendedFilter(string $extendedFilter, array $bindExtendedValues = array()): void
+    public function addToExtendedFilter(string $extendedFilter, array $extendedValues = array()): void
     {
         $this->extendedFilter .= $extendedFilter . ' ';
-        $this->bindExtendedValues = array_merge($this->bindExtendedValues, $bindExtendedValues);
+        $this->extendedValues = array_merge($this->extendedValues, $extendedValues);
     }
 
     public function destroy(): bool
@@ -751,12 +751,19 @@ abstract class AbstractEntity implements CrudInterface
             $tagsSelect = ", GROUP_CONCAT(DISTINCT tags.tag ORDER BY tags.id SEPARATOR '|') as tags, GROUP_CONCAT(DISTINCT tags.id) as tags_id";
             $tagsJoin = 'LEFT JOIN tags2entity ON (entity.id = tags2entity.item_id AND tags2entity.item_type = \'%1$s\') LEFT JOIN tags ON (tags2entity.tag_id = tags.id)';
         }
+
+        // only include columns if actually searching for comments/filenames
+        $searchAttachments = '';
+        if (!empty(array_column($this->extendedValues, 'searchAttachments'))) {
+            $searchAttachments = ',
+                GROUP_CONCAT(uploads.comment) AS comments,
+                GROUP_CONCAT(uploads.real_name) AS real_names';
+        }
+
         $uploadsJoin = 'LEFT JOIN (
             SELECT uploads.item_id AS up_item_id,
                 (uploads.item_id IS NOT NULL) AS has_attachment,
-                uploads.type,
-                GROUP_CONCAT(DISTINCT uploads.comment SEPARATOR '|') AS comments,
-                GROUP_CONCAT(DISTINCT uploads.real_name SEPARATOR '|') AS real_names
+                uploads.type' . $searchAttachments . '
             FROM uploads
             GROUP BY uploads.item_id, uploads.type)
             AS uploads
@@ -828,7 +835,7 @@ abstract class AbstractEntity implements CrudInterface
 
     private function bindExtendedValues(PDOStatement $req): void
     {
-        foreach ($this->bindExtendedValues as $bindValue) {
+        foreach ($this->extendedValues as $bindValue) {
             $req->bindValue($bindValue['param'], $bindValue['value'], $bindValue['type']);
         }
     }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -754,7 +754,9 @@ abstract class AbstractEntity implements CrudInterface
         $uploadsJoin = 'LEFT JOIN (
             SELECT uploads.item_id AS up_item_id,
                 (uploads.item_id IS NOT NULL) AS has_attachment,
-                uploads.type
+                uploads.type,
+                GROUP_CONCAT(DISTINCT uploads.comment SEPARATOR '|') AS comments,
+                GROUP_CONCAT(DISTINCT uploads.real_name SEPARATOR '|') AS real_names
             FROM uploads
             GROUP BY uploads.item_id, uploads.type)
             AS uploads

--- a/src/node/grammar/generateParser.js
+++ b/src/node/grammar/generateParser.js
@@ -20,7 +20,7 @@ fs.readFile('./src/node/grammar/queryGrammar.pegjs', 'utf8', (err, data) => {
 
   fs.mkdir(
     './cache/advancedSearchQuery',
-    { recursive: true, mode: 0777 },
+    {recursive: true, mode: 0700},
     err => {
       if (err) {
         throw err;
@@ -36,6 +36,7 @@ fs.readFile('./src/node/grammar/queryGrammar.pegjs', 'utf8', (err, data) => {
             parserClassName: 'Parser',
           },
         }),
+        {mode: 0600},
         err => {
           if (err) {
             throw err;

--- a/src/node/grammar/generateParser.js
+++ b/src/node/grammar/generateParser.js
@@ -20,7 +20,7 @@ fs.readFile('./src/node/grammar/queryGrammar.pegjs', 'utf8', (err, data) => {
 
   fs.mkdir(
     './cache/advancedSearchQuery',
-    {recursive: true, mode: 0700},
+    {recursive: true, mode: 0755},
     err => {
       if (err) {
         throw err;
@@ -36,7 +36,7 @@ fs.readFile('./src/node/grammar/queryGrammar.pegjs', 'utf8', (err, data) => {
             parserClassName: 'Parser',
           },
         }),
-        {mode: 0600},
+        {mode: 0644},
         err => {
           if (err) {
             throw err;

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -163,15 +163,15 @@ FieldAttachment
   = 'attachment'i ':' term:(
     bool:Boolean
       {
-        return new SimpleValueWrapper($bool)
+        return new SimpleValueWrapper($bool);
       }
     / terms:(List / Literal)
       {
-        return $terms
+        return $terms;
       }
   )
   {
-    return new Field('attachment', $term));
+    return new Field('attachment', $term);
   }
 
 List 'quoted term'

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -71,6 +71,7 @@ Fields
   / FieldDate
   / FieldBoolean
   / FieldRating
+  / FieldAttachment
 
 Field
   = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' term:(List / Literal)
@@ -135,7 +136,7 @@ DD
   }
 
 FieldBoolean
-  = field:('locked'i / 'timestamped'i / 'attachment'i) ':' term:Boolean
+  = field:('locked'i / 'timestamped'i) ':' term:Boolean
   {
     return new Field($field, new SimpleValueWrapper($term));
   }
@@ -146,7 +147,7 @@ Boolean
   {
     return '0';
   }
-  / ('1' / 'true' / 'yes' / 'on' / '')
+  / ('1' / 'true' / 'yes' / 'on')
   {
     return '1';
   }
@@ -156,6 +157,21 @@ FieldRating
   = 'rating'i ':' term:($([0-5]) / 'unrated'i { return '0';})
   {
     return new Field('rating', new SimpleValueWrapper($term));
+  }
+
+FieldAttachment
+  = 'attachment'i ':' term:(
+    bool:Boolean
+      {
+        return new SimpleValueWrapper($bool)
+      }
+    / terms:(List / Literal)
+      {
+        return $terms
+      }
+  )
+  {
+    return new Field('attachment', $term));
   }
 
 List 'quoted term'

--- a/src/services/Filter.php
+++ b/src/services/Filter.php
@@ -127,11 +127,13 @@ class Filter
         // create base config for html5
         $config = HTMLPurifier_HTML5Config::createDefault();
         // allow only certain elements
-        $config->set('HTML.Allowed', 'div[class],br,p[class|style],sub,img[src|class],sup,strong,b,em,u,a[href],s,span[style],ul,li,ol,dl,dt,dd,blockquote,h1,h2,h3,h4,h5,h6,hr,table[style],tr[style],td[style],th[style],code,video,audio,pre[class],details,summary,figure,figcaption');
+        $config->set('HTML.Allowed', 'div[class],br,p[class|style],sub,img[src|class|style],sup,strong,b,em,u,a[href],s,span[style],ul,li,ol,dl,dt,dd,blockquote,h1,h2,h3,h4,h5,h6,hr,table[style],tr[style],td[style],th[style],code,video,audio,pre[class],details,summary,figure,figcaption');
         $config->set('HTML.TargetBlank', true);
         // configure the cache for htmlpurifier
         $tmpDir = FsTools::getCacheFolder('purifier');
         $config->set('Cache.SerializerPath', $tmpDir);
+        // allow "display" css attribute
+        $config->set('CSS.AllowTricky', true);
 
         $purifier = new HTMLPurifier($config);
         return $purifier->purify($input);

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -216,11 +216,12 @@ class QueryBuilderVisitor implements Visitor
         $param = $this->getUniqueID();
 
         return new WhereCollector(
-            '(uploads.comments LIKE ' . $param . ' OR uploads.real_names LIKE ' . $param ')',
+            '(uploads.comments LIKE ' . $param . ' OR uploads.real_names LIKE ' . $param . ')',
             array(array(
                 'param' => $param,
                 'value' => '%' . $searchTerm . '%',
                 'type' => PDO::PARAM_STR,
+                'searchAttachments' => true,
            )),
         );
     }

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -222,7 +222,7 @@ class QueryBuilderVisitor implements Visitor
                 'value' => '%' . $searchTerm . '%',
                 'type' => PDO::PARAM_STR,
                 'searchAttachments' => true,
-           )),
+            )),
         );
     }
 

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -37,11 +37,14 @@ class QueryBuilderVisitor implements Visitor
     public function visitSimpleValueWrapper(SimpleValueWrapper $simpleValueWrapper, VisitorParameters $parameters): WhereCollector
     {
         $param = $this->getUniqueID();
-        $query = '(entity.body' . ' LIKE ' . $param . ' OR ' . 'entity.title' . ' LIKE ' . $param . ')';
 
         return new WhereCollector(
-            $query,
-            array(array('param' => $param, 'value' => '%' . $simpleValueWrapper->getValue() . '%', 'type' => PDO::PARAM_STR)),
+            '(entity.body LIKE ' . $param . ' OR entity.title LIKE ' . $param . ')',
+            array(array(
+                'param' => $param,
+                'value' => '%' . $simpleValueWrapper->getValue() . '%',
+                'type' => PDO::PARAM_STR,
+            )),
         );
     }
 
@@ -56,13 +59,25 @@ class QueryBuilderVisitor implements Visitor
         if ($dateType === 'simple') {
             $param = $this->getUniqueID();
             $query = $column . $dateField->getOperator() . $param;
-            $bindValues[] = array('param' => $param, 'value' => $dateField->getValue(), 'type' => PDO::PARAM_INT);
+            $bindValues[] = array(
+                'param' => $param,
+                'value' => $dateField->getValue(),
+                'type' => PDO::PARAM_INT,
+            );
         } elseif ($dateType === 'range') {
             $paramMin = $this->getUniqueID();
             $paramMax = $this->getUniqueID();
             $query = $column . ' BETWEEN ' . $paramMin . ' AND ' . $paramMax;
-            $bindValues[] = array('param' => $paramMin, 'value' => $dateField->getValue(), 'type' => PDO::PARAM_INT);
-            $bindValues[] = array('param' => $paramMax, 'value' => $dateField->getDateTo(), 'type' => PDO::PARAM_INT);
+            $bindValues[] = array(
+                'param' => $paramMin,
+                'value' => $dateField->getValue(),
+                'type' => PDO::PARAM_INT,
+            );
+            $bindValues[] = array(
+                'param' => $paramMax,
+                'value' => $dateField->getDateTo(),
+                'type' => PDO::PARAM_INT,
+            );
         }
         return new WhereCollector($query, $bindValues);
     }

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -203,10 +203,25 @@ class QueryBuilderVisitor implements Visitor
 
     private function visitFieldAttachment(string $searchTerm, VisitorParameters $parameters): WhereCollector
     {
-        return $this->getWhereCollector(
-            'IFNULL(uploads.has_attachment, 0) = ',
-            $searchTerm,
-            PDO::PARAM_INT,
+        // Are we checking if there is any attachment at all
+        if ($searchTerm === '0' || $searchTerm === '1') {
+            return $this->getWhereCollector(
+                'IFNULL(uploads.has_attachment, 0) = ',
+                $searchTerm,
+                PDO::PARAM_INT,
+            );
+        }
+
+        // Or are we searching in comments or real_names
+        $param = $this->getUniqueID();
+
+        return new WhereCollector(
+            '(uploads.comments LIKE ' . $param . ' OR uploads.real_names LIKE ' . $param ')',
+            array(array(
+                'param' => $param,
+                'value' => '%' . $searchTerm . '%',
+                'type' => PDO::PARAM_STR,
+           )),
         );
     }
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -12,7 +12,8 @@
       </div>
       <div class='modal-body' data-wait='{{ 'Please wait…' }}'>
         <h3>Search terms</h3>
-        <p>The search is performed against the title and the body.</p>
+        <p>The search is performed against the title and the body.<br>
+            The entire team will be searched unless there is an author fields.</p>
         <dl>
           <dt>Term</dt>
           <dd>A sequence of characters without space (<code>&blank;</code>).<br>
@@ -38,7 +39,10 @@
         <p>Basic syntax <code>[<strong>field</strong>]:[value]</code></p>
         <dl>
           <dt>attachment</dt>
-          <dd>yes or no, true or false, 1 or 0, on or off</dd>
+          <dd>yes or no, true or false, 1 or 0, on or off:<br>
+              search entries with/out attachments<br>
+              Term or Quoted term:<br>
+              search in filenames and comments of attachments</dd>
           <dt>author</dt>
           <dd>
             Term or Quoted term<br>
@@ -65,7 +69,8 @@
           <dt>title</dt>
           <dd>Term or Quoted term</dd>
           <dt>visibility</dt>
-          <dd>Term or Quoted term<br>A group name (e.g., 'Lab Heroes') or 'public', 'organization', 'team', 'user', or 'useronly'.</dd>
+          <dd>Term or Quoted term<br>
+              A group name (e.g., 'Lab Heroes') or 'public', 'organization', 'team', 'user', or 'useronly'.</dd>
         </dl>
         <h3 id='dateFormats'>Date formats</h3>
         <p>A date has to be provided in the following format: <code>YYYYMMDD</code>,
@@ -152,7 +157,7 @@
       <div class='col-md-4 mb-2'>
         <p>Allowed Fields (<code><strong>field</strong>:value</code>):</p>
         <ul class='list-unstyled'>
-          <li><strong>attachment</strong>: yes or no</li>
+          <li><strong>attachment</strong>: yes, no, Simple or Quoted term</li>
           <li><strong>author</strong>: Simple or Quoted term</li>
           <li><strong>body</strong>: Simple or Quoted term</li>
           <li><strong>category</strong>: Simple or Quoted term</li>

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -54,6 +54,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $query .= ' timestamped: timestamped:true title:"very cool experiment" visibility:me';
         $query .= ' date:>2020.06,21 date:2020/06-21..20201231';
         $query .= ' group:"Group Name"';
+        $query .= ' attachment:"hello world"';
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,10 +2870,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-phpeggy@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/phpeggy/-/phpeggy-1.0.0.tgz#585aa680b813c3d6b78ad1427e2162b5cfa590a2"
-  integrity sha512-nFeM0sE6WfxZ5PlQvBoo0TWvwm3W819RDkv16Or02PQIfVlO0FVmFq56kH6F0aNifBxE5DQKHwhw5HBNA4xCtQ==
+phpeggy@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/phpeggy/-/phpeggy-1.0.1.tgz#c5914fe960a9880b27c9270678b93f5748640983"
+  integrity sha512-wMrxoPlCmKHCRdY4UriTzDE5hBdBaXxCIBuebLeMlk+LkAIBsZAF251i7EspetlZSqcKkT0eo93v+tzZ053glw==
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
See #1126.
This PR will allow users to search within filenames and the eLabFTW file comment via the attachment field.
I.e., `attachment:'this comment now'` or `attachment:'this_filename'` or all PNGs `attachment:'.png'`

<img src='https://user-images.githubusercontent.com/65481677/164152557-c3dc721b-b4d5-4965-915a-06e47391b5a4.png' width='300'>