### PR TITLE
Improve jsoneditor/doodle/moldrawer interface

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -6,7 +6,6 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
@@ -23,9 +22,9 @@ use function sha1;
  *
  * How to modify the structure:
  * 1. add a file in src/sql/ named 'schemaXX.sql' where XX is the current schema version + 1
- * 2. increment the REQUIRED_SCHEMA number
- * 4. Run `bin/console db:update`
- * 5. reflect the changes in src/sql/structure.sql (or models/Config.php for the config table)
+ * 2. increment the REQUIRED_SCHEMA number in this file
+ * 3. Run `bin/console db:update`
+ * 4. reflect the changes in src/sql/structure.sql (or models/Config.php for the config table)
  */
 class Update
 {

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -23,15 +23,14 @@ use function sha1;
  *
  * How to modify the structure:
  * 1. add a file in src/sql/ named 'schemaXX.sql' where XX is the current schema version + 1
- * 2. this file should use transactions (see other files for examples)
- * 3. increment the REQUIRED_SCHEMA number
+ * 2. increment the REQUIRED_SCHEMA number
  * 4. Run `bin/console db:update`
  * 5. reflect the changes in src/sql/structure.sql (or models/Config.php for the config table)
  */
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 87;
+    private const REQUIRED_SCHEMA = 88;
 
     private Db $Db;
 

--- a/src/maps/UserPreferences.php
+++ b/src/maps/UserPreferences.php
@@ -74,8 +74,6 @@ class UserPreferences implements MapInterface
 
     private int $chemEditor = 0;
 
-    private int $jsonEditor = 0;
-
     private string $lang = 'en_GB';
 
     private string $defaultRead = 'team';
@@ -104,7 +102,6 @@ class UserPreferences implements MapInterface
             show_team_templates = :new_show_team_templates,
             show_public = :new_show_public,
             chem_editor = :new_chem_editor,
-            json_editor = :new_json_editor,
             lang = :new_lang,
             default_read = :new_default_read,
             default_write = :new_default_write,
@@ -133,7 +130,6 @@ class UserPreferences implements MapInterface
         $req->bindParam(':new_show_team_templates', $this->showTeamTemplates);
         $req->bindParam(':new_show_public', $this->showPublic);
         $req->bindParam(':new_chem_editor', $this->chemEditor);
-        $req->bindParam(':new_json_editor', $this->jsonEditor);
         $req->bindParam(':new_lang', $this->lang);
         $req->bindParam(':new_default_read', $this->defaultRead);
         $req->bindParam(':new_default_write', $this->defaultWrite);
@@ -258,11 +254,6 @@ class UserPreferences implements MapInterface
         $this->chemEditor = Filter::toBinary($setting);
     }
 
-    final public function setJsonEditor(string $setting): void
-    {
-        $this->jsonEditor = Filter::toBinary($setting);
-    }
-
     final public function setLang(string $setting): void
     {
         if (array_key_exists($setting, Tools::getLangsArr())) {
@@ -312,7 +303,6 @@ class UserPreferences implements MapInterface
         $this->setIncFilesPdf($source['inc_files_pdf'] ?? '0');
         $this->setAppendPdfs($source['append_pdfs'] ?? '0');
         $this->setChemEditor($source['chem_editor'] ?? '0');
-        $this->setJsonEditor($source['json_editor'] ?? '0');
         $this->setDefaultRead($source['default_read'] ?? $this->defaultRead);
         $this->setDefaultWrite($source['default_write'] ?? $this->defaultWrite);
     }
@@ -345,7 +335,6 @@ class UserPreferences implements MapInterface
             inc_files_pdf,
             append_pdfs,
             chem_editor,
-            json_editor,
             default_read,
             default_write
             FROM users WHERE userid = :id';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -198,7 +198,7 @@ h2 {
 h3 {
     color: $maingray;
     font-size: 150%;
-    margin: 0 auto 10px;
+    margin: 0 auto;
 }
 
 h4 {
@@ -405,12 +405,6 @@ label {
 
 button:disabled {
     cursor: not-allowed;
-}
-
-/* make the +/- button rounder */
-/* stylelint-disable-next-line selector-class-pattern */
-.plusMinusButton {
-    font-size: 110%;
 }
 
 .separator {

--- a/src/sql/schema88.sql
+++ b/src/sql/schema88.sql
@@ -1,0 +1,4 @@
+-- Schema 88
+-- remove json_editor user config
+ALTER TABLE `users` DROP COLUMN `json_editor`;
+UPDATE config SET conf_value = 88 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -725,7 +725,6 @@ CREATE TABLE `users` (
   `use_isodate` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   `uploads_layout` tinyint(1) UNSIGNED NOT NULL DEFAULT '1',
   `chem_editor` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
-  `json_editor` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   `validated` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   `lang` varchar(5) NOT NULL DEFAULT 'en_GB',
   `default_read` varchar(255) NULL DEFAULT 'team',

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -211,15 +211,12 @@
 
 {% include 'uploads.html' %}
 
-{% if Entity.Users.userData.json_editor %}
-  {% include 'json-editor.html' %}
-{% endif %}
+{% include 'json-editor.html' %}
 
 <!-- DOODLE -->
 <section class='box' id='doodle-anchor'>
-  <i class='fas fa-fw fa-paint-brush mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'Draw something'|trans }}</h3>
-  <button class='button btn btn-primary plusMinusButton' data-toggle='collapse' data-target='#doodleDiv' aria-expanded='false' aria-controls='doodleDiv'>+</button>
-  <div id='doodleDiv' class='collapse mt-2'>
+  <h3 data-action='toggle-next' data-icon='doodleDivIcon' class='d-inline'><i id='doodleDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paint-brush'></i> {{ 'Draw something'|trans }}</h3>
+  <div id='doodleDiv' hidden class='mt-2' data-save-hidden='doodleDiv'>
     <div class='row'>
       <div>
         <canvas class='doodle' id='doodleCanvas' width='600' height='600'></canvas>
@@ -252,9 +249,8 @@
 <!-- CHEM EDITOR -->
 {% if Entity.Users.userData.chem_editor %}
   <div class='box chemdoodle'>
-    <i class='fas fa-fw fa-dna mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'Molecule drawer'|trans }}</h3>
-    <button class='button btn btn-primary plusMinusButton' data-toggle='collapse' data-target='#chemDiv' aria-expanded='false' aria-controls='chemDiv'>+</button>
-    <div id='chemDiv' class='collapse mt-2 text-center'>
+    <h3 data-action='toggle-next' data-icon='chemDivIcon' class='d-inline'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
+    <div id='chemDiv' hidden data-save-hidden='chemDiv' class='mt-2 text-center'>
       <script src='assets/chemdoodle-canvas.bundle.js?v={{ v }}'></script>
     </div>
   </div>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -1,11 +1,10 @@
 <!-- JSON EDITOR -->
 <!-- json metadata is preloaded for templates -->
 <section class='box' id='json-editor'>
-  <i class='fas fa-fw fa-list mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'JSON Editor'|trans }}</h3>
-  <button class='button btn btn-primary plusMinusButton jsonEditorPlusMinusButton' data-toggle='collapse' data-target='#jsonEditorDiv' aria-expanded='false' aria-controls='jsonEditorDiv'>+</button>
-  <div id='jsonEditorDiv' class='collapse mt-2'>
+  <h3 data-action='toggle-next' data-icon='jsonEditorIcon' class='d-inline'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
+  <div id='jsonEditorDiv' class='mt-2' hidden data-save-hidden='jsonEditorDiv'>
     {% if mode == 'edit' %}
-      <button type='button' data-action='json-load-metadata' class='btn btn-neutral mb-2'>{{ 'Load metadata'|trans }}</button>
+    <button type='button' id='jsonEditorMetadataLoadButton' data-action='json-load-metadata' class='btn btn-neutral mb-2'>{{ 'Load metadata'|trans }}</button> <span data-action='toggle-next'><i class='fas fa-fw fa-info-circle'></i></span><span hidden><a target='_blank' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>
     {% endif %}
     <h6 id='jsonEditorTitle'></h6>
     <div id='jsonEditorContainer' {{ mode == 'edit-template' ? 'data-preload-json="1"' : '' }}></div>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -211,11 +211,6 @@
         />
         <label for='chem_editor'>{{ 'Display the molecule editor in edit mode'|trans }}</label>
         <br>
-        <input id='json_editor' type='checkbox' name='json_editor'
-          {{ App.Users.userData.json_editor == '1' ? " checked='checked'" }}
-        />
-        <label for='json_editor'>{{ 'Display the JSON editor in edit mode'|trans }}</label>
-        <br>
         <input id='use_markdown' type='checkbox' name='use_markdown'
           {{ App.Users.userData.use_markdown == '1' ? " checked='checked'" }}
         />

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -2,7 +2,7 @@
 <div id='filesdiv'>
   {% if uploadsArr %}
     <div class='box'>
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='uploadedFilesIcon'><i id='uploadedFilesIcon' class='fas fa-chevron-circle-down'></i> {% trans %}Attached file
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='uploadedFilesIcon'><i id='uploadedFilesIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {% trans %}Attached file
             {% plural uploadsArr|length %}
             Attached files
             {% endtrans %}

--- a/src/ts/JsonEditorHelper.class.ts
+++ b/src/ts/JsonEditorHelper.class.ts
@@ -56,17 +56,15 @@ export default class JsonEditorHelper {
   }
 
   focus(): void {
-    // show the editor (use jQuery selector here for collapse())
-    ($('#jsonEditorDiv') as JQuery<HTMLDivElement>).collapse('show');
-    // toggle the +/- button
-    const plusMinusButton = document.querySelector('.jsonEditorPlusMinusButton') as HTMLButtonElement;
-    if (plusMinusButton.innerText === '+') {
-      plusMinusButton.innerText = '-';
-      plusMinusButton.classList.add('btn-neutral');
-      plusMinusButton.classList.remove('btn-primary');
-    }
+    // toggle the arrow icon
+    const iconEl = document.getElementById('jsonEditorIcon');
+    iconEl.classList.add('fa-chevron-circle-down');
+    iconEl.classList.remove('fa-chevron-circle-right');
+    const jsonEditorDiv = document.getElementById('jsonEditorDiv');
+    // make sure it's not hidden
+    jsonEditorDiv.toggleAttribute('hidden', false);
     // and scroll page into editor view
-    document.getElementById('jsonEditorContainer').scrollIntoView();
+    jsonEditorDiv.scrollIntoView();
   }
 
   loadFile(link: string, name: string, uploadid: string): void {
@@ -101,6 +99,8 @@ export default class JsonEditorHelper {
     this.editorTitle.innerText = i18next.t('editing-metadata');
     this.MetadataC.read().then(metadata => this.editor.set(metadata));
     this.editorDiv.dataset.what = 'metadata';
+    // disable the button
+    document.getElementById('jsonEditorMetadataLoadButton').toggleAttribute('disabled', true);
   }
 
   loadMetadataFromId(entity: Entity): void {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -63,25 +63,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   makeSortableGreatAgain();
 
-  // SHOW/HIDE THE DOODLE CANVAS/CHEM EDITOR/JSON EDITOR
-  const plusMinusButton = document.getElementsByClassName('plusMinusButton');
-  if (plusMinusButton) {
-    Array.from(plusMinusButton).forEach(element => {
-      element.addEventListener('click', (event) => {
-        const el = (event.target as HTMLElement);
-        if (el.innerText === '+') {
-          el.classList.add('btn-neutral');
-          el.classList.remove('btn-primary');
-          el.innerText = '-';
-        } else {
-          el.classList.add('btn-primary');
-          el.classList.remove('btn-neutral');
-          el.innerText = '+';
-        }
-      });
-    });
-  }
-
   // BACK TO TOP BUTTON
   const btn = document.createElement('div');
   btn.dataset.action = 'scroll-top';

--- a/src/ts/fontawesome.ts
+++ b/src/ts/fontawesome.ts
@@ -15,6 +15,7 @@ import { library, dom } from '@fortawesome/fontawesome-svg-core';
 // SOLID
 import {
   faArrowUp,
+  faArrowUpRightFromSquare,
   faArrowsDownToLine,
   faBold,
   faBug,
@@ -96,6 +97,7 @@ import {
 
 library.add(
   faArrowUp,
+  faArrowUpRightFromSquare,
   faArrowsDownToLine,
   faBold,
   faBug,

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -99,7 +99,6 @@ class UsersTest extends \PHPUnit\Framework\TestCase
             'sc_todo' => 't',
             'show_team' => 'on',
             'chem_editor' => 'on',
-            'json_editor' => 'on',
             'lang' => 'en_GB',
             'pdf_format' => 'A4',
             'default_vis' => 'organization',


### PR DESCRIPTION
* get rid of the plus/minus ugly button and use the chevrons instead
* homogeneize the interface in edit mode for bottom of page
* remove json editor user setting: this hides a feature for no good reason. Another option would have been to make it ON by default, but removing this user option is the best approach I think. Also, now the sections take less vertical space.
* make the "Load metadata" button disabled on click
* add a link to the documentation for metadata
* remove a margin-bottom 10px for h3: better to use mb-X when needed, this showed up for attached files section

Before:
![before](https://user-images.githubusercontent.com/3043706/165172956-cbccd5aa-435a-47e7-926e-21525339ef6f.jpg)

After:
![after](https://user-images.githubusercontent.com/3043706/165172986-39de6fb7-1b78-4e39-ae87-d2e036d406a3.jpg)

