### PR TITLE
Add src and controls attributes to audio and video elements

### DIFF
--- a/src/services/Filter.php
+++ b/src/services/Filter.php
@@ -134,7 +134,7 @@ class Filter
         // create base config for html5
         $config = HTMLPurifier_HTML5Config::createDefault();
         // allow only certain elements
-        $config->set('HTML.Allowed', 'div[class|style],br,p[class|style],sub,img[src|class|style|width|height],sup,strong,b,em,u,a[href],s,span[style],ul,li,ol,dl,dt,dd,blockquote,h1[class|style],h2[class|style],h3[class|style],h4[class|style],h5[class|style],h6[class|style],hr,table[style],tr[style],td[style|colspan|rowspan],th[style|colspan|rowspan],code,video,audio,pre[class],details,summary,figure,figcaption');
+        $config->set('HTML.Allowed', 'div[class|style],br,p[class|style],sub,img[src|class|style|width|height],sup,strong,b,em,u,a[href],s,span[style],ul,li,ol,dl,dt,dd,blockquote,h1[class|style],h2[class|style],h3[class|style],h4[class|style],h5[class|style],h6[class|style],hr,table[style],tr[style],td[style|colspan|rowspan],th[style|colspan|rowspan],code,video[src|controls],audio[src|controls],pre[class],details,summary,figure,figcaption');
         $config->set('HTML.TargetBlank', true);
         // configure the cache for htmlpurifier
         $tmpDir = FsTools::getCacheFolder('purifier');


### PR DESCRIPTION
Currently the video and audio elements cannot be used because no src attribute can be added.
Not sure if anyone is embedding videos in their ELN but who knows.
There is also a tinymce [open source media plugin](https://www.tiny.cloud/docs/plugins/opensource/media/).