### PR TITLE
Remove mathjax code that is not necessary anymore

### DIFF
--- a/src/ts/mathjax.ts
+++ b/src/ts/mathjax.ts
@@ -32,15 +32,7 @@ Loader.preLoad(
   'a11y/assistive-mml',
 );
 
-// Update the configuration
-import { MathJaxObject as MJObject } from 'mathjax-full/js/components/startup';
-// We need this because defaultPageReady() is not part of the MathJaxObject interface.
-// See https://github.com/mathjax/MathJax/issues/2774
-interface MathJaxObject extends MJObject {
-  startup: MJObject['startup'] & {
-    defaultPageReady(): Promise<void>;
-  };
-}
+import { MathJaxObject } from 'mathjax-full/js/components/startup';
 declare const MathJax: MathJaxObject;
 
 // Now insert the config
@@ -58,9 +50,6 @@ insert(
       ignoreHtmlClass: 'mathjax-ignore',
     },
     startup: {
-      ready: (): void => {
-        MathJax.startup.defaultReady();
-      },
       pageReady(): Promise<void> {
         const options = MathJax.startup.document.options;
         const BaseMathItem = options.MathItem;


### PR DESCRIPTION
After https://github.com/mathjax/MathJax-src/pull/820 is published with MathJax v3.2.2 there is no need to do it ourselves anymore.