### PR TITLE
Display read/write permissions via icons in show mode

### DIFF
--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -476,9 +476,24 @@ abstract class AbstractEntity implements CrudInterface
         // if it's a number, then lookup the name of the team group
         if (Check::id((int) $permission) !== false) {
             $this->TeamGroups->setId((int) $permission);
-            return ucfirst($this->TeamGroups->readOne()['name']);
+            return $this->TeamGroups->readOne()['name'];
         }
         return Transform::permission($permission);
+    }
+
+    /**
+     * Get a fontawesome icon-name representing the visibility/can write permissions
+     *
+     * @param string $permission raw value (public, organization, team, user, useronly)
+     * @return string fontawesome icon name without 'fa-' prefix
+     */
+    public function getCanIcon(string $permission): string
+    {
+        // if it's a number, it is a team group -> team icon
+        if (Check::id((int) $permission) !== false) {
+            $permission = 'team';
+        }
+        return Transform::permissionIcon($permission);
     }
 
     /**

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -39,6 +39,25 @@ class Transform
     }
 
     /**
+     * Transform the raw permission value into something human readable
+     *
+     * @param string $permission raw value (public, organization, team, user, useronly)
+     * @return string capitalized and translated permission level
+     */
+    public static function permissionIcon(string $permission): string
+    {
+        $res = match ($permission) {
+            'public' => 'globe',
+            'organization' => 'building',
+            'team' => 'users',
+            'user' => 'user-plus',
+            'useronly' => 'user',
+            default => 'circle-question',
+        };
+        return $res;
+    }
+
+    /**
      * Create a hidden input element for injecting CSRF token
      */
     public static function csrf(string $token): string

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -37,8 +37,12 @@
               <input autocomplete='off' type='checkbox' data-action='checkbox-entity' data-id='{{ item.id }}' data-randomid='{{ randomId }}' data-type='{{ Entity.type }}' aria-label='Select' style='width:15px;vertical-align:0.5px;' />
               <!-- edit icon -->
               {% if not item.locked and (item.userid == App.Users.userData.userid or Entity.type == 'items' or App.Session.get('is_admin')) %}
-                <a href='{{ Entity.page }}.php?mode=edit&id={{ item.id }}' title='{{ 'Edit'|trans }}'><i class='fas fa-pencil-alt link-like'></i></a>
-              {% endif %}
+                <a href='{{ Entity.page }}.php?mode=edit&id={{ item.id }}' title='{{ 'Edit'|trans }}'><i class='fas fa-pencil-alt link-like'></i></a>:
+              {%- else -%}
+                <span title='{{ 'Edit'|trans }}'><i class='fas fa-pencil-alt'></i>:</span>
+              {%- endif -%}
+              <span title='{{ 'Edit'|trans ~ ': ' ~ Entity.getCan(item.canwrite) }}'><i class='fas fa-{{ Entity.getCanIcon(item.canwrite) }}'></i></span>
+              <span title='{{ 'Visibility'|trans }}'><i class='fas fa-eye'></i></span>:<span title='{{ 'Visibility'|trans ~ ': ' ~ Entity.getCan(item.canread) }}'><i class='fas fa-{{ Entity.getCanIcon(item.canread) }}'></i></span>
               <!-- toggle body -->
               <span data-type='{{ Entity.type }}' data-id='{{ item.id }}' data-randid={{ randomId }} data-action='toggle-body' title='{{ 'Toggle content'|trans }}'>
                 <i class='fas fa-plus-circle'></i>

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -119,4 +119,17 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(0, $this->Experiments->getTimestampLastMonth());
     }
+
+    public function testGetCan(): void
+    {
+        $this->assertEquals('Public', $this->Experiments->getCan('public'));
+        $this->assertEquals('An error occurred!', $this->Experiments->getCan('unknown'));
+    }
+
+    public function testGetCanIcon(): void
+    {
+        $this->assertEquals('globe', $this->Experiments->getCanIcon('public'));
+        $this->assertEquals('users', $this->Experiments->getCanIcon('1'));
+        $this->assertEquals('circle-question', $this->Experiments->getCanIcon('unknown'));
+    }
 }

--- a/tests/unit/services/TransformTest.php
+++ b/tests/unit/services/TransformTest.php
@@ -33,7 +33,6 @@ class TransformTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('circle-question', Transform::permissionIcon('unknown'));
     }
 
-
     public function testCsrf(): void
     {
         $token = 'fake-token';

--- a/tests/unit/services/TransformTest.php
+++ b/tests/unit/services/TransformTest.php
@@ -20,8 +20,19 @@ class TransformTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Team', Transform::permission('team'));
         $this->assertEquals('Owner + Admin(s)', Transform::permission('user'));
         $this->assertEquals('Owner only', Transform::permission('useronly'));
-        $this->assertEquals('An error occurred!', Transform::permission('user2'));
+        $this->assertEquals('An error occurred!', Transform::permission('unknown'));
     }
+
+    public function testPermissionIcon(): void
+    {
+        $this->assertEquals('globe', Transform::permissionIcon('public'));
+        $this->assertEquals('building', Transform::permissionIcon('organization'));
+        $this->assertEquals('users', Transform::permissionIcon('team'));
+        $this->assertEquals('user-plus', Transform::permissionIcon('user'));
+        $this->assertEquals('user', Transform::permissionIcon('useronly'));
+        $this->assertEquals('circle-question', Transform::permissionIcon('unknown'));
+    }
+
 
     public function testCsrf(): void
     {


### PR DESCRIPTION
The way the icons are presented in the UI could be optimized but the functionality is there. The icons have a title attribute too.

![image](https://user-images.githubusercontent.com/65481677/183565178-1b996e16-7f20-4c9d-9624-2701f6051909.png)

- only me: [![image](https://user-images.githubusercontent.com/65481677/183563409-6443790d-fd56-4ae6-9628-7e00c52fda06.png)](https://fontawesome.com/v5/icons/user?s=solid), alternative: [![image](https://user-images.githubusercontent.com/65481677/183564019-7a3f12b9-edf1-4f7a-b2a1-523505be0d57.png)](https://fontawesome.com/v5/icons/user-secret?s=solid)
- me + admins: [![image](https://user-images.githubusercontent.com/65481677/183563507-88abb209-31eb-4f91-8168-a1f126a0db2d.png)](https://fontawesome.com/v5/icons/user-plus?s=solid)
- team or group: [![image](https://user-images.githubusercontent.com/65481677/183563595-ea35e5ef-3771-4b19-b076-254fbcc6e27e.png)](https://fontawesome.com/v5/icons/users?s=solid)
- all with account (company/institution): [![image](https://user-images.githubusercontent.com/65481677/183563784-9e59cbde-7f33-4b92-95bf-7f800fbbca72.png)](https://fontawesome.com/v5/icons/building?s=solid), alternative [![image](https://user-images.githubusercontent.com/65481677/183564130-b89e5286-ea0d-427d-b31c-97d154a59ddb.png)](https://fontawesome.com/v5/icons/university?s=solid)
- public: [![image](https://user-images.githubusercontent.com/65481677/183563896-4fc8b46c-91f3-4997-8def-533f1af0b5a6.png)](https://fontawesome.com/v5/icons/globe?s=solid)

closes #2365
