### PR TITLE
Use enum for advanced search fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,9 @@
       "Elabftw\\Services\\AdvancedSearchQuery\\Collectors\\": [
         "src/services/advancedSearchQuery/collectors"
       ],
+      "Elabftw\\Services\\AdvancedSearchQuery\\Enums\\": [
+        "src/services/advancedSearchQuery/enums"
+      ],
       "Elabftw\\Services\\AdvancedSearchQuery\\Exceptions\\": [
         "src/services/advancedSearchQuery/exceptions"
       ],

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -72,7 +72,7 @@ Fields
 Field
   = field:('author'i / 'body'i / 'category'i / 'elabid'i / 'group'i / 'status'i / 'title'i / 'visibility'i) ':' strict:('s:' {return true;})? term:(List / LiteralInField)
   {
-    return new Field($field, $term, $strict);
+    return new Field(strtolower($field), $term, $strict);
   }
 
 FieldDate
@@ -131,7 +131,7 @@ DD
 FieldBoolean
   = field:('locked'i / 'timestamped'i) ':' term:Boolean
   {
-    return new Field($field, new SimpleValueWrapper($term));
+    return new Field(strtolower($field), new SimpleValueWrapper($term));
   }
 
 // return strings because SimpleValueWrapper() takes strings

--- a/src/services/advancedSearchQuery/enums/Fields.php
+++ b/src/services/advancedSearchQuery/enums/Fields.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services\AdvancedSearchQuery\Enums;
+
+enum Fields: string
+{
+    case Attachment = 'attachment';
+    case Author = 'author';
+    case Body = 'body';
+    case Category = 'category';
+    case Elabid = 'elabid';
+    case Group = 'group';
+    case Locked = 'locked';
+    case Rating = 'rating';
+    case Status = 'status';
+    case Timestamped = 'timestamped';
+    case Title = 'title';
+    case Visibility = 'visibility';
+}

--- a/src/services/advancedSearchQuery/grammar/Field.php
+++ b/src/services/advancedSearchQuery/grammar/Field.php
@@ -10,13 +10,12 @@
 
 namespace Elabftw\Services\AdvancedSearchQuery\Grammar;
 
+use Elabftw\Services\AdvancedSearchQuery\Enums\Fields;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\FieldType;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Term;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitable;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitor;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
-use function filter_var;
-use function strtolower;
 
 class Field implements Term, Visitable, FieldType
 {
@@ -34,9 +33,9 @@ class Field implements Term, Visitable, FieldType
         return $this->valueWrapper->getValue();
     }
 
-    public function getFieldType(): string
+    public function getFieldType(): Fields
     {
-        return filter_var(strtolower($this->field), FILTER_SANITIZE_STRING) ?: '';
+        return Fields::from($this->field);
     }
 
     public function getAffix(): string

--- a/src/services/advancedSearchQuery/interfaces/FieldType.php
+++ b/src/services/advancedSearchQuery/interfaces/FieldType.php
@@ -10,7 +10,9 @@
 
 namespace Elabftw\Services\AdvancedSearchQuery\Interfaces;
 
+use Elabftw\Services\AdvancedSearchQuery\Enums\Fields;
+
 interface FieldType
 {
-    public function getFieldType(): string;
+    public function getFieldType(): Fields;
 }

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -22,6 +22,7 @@ use Elabftw\Services\AdvancedSearchQuery\Grammar\SimpleValueWrapper;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitable;
 use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitor;
 use function sprintf;
+use function ucfirst;
 
 /** @psalm-suppress UnusedParam */
 class FieldValidatorVisitor implements Visitor
@@ -54,7 +55,7 @@ class FieldValidatorVisitor implements Visitor
     {
         // Call class methods dynamically to avoid many if statements.
         // This works here because the parser defines the list of fields.
-        $method = 'visitField' . ucfirst($field->getFieldType());
+        $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }
 

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -54,7 +54,7 @@ class FieldValidatorVisitor implements Visitor
     public function visitField(Field $field, VisitorParameters $parameters): InvalidFieldCollector
     {
         // Call class methods dynamically to avoid many if statements.
-        // This works here because the parser defines the list of fields.
+        // This works here flawless because the parser and the Fields enum define the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -54,7 +54,7 @@ class FieldValidatorVisitor implements Visitor
     public function visitField(Field $field, VisitorParameters $parameters): InvalidFieldCollector
     {
         // Call class methods dynamically to avoid many if statements.
-        // This works here flawless because the parser and the Fields enum define the list of fields.
+        // This works because the parser and the Fields enum define the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -101,7 +101,7 @@ class QueryBuilderVisitor implements Visitor
         // Tag and Metadata not implemented!
 
         // Call class methods dynamically to avoid many if statements.
-        // This works here flawless because the parser and the Fields enum define the list of fields.
+        // This works because the parser and the Fields enum define the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -101,7 +101,7 @@ class QueryBuilderVisitor implements Visitor
         // Tag and Metadata not implemented!
 
         // Call class methods dynamically to avoid many if statements.
-        // This works here because the parser defines the list of fields.
+        // This works here flawless because the parser and the Fields enum define the list of fields.
         $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -102,7 +102,7 @@ class QueryBuilderVisitor implements Visitor
 
         // Call class methods dynamically to avoid many if statements.
         // This works here because the parser defines the list of fields.
-        $method = 'visitField' . ucfirst($field->getFieldType());
+        $method = 'visitField' . ucfirst($field->getFieldType()->value);
         return $this->$method($field->getValue(), $field->getAffix(), $parameters);
     }
 

--- a/src/templates/filter-order-sort.html
+++ b/src/templates/filter-order-sort.html
@@ -1,11 +1,9 @@
+{% if not searchPage %}
 <div class='row'>
   <!-- LEFT MENU: FILTER/ORDER/SORT/LIMIT -->
   <!-- we hide this menu for small devices -->
   <div class='col-md-10 hidden-xs {{ searchPage ? 'mt-2' }}'>
-
-    {% if not searchPage %}
-      <form>
-    {% endif %}
+    <form>
     <div class='form-group form-inline'>
       <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
       {% if DisplayParams.searchType == 'related' %}
@@ -88,21 +86,18 @@
         {% endfor %}
       </select>
 
-      {% if not searchPage %}
-        <!-- SEARCH WITH TAG -->
-        <select multiple name='tags[]' class='form-control mr-1 selectpicker' data-show-subtext='true' data-none-selected-text='{{ 'Tags'|trans }}' data-live-search='true' data-style='' data-style-base='form-control' data-showtick='true' data-actions-box='true'>
-          {% for tag in tagsArrForSelect %}
-            <option value='{{ tag.tag }}'{{ tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag|raw }}</option>
-          {% endfor %}
-        </select>
-        <!-- onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button -->
-        <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
-      {% endif %}
+      <!-- SEARCH WITH TAG -->
+      <select multiple name='tags[]' class='form-control mr-1 selectpicker' data-show-subtext='true' data-none-selected-text='{{ 'Tags'|trans }}' data-live-search='true' data-style='' data-style-base='form-control' data-showtick='true' data-actions-box='true'>
+        {% for tag in tagsArrForSelect %}
+          <option value='{{ tag.tag }}'{{ tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag|raw }}</option>
+        {% endfor %}
+      </select>
+      <!-- onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button -->
+      <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
 
     </div>
     </form>
   </div>
-  {% if not searchPage %}
-    {% include 'create-new.html' %}
-  {% endif %}
+  {% include 'create-new.html' %}
 </div>
+{% endif %}


### PR DESCRIPTION
I think this is a cleaner way to filter/check for allowed fields.
Actually the parser makes sure there will be no call to an not-existing field but the enumeration is a nice way to have all allowed fields listed in one place.