### PR TITLE
Fix tinymce mention autocomplete position calculation

### DIFF
--- a/src/js/tinymce-plugins/mention/plugin.js
+++ b/src/js/tinymce-plugins/mention/plugin.js
@@ -351,7 +351,7 @@
                 nodePosition = $(this.editor.dom.select('span#autocomplete')).offset();
 
             return {
-                top: contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() + 5,
+                top: contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() - $(this.editor.getDoc()).scrollTop() + 5,
                 left: contentAreaPosition.left + nodePosition.left
             };
         },

--- a/src/js/tinymce-plugins/mention/plugin.js
+++ b/src/js/tinymce-plugins/mention/plugin.js
@@ -347,13 +347,12 @@
         },
 
         offset: function () {
-            var rtePosition = $(this.editor.getContainer()).offset(),
-                contentAreaPosition = $(this.editor.getContentAreaContainer()).position(),
-                nodePosition = $(this.editor.dom.select('span#autocomplete')).position();
+            var contentAreaPosition = $(this.editor.getContentAreaContainer()).offset(),
+                nodePosition = $(this.editor.dom.select('span#autocomplete')).offset();
 
             return {
-                top: rtePosition.top + contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() - $(this.editor.getDoc()).scrollTop() + 5,
-                left: rtePosition.left + contentAreaPosition.left + nodePosition.left
+                top: contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() + 5,
+                left: contentAreaPosition.left + nodePosition.left
             };
         },
 


### PR DESCRIPTION
I'm not sure if this will have some side effects for some other users but in Firefox and Edge the autocomplete list is now positioned at the correct location.

* Directly in the body (p element)
  ![image](https://user-images.githubusercontent.com/65481677/178867388-3ed401cb-f7e2-4f8c-a805-beabce9868ef.png)
* First row and column
  ![image](https://user-images.githubusercontent.com/65481677/178867476-6fc4e08a-55e7-40bb-87b3-47a704b2607a.png)
* somewhere in a bit table
  ![image](https://user-images.githubusercontent.com/65481677/178867623-ca6bed2f-2e2d-4d9c-9a20-ee48433d66f5.png)
* also when scrolled in the editor
  ![image](https://user-images.githubusercontent.com/65481677/178875145-561d9285-13c9-4021-b56a-c0ca3fd21d5e.png)
