### PR TITLE
UI cosmetics

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -106,10 +106,6 @@ a:hover,
 }
 
 /* LISTS */
-.list-group-item {
-    margin-bottom: 3px;
-}
-
 .clean-list {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
remove bottom margin from .list-group-item to avoid gap

Some lists have gaps:
![image](https://user-images.githubusercontent.com/65481677/173762224-113e196a-3dd4-4459-80aa-20e617f29503.png) ![image](https://user-images.githubusercontent.com/65481677/173761967-b231d4a5-f1bd-489e-9e54-32226ddde56f.png)