### PR TITLE
Prevent potential Regular expression Denial of Service

### DIFF
--- a/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
+++ b/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
@@ -41,7 +41,7 @@ class VisibilityFieldHelper
         $this->possibleInput = "'" . implode("', '", array_keys($searchArr)) . "'";
 
         // Emulate SQL LIKE search functionality so the user can use the same placeholders
-        $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), preg_quote($this->userInput)) . '$/i';
+        $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), preg_quote($this->userInput, '/')) . '$/i';
         // Filter visibility entries based on user input
         $filteredArr = preg_grep($pattern, array_keys($searchArr)) ?: array();
 

--- a/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
+++ b/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
@@ -10,6 +10,19 @@
 
 namespace Elabftw\Services\AdvancedSearchQuery\Visitors;
 
+use function array_combine;
+use function array_filter;
+use function array_flip;
+use function array_intersect_key;
+use function array_keys;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function implode;
+use function preg_grep;
+use function preg_quote;
+use function str_replace;
+
 class VisibilityFieldHelper
 {
     public string $possibleInput;
@@ -28,7 +41,7 @@ class VisibilityFieldHelper
         $this->possibleInput = "'" . implode("', '", array_keys($searchArr)) . "'";
 
         // Emulate SQL LIKE search functionality so the user can use the same placeholders
-        $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), $this->userInput) . '$/i';
+        $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), preg_quote($this->userInput)) . '$/i';
         // Filter visibility entries based on user input
         $filteredArr = preg_grep($pattern, array_keys($searchArr)) ?: array();
 


### PR DESCRIPTION
I don't know if it is possible to write a regex pattern that would trigger a ReDoS but let's be on the safe side and prevent it by escaping all special regular expression characters with `preg_quote()`.

Compare to https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS