### PR TITLE
Start with a clean elabftw directory in scrutinizer.dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
       - run:
           name: Build elabtmp image and start containers
           command: |
-            ls -la
             docker build -q -t elabtmp -f tests/scrutinizer.dockerfile .
             docker compose --ansi never -f tests/docker-compose.yml up -d --quiet-pull
       # Restore dependency cache

--- a/tests/scrutinizer.dockerfile
+++ b/tests/scrutinizer.dockerfile
@@ -16,6 +16,10 @@ ADD --chmod=755 https://github.com/vimeo/psalm/releases/download/$PSALM_VERSION/
 #Phan
 ADD --chmod=755 https://github.com/phan/phan/releases/download/$PHAN_VERSION/phan.phar /usr/bin/phan
 
+# Remove all stuff in /elabftw/ to avoid carry over from hypernext branch
+RUN rm -rf /elabftw/*
+
+# Add files
 COPY ./bin /elabftw/bin
 COPY ./src /elabftw/src
 COPY ./tests /elabftw/tests


### PR DESCRIPTION
> build is failing because of scrutinizer.dockerfile using hypernext version?

You were so close to solve the riddle. But is it actually the influence of the Upside Down? 😉