### PR TITLE
Make quick search great again

### DIFF
--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -104,7 +104,7 @@ class DisplayParams
             $this->offset = $this->Request->query->getInt('offset');
         }
         if (!empty($this->Request->query->get('q'))) {
-            $this->query = (string) $this->Request->query->get('q', '');
+            $this->query = trim((string) $this->Request->query->get('q'));
             $this->searchType = 'query';
         }
         if (!empty($this->Request->query->get('extended'))) {

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -104,7 +104,7 @@ class DisplayParams
             $this->offset = $this->Request->query->getInt('offset');
         }
         if (!empty($this->Request->query->get('q'))) {
-            $this->query = $this->Request->query->filter('q', null, FILTER_SANITIZE_STRING);
+            $this->query = (string) $this->Request->query->get('q', '');
             $this->searchType = 'query';
         }
         if (!empty($this->Request->query->get('extended'))) {

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -20,7 +20,7 @@ use function trim;
 
 /**
  * This class holds the values for limit, offset, order and sort
- * It is based on user preferences, overriden by request parameters
+ * It is based on user preferences, overridden by request parameters
  */
 class DisplayParams
 {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -211,13 +211,9 @@ abstract class AbstractEntity implements RestInterface
      */
     public function readShow(DisplayParams $displayParams, bool $extended = false): array
     {
-        // extended search (this block must be before the call to getReadSqlBeforeWhere so extendedValues is filled)
-        if ($displayParams->searchType === 'extended') {
-            $this->processExtendedQuery($displayParams->extendedQuery);
-        }
-        // quick search (block must be before the call to getReadSqlBeforeWhere so extendedValues is filled)
-        if (!empty($displayParams->query)) {
-            $this->processExtendedQuery($displayParams->query, true);
+        // (extended) search (block must be before the call to getReadSqlBeforeWhere so extendedValues is filled)
+        if (!empty($displayParams->query) or !empty($displayParams->extendedQuery)) {
+            $this->processExtendedQuery(trim($displayParams->query . ' ' . $displayParams->extendedQuery));
         }
 
         $sql = $this->getReadSqlBeforeWhere($extended, $extended, $displayParams->hasMetadataSearch);
@@ -778,13 +774,12 @@ abstract class AbstractEntity implements RestInterface
         }
     }
 
-    private function processExtendedQuery(string $extendedQuery, bool $isQuickSearch = false): void
+    private function processExtendedQuery(string $extendedQuery): void
     {
         $advancedQuery = new AdvancedSearchQuery($extendedQuery, new VisitorParameters(
             $this->type,
             $this->TeamGroups->getVisibilityList(),
             $this->TeamGroups->readGroupsWithUsersFromUser(),
-            $isQuickSearch,
         ));
         $whereClause = $advancedQuery->getWhereClause();
         if ($whereClause) {

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -19,7 +19,7 @@ OrOperand
     return new OrOperand($operand, $tail);
   }
 
-OrOperator '"OR", "|"'
+OrOperator '" OR ", "|"'
   = (_+ 'OR'i _+)
   / (_* '|' _*)
 
@@ -35,7 +35,7 @@ AndOperand
     return new AndOperand($operand, $tail);
   }
 
-AndOperator '"AND", "&"'
+AndOperator 'space, " AND ", "&"'
   = (_+ 'AND'i _+)
   / (_* '&' _*)
   / _+
@@ -46,7 +46,7 @@ NotExpression
     return new NotExpression($expression);
   }
 
-NotOperator '"NOT", "!"'
+NotOperator '"NOT ", "!"'
   = ('NOT'i _+)
   / ('!' _*)
 

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -39,8 +39,13 @@ class QueryBuilderVisitor implements Visitor
     {
         $param = $this->getUniqueID();
 
+        $query = '(entity.body LIKE ' . $param . ' OR entity.title LIKE ' . $param . ')';
+        if ($parameters->isQuickSearch()) {
+            $query = '(entity.title LIKE ' . $param . ' OR entity.body LIKE ' . $param;
+            $query .= ' OR entity.date LIKE ' . $param . ' OR entity.elabid LIKE ' . $param . ')';
+        }
         return new WhereCollector(
-            '(entity.body LIKE ' . $param . ' OR entity.title LIKE ' . $param . ')',
+            $query,
             array(array(
                 'param' => $param,
                 'value' => '%' . $simpleValueWrapper->getValue() . '%',

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -38,12 +38,8 @@ class QueryBuilderVisitor implements Visitor
     public function visitSimpleValueWrapper(SimpleValueWrapper $simpleValueWrapper, VisitorParameters $parameters): WhereCollector
     {
         $param = $this->getUniqueID();
+        $query = sprintf('(entity.title LIKE %1$s OR entity.body LIKE %1$s OR entity.date LIKE %1$s OR entity.elabid LIKE %1$s)', $param);
 
-        $query = '(entity.body LIKE ' . $param . ' OR entity.title LIKE ' . $param . ')';
-        if ($parameters->isQuickSearch()) {
-            $query = '(entity.title LIKE ' . $param . ' OR entity.body LIKE ' . $param;
-            $query .= ' OR entity.date LIKE ' . $param . ' OR entity.elabid LIKE ' . $param . ')';
-        }
         return new WhereCollector(
             $query,
             array(array(

--- a/src/services/advancedSearchQuery/visitors/VisitorParameters.php
+++ b/src/services/advancedSearchQuery/visitors/VisitorParameters.php
@@ -12,7 +12,7 @@ namespace Elabftw\Services\AdvancedSearchQuery\Visitors;
 
 class VisitorParameters
 {
-    public function __construct(private string $entityType, private array $visArr, private array $teamGroups, private bool $isQuickSearch = false)
+    public function __construct(private string $entityType, private array $visArr, private array $teamGroups)
     {
     }
 
@@ -29,10 +29,5 @@ class VisitorParameters
     public function getTeamGroups(): array
     {
         return $this->teamGroups;
-    }
-
-    public function isQuickSearch(): bool
-    {
-        return $this->isQuickSearch;
     }
 }

--- a/src/services/advancedSearchQuery/visitors/VisitorParameters.php
+++ b/src/services/advancedSearchQuery/visitors/VisitorParameters.php
@@ -12,7 +12,7 @@ namespace Elabftw\Services\AdvancedSearchQuery\Visitors;
 
 class VisitorParameters
 {
-    public function __construct(private string $entityType, private array $visArr, private array $teamGroups)
+    public function __construct(private string $entityType, private array $visArr, private array $teamGroups, private bool $isQuickSearch = false)
     {
     }
 
@@ -29,5 +29,10 @@ class VisitorParameters
     public function getTeamGroups(): array
     {
         return $this->teamGroups;
+    }
+
+    public function isQuickSearch(): bool
+    {
+        return $this->isQuickSearch;
     }
 }

--- a/src/templates/filter-order-sort.html
+++ b/src/templates/filter-order-sort.html
@@ -1,17 +1,17 @@
-{% if not searchPage %}
 <div class='row'>
-  <!-- LEFT MENU: FILTER/ORDER/SORT/LIMIT -->
-  <!-- we hide this menu for small devices -->
+  {# LEFT MENU: FILTER/ORDER/SORT/LIMIT #}
+  {# we hide this menu for small devices #}
   <div class='col-md-10 hidden-xs {{ searchPage ? 'mt-2' }}'>
     <form>
     <div class='form-group form-inline'>
-      <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
+      {% if not searchPage %}
+        <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
+      {% endif %}
       {% if DisplayParams.searchType == 'related' %}
         <input type='hidden' name='related' value='{{ App.Request.query.get('related')|number_format }}' />
       {% endif %}
 
-
-      <!-- CATEGORY -->
+      {# CATEGORY #}
       <select name='cat' class='autosubmit mr-1 form-control' aria-label='Filter category'>
         <option value=''>{{ Entity.type == 'experiments' ? 'Filter status'|trans : 'Filter by type'|trans }}</option>
         {% for category in categoryArr %}
@@ -20,7 +20,7 @@
         {% endfor %}
       </select>
 
-      <!-- OWNER filter -->
+      {# OWNER filter #}
       <select name='owner' class='autosubmit mr-1 form-control' aria-label='Filter owner'>
         <option value=''>{{ 'Filter owner'|trans }}</option>
         {% for user in allTeamUsersArr %}
@@ -29,28 +29,30 @@
         {% endfor %}
       </select>
 
-      <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter visibility'>
-        <option value=''>{{ 'Filter visibility'|trans }}</option>
-        {% for vis in visibilityArr %}
-        <option value='visibility:"{{ vis }}"'>
-          {{ vis|raw }}</option>
-        {% endfor %}
-      </select>
-
-      <!-- TEAMGROUP filter -->
-      {% if teamGroupsFromUser %}
-        <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter team group'>
-          <option value=''>{{ 'Filter team group'|trans }}</option>
-          {% for group in teamGroupsFromUser %}
-          <option value='group:"{{ group.name }}"'>
-            {{ group.name|raw }}</option>
+      {% if not searchPage %}
+        {# VISIBILITY filter #}
+        <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter visibility'>
+          <option value=''>{{ 'Filter visibility'|trans }}</option>
+          {% for vis in visibilityArr %}
+          <option value='visibility:"{{ vis }}"'{{ App.Request.query.get('extended') == 'visibility:"' ~ vis|raw ~ '"' ? ' selected'}}>
+            {{ vis|raw }}</option>
           {% endfor %}
         </select>
-      {% endif %}
 
+        {# TEAMGROUP filter #}
+        {% if teamGroupsFromUser %}
+          <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter team group'>
+            <option value=''>{{ 'Filter team group'|trans }}</option>
+            {% for group in teamGroupsFromUser %}
+            <option value='group:"{{ group.name }}"'{{ App.Request.query.get('extended') == 'group:"' ~ group.name|raw ~ '"' ? ' selected'}}>
+              {{ group.name|raw }}</option>
+            {% endfor %}
+          </select>
+        {% endif %}
+      {% endif %}
       <input type='hidden' name='mode' value='show' />
 
-      <!-- LIMIT if there is nothing in the query params, take the user configured one -->
+      {# LIMIT if there is nothing in the query params, take the user configured one #}
       {% set thelimit = App.Request.query.get('limit') %}
       {% if thelimit is empty %}
         {% set thelimit = App.Users.userData.limit_nb %}
@@ -62,13 +64,13 @@
         {% endfor %}
       </select>
 
-      <!-- SEARCH WITH TAG -->
+      {# SEARCH WITH TAG #}
       <select multiple name='tags[]' class='form-control mr-1 selectpicker' data-show-subtext='true' data-none-selected-text='{{ 'Tags'|trans }}' data-live-search='true' data-style='' data-style-base='form-control' data-showtick='true' data-actions-box='true'>
         {% for tag in tagsArrForSelect %}
           <option value='{{ tag.tag }}'{{ tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag|raw }}</option>
         {% endfor %}
       </select>
-      <!-- onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button -->
+      {# onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button #}
       <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
 
     </div>
@@ -76,4 +78,3 @@
   </div>
   {% include 'create-new.html' %}
 </div>
-{% endif %}

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -12,7 +12,7 @@
       </div>
       <div class='modal-body' data-wait='{{ 'Please wait…' }}'>
         <h3>Search terms</h3>
-        <p>The search is performed against the title and the body.<br>
+        <p>The search is performed against title, body, date, and elabid.<br>
             The entire team will be searched unless there is an author fields.</p>
         <dl>
           <dt>Term</dt>
@@ -387,12 +387,12 @@
         <div style='position:relative;'>
           <textarea
             id='extendedArea'
-            name='extended'
+            name='q'
             rows='10'
             class='form-control'
             placeholder='author:"{{ App.Users.userData.fullname|raw }}" status:"Running"'
             spellcheck='false'
-          >{{ App.Request.query.get('extended') ? App.Request.query.get('extended')|trim : 'author:"' ~ App.Users.userData.fullname ~ '" ' }}</textarea>
+          >{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim : 'author:"' ~ App.Users.userData.fullname ~ '" ' }}</textarea>
           <pre id='search-highlighting' class='form-control d-none' aria-hidden='true'><code></code></pre>
 
         </div>

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -62,21 +62,9 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         ));
         $whereClause = $advancedSearchQuery->getWhereClause();
         $this->assertIsArray($whereClause);
-        $this->assertStringStartsWith(' AND (((entity.body LIKE :', $whereClause['where']);
-        $this->assertStringEndsWith(')))', $whereClause['where']);
-
-        // Quick search
-        $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
-            'experiments',
-            $this->visibilityList,
-            $this->groups,
-            true,
-        ));
-        $whereClause = $advancedSearchQuery->getWhereClause();
-        $this->assertIsArray($whereClause);
         $this->assertStringStartsWith(' AND (((entity.title LIKE :', $whereClause['where']);
         $this->assertStringEndsWith(')))', $whereClause['where']);
-        
+
         $query = 'category:"only meaningful with items but no error"';
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'items',

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -65,6 +65,18 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $this->assertStringStartsWith(' AND (((entity.body LIKE :', $whereClause['where']);
         $this->assertStringEndsWith(')))', $whereClause['where']);
 
+        // Quick search
+        $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
+            'experiments',
+            $this->visibilityList,
+            $this->groups,
+            true,
+        ));
+        $whereClause = $advancedSearchQuery->getWhereClause();
+        $this->assertIsArray($whereClause);
+        $this->assertStringStartsWith(' AND (((entity.title LIKE :', $whereClause['where']);
+        $this->assertStringEndsWith(')))', $whereClause['where']);
+        
         $query = 'category:"only meaningful with items but no error"';
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'items',


### PR DESCRIPTION
Hi Nico,

During all the code changes on the way to version 4.4.0 the quick search input does not get parsed for fields anymore. [We talked about it already](https://github.com/elabftw/elabftw/discussions/3642#discussioncomment-3946217).

I guess this was primarily to revert to the initial behavior that the quick search was looking for the search term in `title`, `body`, `date`, and `elabid`. This behavior will be retained but in addition the fields can also be used. This is achieved by passing an additional parameter (`isQuickSearch`) to the `AdvancedSearchQuery` via `VisitorParameters`.