### PR TITLE
fix images in pdf

### DIFF
--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -242,6 +242,15 @@ class Uploads implements CrudInterface
         }
     }
 
+    public function getStorageFromLongname(string $longname): int
+    {
+        $sql = 'SELECT storage FROM uploads WHERE long_name = :long_name LIMIT 1';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':long_name', $longname, PDO::PARAM_STR);
+        $this->Db->execute($req);
+        return (int) $req->fetchColumn();
+    }
+
     /**
      * This function will not remove the files but set them to "deleted" state
      * A manual purge must be made by sysadmin if they wish to really remove them.

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -9,6 +9,7 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Elabftw\ContentParams;
 use Elabftw\Elabftw\CreateUpload;
 use Elabftw\Services\StorageFactory;
 
@@ -60,5 +61,14 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
 
         $Uploads = new Uploads($this->Entity);
         $Uploads->create($params);
+    }
+
+    public function testGetStorageFromLongname(): void
+    {
+        $Uploads = new Uploads($this->Entity);
+        $id = $Uploads->create(new CreateUpload('example.png', dirname(__DIR__, 2) . '/_data/example.png'));
+        $Uploads->setId($id);
+        $upArr = $Uploads->read(new ContentParams());
+        $this->assertEquals($upArr['storage'], $Uploads->getStorageFromLongname($upArr['long_name']));
     }
 }


### PR DESCRIPTION
Following up on [my comment](https://github.com/elabftw/elabftw/commit/2cabd0f739c03200fedbda51977f68990d0ede89#r74002432) this PR will provide backward compatibility in case there is no 'storage' parameter in the query string.
Maybe the regex should also be able to handle the case where 'storage' and 'f' are swapped, i.e., `app/download.php?f=c2/c2741a{...}016a3.png&amp;storage=1` vs `app/download.php?storage=1&amp;f=c2/c2741a{...}016a3.png`.