### PR TITLE
Allow drawing reactions in the chemdoodle

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -69,9 +69,6 @@ module.exports = {
     '3Dmol-notrack': [
       './src/ts/3Dmol-notrack.ts',
     ],
-    'chemdoodle-canvas': [
-      './src/js/chemdoodle-canvas.js',
-    ],
   },
   // uncomment this to find where the error is coming from
   // makes the build slower

--- a/src/enums/FileFromString.php
+++ b/src/enums/FileFromString.php
@@ -14,4 +14,5 @@ enum FileFromString: string
     case Png = 'png';
     case Mol = 'mol';
     case Json = 'json';
+    case ChemJson = 'chemjson';
 }

--- a/src/js/chemdoodle-canvas.js
+++ b/src/js/chemdoodle-canvas.js
@@ -1,6 +1,0 @@
-/**
- * This spawns the chem doodle canvas where the script is called
- */
-new ChemDoodle.SketcherCanvas('sketcher', 550, 300, {
-  oneMolecule: true,
-});

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -251,8 +251,12 @@
 {% if Entity.Users.userData.chem_editor %}
   <div class='box chemdoodle'>
     <h3 data-action='toggle-next' data-icon='chemDivIcon' class='d-inline'><i id='chemDivIcon' class='fas fa-chevron-circle-down'></i> <i class='fas fa-fw fa-dna'></i> {{ 'Molecule drawer'|trans }}</h3>
+    <div class='text-center'>
+      <button class='btn btn-primary' data-filetype='chemjson' data-action='save-chem-as-file'>{{ 'Save as Json'|trans }}</button>
+      <button class='btn btn-primary' data-filetype='png' data-action='save-chem-as-file'>{{ 'Save as Png'|trans }}</button>
+    </div>
     <div id='chemDiv' hidden data-save-hidden='chemDiv' class='mt-2 text-center'>
-      <script src='assets/chemdoodle-canvas.bundle.js?v={{ v }}'></script>
+      <canvas id='sketcher'></canvas>
     </div>
   </div>
 {% endif %}

--- a/src/ts/doodle.ts
+++ b/src/ts/doodle.ts
@@ -73,8 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('saveCanvas').addEventListener('click', (e) => {
     const image = doodleCanvas.toDataURL();
     const elDataset = (e.target as HTMLButtonElement).dataset;
-    let type = elDataset.type;
-    const id = elDataset.id;
     const realName = prompt(i18next.t('request-filename'));
     if (realName === null || realName === '') {
       return;
@@ -84,12 +82,9 @@ document.addEventListener('DOMContentLoaded', () => {
       fileType: 'png',
       realName: realName,
       content: image,
-      id: id,
-      type: type,
+      id: elDataset.id,
+      type: elDataset.type,
     }).done(function(json) {
-      if (type === 'items') {
-        type = 'database';
-      }
       reloadElement('filesdiv');
       notif(json);
     });

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -6,6 +6,7 @@
  * @package elabftw
  */
 declare let key: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+declare let ChemDoodle: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 import { notif, reloadElement, updateCategory, showContentPlainText, escapeRegExp } from './misc';
 import { getTinymceBaseConfig, quickSave } from './tinymce';
 import { EntityType, Target, Upload, Model, Payload, Method, Action, PartialEntity } from './interfaces';
@@ -134,7 +135,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const UploadC = new UploadClass(entity);
     UploadC.read().then(json => {
       for (const upload of json.value as Array<Upload>) {
-        if (upload.real_name.split('.').pop() === 'mol') {
+        const extension = upload.real_name.split('.').pop();
+        if (['mol', 'chemjson'].includes(extension)) {
           mols.push([upload.real_name, upload.long_name]);
         }
       }
@@ -158,6 +160,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Load the content of a mol file from the list in the mol editor
   $(document).on('click', '.loadableMolLink', function() {
     $.get($(this).data('target')).done(function(molContent) {
+      // a .chemjson file will be an object but we want a string
+      if (typeof molContent === 'object') {
+        molContent = JSON.stringify(molContent);
+      }
       $('#sketcher_open_text').val(molContent);
     });
   });
@@ -180,6 +186,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // KEYBOARD SHORTCUT
   key(about.scsubmit, () => updateEntityBody());
 
+  // DRAW THE MOLECULE SKETCHER
+  // documentation: https://web.chemdoodle.com/tutorial/2d-structure-canvases/sketcher-canvas#options
+  const sketcher = new ChemDoodle.SketcherCanvas('sketcher', 750, 300, {
+    oneMolecule: false,
+  });
+
   // Add click listener and do action based on which element is clicked
   document.querySelector('.real-container').addEventListener('click', event => {
     const el = (event.target as HTMLElement);
@@ -190,6 +202,33 @@ document.addEventListener('DOMContentLoaded', () => {
     // SWITCH EDITOR
     } else if (el.matches('[data-action="switch-editor"]')) {
       EntityC.update(entity.id, Target.ContentType, editor.switch() === 'tiny' ? '1' : '2');
+
+    // SAVE CHEM CANVAS AS FILE: chemjson or png
+    } else if (el.matches('[data-action="save-chem-as-file"]')) {
+      const realName = prompt(i18next.t('request-filename'));
+      if (realName === null || realName === '') {
+        return;
+      }
+      const content = el.dataset.filetype === 'chemjson' ?
+        // CHEMJSON
+        JSON.stringify(new ChemDoodle.io.JSONInterpreter().contentTo(sketcher.molecules, sketcher.shapes))
+        // PNG
+        : (document.getElementById('sketcher') as HTMLCanvasElement).toDataURL();
+
+      const params = {
+        'addFromString': 'true',
+        'fileType': el.dataset.filetype,
+        'realName': realName,
+        'content': content,
+        'id': String(entity.id),
+        'type': entity.type,
+      };
+
+      AjaxC.postForm('app/controllers/EntityAjaxController.php', params)
+        .then(res => res.json().then(json => {
+          reloadElement('filesdiv');
+          notif(json);
+        }));
 
     // ANNOTATE IMAGE
     } else if (el.matches('[data-action="annotate-image"]')) {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // show a little green check if we have latest version
       const successIcon = document.createElement('i');
       successIcon.style.color = 'green';
-      successIcon.classList.add('fas', 'fa-check', 'fa-lg', 'align-top', 'ml-1');
+      successIcon.classList.add('fas', 'fa-check', 'fa-lg', 'ml-1');
       latestVersionDiv.appendChild(successIcon);
     } else {
       currentVersionDiv.style.color = 'red';


### PR DESCRIPTION
allow drawing reactions in the chemdoodle. fix #1363

* allow saving it as .chemjson files, which can also be loaded back into
    the editor
* allow saving as png
* move the chemdoodle code into edit.ts instead of its own js file
* small touch up on the doodle.ts code that had dead code

