### PR TITLE
Allow codecov to pass even if coverage drops by 0.5%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%
 # Disable PR comments
 comment: false


### PR DESCRIPTION
Every now and then there is a test failing indicator due to some drop in codecov for no good reason.
With this PR this should happen less frequently.

(cherry picked from commit 24566d81212017b3d3f6bed7b5d751fc495f02e5)
