### PR TITLE
UI cosmetics

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -111,10 +111,6 @@ a:hover,
 }
 
 /* LISTS */
-.list-group-item {
-    margin-bottom: 3px;
-}
-
 .clean-list {
     margin: 0;
     padding: 0;

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -205,7 +205,7 @@
 
 <!-- UPLOAD FORM -->
 <section class='box'>
-  <h3><i class='fas fa-fw fa-paperclip align-baseline'></i> {{ 'Attach a file'|trans }}</h3>
+  <h3><i class='fas fa-fw fa-paperclip'></i> {{ 'Attach a file'|trans }}</h3>
   <form action='app/controllers/EntityAjaxController.php' class='dropzone' id='elabftw-dropzone'></form>
 </section>
 

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -205,8 +205,8 @@
 
 <!-- UPLOAD FORM -->
 <section class='box'>
-  <h3><i class='fas fa-fw fa-paperclip'></i> {{ 'Attach a file'|trans }}</h3>
-  <form action='app/controllers/EntityAjaxController.php' class='dropzone' id='elabftw-dropzone'></form>
+  <h3 class='d-inline'><i class='fas fa-fw fa-paperclip'></i> {{ 'Attach a file'|trans }}</h3>
+  <form action='app/controllers/EntityAjaxController.php' class='dropzone mt-2' id='elabftw-dropzone'></form>
 </section>
 
 {% include 'uploads.html' %}
@@ -215,8 +215,8 @@
 
 <!-- DOODLE -->
 <section class='box'>
-  <h3 data-action='toggle-next' data-icon='doodleDivIcon'><i id='doodleDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paint-brush'></i> {{ 'Draw something'|trans }}</h3>
-  <div id='doodleDiv' hidden data-save-hidden='doodleDiv'>
+  <h3 data-action='toggle-next' data-icon='doodleDivIcon' class='d-inline'><i id='doodleDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paint-brush'></i> {{ 'Draw something'|trans }}</h3>
+  <div id='doodleDiv' hidden class='mt-2' data-save-hidden='doodleDiv'>
     <div class='row'>
       <div>
         <canvas class='doodle' id='doodleCanvas' width='600' height='600'></canvas>
@@ -250,8 +250,8 @@
 <!-- CHEM EDITOR -->
 {% if Entity.Users.userData.chem_editor %}
   <div class='box chemdoodle'>
-    <h3 data-action='toggle-next' data-icon='chemDivIcon'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
-    <div id='chemDiv' hidden data-save-hidden='chemDiv' class='text-center'>
+    <h3 data-action='toggle-next' data-icon='chemDivIcon' class='d-inline'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
+    <div id='chemDiv' hidden data-save-hidden='chemDiv' class='mt-2 text-center'>
       <script src='assets/chemdoodle-canvas.bundle.js?v={{ v }}'></script>
     </div>
   </div>

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -205,7 +205,7 @@
 
 <!-- UPLOAD FORM -->
 <section class='box'>
-  <i class='fas fa-fw fa-paperclip mr-1 align-baseline'></i><h3 class='d-inline'>{{ 'Attach a file'|trans }}</h3>
+  <h3><i class='fas fa-fw fa-paperclip align-baseline'></i> {{ 'Attach a file'|trans }}</h3>
   <form action='app/controllers/EntityAjaxController.php' class='dropzone' id='elabftw-dropzone'></form>
 </section>
 
@@ -215,8 +215,8 @@
 
 <!-- DOODLE -->
 <section class='box'>
-  <h3 data-action='toggle-next' data-icon='doodleDivIcon' class='d-inline'><i id='doodleDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paint-brush'></i> {{ 'Draw something'|trans }}</h3>
-  <div id='doodleDiv' hidden class='mt-2' data-save-hidden='doodleDiv'>
+  <h3 data-action='toggle-next' data-icon='doodleDivIcon'><i id='doodleDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paint-brush'></i> {{ 'Draw something'|trans }}</h3>
+  <div id='doodleDiv' hidden data-save-hidden='doodleDiv'>
     <div class='row'>
       <div>
         <canvas class='doodle' id='doodleCanvas' width='600' height='600'></canvas>
@@ -250,8 +250,8 @@
 <!-- CHEM EDITOR -->
 {% if Entity.Users.userData.chem_editor %}
   <div class='box chemdoodle'>
-    <h3 data-action='toggle-next' data-icon='chemDivIcon' class='d-inline'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
-    <div id='chemDiv' hidden data-save-hidden='chemDiv' class='mt-2 text-center'>
+    <h3 data-action='toggle-next' data-icon='chemDivIcon'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
+    <div id='chemDiv' hidden data-save-hidden='chemDiv' class='text-center'>
       <script src='assets/chemdoodle-canvas.bundle.js?v={{ v }}'></script>
     </div>
   </div>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -1,7 +1,7 @@
 <!-- JSON EDITOR -->
 <!-- json metadata is preloaded for templates -->
 <section class='box' id='json-editor'>
-  <h3 data-action='toggle-next' data-icon='jsonEditorIcon'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
+  <h3 data-action='toggle-next' data-icon='jsonEditorIcon' class='d-inline'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
   <div id='jsonEditorDiv' class='mt-2' hidden data-save-hidden='jsonEditorDiv'>
     <button type='button' id='jsonEditorMetadataLoadButton' data-action='json-load-metadata' class='btn btn-neutral mb-2'>{{ 'Load metadata'|trans }}</button> <button type='button' data-action='json-clear' class='btn btn-danger mb-2'>{{ 'Clear'|trans }}</button>
     <span data-action='toggle-next'><i class='fas fa-fw fa-info-circle'></i></span><span hidden><a target='_blank' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -1,8 +1,8 @@
 <!-- JSON EDITOR -->
 <!-- json metadata is preloaded for templates -->
 <section class='box' id='json-editor'>
-  <h3 data-action='toggle-next' data-icon='jsonEditorIcon' class='d-inline'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
-  <div id='jsonEditorDiv' class='mt-2' hidden data-save-hidden='jsonEditorDiv'>
+  <h3 data-action='toggle-next' data-icon='jsonEditorIcon'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
+  <div id='jsonEditorDiv' hidden data-save-hidden='jsonEditorDiv'>
     <button type='button' id='jsonEditorMetadataLoadButton' data-action='json-load-metadata' class='btn btn-neutral mb-2'>{{ 'Load metadata'|trans }}</button> <button type='button' data-action='json-clear' class='btn btn-danger mb-2'>{{ 'Clear'|trans }}</button>
     <span data-action='toggle-next'><i class='fas fa-fw fa-info-circle'></i></span><span hidden><a target='_blank' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>
     <h6 id='jsonEditorTitle'></h6>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -2,7 +2,7 @@
 <!-- json metadata is preloaded for templates -->
 <section class='box' id='json-editor'>
   <h3 data-action='toggle-next' data-icon='jsonEditorIcon'><i id='jsonEditorIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-list'></i> {{ 'JSON Editor'|trans }}</h3>
-  <div id='jsonEditorDiv' hidden data-save-hidden='jsonEditorDiv'>
+  <div id='jsonEditorDiv' class='mt-2' hidden data-save-hidden='jsonEditorDiv'>
     <button type='button' id='jsonEditorMetadataLoadButton' data-action='json-load-metadata' class='btn btn-neutral mb-2'>{{ 'Load metadata'|trans }}</button> <button type='button' data-action='json-clear' class='btn btn-danger mb-2'>{{ 'Clear'|trans }}</button>
     <span data-action='toggle-next'><i class='fas fa-fw fa-info-circle'></i></span><span hidden><a target='_blank' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>
     <h6 id='jsonEditorTitle'></h6>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,11 +1,10 @@
 <div class='row justify-content-around mt-4'>
     <!-- STEPS -->
     <section class='col-md-6'>
-      <i class='fas fa-fw fa-check-square mr-1 align-baseline'></i><h5 class='d-inline'>{{ 'Steps'|trans }}</h5>
-      <br>
+      <h4><i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
       <!-- the stepsDiv id is in its own div because otherwise if it's on the section above it doesn't work well, not sure why -->
       <div id='stepsDiv'>
-        <div class='mt-2 sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types'}}_steps'>
+        <div class='sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types'}}_steps'>
           {% for step in Entity.entityData.steps %}
             <div class='input-group mb-2' id='step_{{ step.id }}'>
               <div class='input-group-prepend'>
@@ -88,9 +87,8 @@
     </section>
     <!-- LINKS -->
     <section class='col-md-6' id='linksDiv'>
-        <i class='fas fa-fw fa-link mr-1 align-baseline'></i><h4 class='d-inline'>{{ 'Linked items'|trans }}</h4>
-        <br>
-        <div class='mt-2' id='links_div_{{ Entity.id }}'>
+        <h4><i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
+        <div id='links_div_{{ Entity.id }}'>
             {% if Entity.entityData.links %}
             <ul class='list-group'>
                 {% for link in Entity.entityData.links %}
@@ -101,7 +99,7 @@
                   <div class='float-right'>
                     {% if mode != 'edit-template' %}
                       <a data-action='import-links' data-target='{{ link.itemid }}' title='{{ 'Import links'|trans }}'>
-                        <i class="fas fa-arrows-down-to-line"></i>
+                        <i class='fas fa-arrows-down-to-line'></i>
                       </a>
 
                       <a data-action='import-link-body' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}'>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,8 +1,14 @@
-<div class='row justify-content-around mt-4'>
+<div class='row mt-4'>
     <!-- STEPS -->
     <section class='col-md-6'>
       <h4><i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
-      <!-- the stepsDiv id is in its own div because otherwise if it's on the section above it doesn't work well, not sure why -->
+      <!-- ADD STEP -->
+      <div class='input-group mb-3'>
+          <div class='input-group-prepend'>
+            <span class='input-group-text'>{{ 'Add a step'|trans }}</span>
+          </div>
+          <input aria-label='{{ 'Add a step'|trans }}' type='text' size='60' class='form-control stepinput' data-id='{{ Entity.id }}' />
+      </div>
       <div id='stepsDiv'>
         <div class='sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types'}}_steps'>
           {% for step in Entity.entityData.steps %}
@@ -74,50 +80,13 @@
           {% endfor %}
         </div>
       </div>
-
-        <!-- ADD STEP -->
-        <div class='input-group mb-3'>
-            <div class='input-group-prepend'>
-              <span class='input-group-text'>{{ 'Add a step'|trans }}</span>
-            </div>
-
-            <input aria-label='{{ 'Add a step'|trans }}' type='text' size='60' class='form-control stepinput' data-id='{{ Entity.id }}' />
-        </div>
-
     </section>
     <!-- LINKS -->
-    <section class='col-md-6' id='linksDiv'>
+    <section class='col-md-6'>
         <h4><i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
-        <div id='links_div_{{ Entity.id }}'>
-            {% if Entity.entityData.links %}
-            <ul class='list-group'>
-                {% for link in Entity.entityData.links %}
-                  <li class='list-group-item'>
-                    <i class='fas fa-link mr-1'></i>
-                    <span class='item-category' style='color:#{{ link.color|raw }}'>{{ link.name|raw }}</span> - <a href='database.php?mode=view&id={{ link.itemid }}'>
-                  {{ link.title|raw }}</a>
-                  <div class='float-right'>
-                    {% if mode != 'edit-template' %}
-                      <a data-action='import-links' data-target='{{ link.itemid }}' title='{{ 'Import links'|trans }}'>
-                        <i class='fas fa-arrows-down-to-line'></i>
-                      </a>
-
-                      <a data-action='import-link-body' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}'>
-                        <i class='fas fa-lg fa-file-import'></i>
-                      </a>
-                    {% endif %}
-                    <a data-action='destroy-link' data-target='{{ link.itemid }}' title='{{ 'Delete'|trans }}'>
-                      <i class='fas fa-lg fa-trash-alt'></i>
-                    </a>
-                  </div>
-                </li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-        </div>
         <!-- ADD LINK -->
-        <div class='mt-2'>
-            <div class='input-group mb-3'>
+        <div class='mb-3'>
+            <div class='input-group'>
                 <div class='input-group-prepend'>
                     <span class='input-group-text'>{{ 'Add a link'|trans }}</span>
                 </div>
@@ -131,6 +100,35 @@
                   </select>
                 </div>
             </div>
+        </div>
+        <div id='linksDiv'>
+          <div id='links_div_{{ Entity.id }}'>
+              {% if Entity.entityData.links %}
+              <ul class='list-group'>
+                  {% for link in Entity.entityData.links %}
+                  <li class='list-group-item'>
+                    <div class='float-right'>
+                      {% if mode != 'edit-template' %}
+                        <a data-action='import-links' data-target='{{ link.itemid }}' title='{{ 'Import links'|trans }}'>
+                          <i class='fas fa-arrows-down-to-line'></i>
+                        </a>
+
+                        <a data-action='import-link-body' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}'>
+                          <i class='fas fa-lg fa-file-import'></i>
+                        </a>
+                      {% endif %}
+                      <a data-action='destroy-link' data-target='{{ link.itemid }}' title='{{ 'Delete'|trans }}'>
+                        <i class='fas fa-lg fa-trash-alt'></i>
+                      </a>
+                    </div>
+                    <i class='fas fa-link mr-1'></i>
+                    <span class='item-category' style='color:#{{ link.color|raw }}'>{{ link.name|raw }}</span> - <a href='database.php?mode=view&id={{ link.itemid }}'>
+                    {{ link.title|raw }}</a>
+                  </li>
+                  {% endfor %}
+              </ul>
+              {% endif %}
+          </div>
         </div>
     </section>
 </div>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -85,20 +85,18 @@
     <section class='col-md-6'>
         <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='linksDivIcon'><i id='linksDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
         <!-- ADD LINK -->
-        <div class='mb-3'>
-            <div class='input-group'>
-                <div class='input-group-prepend'>
-                    <span class='input-group-text'>{{ 'Add a link'|trans }}</span>
-                </div>
-                <input aria-label='{{ 'Add a link'|trans }}' type='text' data-autocomplete='links' id='linkinput' class='form-control' data-id='{{ Entity.id }}' placeholder='{{ 'from the database'|trans }}' />
-                <div class='input-group-append' style='max-width:33%;'>
-                  <select id='addLinkCatFilter' class='brl-none form-control'>
-                    <option selected value=''>{{ 'Any category'|trans }}</option>
-                    {% for cat in itemsCategoryArr %}
-                      <option value='{{ cat.category_id }}'>{{ cat.category }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
+        <div class='input-group mb-3'>
+            <div class='input-group-prepend'>
+                <span class='input-group-text'>{{ 'Add a link'|trans }}</span>
+            </div>
+            <input aria-label='{{ 'Add a link'|trans }}' type='text' data-autocomplete='links' id='linkinput' class='form-control' data-id='{{ Entity.id }}' placeholder='{{ 'from the database'|trans }}' />
+            <div class='input-group-append' style='max-width:33%;'>
+              <select id='addLinkCatFilter' class='brl-none form-control'>
+                <option selected value=''>{{ 'Any category'|trans }}</option>
+                {% for cat in itemsCategoryArr %}
+                  <option value='{{ cat.category_id }}'>{{ cat.category }}</option>
+                {% endfor %}
+              </select>
             </div>
         </div>
         <div id='linksDiv'>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,7 +1,7 @@
 <div class='row mt-4'>
     <!-- STEPS -->
     <section class='col-md-6'>
-      <h4><i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
+      <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='stepsDivIcon'><i id='stepsDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
       <!-- ADD STEP -->
       <div class='input-group mb-3'>
           <div class='input-group-prepend'>
@@ -53,9 +53,9 @@
                   <div id='stepDeadlineDiv_{{ step.id }}'>
                     {{ 'Deadline:'|trans }}
                     {% if step.deadline %}
-                    <!-- here the data-ma-input-value is formatted so it works with the datetime-local input type, and the displayed one is formatted differently to be more readable -->
+                    {# here the data-ma-input-value is formatted so it works with the datetime-local input type, and the displayed one is formatted differently to be more readable #}
                     <span data-stepid='{{ step.id }}' data-target='deadline' data-ma-type='datetime-local' data-ma-input-value='{{ step.deadline|date('Y-m-d\\TH:i') }}' class='step editable hl-hover'>{{ step.deadline|format_datetime() }}</span>
-                    <!-- notification bell is only shown if the user has at least one notification setting activated for that type of notif -->
+                    {# notification bell is only shown if the user has at least one notification setting activated for that type of notif #}
                     {% if App.Users.userData.notif_step_deadline or App.Users.userData.notif_step_deadline_email %}
                       <span class='ml-2' data-action='step-toggle-deadline-notif' data-stepid='{{ step.id }}' title='{{ 'Toggle notifications'|trans }}'><i class='far fa-bell {{ step.deadline_notif ? 'active' }}' ></i></span>
                     {% endif %}
@@ -83,7 +83,7 @@
     </section>
     <!-- LINKS -->
     <section class='col-md-6'>
-        <h4><i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
+        <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='linksDivIcon'><i id='linksDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
         <!-- ADD LINK -->
         <div class='mb-3'>
             <div class='input-group'>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -121,7 +121,7 @@
                         <i class='fas fa-lg fa-trash-alt'></i>
                       </a>
                     </div>
-                    <i class='fas fa-link mr-1'></i>
+                    <i class='fas fa-link'></i>
                     <span class='item-category' style='color:#{{ link.color|raw }}'>{{ link.name|raw }}</span> - <a href='database.php?mode=view&id={{ link.itemid }}'>
                     {{ link.title|raw }}</a>
                   </li>

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,9 +1,9 @@
 <div class='row mt-4'>
     <!-- STEPS -->
     <section class='col-md-6'>
-      <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='stepsDivIcon'><i id='stepsDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
+      <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='stepsDivIcon' class='d-inline'><i id='stepsDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h4>
       <!-- ADD STEP -->
-      <div class='input-group mb-3'>
+      <div class='input-group mt-2 mb-3'>
           <div class='input-group-prepend'>
             <span class='input-group-text'>{{ 'Add a step'|trans }}</span>
           </div>
@@ -83,9 +83,9 @@
     </section>
     <!-- LINKS -->
     <section class='col-md-6'>
-        <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='linksDivIcon'><i id='linksDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
+        <h4 data-action='toggle-next' data-toggle-next-n='2' data-icon='linksDivIcon' class='d-inline'><i id='linksDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-link'></i> {{ 'Linked items'|trans }}</h4>
         <!-- ADD LINK -->
-        <div class='input-group mb-3'>
+        <div class='input-group mt-2 mb-3'>
             <div class='input-group-prepend'>
                 <span class='input-group-text'>{{ 'Add a link'|trans }}</span>
             </div>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -2,7 +2,7 @@
 <div id='stepsDiv'>
 {% if Entity.entityData.steps %}
   <div class='box'>
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='stepsIcon'><i id='stepsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h3>
+    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='stepsIcon' class='d-inline'><i id='stepsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h3>
     <div class='row mt-2' id='stepsDivContent' data-save-hidden='stepsDivContent'>
       <ul class='list-group ml-3' id='steps_div_{{ Entity.id }}' >
           {% for step in Entity.entityData.steps %}
@@ -29,7 +29,7 @@
 <!-- LINKS -->
 {% if Entity.entityData.links %}
   <div class='box'>
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='linkedItemsIcon'><i id='linkedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Linked items'|trans }}</h3>
+    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='linkedItemsIcon' class='d-inline'><i id='linkedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Linked items'|trans }}</h3>
     <div class='row mt-2' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
       <ul class='list-group ml-3'>
         {% for link in Entity.entityData.links %}
@@ -49,7 +49,7 @@
 {% if Entity.type == 'items' %}
   {% if relatedItemsArr %}
     <div class='box'>
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedItemsIcon'><i id='relatedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related items'|trans }}</h3>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedItemsIcon' class='d-inline'><i id='relatedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related items'|trans }}</h3>
       <div class='row mt-2' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
         <ul class='list-group ml-3'>
           <li class='list-group-item'>
@@ -73,7 +73,7 @@
 
   {% if relatedExperimentsArr %}
     <div class='box'>
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedExperimentsIcon'><i id='relatedExperimentsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related experiments'|trans }}</h3>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedExperimentsIcon' class='d-inline'><i id='relatedExperimentsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related experiments'|trans }}</h3>
       <div class='row mt-2' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
         <ul class='list-group ml-3'>
           <li class='list-group-item'>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -53,8 +53,8 @@
       <div class='row' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
         <ul class='list-group mt-2 ml-3'>
           <li class='list-group-item'>
-            <i title='{{ 'Show linked items'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1'></i>
-            <a href='database.php?mode=show&related={{ Entity.id }}'>
+            <i title='{{ 'Show linked items'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>
+            <a href='database.php?mode=show&related={{ Entity.id }}' class='align-middle'>
               <span>{{ 'Show linked items'|trans }}</span>
             </a>
           </li>
@@ -77,8 +77,8 @@
       <div class='row' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
         <ul class='list-group mt-2 ml-3'>
           <li class='list-group-item'>
-            <i title='{{ 'Show related'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1'></i>
-            <a href='experiments.php?mode=show&related={{ Entity.id }}'>
+            <i title='{{ 'Show related'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>
+            <a href='experiments.php?mode=show&related={{ Entity.id }}' class='align-middle'>
               <span>{{ 'Show related'|trans }}</span>
             </a>
           </li>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -3,7 +3,7 @@
 {% if Entity.entityData.steps %}
   <div class='box'>
     <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='stepsIcon'><i id='stepsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h3>
-    <div class='row' id='stepsDivContent' data-save-hidden='stepsDivContent'>
+    <div class='row mt-2' id='stepsDivContent' data-save-hidden='stepsDivContent'>
       <ul class='list-group ml-3' id='steps_div_{{ Entity.id }}' >
           {% for step in Entity.entityData.steps %}
           <li class='list-group-item {{ step.finished ? 'finished' }}'>
@@ -30,7 +30,7 @@
 {% if Entity.entityData.links %}
   <div class='box'>
     <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='linkedItemsIcon'><i id='linkedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Linked items'|trans }}</h3>
-    <div class='row' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
+    <div class='row mt-2' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
       <ul class='list-group ml-3'>
         {% for link in Entity.entityData.links %}
           <li class='list-group-item'>
@@ -50,7 +50,7 @@
   {% if relatedItemsArr %}
     <div class='box'>
       <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedItemsIcon'><i id='relatedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related items'|trans }}</h3>
-      <div class='row' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
+      <div class='row mt-2' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
         <ul class='list-group ml-3'>
           <li class='list-group-item'>
             <i title='{{ 'Show linked items'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>
@@ -74,7 +74,7 @@
   {% if relatedExperimentsArr %}
     <div class='box'>
       <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedExperimentsIcon'><i id='relatedExperimentsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related experiments'|trans }}</h3>
-      <div class='row' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
+      <div class='row mt-2' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
         <ul class='list-group ml-3'>
           <li class='list-group-item'>
             <i title='{{ 'Show related'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -4,7 +4,7 @@
   <div class='box'>
     <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='stepsIcon'><i id='stepsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-check-square'></i> {{ 'Steps'|trans }}</h3>
     <div class='row' id='stepsDivContent' data-save-hidden='stepsDivContent'>
-      <ul class='list-group mt-2 ml-3' id='steps_div_{{ Entity.id }}' >
+      <ul class='list-group ml-3' id='steps_div_{{ Entity.id }}' >
           {% for step in Entity.entityData.steps %}
           <li class='list-group-item {{ step.finished ? 'finished' }}'>
             <input aria-label='{{ 'Toggle completion'|trans }}' type='checkbox' {{ step.finished ? 'checked' }} {{ Entity.type == 'experiments_templates' ? 'disabled' }} data-id='{{ Entity.id }}' autocomplete='off' data-stepid='{{ step.id }}' class='stepbox mr-1' id='stepCheckbox_{{ step.id }}' />{{ step.body|raw }}
@@ -31,7 +31,7 @@
   <div class='box'>
     <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='linkedItemsIcon'><i id='linkedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Linked items'|trans }}</h3>
     <div class='row' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
-      <ul class='list-group mt-2 ml-3'>
+      <ul class='list-group ml-3'>
         {% for link in Entity.entityData.links %}
           <li class='list-group-item'>
             <i class='fas fa-link mr-1'></i>
@@ -51,7 +51,7 @@
     <div class='box'>
       <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedItemsIcon'><i id='relatedItemsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related items'|trans }}</h3>
       <div class='row' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
-        <ul class='list-group mt-2 ml-3'>
+        <ul class='list-group ml-3'>
           <li class='list-group-item'>
             <i title='{{ 'Show linked items'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>
             <a href='database.php?mode=show&related={{ Entity.id }}' class='align-middle'>
@@ -75,7 +75,7 @@
     <div class='box'>
       <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='relatedExperimentsIcon'><i id='relatedExperimentsIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {{ 'Related experiments'|trans }}</h3>
       <div class='row' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
-        <ul class='list-group mt-2 ml-3'>
+        <ul class='list-group ml-3'>
           <li class='list-group-item'>
             <i title='{{ 'Show related'|trans }}' class='fas fa-external-link-square-alt fa-2x mr-1 align-middle'></i>
             <a href='experiments.php?mode=show&related={{ Entity.id }}' class='align-middle'>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -2,7 +2,7 @@
 <div id='filesdiv'>
   {% if Entity.entityData.uploads %}
     <div class='box'>
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='uploadedFilesIcon'><i id='uploadedFilesIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {% trans %}Attached file
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-icon='uploadedFilesIcon' class='d-inline'><i id='uploadedFilesIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-paperclip'></i> {% trans %}Attached file
             {% plural Entity.entityData.uploads|length %}
             Attached files
             {% endtrans %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -229,7 +229,7 @@
 <section id='commentsDiv'>
   {% if App.Session.get('is_auth') and not App.Session.has('is_anon') %}
     <div id='comment' class='box'>
-      <i class='fas fa-comments mr-1 align-baseline'></i><h2 class='d-inline'>{{ 'Comments'|trans }}</h2>
+      <h3><i class='fas fa-comments'></i> {{ 'Comments'|trans }}</h3>
         {% for comment in Entity.entityData.comments %}
           <div class='box'>
             <div class='comment-header p-2'>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -229,7 +229,7 @@
 <section id='commentsDiv'>
   {% if App.Session.get('is_auth') and not App.Session.has('is_anon') %}
     <div id='comment' class='box'>
-      <h3><i class='fas fa-comments'></i> {{ 'Comments'|trans }}</h3>
+      <h3><i class='fas fa-comments' class='d-inline'></i> {{ 'Comments'|trans }}</h3>
         {% for comment in Entity.entityData.comments %}
           <div class='box'>
             <div class='comment-header p-2'>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -186,11 +186,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     /* TOGGLE NEXT ACTION
      * An element with "toggle-next" as data-action value will appear clickable.
-     * Clicking on it will toggle the "hidden" attribute of the next sibling element.
+     * Clicking on it will toggle the "hidden" attribute of the next sibling element by default.
+     * If there is a data-toggle-next-n value, the "hidden" attribute of the nth next sibling element will be toggled. 
      * If there is a data-icon value, it is toggled > or V
      */
     } else if (el.matches('[data-action="toggle-next"]')) {
-      const targetEl = el.nextElementSibling as HTMLElement;
+      const n = Array.from(el.parentNode.children).indexOf(el) + (parseInt(el.dataset.toggleNextN, 10) || 1);
+      const targetEl = el.parentNode.children[n] as HTMLElement;
       targetEl.toggleAttribute('hidden');
       if (el.dataset.icon) {
         const iconEl = document.getElementById(el.dataset.icon);


### PR DESCRIPTION
While I was working on the experiments to experiments links I ran into inconsistencies in the UI and try to address them in this PR first.

Some lists have gaps (51464982da35deefd0797962c150a27c6de47874):
![image](https://user-images.githubusercontent.com/65481677/173762224-113e196a-3dd4-4459-80aa-20e617f29503.png) ![image](https://user-images.githubusercontent.com/65481677/173761967-b231d4a5-f1bd-489e-9e54-32226ddde56f.png)

Align "Show related" and icon (e0dd245aa01621cd77a4da06ba8389fc8f3638b3):
![image](https://user-images.githubusercontent.com/65481677/173762581-c8b2970c-c435-4cac-8e15-af1aedf3e6bc.png) ![image](https://user-images.githubusercontent.com/65481677/173762722-69e91263-363d-42c1-9a21-9382051cc181.png)

Put the steps and links input at the top (4f45c38365ff847c9f8d2879883068e3d3153da2) and make the lists toggleable (6b4a75c0dfce0b9d235da3f0484b85d36f5a4883). This needs a change in toggle-next (e8d2c8370e4c9f4b37e5424102a35ad2dac2b4c8)
![image](https://user-images.githubusercontent.com/65481677/173767120-f4a02fe6-7cd7-4e5e-a2d3-b71604a5334a.png)

