### PR TITLE
sort icons table show mode

### DIFF
--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -326,9 +326,16 @@ document.addEventListener('DOMContentLoaded', () => {
   // we don't want the favtags opener on search page
   // when a search is done, about.page will be show
   // so check for the type param in url that will be present on search page
-  const params = new URLSearchParams(document.location.search.slice(1));
+  const params = new URLSearchParams(document.location.search);
   if (!params.get('type')) {
     document.getElementById('favtags-opener').removeAttribute('hidden');
+  }
+
+  // item table asc/desc icons
+  const orderBy = ['date', 'title', 'cat', 'rating', 'user'].includes(params.get('order')) ? params.get('order') : false;
+  if (orderBy) {
+    const iconEl = document.getElementById('itemList').querySelector(`:scope th > a[data-orderby="${orderBy}"] > i`) as HTMLElement;
+    iconEl.classList.replace('fa-sort', params.get('sort') === 'desc' ? 'fa-sort-down' : 'fa-sort-up');
   }
 
   // FAVTAGS PANEL

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -211,7 +211,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (params.get('sort') === 'desc') {
         sort = 'asc';
       }
-      window.location.href = `?order=${el.dataset.orderby}&sort=${sort}`;
+      params.set('sort', sort);
+      params.set('order', el.dataset.orderby);
+      window.location.href = `?${params.toString()}`;
 
     // CHECK AN ENTITY BOX
     } else if (el.matches('[data-action="checkbox-entity"]')) {


### PR DESCRIPTION
@NicolasCARPi 
Following up on your comment in [#3852](https://github.com/elabftw/elabftw/pull/3852#issuecomment-1279983934)

> The sort icons code should be reused for the table mode of items show.

Well, not really reused but anyways, this PR will add dynamic icon changes and fixea a small bug related to the query string.
However, this implementation is very laggy due to the page reload. Maybe it would be better to change the icon dynamically in the template.

I think, there is still a bug on the search page in tabular mode. Needs further investigation. No time right now.

