### PR TITLE
Pass image data to mpdf via variable

### DIFF
--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -324,8 +324,8 @@ class MakePdf extends AbstractMake implements FileMakerInterface
             // there might be no storage value. In this case get it from the uploads table via the long name
             $storage = (int) ($res['amp;storage'] ?? $this->Entity->Uploads->getStorageFromLongname($res['f']));
             $storageFs = (new StorageFactory($storage))->getStorage()->getFs();
-            // use mpdf image data as variable
-            // https://mpdf.github.io/what-else-can-i-do/images.html#image-data-as-a-variable
+            // pass image data to mpdf via variable. See https://mpdf.github.io/what-else-can-i-do/images.html#image-data-as-a-variable
+            // avoid using data URLs (data:...) because it add too many characters to $body, see https://github.com/elabftw/elabftw/issues/3627
             $this->mpdf->imageVars[$res['f']] = $storageFs->read($res['f']);
             $body = str_replace($src, 'var:' . $res['f'], $body);
         }

--- a/src/services/MakePdf.php
+++ b/src/services/MakePdf.php
@@ -324,9 +324,10 @@ class MakePdf extends AbstractMake implements FileMakerInterface
             // there might be no storage value. In this case get it from the uploads table via the long name
             $storage = (int) ($res['amp;storage'] ?? $this->Entity->Uploads->getStorageFromLongname($res['f']));
             $storageFs = (new StorageFactory($storage))->getStorage()->getFs();
-            $encoded = base64_encode($storageFs->read($res['f']));
-            // get filetype based on extension so we can declare correctly the type of image
-            $body = str_replace($src, 'data:image/' . Tools::getMimeExt($res['f']) . ';base64,' . $encoded, $body);
+            // use mpdf image data as variable
+            // https://mpdf.github.io/what-else-can-i-do/images.html#image-data-as-a-variable
+            $this->mpdf->imageVars[$res['f']] = $storageFs->read($res['f']);
+            $body = str_replace($src, 'var:' . $res['f'], $body);
         }
         return $body;
     }

--- a/tests/scrutinizer.dockerfile
+++ b/tests/scrutinizer.dockerfile
@@ -16,6 +16,10 @@ ADD --chmod=755 https://github.com/vimeo/psalm/releases/download/$PSALM_VERSION/
 #Phan
 ADD --chmod=755 https://github.com/phan/phan/releases/download/$PHAN_VERSION/phan.phar /usr/bin/phan
 
+# Remove all stuff in /elabftw/ to avoid carry over from hypernext branch
+RUN rm -rf /elabftw/*
+
+# Add files
 COPY ./bin /elabftw/bin
 COPY ./src /elabftw/src
 COPY ./tests /elabftw/tests


### PR DESCRIPTION
Hi Nico,

It took a bit longer but I wanted to understand the reason for #3627.
The problem is not the file size of the images in the first place (like on hard drive) but the length of the string of the base64 encoded image. Mpdf heavily relies on regex and the base64 encoded images just add too many characters to the "HTML input".

Using [Mpdf's possibility to pass the image data as variable](https://mpdf.github.io/what-else-can-i-do/images.html#image-data-as-a-variable) helps a lot because we can use a short identifier for each image. I chose the "long name" as this is already available and a lot shorter than e.g. a base64 encoded 1 MB jpeg image.

Closes #3627