### PR TITLE
limit user input to extra fields for certain item types

### DIFF
--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -172,8 +172,9 @@ abstract class AbstractEntityController implements ControllerInterface
         // the mode parameter is for the uploads tpl
         $renderArr = array(
             'allTeamUsersArr' => $this->allTeamUsersArr,
-            'Entity' => $this->Entity,
             'categoryArr' => $this->categoryArr,
+            'Entity' => $this->Entity,
+            'hideBody' => $this->hasHideBody(),
             'itemsCategoryArr' => $itemsCategoryArr,
             'mode' => 'view',
             'revNum' => $Revisions->readCount(),
@@ -229,10 +230,11 @@ abstract class AbstractEntityController implements ControllerInterface
 
         $renderArr = array(
             'allTeamUsersArr' => $this->allTeamUsersArr,
-            'Entity' => $this->Entity,
-            'entityData' => $this->Entity->entityData,
             'categoryArr' => $this->categoryArr,
             'deletableXp' => $this->getDeletableXp(),
+            'Entity' => $this->Entity,
+            'entityData' => $this->Entity->entityData,
+            'hideBody' => $this->hasHideBody(),
             'itemsCategoryArr' => $itemsCategoryArr,
             'lastModifierFullname' => $lastModifierFullname,
             'maxUploadSize' => Tools::getMaxUploadSize(),
@@ -284,5 +286,20 @@ abstract class AbstractEntityController implements ControllerInterface
             $deletableXp = true;
         }
         return $deletableXp;
+    }
+
+    private function hasHideBody(): bool
+    {
+        $hideBody = false;
+
+        // if metadata contains {"eLabFTW_hide_body": true, ... } hide the body
+        $metadata = json_decode($this->Entity->entityData['metadata'] ?? '{}', true);
+
+        $key = 'eLabFTW_hide_body';
+        if (array_key_exists($key, $metadata)) {
+            $hideBody = $metadata[$key] === true;
+        }
+
+        return $hideBody;
     }
 }

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -174,9 +174,10 @@
 
   <!-- BODY -->
   {% if editor == 'md' %}
-  <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='markdown-textarea' data-language='{{ App.getJsLang }}' name='body'>{{ Entity.entityData.body }}</textarea>
+  <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='markdown-textarea' data-language='{{ App.getJsLang }}' name='body'{{ hideBody == true ? ' style="display:none;"' : ''}}>{{ Entity.entityData.body }}</textarea>
   {% else %}
-  <div><!-- << this div is added around the textarea to fix an issue on mobile editor. See #3107 -->
+  {# hide body if set in metadata, done via css to avoid delayed disappearance after JS is executed #}
+  <div{{ hideBody == true ? ' style="display:none;"' : ''}}>{# << this div is added around the textarea to fix an issue on mobile editor. See #3107 #}
     <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='mceditable invisible' name='body' rows='15' cols='80'>{{ Entity.entityData.body }}</textarea>
   </div>
   {% endif %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -212,7 +212,8 @@
       {% if body|trim == '' %}
           {% set body = Entity.entityData.body %}
       {% endif %}
-      <div id='body_view' class='pt-2'>{{ body|raw }}</div>
+      {# hide body if set in metadata, done via css to avoid delayed disappearance after JS is executed #}
+      <div id='body_view' class='pt-2'{{ hideBody == true ? ' style="display:none;"' : ''}}>{{ body|raw }}</div>
   {% endif %}
 
   <div id='metadataDiv' class='col-md-6'></div>

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -254,8 +254,7 @@ export class Metadata {
         return;
       }
       this.metadataDiv.append(this.getHeaderDiv());
-      this.metadataDiv.classList.add('col-md-12');
-      this.metadataDiv.classList.add('box');
+      this.metadataDiv.classList.add('col-md-12', 'box');
       // the input elements that will be created from the extra fields
       const elements = [];
       for (const [name, description] of Object.entries(json.extra_fields)) {
@@ -300,6 +299,7 @@ export class Metadata {
         rowDiv.classList.add('row');
         this.metadataDiv.append(rowDiv);
         const label = document.createElement('label');
+        label.style.marginRight = '10px';
         label.htmlFor = element.element.id;
         label.innerText = element.name as string;
         if (element.element.type === 'checkbox') {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -9,9 +9,10 @@ import $ from 'jquery';
 import { Api } from './Apiv2.class';
 import 'bootstrap-select';
 import 'bootstrap/js/src/modal.js';
-import { makeSortableGreatAgain, reloadElement, adjustHiddenState, getEntity } from './misc';
+import { makeSortableGreatAgain, reloadElement, adjustHiddenState, getEntity, generateMetadataLink } from './misc';
 import i18next from 'i18next';
 import EntityClass from './Entity.class';
+import { Metadata } from './Metadata.class';
 import { EntityType, Model } from './interfaces';
 import { MathJaxObject } from 'mathjax-full/js/components/startup';
 declare const MathJax: MathJaxObject;
@@ -368,18 +369,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // prepare the get request
       const entityType = el.dataset.type === 'experiments' ? EntityType.Experiment : EntityType.Item;
-      (new EntityClass(entityType)).read(parseInt(el.dataset.id, 10)).then(json => {
-        // add html content and adjust the width of the children
-        bodyDiv.innerHTML = json.body_html;
-        // get the width of the parent. The -30 is to make it smaller than parent even with the margins
-        const width = document.getElementById('parent_' + randId).clientWidth - 30;
-        bodyDiv.style.width = String(width);
+      const entityId = parseInt(el.dataset.id, 10);
+      (new EntityClass(entityType)).read(entityId).then(json => {
+        // do we display the body
+        const metadata = JSON.parse(json.metadata || '{}');
+        if (Object.prototype.hasOwnProperty.call(metadata, 'eLabFTW_hide_body') && metadata.eLabFTW_hide_body) {
+          // add extra fields elements from metadata json
+          const MetadataC = new Metadata({type: entityType, id: entityId});
+          MetadataC.metadataDiv = bodyDiv;
+          MetadataC.display('view').then(() => {
+            bodyDiv.classList.remove('col-md-12');
+            bodyDiv.style.border = '0';
+            bodyDiv.style.padding = '0 20px';
+            bodyDiv.firstChild.remove();
+
+            // go over all the type: url elements and create a link dynamically
+            generateMetadataLink();
+          });
+        } else {
+          // add html content
+          bodyDiv.innerHTML = json.body_html;
+
+          // adjust the width of the children
+          // get the width of the parent. The -30 is to make it smaller than parent even with the margins
+          const width = document.getElementById('parent_' + randId).clientWidth - 30;
+          bodyDiv.style.width = String(width);
+
+          // ask mathjax to reparse the page
+          MathJax.typeset();
+
+          TableSortingC.init();
+        }
+
         bodyDiv.toggleAttribute('hidden');
         bodyDiv.dataset.bodyLoaded = '1';
-        // ask mathjax to reparse the page
-        MathJax.typeset();
-
-        TableSortingC.init();
       });
     }
   });

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -393,3 +393,14 @@ export function removeEmpty(params: object): object {
   }
   return params;
 }
+
+// go over all the type: url elements and create a link dynamically
+export function generateMetadataLink(): void {
+  document.querySelectorAll('[data-gen-link="true"]').forEach(el => {
+    const link = document.createElement('a');
+    const url = (el as HTMLSpanElement).innerText;
+    link.href = url;
+    link.text = url;
+    el.replaceWith(link);
+  });
+}

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -9,7 +9,7 @@ import i18next from 'i18next';
 import { InputType, Malle } from '@deltablot/malle';
 import { Metadata } from './Metadata.class';
 import { Api } from './Apiv2.class';
-import { getEntity, updateCategory, relativeMoment, reloadElement, showContentPlainText } from './misc';
+import { getEntity, updateCategory, relativeMoment, reloadElement, showContentPlainText, generateMetadataLink } from './misc';
 import { EntityType, Action, Model } from './interfaces';
 import { DateTime } from 'luxon';
 import EntityClass from './Entity.class';
@@ -39,13 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const MetadataC = new Metadata(entity);
   MetadataC.display('view').then(() => {
     // go over all the type: url elements and create a link dynamically
-    document.querySelectorAll('[data-gen-link="true"]').forEach(el => {
-      const link = document.createElement('a');
-      const url = (el as HTMLSpanElement).innerText;
-      link.href = url;
-      link.text = url;
-      el.replaceWith(link);
-    });
+    generateMetadataLink();
   });
 
   // EDIT SHORTCUT


### PR DESCRIPTION
Closes #3984

If `{"eLabFTW_hide_body": true}` is set in the metadata root, an entities body (experiment or items) will not be displayed in view and edit mode via css: `display:none;`. css is used to avoid first showing the body and than hiding it after JS is executed.
In show mode the metadata will be shown instead of the body if the 'toggle content' button is pressed.
