### PR TITLE
Add IGNORE to mysql insert statment of links

### DIFF
--- a/src/commands/AddMissingLinks.php
+++ b/src/commands/AddMissingLinks.php
@@ -88,17 +88,8 @@ class AddMissingLinks extends Command
                             // locked/timestamped entities are a problem because of canOrExplode
                             if ($data['lockedby']) {
                                 // manually create new link
-                                $sql = 'INSERT INTO ' . $table . '_links (item_id, link_id)';
-                                $sql .= ' SELECT ' . $data['id'] . ' item_id, ' . $match . ' link_id FROM DUAL';
-                                // if it does not exist
-                                $sql .= ' WHERE NOT EXISTS (';
-                                $sql .= 'SELECT 1 FROM ' . $table . '_links WHERE item_id = :item_id AND link_id = :link_id LIMIT 1';
-                                $sql .= ')';
-
-                                // https://stackoverflow.com/a/8534693
-                                // it would be better to add a UNIQUE KEY to (item_id, link_id) for all the link tables:
-                                // ALTER TABLE `x` ADD UNIQUE KEY `link_uniq_key` (item_id, link_id);
-                                // and than use "INSERT IGNORE INTO ' . $table . '_links (item_id, link_id) VALUES(:item_id, :link_id)";
+                                // use IGNORE to avoid failure due to a key constraint violations
+                                $sql = 'INSERT IGNORE INTO ' . $table . '_links (item_id, link_id) VALUES (:item_id, :link_id);';
 
                                 $req = $Db->prepare($sql);
                                 $req->bindParam(':item_id', $data['id'], PDO::PARAM_INT);

--- a/src/models/Links.php
+++ b/src/models/Links.php
@@ -41,7 +41,8 @@ class Links implements CrudInterface
         $Items->canOrExplode('read');
         $this->Entity->canOrExplode('write');
 
-        $sql = 'INSERT INTO ' . $this->Entity->type . '_links (item_id, link_id) VALUES(:item_id, :link_id)';
+        // use IGNORE to avoid failure due to a key constraint violations
+        $sql = 'INSERT IGNORE INTO ' . $this->Entity->type . '_links (item_id, link_id) VALUES(:item_id, :link_id)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
         $req->bindParam(':link_id', $link, PDO::PARAM_INT);


### PR DESCRIPTION
Now that all links tables use a composite primary key, IGNORE will avoid errors that might be encountered during link creation.
This will fix AddMissingLinks for unlocked enteties where a link already exists.
This will also avoid a 'silent' error during duplicate link creation from the steps/links input:

Request (run twice): POST | https://demo.elabftw.net/app/controllers/RequestHandler.php
```JSON
{"method":"POST","action":"create","model":"link","entity":{"type":"experiment","id":9689},"content":"2156"}
```
second Response:
```JSON
{"res":false,"msg":"An error occured during the execution of the SQL query."}
```