### PR TITLE
fix addMissingLinks

### DIFF
--- a/src/models/AbstractLinks.php
+++ b/src/models/AbstractLinks.php
@@ -160,7 +160,6 @@ abstract class AbstractLinks implements RestInterface
         };
     }
 
-    // make params parameter optional so we don't break the interface
     public function destroy(): bool
     {
         $this->Entity->canOrExplode('write');


### PR DESCRIPTION
New: entities will also be search for links with `mode=edit`
Fix: links to experiments and items will be added
Fix: Team id is added to Users in case of items types

Basically what this tool does now is adding all links again. If a link already exists the mysql database will not be updated because of the ignore in the `INSERT IGNORE INTO ...` query. However, the link will still be counted in the console output as missing.

It is highly advisable to run a backup of the mysql database before executing this command although it will not destroy anything.

Fix #3982