### PR TITLE
Improve search syntax

### DIFF
--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -74,9 +74,9 @@ Fields
   / FieldAttachment
 
 Field
-  = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' term:(List / Literal)
+  = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' strict:('s:' {return true;})? term:(List / Literal)
   {
-    return new Field($field, $term);
+    return new Field($field, $term, $strict);
   }
 
 FieldDate
@@ -160,7 +160,7 @@ FieldRating
   }
 
 FieldAttachment
-  = 'attachment'i ':' term:(
+  = 'attachment'i ':' strict:('s:' {return true;})? term:(
     bool:Boolean
       {
         return new SimpleValueWrapper($bool);
@@ -171,7 +171,7 @@ FieldAttachment
       }
   )
   {
-    return new Field('attachment', $term);
+    return new Field('attachment', $term, $strict);
   }
 
 List 'quoted term'

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -8,51 +8,47 @@
  */
 
 OrExpression
-  = _* expression:AndExpression tail:(_+ tail:Or {return $tail;})?
+  = _* expression:AndExpression tail:OrOperand?
   {
     return new OrExpression($expression, $tail);
   }
 
-Or
-  = OrOp operand:AndExpression tail:(_+ tail:Or {return $tail;})?
+OrOperand
+  = OrOperator operand:AndExpression tail:OrOperand?
   {
     return new OrOperand($operand, $tail);
   }
 
-OrOp '"OR", "|"'
-  = $('OR'i_+)
-  / $('|'_*)
+OrOperator '"OR", "|"'
+  = (_+ 'OR'i _+)
+  / (_* '|' _*)
 
 AndExpression
-  = expression:Not tail:(_+ tail:And {return $tail;})?
+  = expression:(NotExpression / Wrapper) tail:AndOperand?
   {
     return new AndExpression($expression, $tail);
   }
 
-And
-  = AndOp? operand:Not tail:(_+ tail:And {return $tail;})?
+AndOperand
+  = AndOperator operand:(NotExpression / Wrapper) tail:AndOperand?
   {
     return new AndOperand($operand, $tail);
   }
 
-AndOp '"AND", "&"'
-  = $('AND'i_+)
-  / $('&'_*)
+AndOperator '"AND", "&"'
+  = (_+ 'AND'i _+)
+  / (_* '&' _*)
+  / _+
 
-Not
-  = NotOp expression:Wrapper
+NotExpression
+  = NotOperator expression:Wrapper
   {
     return new NotExpression($expression);
   }
-  / e:Wrapper
-  {
-    return $e;
-  }
 
-NotOp '"NOT", "-", "!"'
-  = $('NOT'i_+)
-  / $('-'_*)
-  / $('!'_*)
+NotOperator '"NOT", "-", "!"'
+  = ('NOT'i _+)
+  / ([!-] _*)
 
 Wrapper
   = Parenthesis
@@ -74,7 +70,7 @@ Fields
   / FieldAttachment
 
 Field
-  = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' strict:('s:' {return true;})? term:(List / Literal)
+  = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' strict:('s:' {return true;})? term:(List / LiteralInField)
   {
     return new Field($field, $term, $strict);
   }
@@ -96,7 +92,7 @@ DateBetween
   }
 
 DateSimple
-  = operator:$('<=' / '<' / '>=' / '>' / '=' / '!=')? date:Date
+  = operator:$([<>] '='? / '!'? '=' )? date:Date
   {
     return array(
       'type' => 'simple',
@@ -112,10 +108,7 @@ Date
   }
 
 DateSeparator
-  = '-'
-  / '/'
-  / '.'
-  / ','
+  = [.,/-]
 
 YYYY
   = year:$(Digit Digit Digit Digit)
@@ -143,11 +136,11 @@ FieldBoolean
 
 // return strings because SimpleValueWrapper() takes strings
 Boolean
-  = ('0' / 'false' / 'no' / 'off')
+  = ('0' / 'false'i / 'no'i / 'off'i)
   {
     return '0';
   }
-  / ('1' / 'true' / 'yes' / 'on')
+  / ('1' / 'true'i / 'yes'i / 'on'i)
   {
     return '1';
   }
@@ -165,7 +158,7 @@ FieldAttachment
       {
         return new SimpleValueWrapper($bool);
       }
-    / terms:(List / Literal)
+    / terms:(List / LiteralInField)
       {
         return $terms;
       }
@@ -189,7 +182,6 @@ List1
 ListString1
   = chars:(
     [^\n\r\f\\']
-    / nlEscaped
     / Escape
   )+
   {
@@ -205,24 +197,34 @@ List2
 ListString2
   = chars:(
     [^\n\r\f\\"]
-    / nlEscaped
     / Escape
   )+
   {
     return join("", $chars);
   }
 
+LiteralInField 'term'
+  = literal:String
+  {
+    return new SimpleValueWrapper($literal);
+  }
+
 Literal 'term'
-  // Need to negate operators here to prevent them being a term themselves
-  = !OrOp !AndOp !NotOp literal:$(String)
+  = literal:String
+  // Prevent operators being a term themselves
+  !{
+    $l = strtolower($literal);
+    return $l === 'not'
+      || $l === 'and'
+      || $l === 'or';
+  }
   {
     return new SimpleValueWrapper($literal);
   }
 
 String
   = chars:(
-    [^\n\r\f\\"\\'() ]
-    / nlEscaped
+    [^\n\r\f\\"'|&!() -]
     / Escape
   )+
   {
@@ -230,32 +232,14 @@ String
   }
 
 Escape
-  = Unicode
-  / '\\' ch:[^\r\n\f0-9a-f]i
-  {
-    return $ch;
-  }
-
-Unicode
-  = '\\u' digits:$(Hex Hex? Hex? Hex? Hex? Hex?)
-  {
-    return chr_unicode(intval($digits, 16));
-  }
-
-Hex
-  = [0-9a-f]i
+  = $('\\' [%_]) // Escape MySQL wildcard characters
+  / '\\' {return '\\\\';} // Search for literal slash by default
 
 Digit
   = [0-9]
 
 Digit19
   = [1-9]
-
-nlEscaped
-  =  '\\' $('\r\n' / '\r' / '\n' / '\f')
-  {
-    return "";
-  }
 
 _ 'whitespace'
   = [\t\n\r ]

--- a/src/services/advancedSearchQuery/grammar/Field.php
+++ b/src/services/advancedSearchQuery/grammar/Field.php
@@ -20,7 +20,7 @@ use function strtolower;
 
 class Field implements Term, Visitable, FieldType
 {
-    public function __construct(private string $field, private SimpleValueWrapper $valueWrapper)
+    public function __construct(private string $field, private SimpleValueWrapper $valueWrapper, private ?bool $strict = null)
     {
     }
 
@@ -37,5 +37,10 @@ class Field implements Term, Visitable, FieldType
     public function getFieldType(): string
     {
         return filter_var(strtolower($this->field), FILTER_SANITIZE_STRING) ?: '';
+    }
+
+    public function getAffix(): string
+    {
+        return $this->strict ? '' : '%';
     }
 }

--- a/src/services/advancedSearchQuery/grammar/SimpleValueWrapper.php
+++ b/src/services/advancedSearchQuery/grammar/SimpleValueWrapper.php
@@ -14,8 +14,6 @@ use Elabftw\Services\AdvancedSearchQuery\Interfaces\Term;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitable;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitor;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
-use function filter_var;
-use function trim;
 
 class SimpleValueWrapper implements Term, Visitable
 {
@@ -30,8 +28,6 @@ class SimpleValueWrapper implements Term, Visitable
 
     public function getValue(): string
     {
-        $value = filter_var(trim($this->value), FILTER_SANITIZE_STRING);
-        // Strict comparison to keep 0
-        return $value !== false ? $value : '';
+        return htmlspecialchars($this->value, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
     }
 }

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -54,7 +54,7 @@ class FieldValidatorVisitor implements Visitor
         // Call class methods dynamically to avoid many if statements.
         // This works here because the parser defines the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType());
-        return $this->$method($field->getValue(), $parameters);
+        return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }
 
     public function visitNotExpression(NotExpression $notExpression, VisitorParameters $parameters): InvalidFieldCollector
@@ -116,22 +116,22 @@ class FieldValidatorVisitor implements Visitor
         ));
     }
 
-    private function visitFieldAttachment(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldAttachment(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldAuthor(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldAuthor(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldBody(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldBody(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldCategory(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldCategory(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         if ($parameters->getEntityType() !== 'items') {
             return new InvalidFieldCollector(array('category: is only allowed when searching in database.'));
@@ -139,12 +139,12 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldElabid(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldElabid(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldGroup(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldGroup(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         $teamGroups = $parameters->getTeamGroups();
         $groupNames = array_column($teamGroups, 'name');
@@ -159,17 +159,17 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldLocked(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldLocked(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldRating(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldRating(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldStatus(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldStatus(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         if ($parameters->getEntityType() !== 'experiments') {
             return new InvalidFieldCollector(array('status: is only allowed when searching in experiments.'));
@@ -177,7 +177,7 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldTimestamped(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldTimestamped(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         if ($parameters->getEntityType() !== 'experiments') {
             return new InvalidFieldCollector(array('timestamped: is only allowed when searching in experiments.'));
@@ -185,14 +185,14 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldTitle(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldTitle(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldVisibility(string $searchTerm, VisitorParameters $parameters): InvalidFieldCollector
+    private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
-        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm, $parameters->getVisArr());
+        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm, $parameters->getVisArr(), $affix);
         if (!$visibilityFieldHelper->getArr()) {
             $message = sprintf(
                 'visibility:%s. Valid values are %s.',

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -102,7 +102,7 @@ class QueryBuilderVisitor implements Visitor
         // Call class methods dynamically to avoid many if statements.
         // This works here because the parser defines the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType());
-        return $this->$method($field->getValue(), $parameters);
+        return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }
 
     public function visitNotExpression(NotExpression $notExpression, VisitorParameters $parameters): WhereCollector
@@ -201,7 +201,7 @@ class QueryBuilderVisitor implements Visitor
         );
     }
 
-    private function visitFieldAttachment(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldAttachment(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         // Are we checking if there is any attachment at all
         if ($searchTerm === '0' || $searchTerm === '1') {
@@ -219,50 +219,50 @@ class QueryBuilderVisitor implements Visitor
             '(uploads.comments LIKE ' . $param . ' OR uploads.real_names LIKE ' . $param . ')',
             array(array(
                 'param' => $param,
-                'value' => '%' . $searchTerm . '%',
+                'value' => $affix . $searchTerm . $affix,
                 'type' => PDO::PARAM_STR,
                 'searchAttachments' => true,
             )),
         );
     }
 
-    private function visitFieldAuthor(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldAuthor(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             "CONCAT(users.firstname, ' ', users.lastname) LIKE ",
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldBody(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldBody(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.body LIKE ',
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldCategory(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldCategory(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'categoryt.name LIKE ',
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldElabid(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldElabid(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.elabid LIKE ',
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldGroup(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldGroup(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         $teamGroups = $parameters->getTeamGroups();
         $users = array();
@@ -286,7 +286,7 @@ class QueryBuilderVisitor implements Visitor
         return new WhereCollector('(' . implode(' OR ', $queryParts) . ')', $bindValues);
     }
 
-    private function visitFieldLocked(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldLocked(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.locked = ',
@@ -295,7 +295,7 @@ class QueryBuilderVisitor implements Visitor
         );
     }
 
-    private function visitFieldRating(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldRating(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.rating = ',
@@ -304,16 +304,16 @@ class QueryBuilderVisitor implements Visitor
         );
     }
 
-    private function visitFieldStatus(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldStatus(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'categoryt.name LIKE ',
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldTimestamped(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldTimestamped(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.timestamped = ',
@@ -322,18 +322,18 @@ class QueryBuilderVisitor implements Visitor
         );
     }
 
-    private function visitFieldTitle(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldTitle(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
         return $this->getWhereCollector(
             'entity.title LIKE ',
-            '%' . $searchTerm . '%',
+            $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
         );
     }
 
-    private function visitFieldVisibility(string $searchTerm, VisitorParameters $parameters): WhereCollector
+    private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
-        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm, $parameters->getVisArr()))->getArr();
+        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm, $parameters->getVisArr(), $affix))->getArr();
 
         $queryParts = array();
         $bindValues = array();

--- a/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
+++ b/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
@@ -14,7 +14,7 @@ class VisibilityFieldHelper
 {
     public string $possibleInput;
 
-    public function __construct(private string $userInput, private array $visArr)
+    public function __construct(private string $userInput, private array $visArr, private string $affix)
     {
     }
 
@@ -28,7 +28,9 @@ class VisibilityFieldHelper
         $this->possibleInput = "'" . implode("', '", array_keys($searchArr)) . "'";
 
         // Emulate SQL LIKE search functionality so the user can use the same placeholders
-        $pattern = '/' . str_replace(array('%', '_'), array('.*', '.'), $this->userInput) . '/i';
+        $prefix = $this->affix === '%' ? '' : '^';
+        $suffix = $this->affix === '%' ? '' : '$';
+        $pattern = '/' . $prefix . str_replace(array('%', '_'), array('.*', '.'), $this->userInput) . $suffix . '/i';
         // Filter visibility entries based on user input
         $filteredArr = preg_grep($pattern, array_keys($searchArr)) ?: array();
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -36,7 +36,8 @@
         <p>The operators are listed in increasing order of precedence. Note the space around the operators. <em>termA termB OR termC</em> is equivalent to <em>(termA AND termB) OR termC</em>. To give priority to <code>OR</code> use parenthesis: <em>termA AND (termB OR termC)</em>.</p>
         <h3>Field/value pair searches</h3>
         <p>Field/value pairs are also applicable in the quick search fields.</p>
-        <p>Basic syntax <code>[<strong>field</strong>]:[value]</code></p>
+        <p>Basic syntax <code><strong>field</strong>:value</code></p>
+        <p>By default wildcards are added to Terms and Quoted terms. The strict switch (<code>field:s:value</code>) disables the wildcards.</p>
         <dl>
           <dt>attachment</dt>
           <dd>yes or no, true or false, 1 or 0, on or off:<br>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -202,6 +202,10 @@
 
         <small class='form-text text-muted'>
           Press <kbd><kbd>ctrl</kbd> + <kbd>enter</kbd></kbd> or <kbd><kbd>⌘</kbd> + <kbd>enter</kbd></kbd> to submit search.
+          {% if App.Config.configArr.debug %}
+            <kbd data-action='toggle-next'>debug</kbd>
+            <pre hidden>{{ whereClause|raw }}</pre>
+          {% endif %}
         </small>
       </div>
       <div class='col-md-4 mb-2'>
@@ -223,9 +227,6 @@
         </ul>
         <a class='clickable' data-action='toggle-modal' data-target='advancedSearchModal'>{{ 'Full syntax'|trans }}</a>
       </div>
-      {% if App.Config.configArr.debug %}
-          <div><pre>{{ whereClause|raw }}</pre></div>
-      {% endif %}
     </div>
 
     <h4 data-action='toggle-next' data-icon='extendedSearchIcon'><i id='extendedSearchIcon' class='fas fa-chevron-circle-right'></i> {{ 'Search helpers'|trans }}</h4>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -16,7 +16,15 @@
             The entire team will be searched unless there is an author fields.</p>
         <dl>
           <dt>Term</dt>
-          <dd>A sequence of characters without space (<code>&blank;</code>).<br>
+          <dd>A sequence of characters without space (<code>&blank;</code>),
+              <code>|</code>,
+              <code>&amp;</code>,
+              <code>-</code>,
+              <code>!</code>,
+              <code>(</code>,
+              <code>)</code>,
+              <code>'</code> and
+              <code>"</code>.<br>
               <em>termA</em> or <em>termB</em> or <em>456</em>
           </dd>
           <dt>Quoted term</dt>
@@ -24,16 +32,57 @@
               <em>'Hello world'</em> or <em>"I love eLabFTW!"</em>
           </dd>
         </dl>
-        <p>Two wildcards are available. The percent sign (<code>%</code>) matches zero or more characters while the underscore (<code>_</code>) matches exactly one character. To search for literal <code>%</code> or <code>_</code> the characters need to be escaped with a backslash  <code>\%</code> or <code>\_</code>.</p>
+        <p>Two wildcards are available. The percent sign
+          (<code>%</code>)
+          matches zero or more characters while the underscore
+          (<code>_</code>)
+          matches exactly one character. To search for literal
+          <code>%</code> or <code>_</code>
+          the characters need to be escaped with a backslash
+          <code>\%</code> or <code>\_</code>.</p>
         <h3>Term concatenation and grouping</h3>
         <p>Terms can be connected in different ways:</p>
         <ul>
-          <li><code>OR</code> or <code>|</code>, <em>termA OR termB</em> or <em>termA | termB</em></li>
-          <li><code>AND</code>, <code>&amp;</code> or space (<code>&blank;</code>), <em>termA termB</em> or <em>termA AND termB</em> or <em>termA & termB</em></li>
-          <li><code>NOT</code>, <code>-</code> or <code>!</code>, <em>! termA</em> or <em>NOT termA</em></li>
-          <li>Parenthesis <code>()</code>, <em>(termA OR termB) AND ! termC</em></li>
+          <li>
+            <code>OR</code> or
+            <code>|</code>,
+            <em>termA OR termB</em> or
+            <em>termA|termB</em>
+          </li>
+          <li>
+            <code>AND</code>,
+            <code>&amp;</code> or
+            space (<code>&blank;</code>),
+            <em>termA AND termB</em> or
+            <em>termA&amp;termB</em> or
+            <em>termA&nbsp;termB</em>
+          </li>
+          <li>
+            <code>NOT</code>,
+            <code>-</code> or
+            <code>!</code>,
+            <em>NOT termA</em> or
+            <em>-termA</em> or
+            <em>!termA</em>
+          </li>
+          <li>Parenthesis <code>()</code>, <em>(termA OR termB) AND !termC</em></li>
         </ul>
-        <p>The operators are listed in increasing order of precedence. Note the space around the operators. <em>termA termB OR termC</em> is equivalent to <em>(termA AND termB) OR termC</em>. To give priority to <code>OR</code> use parenthesis: <em>termA AND (termB OR termC)</em>.</p>
+        <p>The operators are listed in increasing order of precedence. Note the whitespace around the operators.
+          <code>OR</code>, <code>AND</code> and <code>NOT</code>
+          require to be surrounded by whitespace while
+          <code>|</code>,
+          <code>&amp;</code>,
+          <code>-</code> and
+          <code>!</code>
+          don't.<br>
+          <em>termA termB OR termC</em>
+          is equivalent to
+          <em>(termA AND termB) OR termC</em>.
+          To give priority to
+          <code>OR</code>
+          use parenthesis:
+          <em>termA AND (termB OR termC)</em>.
+        </p>
         <h3>Field/value pair searches</h3>
         <p>Field/value pairs are also applicable in the quick search fields.</p>
         <p>Basic syntax <code><strong>field</strong>:value</code></p>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -173,6 +173,9 @@
         </ul>
         <a class='clickable' data-action='toggle-modal' data-target='advancedSearchModal'>{{ 'Full syntax'|trans }}</a>
       </div>
+      {% if App.Config.configArr.debug %}
+          <div><pre>{{ whereClause|raw }}</pre></div>
+      {% endif %}
     </div>
 
     <h4 data-action='toggle-next' data-icon='extendedSearchIcon'><i id='extendedSearchIcon' class='fas fa-chevron-circle-right'></i> {{ 'Search helpers'|trans }}</h4>

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -106,7 +106,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
     public function testFieldValidatorInvalidFields(): void
     {
-        $visInput = 'no-valid-input';
+        $visInput = 'noValidInput';
         $from = '20210101';
         $to = '20200101';
         $query = 'visibility:' . $visInput;

--- a/web/search.php
+++ b/web/search.php
@@ -87,6 +87,7 @@ $renderArr = array(
     'extended' => $extended,
     'extendedError' => $extendedError,
     'teamGroups' => array_column($teamGroupsArr, 'name'),
+    'whereClause' => print_r($whereClause ?? '', true), // only for dev
 );
 echo $App->render('search.html', $renderArr);
 


### PR DESCRIPTION
Hi Nico,
There are a few shortcomings with the search syntax that are improved with this PR:
* Add strict mode switch to the fields e.g., `title:s:'Many words'` will not find 'Many words in the title' but 'Many words'
* Whitespace handling around the operators
* Make MySQL wildcards actually work
* Prevent alphabetical operators to be a term
* Search for literal backslash by default if not MySQL wildcard
* Remove general and newline escaping
* Remove "unicode parsing" like `\uxxxx`
* Don't use `filter_var` but `htmlspecialchars`, this is in alignment with HTMLPurifier, avoid truncation after `<` and find encoded `<` and `>`.

Side note: I think it could be a problem that the body input does encoding of `<` and `>` (if not a html tag) but no other user input is handled like this. I.e., the title or comments. Also there is now some inconsistency between entries before the use of HTMLPurifier and after. This will impact the search function to some (hopefully minor) extent. How often do people search for these characters?