### PR TITLE
Small changes to UI/UX

### DIFF
--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -94,7 +94,10 @@ document.addEventListener('DOMContentLoaded', () => {
         notif(nothingSelectedError);
         return;
       }
-      window.location.href = `make.php?format=${el.value}&type=${about.type}&id=${checked.map(value => value.id).join('+')}`;
+      const format = el.value;
+      // reset selection so button can be used again with same format
+      el.selectedIndex = 0;
+      window.location.href = `make.php?format=${format}&type=${about.type}&id=${checked.map(value => value.id).join('+')}`;
 
     // UPDATE CATEGORY
     } else if (el.matches('[data-action="update-category-selected-entities"]')) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -86,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
         processNewFilename(event, filenameLink, parentSpan);
       });
       filenameLink.replaceWith(filenameInput);
+      filenameInput.focus();
 
     // TOGGLE DISPLAY
     } else if (el.matches('[data-action="toggle-uploads-layout"]')) {


### PR DESCRIPTION
The export button in show mode can only export the same format once because only a change will trigger the event.
This PR will reset the select element every time a change is made. Hence a user can select a different entry and export with the same format.

In edit mode the upload file rename will create an input element but the user will need to select this input element manually.
This PR will automatically set the focus on the input element so editing can start right away.