### PR TITLE
Fix search

### DIFF
--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -192,7 +192,7 @@ class FieldValidatorVisitor implements Visitor
 
     private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
-        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm, $parameters->getVisArr(), $affix);
+        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm, $parameters->getVisArr());
         if (!$visibilityFieldHelper->getArr()) {
             $message = sprintf(
                 'visibility:%s. Valid values are %s.',

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -333,7 +333,7 @@ class QueryBuilderVisitor implements Visitor
 
     private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
-        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm, $parameters->getVisArr(), $affix))->getArr();
+        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm, $parameters->getVisArr()))->getArr();
 
         $queryParts = array();
         $bindValues = array();

--- a/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
+++ b/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
@@ -14,7 +14,7 @@ class VisibilityFieldHelper
 {
     public string $possibleInput;
 
-    public function __construct(private string $userInput, private array $visArr, private string $affix)
+    public function __construct(private string $userInput, private array $visArr)
     {
     }
 
@@ -28,9 +28,7 @@ class VisibilityFieldHelper
         $this->possibleInput = "'" . implode("', '", array_keys($searchArr)) . "'";
 
         // Emulate SQL LIKE search functionality so the user can use the same placeholders
-        $prefix = $this->affix === '%' ? '' : '^';
-        $suffix = $this->affix === '%' ? '' : '$';
-        $pattern = '/' . $prefix . str_replace(array('%', '_'), array('.*', '.'), $this->userInput) . $suffix . '/i';
+        $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), $this->userInput) . '$/i';
         // Filter visibility entries based on user input
         $filteredArr = preg_grep($pattern, array_keys($searchArr)) ?: array();
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -394,7 +394,7 @@
       </div>
       <div class='row'>
         <div class='col'>
-          <small class="form-text text-muted">
+          <small class='form-text text-muted'>
             Tip: Add a field/value pair to the query at the cursor position by pressing <kbd>ctrl</kbd> or <kbd>⌘</kbd> while selecting.
           </small>
         </div>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -385,8 +385,8 @@
           <label for='visibility'>{{ 'And visibility is:'|trans }} </label><br>
           <select id='visibility' name='vis' data-filter='visibility' class='form-control filterHelper'>
             <option value='' data-action='clear'>{{ 'Select visibility'|trans }}</option>
-            {% for key, value in visibilityArr %}
-              <option value='{{ key }}' {{- Request.query.get('vis') == key ? ' selected' }}>{{ value|trans }}</option>
+            {% for value in visibilityArr %}
+              <option {{- Request.query.get('vis') == value ? ' selected' }}>{{ value|trans }}</option>
             {% endfor %}
           </select>
         </div>

--- a/src/ts/search.ts
+++ b/src/ts/search.ts
@@ -94,11 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         return date + '..' + dateTo;
       }
-      // filter on owner
-      if (element.getAttribute('name') === 'owner') {
-        return `${element.options[element.selectedIndex].value}`;
-      }
-      return `${element.options[element.selectedIndex].text}`;
+      return `${element.options[element.selectedIndex].value}`;
     }
     if (element instanceof HTMLInputElement) {
       if (element.id === 'date') {

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -51,7 +51,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $query .= ' attachment:0 author:"Phpunit TestUser" body:"some text goes here"';
         $query .= ' elabid:7bebdd3512dc6cbee0b1 locked:yes rating:5 rating:unrated';
         $query .= ' status:"only meaningful with experiments but no error"';
-        $query .= ' timestamped: timestamped:true title:"very cool experiment" visibility:me';
+        $query .= ' timestamped: timestamped:true title:"very cool experiment" visibility:%me';
         $query .= ' date:>2020.06,21 date:2020/06-21..20201231';
         $query .= ' group:"Group Name"';
         $query .= ' attachment:"hello world"';


### PR DESCRIPTION
Hi Nico,

It turned out that some search helpers didn't work well with languages other than English, i.e. translations of 'yes', 'no', 'unrated' are not recognized by the search grammar. Should be fixed with this PR.
Also, the visibility needs to be strict by default because otherwise there is an unspecific search: 'user' will also include 'useronly' (this would be OK) but "Only me" (useronly) will also include "Only me and admins" (user). Anyways, it is fixed.