### PR TITLE
remove visibility array from VisitorParameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Build elabtmp image and start containers
           command: |
-            docker build -q --build-arg BASE_IMAGE_VERSION=${CIRCLE_BRANCH} -t elabtmp -f tests/elabtmp.Dockerfile .
+            docker build -q --no-cache -t elabtmp -f tests/elabtmp.Dockerfile .
             docker build -q --no-cache -t elabtmp -f tests/circleci.Dockerfile .
             printf "ELABFTW_USER=nginx\nELABFTW_GROUP=nginx\nELABFTW_USERID=101\nELABFTW_GROUPID=101\n" > tests/elabftw-user.env
             docker compose --ansi never -f tests/docker-compose.yml up -d --quiet-pull

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,23 +20,22 @@ checks:
     symfony_request_injection: false
     no_exit: false
 build:
-    environment:
-        docker:
-            remote_engine: true
-
-    nodes:
-        tests:
-            dependencies:
-                override:
-                    - echo do nothing here
-                before:
-                    - echo do nothing here
-
+  environment:
+    docker:
+      remote_engine: true
+    php:
+      version: 8.1
+  nodes:
     tests:
+      dependencies:
         override:
-            - command: tests/run.sh
-              idle_timeout: 500
-              coverage:
-                  file: coverage.xml
-                  format: clover
-
+          - echo do nothing here
+        before:
+          - echo do nothing here
+  tests:
+    override:
+      - command: tests/run.sh
+        idle_timeout: 500
+        coverage:
+          file: coverage.xml
+          format: clover

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -17,7 +17,6 @@ use Elabftw\Elabftw\DisplayParams;
 use Elabftw\Elabftw\EntityParams;
 use Elabftw\Elabftw\EntitySqlBuilder;
 use Elabftw\Elabftw\Permissions;
-use Elabftw\Elabftw\PermissionsHelper;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
@@ -661,10 +660,8 @@ abstract class AbstractEntity implements RestInterface
 
     private function processExtendedQuery(string $extendedQuery): void
     {
-        $PermissionsHelper = new PermissionsHelper();
         $advancedQuery = new AdvancedSearchQuery($extendedQuery, new VisitorParameters(
             $this->type,
-            $PermissionsHelper->getExtendedSearchAssociativeArray(),
             $this->TeamGroups->readGroupsWithUsersFromUser(),
         ));
         $whereClause = $advancedQuery->getWhereClause();

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -235,7 +235,7 @@ class FieldValidatorVisitor implements Visitor
 
     private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
-        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm, $parameters->getVisArr());
+        $visibilityFieldHelper = new VisibilityFieldHelper($searchTerm);
         if (!$visibilityFieldHelper->getArr()) {
             $message = sprintf(
                 'visibility:%s. Valid values are %s.',

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -415,7 +415,7 @@ class QueryBuilderVisitor implements Visitor
 
     private function visitFieldVisibility(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
     {
-        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm, $parameters->getVisArr()))->getArr();
+        $filteredSearchArr = (new VisibilityFieldHelper($searchTerm))->getArr();
 
         $queryParts = array();
         $bindValues = array();

--- a/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
+++ b/src/services/advancedSearchQuery/visitors/VisibilityFieldHelper.php
@@ -14,6 +14,7 @@ use function array_intersect_key;
 use function array_keys;
 use function array_unique;
 use function array_values;
+use Elabftw\Elabftw\PermissionsHelper;
 use function implode;
 use function preg_grep;
 use function preg_quote;
@@ -23,21 +24,22 @@ class VisibilityFieldHelper
 {
     public string $possibleInput = '';
 
-    public function __construct(private string $userInput, private array $visArr)
+    public function __construct(private string $userInput)
     {
     }
 
     public function getArr(): array
     {
+        $visArr = (new PermissionsHelper())->getExtendedSearchAssociativeArray();
         // ToDo: add back team groups, add teams and users
-        $this->possibleInput = "'" . implode("', '", array_keys($this->visArr)) . "'";
+        $this->possibleInput = "'" . implode("', '", array_keys($visArr)) . "'";
 
         // Emulate SQL LIKE search functionality so the user can use the same placeholders
         $pattern = '/^' . str_replace(array('%', '_'), array('.*', '.'), preg_quote($this->userInput, '/')) . '$/i';
         // Filter visibility entries based on user input
-        $filteredArr = preg_grep($pattern, array_keys($this->visArr)) ?: array();
+        $filteredArr = preg_grep($pattern, array_keys($visArr)) ?: array();
 
         // Return a unique list of visibility entries that can be used in the SQL where clause
-        return array_unique(array_intersect_key(array_values($this->visArr), $filteredArr));
+        return array_unique(array_intersect_key(array_values($visArr), $filteredArr));
     }
 }

--- a/src/services/advancedSearchQuery/visitors/VisitorParameters.php
+++ b/src/services/advancedSearchQuery/visitors/VisitorParameters.php
@@ -12,18 +12,13 @@ namespace Elabftw\Services\AdvancedSearchQuery\Visitors;
 
 class VisitorParameters
 {
-    public function __construct(private string $entityType, private array $visArr, private array $teamGroups)
+    public function __construct(private string $entityType, private array $teamGroups)
     {
     }
 
     public function getEntityType(): string
     {
         return $this->entityType;
-    }
-
-    public function getVisArr(): array
-    {
-        return $this->visArr;
     }
 
     public function getTeamGroups(): array

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -57,12 +57,22 @@ services:
             - ..:/elabftw
         networks:
             - elabftw-net
+        # make sure we wait for mysql to be available before starting
+        # note: the mysql container needs an healthcheck block for this to work
         depends_on:
-          - mysql
+            mysql:
+                condition: service_healthy
 
     mysql:
         image: mysql:8.0
         container_name: mysqltmp
+        # add an healthcheck block so the web container knows when it is ready to accept connections
+        # use double $ here so env vars are correctly found
+        healthcheck:
+            test: "/usr/bin/mysql --user=$$MYSQL_USER --password=$$MYSQL_PASSWORD --execute 'SHOW DATABASES;'"
+            interval: 2s
+            timeout: 5s
+            retries: 20
         # drop some capabilities
         cap_drop:
             - AUDIT_WRITE

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -39,7 +39,7 @@ if [ ! "$(docker ps -q -f name=mysqltmp)" ]; then
         # Use the freshly built elabtmp image
         # use DOCKER_BUILDKIT env instead of calling "docker buildx" or it fails in scrutinizer
         export DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain COMPOSE_DOCKER_CLI_BUILD=1
-        docker build --build-arg BASE_IMAGE_VERSION=${SCRUTINIZER_PR_SOURCE_BRANCH:-hypernext} -q -t elabtmp -f tests/elabtmp.Dockerfile .
+        docker build -q -t elabtmp -f tests/elabtmp.Dockerfile .
     fi
     docker-compose -f tests/docker-compose.yml up -d --quiet-pull
     # give some time for containers to start

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -10,7 +10,6 @@
 
 namespace Elabftw\Services;
 
-use Elabftw\Elabftw\PermissionsHelper;
 use Elabftw\Enums\Action;
 use Elabftw\Models\TeamGroups;
 use Elabftw\Models\Users;
@@ -22,8 +21,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
     private TeamGroups $TeamGroups;
 
-    private array $visibilityList;
-
     private array $groups;
 
     protected function setUp(): void
@@ -33,8 +30,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $this->TeamGroups->setId($this->groupId);
         $this->TeamGroups->patch(Action::Update, array('userid' => 1, 'how' => Action::Add->value));
 
-        $PermissionsHelper = new PermissionsHelper();
-        $this->visibilityList = $PermissionsHelper->getExtendedSearchAssociativeArray();
         $this->groups = $this->TeamGroups->readGroupsWithUsersFromUser();
     }
 
@@ -64,7 +59,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
-            $this->visibilityList,
             $this->groups,
         ));
         $whereClause = $advancedSearchQuery->getWhereClause();
@@ -75,7 +69,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $query = 'category:"only meaningful with items but no error"';
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'items',
-            $this->visibilityList,
             $this->groups,
         ));
         $whereClause = $advancedSearchQuery->getWhereClause();
@@ -89,7 +82,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
-            $this->visibilityList,
             $this->groups,
         ));
         $advancedSearchQuery->getWhereClause();
@@ -103,7 +95,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         // Depth of abstract syntax tree is set to 1 with the last parameter
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
-            $this->visibilityList,
             $this->groups,
         ), 1);
         $advancedSearchQuery->getWhereClause();
@@ -125,7 +116,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
-            $this->visibilityList,
             $this->groups,
         ));
         $advancedSearchQuery->getWhereClause();
@@ -143,7 +133,6 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'itmes',
-            $this->visibilityList,
             $this->groups,
         ));
         $advancedSearchQuery->getWhereClause();


### PR DESCRIPTION
In a previous PR [#4035-comment](https://github.com/elabftw/elabftw/pull/4035#discussion_r1070106331) you talked about removing the visibility array that is passed around via VisitorParameters.