### PR TITLE
keep search input

### DIFF
--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -237,10 +237,6 @@
         </div>
         <small class='form-text text-muted'>
           Press <kbd><kbd>ctrl</kbd> + <kbd>enter</kbd></kbd> or <kbd><kbd>⌘</kbd> + <kbd>enter</kbd></kbd> to submit search.
-          {% if App.Config.configArr.debug %}
-            <kbd data-action='toggle-next'>debug</kbd>
-            <pre hidden>{{ whereClause|raw }}</pre>
-          {% endif %}
         </small>
       </div>
       <div class='col-md-4 mb-2'>

--- a/web/search.php
+++ b/web/search.php
@@ -73,7 +73,6 @@ $renderArr = array(
     'visibilityArr' => $visibilityArr,
     'extended' => $extended,
     'teamGroups' => array_column($teamGroupsArr, 'name'),
-    'whereClause' => print_r($whereClause ?? '', true), // only for dev
 );
 echo $App->render('search.html', $renderArr);
 

--- a/web/search.php
+++ b/web/search.php
@@ -56,6 +56,10 @@ if ($App->Request->query->get('type') === 'experiments') {
 // default input for extendedArea
 $extended = 'author:"' . $Entity->Users->userData['fullname'] . '" ';
 
+if ($App->Request->query->has('extended') && !empty($App->Request->query->get('extended'))) {
+    $extended = trim((string) $App->Request->query->get('extended'));
+}
+
 // RENDER THE FIRST PART OF THE PAGE (search form)
 $renderArr = array(
     'Request' => $App->Request,


### PR DESCRIPTION
After refactoring the advanced search query code into AbstractEntity (a92bf3205f9af58ffdb31aa69b0fb37961d87f88) the user input is 'reset' after each search execution.
Also, there is some residual code for debugging which is not working anymore.

This PR fixes the 'reset' of the search input and removes the not working debug code.