### PR TITLE
make all status timestampable

### DIFF
--- a/src/classes/ParamsBuilder.php
+++ b/src/classes/ParamsBuilder.php
@@ -57,7 +57,6 @@ class ParamsBuilder
             return new StatusParams(
                 $this->content,
                 $this->extra['color'] ?? '000000',
-                (bool) ($this->extra['isTimestampable'] ?? false),
                 (bool) ($this->extra['isDefault'] ?? false),
             );
         }

--- a/src/classes/StatusParams.php
+++ b/src/classes/StatusParams.php
@@ -15,7 +15,7 @@ use Elabftw\Services\Check;
 
 final class StatusParams extends ContentParams implements StatusParamsInterface
 {
-    public function __construct(string $content, private string $color, private bool $isTimestampable = false, private bool $isDefault = false)
+    public function __construct(string $content, private string $color, private bool $isDefault = false)
     {
         parent::__construct($content);
         $this->content = $content;
@@ -24,11 +24,6 @@ final class StatusParams extends ContentParams implements StatusParamsInterface
     public function getColor(): string
     {
         return Check::color($this->color);
-    }
-
-    public function getIsTimestampable(): int
-    {
-        return (int) $this->isTimestampable;
     }
 
     public function getIsDefault(): int

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -29,7 +29,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    private const REQUIRED_SCHEMA = 89;
+    private const REQUIRED_SCHEMA = 90;
 
     private Db $Db;
 

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -714,14 +714,12 @@ class ApiController implements ControllerInterface
      *             "category_id": "1",
      *             "category": "Running",
      *             "color": "3360ff",
-     *             "is_timestampable": "1",
      *             "is_default": "1"
      *           },
      *           {
      *             "category_id": "2",
      *             "category": "Success",
      *             "color": "54aa08",
-     *             "is_timestampable": "1",
      *             "is_default": "0"
      *             }
      *         ]

--- a/src/interfaces/StatusParamsInterface.php
+++ b/src/interfaces/StatusParamsInterface.php
@@ -14,7 +14,5 @@ interface StatusParamsInterface extends ContentParamsInterface
 {
     public function getColor(): string;
 
-    public function getIsTimestampable(): int;
-
     public function getIsDefault(): int;
 }

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -101,18 +101,6 @@ class Experiments extends AbstractEntity
     }
 
     /**
-     * Can this experiment be timestamped?
-     */
-    public function isTimestampable(): bool
-    {
-        $sql = 'SELECT is_timestampable FROM status WHERE id = (SELECT category FROM experiments WHERE id = :id)';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-        $this->Db->execute($req);
-        return (bool) $req->fetchColumn();
-    }
-
-    /**
      * Set the experiment as timestamped with a path to the token
      *
      * @param string $responseTime the date of the timestamp

--- a/src/models/Status.php
+++ b/src/models/Status.php
@@ -31,13 +31,12 @@ class Status extends AbstractCategory
 
     public function create(StatusParamsInterface $params): int
     {
-        $sql = 'INSERT INTO status(name, color, team, is_timestampable, is_default)
-            VALUES(:name, :color, :team, :is_timestampable, :is_default)';
+        $sql = 'INSERT INTO status(name, color, team, is_default)
+            VALUES(:name, :color, :team, :is_default)';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':name', $params->getContent(), PDO::PARAM_STR);
         $req->bindValue(':color', $params->getColor(), PDO::PARAM_STR);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
-        $req->bindValue(':is_timestampable', $params->getIsTimestampable(), PDO::PARAM_INT);
         $req->bindValue(':is_default', $params->getIsDefault(), PDO::PARAM_INT);
         $this->Db->execute($req);
 
@@ -50,19 +49,19 @@ class Status extends AbstractCategory
     public function createDefault(): bool
     {
         return $this->create(
-            new StatusParams('Running', '#29AEB9', false, true)
+            new StatusParams('Running', '#29AEB9', true)
         ) && $this->create(
-            new StatusParams('Success', '#54AA08', true)
+            new StatusParams('Success', '#54AA08')
         ) && $this->create(
-            new StatusParams('Need to be redone', '#C0C0C0', true)
+            new StatusParams('Need to be redone', '#C0C0C0')
         ) && $this->create(
-            new StatusParams('Fail', '#C24F3D', true)
+            new StatusParams('Fail', '#C24F3D')
         );
     }
 
     public function read(ContentParamsInterface $params): array
     {
-        $sql = 'SELECT id as category_id, name as category, color, is_timestampable, is_default
+        $sql = 'SELECT id as category_id, name as category, color, is_default
             FROM status WHERE team = :team AND id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
@@ -79,7 +78,6 @@ class Status extends AbstractCategory
         $sql = 'SELECT status.id AS category_id,
             status.name AS category,
             status.color,
-            status.is_timestampable,
             status.is_default
             FROM status WHERE team = :team ORDER BY ordering ASC';
         $req = $this->Db->prepare($sql);
@@ -102,14 +100,12 @@ class Status extends AbstractCategory
         $sql = 'UPDATE status SET
             name = :name,
             color = :color,
-            is_timestampable = :is_timestampable,
             is_default = :is_default
             WHERE id = :id AND team = :team';
 
         $req = $this->Db->prepare($sql);
         $req->bindValue(':name', $params->getContent(), PDO::PARAM_STR);
         $req->bindValue(':color', $params->getColor(), PDO::PARAM_STR);
-        $req->bindValue(':is_timestampable', $params->getIsTimestampable(), PDO::PARAM_INT);
         $req->bindValue(':is_default', $params->getIsDefault(), PDO::PARAM_INT);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);

--- a/src/services/AbstractMakeTimestamp.php
+++ b/src/services/AbstractMakeTimestamp.php
@@ -74,9 +74,6 @@ abstract class AbstractMakeTimestamp extends AbstractMake
      */
     public function generatePdf(): string
     {
-        if (!$this->Entity->isTimestampable()) {
-            throw new ImproperActionException('Timestamping is not allowed for this experiment.');
-        }
         $userData = $this->Entity->Users->userData;
         $MpdfProvider = new MpdfProvider(
             $userData['fullname'],

--- a/src/sql/schema90.sql
+++ b/src/sql/schema90.sql
@@ -1,0 +1,4 @@
+-- Schema 90
+-- drop is_timestampable from status
+ALTER TABLE `status` DROP COLUMN `is_timestampable`;
+UPDATE config SET conf_value = 90 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -520,7 +520,6 @@ CREATE TABLE `status` (
   `team` int(10) UNSIGNED NOT NULL,
   `name` text NOT NULL,
   `color` varchar(6) NOT NULL,
-  `is_timestampable` tinyint(1) UNSIGNED NOT NULL DEFAULT '1',
   `is_default` tinyint(1) UNSIGNED DEFAULT NULL,
   `ordering` int(10) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`id`)

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -179,13 +179,6 @@
         <input class='form-control randomColor' type='color' id='statusColor' />
       </div>
 
-      <div class='col-auto'>
-        <div class='form-check mt-4'>
-          <input class='form-check-input' type='checkbox' id='statusTimestamp' />
-          <label class='form-check-label' for='statusTimestamp'>{{ 'Allow timestamp'|trans }}</label>
-        </div>
-      </div>
-
       <div class='col-auto mt-4'>
         <button class='button btn btn-primary' data-action='create-status'>{{ 'Save'|trans }}</button>
       </div>
@@ -208,10 +201,6 @@
             <li class='list-inline-item col-1 align-top'>
               <label for='statusColor_{{ status.category_id }}'>{{ 'Color'|trans }}</label>
               <input class='form-control' type='color' id='statusColor_{{ status.category_id }}' value='#{{ status.color }}' />
-            </li>
-            <li class='list-inline-item'>
-              <input type='checkbox' id='statusTimestamp_{{ status.category_id }}' {{ status.is_timestampable ? " checked" }} />
-              <label for='statusTimestamp_{{ status.category_id }}'>{{ 'Allow timestamp'|trans }}</label>
             </li>
 
             <li class='list-inline-item'>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -104,7 +104,7 @@
     {% endif %}
 
     <!-- show timestamp button -->
-    {% if Entity.isTimestampable and Entity.type == 'experiments' and not App.Session.has('is_anon') %}
+    {% if Entity.type == 'experiments' and not App.Session.has('is_anon') %}
       <a href='#' class='elab-tooltip mr-1' data-action='toggle-modal' data-target='timestampModal'>
         <span>{{ 'Timestamp Experiment'|trans }}</span>
         <i title='{{ 'Timestamp Experiment'|trans }}' class='far fa-calendar-check fa-2x'></i>

--- a/src/ts/Status.class.ts
+++ b/src/ts/Status.class.ts
@@ -17,7 +17,7 @@ export default class Status {
     this.sender = new Ajax();
   }
 
-  create(content: string, color: string, isTimestampable: boolean): Promise<ResponseMsg> {
+  create(content: string, color: string): Promise<ResponseMsg> {
     const payload: Payload = {
       method: Method.POST,
       action: Action.Create,
@@ -25,14 +25,13 @@ export default class Status {
       content: content,
       extraParams: {
         color: color,
-        isTimestampable: isTimestampable,
       },
       notif: true,
     };
     return this.sender.send(payload);
   }
 
-  update(id: number, content: string, color: string, isTimestampable: boolean, isDefault: boolean): Promise<ResponseMsg> {
+  update(id: number, content: string, color: string, isDefault: boolean): Promise<ResponseMsg> {
     const payload: Payload = {
       method: Method.POST,
       action: Action.Update,
@@ -41,7 +40,6 @@ export default class Status {
       id : id,
       extraParams: {
         color: color,
-        isTimestampable: isTimestampable,
         isDefault: isDefault,
       },
       notif: true,

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -148,9 +148,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelector('[data-action="create-status"]').addEventListener('click', () => {
     const content = (document.getElementById('statusName') as HTMLInputElement).value;
     const color = (document.getElementById('statusColor') as HTMLInputElement).value;
-    const isTimestampable = (document.getElementById('statusTimestamp') as HTMLInputElement).checked;
     if (content.length > 1) {
-      StatusC.create(content, color, isTimestampable).then(() => window.location.replace('admin.php?tab=4'));
+      StatusC.create(content, color).then(() => window.location.replace('admin.php?tab=4'));
     }
   });
 
@@ -159,9 +158,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const statusId = parseInt((ev.target as HTMLElement).dataset.statusid);
       const content = (document.getElementById('statusName_' + statusId) as HTMLInputElement).value;
       const color = (document.getElementById('statusColor_' + statusId) as HTMLInputElement).value;
-      const isTimestampable = (document.getElementById('statusTimestamp_' + statusId) as HTMLInputElement).checked;
       const isDefault = (document.getElementById('statusDefault_' + statusId) as HTMLInputElement).checked;
-      StatusC.update(statusId, content, color, isTimestampable, isDefault);
+      StatusC.update(statusId, content, color, isDefault);
     });
   });
 

--- a/tests/unit/classes/ParamsBuilderTest.php
+++ b/tests/unit/classes/ParamsBuilderTest.php
@@ -74,7 +74,6 @@ class ParamsBuilderTest extends \PHPUnit\Framework\TestCase
         // Status
         $builder = new ParamsBuilder(new Status(1), 'status-name', '', array(
             'color' => '00FF00',
-            'isTimestampable' => '1',
             'isDefault' => '0',
         ));
         $this->assertInstanceOf(StatusParams::class, $builder->getParams());

--- a/tests/unit/models/StatusTest.php
+++ b/tests/unit/models/StatusTest.php
@@ -25,7 +25,7 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testCreate(): void
     {
-        $new = $this->Status->create(new StatusParams('New status', '#29AEB9', false, true));
+        $new = $this->Status->create(new StatusParams('New status', '#29AEB9', true));
         $this->assertTrue((bool) Check::id($new));
     }
 
@@ -36,24 +36,21 @@ class StatusTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdate(): void
     {
-        $id = $this->Status->create(new StatusParams('Yep', '#29AEB9', false, true));
+        $id = $this->Status->create(new StatusParams('Yep', '#29AEB9'));
         $Status = new Status(1, $id);
-        $Status->update(new StatusParams('Updated', '#121212', true, false));
+        $Status->update(new StatusParams('Updated', '#121212'));
         $status = $Status->read(new ContentParams());
         $this->assertEquals('Updated', $status['category']);
         $this->assertEquals('121212', $status['color']);
-        $this->assertTrue((bool) $status['is_timestampable']);
         $this->assertFalse((bool) $status['is_default']);
-        $Status->update(new StatusParams('Updated', '#121212', true, true));
+        $Status->update(new StatusParams('Updated', '#121212', true));
         $status = $Status->read(new ContentParams());
         $this->assertTrue((bool) $status['is_default']);
-        // undo changes so that MakeTimestampTest.php:testNonTimestampableExperiment works
-        $Status->update(new StatusParams('Updated', '#121212', false, true));
     }
 
     public function testDestroy(): void
     {
-        $id = $this->Status->create(new StatusParams('Yep1', '#29AEB9', false, false));
+        $id = $this->Status->create(new StatusParams('Yep1', '#29AEB9'));
         $Status = new Status(1, $id);
         $this->assertTrue($Status->destroy());
         $this->expectException(ImproperActionException::class);

--- a/tests/unit/services/MakeTimestampTest.php
+++ b/tests/unit/services/MakeTimestampTest.php
@@ -43,17 +43,6 @@ class MakeTimestampTest extends \PHPUnit\Framework\TestCase
         $this->fixturesFs = (new StorageFactory(StorageFactory::FIXTURES))->getStorage()->getFs();
     }
 
-    public function testNonTimestampableExperiment(): void
-    {
-        $Entity = new Experiments(new Users(1, 1));
-        // create a new experiment for timestamping tests
-        $Entity->setId($Entity->create(new EntityParams('ts test')));
-        // default status is not timestampable
-        $Maker = new MakeDfnTimestamp($this->configArr, $Entity);
-        $this->expectException(ImproperActionException::class);
-        $Maker->generatePdf();
-    }
-
     public function testTimestampLimitReached(): void
     {
         $configArr = array(
@@ -189,8 +178,6 @@ class MakeTimestampTest extends \PHPUnit\Framework\TestCase
         $Entity = new Experiments(new Users(1, 1));
         // create a new experiment for timestamping tests
         $Entity->setId($Entity->create(new EntityParams('ts test')));
-        // set it to a status that is timestampable
-        $Entity->updateCategory(2);
         return $Entity;
     }
 }


### PR DESCRIPTION
having the option to set some status as non timestampable doesn't make
sense now that an experiment can be timestamped several times. Also it
hid that feature from most experiments. This change also simplifies the
code a bit, which is always nice.
