### PR TITLE
fix 4082

### DIFF
--- a/src/services/MakeQrPdf.php
+++ b/src/services/MakeQrPdf.php
@@ -44,7 +44,7 @@ class MakeQrPdf extends AbstractMakePdf
             'entityArr' => $this->readAll(),
         );
         $html = $this->getTwig(Config::getConfig())->render('qr-pdf.html', $renderArr);
-        $this->mpdf->WriteHTML($html);
+        $this->mpdf->WriteHTML(html_entity_decode($html, ENT_HTML5, 'UTF-8'));
         return $this->mpdf->Output('', 'S');
     }
 


### PR DESCRIPTION
In the "normal" PDF the output from twig is processed by `html_entity_decode` in https://github.com/elabftw/elabftw/blob/f538788ca136be8958f8a1f02c02c8b849a2c9dc/src/services/Tex2Svg.php#L53 so let's do it in the QR PDF too.

Closes #4082.