### PR TITLE
Sort metadata entries based on elabftwPosition key

### DIFF
--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -276,7 +276,7 @@ export class Metadata {
         elements.push({
           name: name,
           element: this.generateElement(name, description),
-          position: parseInt(description.elabftwPosition, 10),
+          position: parseInt(description.elabftwPosition, 10) || 99999,
         });
       }
       // now display the names/values from extra_fields
@@ -305,7 +305,7 @@ export class Metadata {
         elements.push({
           name: name,
           element: this.generateInput(name, description),
-          position: parseInt(description.elabftwPosition, 10),
+          position: parseInt(description.elabftwPosition, 10) || 99999,
         });
       }
       // now display the inputs from extra_fields

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -273,7 +273,11 @@ export class Metadata {
       // the input elements that will be created from the extra fields
       const elements = [];
       for (const [name, description] of Object.entries(json.extra_fields)) {
-        elements.push({ name: name, element: this.generateElement(name, description), position: parseInt(description.elabftwPosition, 10)});
+        elements.push({
+          name: name,
+          element: this.generateElement(name, description),
+          position: parseInt(description.elabftwPosition, 10),
+        });
       }
       // now display the names/values from extra_fields
       for (const element of elements.sort((a, b) => a.position - b.position)) {
@@ -298,7 +302,11 @@ export class Metadata {
       // the input elements that will be created from the extra fields
       const elements = [];
       for (const [name, description] of Object.entries(json.extra_fields)) {
-        elements.push({ name: name, element: this.generateInput(name, description), position: parseInt(description.elabftwPosition, 10)});
+        elements.push({
+          name: name,
+          element: this.generateInput(name, description),
+          position: parseInt(description.elabftwPosition, 10),
+        });
       }
       // now display the inputs from extra_fields
       for (const element of elements.sort((a, b) => a.position - b.position)) {

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -276,7 +276,7 @@ export class Metadata {
         elements.push({
           name: name,
           element: this.generateElement(name, description),
-          position: parseInt(description.elabftwPosition, 10) || 99999,
+          position: parseInt(description.position, 10) || 99999,
         });
       }
       // now display the names/values from extra_fields
@@ -305,7 +305,7 @@ export class Metadata {
         elements.push({
           name: name,
           element: this.generateInput(name, description),
-          position: parseInt(description.elabftwPosition, 10) || 99999,
+          position: parseInt(description.position, 10) || 99999,
         });
       }
       // now display the inputs from extra_fields

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -273,10 +273,10 @@ export class Metadata {
       // the input elements that will be created from the extra fields
       const elements = [];
       for (const [name, description] of Object.entries(json.extra_fields)) {
-        elements.push({ name: name, element: this.generateElement(name, description)});
+        elements.push({ name: name, element: this.generateElement(name, description), position: parseInt(description.elabftwPosition, 10)});
       }
       // now display the names/values from extra_fields
-      for (const element of elements) {
+      for (const element of elements.sort((a, b) => a.position - b.position)) {
         const rowDiv = document.createElement('div');
         rowDiv.classList.add('row');
         this.metadataDiv.append(rowDiv);
@@ -298,10 +298,10 @@ export class Metadata {
       // the input elements that will be created from the extra fields
       const elements = [];
       for (const [name, description] of Object.entries(json.extra_fields)) {
-        elements.push({ name: name, element: this.generateInput(name, description)});
+        elements.push({ name: name, element: this.generateInput(name, description), position: parseInt(description.elabftwPosition, 10)});
       }
       // now display the inputs from extra_fields
-      for (const element of elements) {
+      for (const element of elements.sort((a, b) => a.position - b.position)) {
         const rowDiv = document.createElement('div');
         rowDiv.classList.add('row');
         this.metadataDiv.append(rowDiv);


### PR DESCRIPTION
See https://github.com/elabftw/elabftw/issues/3056#issuecomment-1179621117

In addition to the already used keys `type`, `value` and `options` there is the new key ~`elabftwP`~`position` ~(I added the 'elabftw' prefix to avoid collision with potentially existing 'position' keys)~.

The value can be numerical (`0`, `1`, `-10`, `3.141592`) or a string representation of a number (`"0"`, `"1"`, `"-10"`, `"3.141592"`). Anyways, it will be converted to an integer so that a float will be floored (`3.9` → `3`).

If ~`elabftwP`~`position` is not present or has a non-numerical value it will be converted to `99999`, i.e., put at the bottom.

Example:
~~~JSON
{
  "extra_fields": {
    "End date": {
      "type": "date",
      "value": "2021-06-09",
      "position": "3"
    },
    "Magnification": {
      "type": "select",
      "value": "20X",
      "options": [
        "10X",
        "20X",
        "40X"
      ],
      "position": 1
    },
    "Pressure (Pa)": {
      "type": "number",
      "value": "12",
      "position": 2
    },
    "Wavelength (nm)": {
      "type": "radio",
      "value": "405",
      "options": [
        "488",
        "405",
        "647"
      ],
      "position": 4
    }
  }
}
~~~