### PR TITLE
Noflag marcel

### DIFF
--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -37,6 +37,9 @@ class DisplayParams
     // the search from the top right search bar on experiments/database
     public string $query = '';
 
+    // the extended search query
+    public string $extendedQuery = '';
+
     // if this variable is not empty the error message shown will be different if there are no results
     public string $searchType = '';
 
@@ -101,12 +104,12 @@ class DisplayParams
             $this->offset = $this->Request->query->getInt('offset');
         }
         if (!empty($this->Request->query->get('q'))) {
-            $this->query = (string) $this->Request->query->get('q', '');
+            $this->query = trim((string) $this->Request->query->get('q'));
             $this->searchType = 'query';
         }
         if (!empty($this->Request->query->get('extended'))) {
-            $this->query = trim((string) $this->Request->query->get('extended'));
-            $this->searchType = 'query';
+            $this->extendedQuery = trim((string) $this->Request->query->get('extended'));
+            $this->searchType = 'extended';
         }
         // now get pref from the filter-order-sort menu
         $this->sort = Sort::tryFrom($this->Request->query->getAlpha('sort')) ?? $this->sort;

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -211,9 +211,9 @@ abstract class AbstractEntity implements RestInterface
      */
     public function readShow(DisplayParams $displayParams, bool $extended = false): array
     {
-        // extended search (block must be before the call to getReadSqlBeforeWhere so extendedValues is filled)
-        if (!empty($displayParams->query)) {
-            $this->processExtendedQuery($displayParams->query);
+        // (extended) search (block must be before the call to getReadSqlBeforeWhere so extendedValues is filled)
+        if (!empty($displayParams->query) or !empty($displayParams->extendedQuery)) {
+            $this->processExtendedQuery(trim($displayParams->query . ' ' . $displayParams->extendedQuery));
         }
 
         $sql = $this->getReadSqlBeforeWhere($extended, $extended, $displayParams->hasMetadataSearch);

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -19,7 +19,7 @@ OrOperand
     return new OrOperand($operand, $tail);
   }
 
-OrOperator '"OR", "|"'
+OrOperator '" OR ", "|"'
   = (_+ 'OR'i _+)
   / (_* '|' _*)
 
@@ -35,7 +35,7 @@ AndOperand
     return new AndOperand($operand, $tail);
   }
 
-AndOperator '"AND", "&"'
+AndOperator 'space, " AND ", "&"'
   = (_+ 'AND'i _+)
   / (_* '&' _*)
   / _+
@@ -46,7 +46,7 @@ NotExpression
     return new NotExpression($expression);
   }
 
-NotOperator '"NOT", "!"'
+NotOperator '"NOT ", "!"'
   = ('NOT'i _+)
   / ('!' _*)
 

--- a/src/templates/filter-order-sort.html
+++ b/src/templates/filter-order-sort.html
@@ -1,11 +1,12 @@
-{% if not searchPage %}
 <div class='row'>
   <!-- LEFT MENU: FILTER/ORDER/SORT/LIMIT -->
   <!-- we hide this menu for small devices -->
   <div class='col-md-10 hidden-xs {{ searchPage ? 'mt-2' }}'>
     <form>
     <div class='form-group form-inline'>
-      <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
+      {% if not searchPage %}
+        <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
+      {% endif %}
       {% if DisplayParams.searchType == 'related' %}
         <input type='hidden' name='related' value='{{ App.Request.query.get('related')|number_format }}' />
       {% endif %}
@@ -29,25 +30,27 @@
         {% endfor %}
       </select>
 
-      <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter visibility'>
-        <option value=''>{{ 'Filter visibility'|trans }}</option>
-        {% for vis in visibilityArr %}
-        <option value='visibility:"{{ vis }}"'>
-          {{ vis|raw }}</option>
-        {% endfor %}
-      </select>
-
-      <!-- TEAMGROUP filter -->
-      {% if teamGroupsFromUser %}
-        <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter team group'>
-          <option value=''>{{ 'Filter team group'|trans }}</option>
-          {% for group in teamGroupsFromUser %}
-          <option value='group:"{{ group.name }}"'>
-            {{ group.name|raw }}</option>
+      {% if not searchPage %}
+        {# VISIBILITY filter #}
+        <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter visibility'>
+          <option value=''>{{ 'Filter visibility'|trans }}</option>
+          {% for vis in visibilityArr %}
+          <option value='visibility:"{{ vis }}"'{{ App.Request.query.get('extended') == 'visibility:"' ~ vis|raw ~ '"' ? ' selected'}}>
+            {{ vis|raw }}</option>
           {% endfor %}
         </select>
-      {% endif %}
 
+        {# TEAMGROUP filter #}
+        {% if teamGroupsFromUser %}
+          <select name='extended' class='autosubmit mr-1 form-control' aria-label='Filter team group'>
+            <option value=''>{{ 'Filter team group'|trans }}</option>
+            {% for group in teamGroupsFromUser %}
+            <option value='group:"{{ group.name }}"'{{ App.Request.query.get('extended') == 'group:"' ~ group.name|raw ~ '"' ? ' selected'}}>
+              {{ group.name|raw }}</option>
+            {% endfor %}
+          </select>
+        {% endif %}
+      {% endif %}
       <input type='hidden' name='mode' value='show' />
 
       <!-- LIMIT if there is nothing in the query params, take the user configured one -->
@@ -76,4 +79,3 @@
   </div>
   {% include 'create-new.html' %}
 </div>
-{% endif %}

--- a/src/templates/filter-order-sort.html
+++ b/src/templates/filter-order-sort.html
@@ -1,6 +1,6 @@
 <div class='row'>
-  <!-- LEFT MENU: FILTER/ORDER/SORT/LIMIT -->
-  <!-- we hide this menu for small devices -->
+  {# LEFT MENU: FILTER/ORDER/SORT/LIMIT #}
+  {# we hide this menu for small devices #}
   <div class='col-md-10 hidden-xs {{ searchPage ? 'mt-2' }}'>
     <form>
     <div class='form-group form-inline'>
@@ -11,8 +11,7 @@
         <input type='hidden' name='related' value='{{ App.Request.query.get('related')|number_format }}' />
       {% endif %}
 
-
-      <!-- CATEGORY -->
+      {# CATEGORY #}
       <select name='cat' class='autosubmit mr-1 form-control' aria-label='Filter category'>
         <option value=''>{{ Entity.type == 'experiments' ? 'Filter status'|trans : 'Filter by type'|trans }}</option>
         {% for category in categoryArr %}
@@ -21,7 +20,7 @@
         {% endfor %}
       </select>
 
-      <!-- OWNER filter -->
+      {# OWNER filter #}
       <select name='owner' class='autosubmit mr-1 form-control' aria-label='Filter owner'>
         <option value=''>{{ 'Filter owner'|trans }}</option>
         {% for user in allTeamUsersArr %}
@@ -53,7 +52,7 @@
       {% endif %}
       <input type='hidden' name='mode' value='show' />
 
-      <!-- LIMIT if there is nothing in the query params, take the user configured one -->
+      {# LIMIT if there is nothing in the query params, take the user configured one #}
       {% set thelimit = App.Request.query.get('limit') %}
       {% if thelimit is empty %}
         {% set thelimit = App.Users.userData.limit_nb %}
@@ -65,13 +64,13 @@
         {% endfor %}
       </select>
 
-      <!-- SEARCH WITH TAG -->
+      {# SEARCH WITH TAG #}
       <select multiple name='tags[]' class='form-control mr-1 selectpicker' data-show-subtext='true' data-none-selected-text='{{ 'Tags'|trans }}' data-live-search='true' data-style='' data-style-base='form-control' data-showtick='true' data-actions-box='true'>
         {% for tag in tagsArrForSelect %}
           <option value='{{ tag.tag }}'{{ tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag|raw }}</option>
         {% endfor %}
       </select>
-      <!-- onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button -->
+      {# onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button #}
       <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
 
     </div>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -387,12 +387,12 @@
         <div style='position:relative;'>
           <textarea
             id='extendedArea'
-            name='extended'
+            name='q'
             rows='10'
             class='form-control'
             placeholder='author:"{{ App.Users.userData.fullname|raw }}" status:"Running"'
             spellcheck='false'
-          >{{ App.Request.query.get('extended') ? App.Request.query.get('extended')|trim : 'author:"' ~ App.Users.userData.fullname ~ '" ' }}</textarea>
+          >{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim : 'author:"' ~ App.Users.userData.fullname ~ '" ' }}</textarea>
           <pre id='search-highlighting' class='form-control d-none' aria-hidden='true'><code></code></pre>
 
         </div>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -12,7 +12,7 @@
       </div>
       <div class='modal-body' data-wait='{{ 'Please wait…' }}'>
         <h3>Search terms</h3>
-        <p>The search is performed against the title and the body.<br>
+        <p>The search is performed against title, body, date, and elabid.<br>
             The entire team will be searched unless there is an author fields.</p>
         <dl>
           <dt>Term</dt>


### PR DESCRIPTION
There was some interference between `extended` and `q` user input. I tried to uncouple the two user inputs but parse them together.
Now filter-order-sort works again on the search page.

Seems to work fine in my hands so far.