### PR TITLE
add team level announcement. fix #4065

### DIFF
--- a/src/classes/TeamParam.php
+++ b/src/classes/TeamParam.php
@@ -18,11 +18,20 @@ final class TeamParam extends ContentParams
     {
         return match ($this->target) {
             'name', 'orgid', 'link_name' => parent::getContent(),
+            'announcement' => $this->getNullableContent(),
             'common_template', 'common_template_md' => $this->getBody(),
             'deletable_xp', 'deletable_item', 'user_create_tag', 'force_exp_tpl', 'public_db', 'do_force_canread', 'do_force_canwrite', 'visible' => parent::getBinary(),
             'link_href' => $this->getUrl(),
             'force_canread', 'force_canwrite' => Check::visibility($this->content),
             default => throw new ImproperActionException('Incorrect parameter for team.' . $this->target),
         };
+    }
+
+    private function getNullableContent(): ?string
+    {
+        if (empty($this->content)) {
+            return null;
+        }
+        return parent::getContent();
     }
 }

--- a/src/sql/schema111.sql
+++ b/src/sql/schema111.sql
@@ -1,3 +1,4 @@
 -- schema 111
 INSERT INTO config (conf_name, conf_value) VALUES ('smtp_verify_cert', '1');
+ALTER TABLE `teams` ADD `announcement` VARCHAR(255) NULL DEFAULT NULL;
 UPDATE config SET conf_value = 111 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -672,13 +672,14 @@ CREATE TABLE `teams` (
   `link_name` varchar(255) NOT NULL,
   `link_href` varchar(255) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `orgid` varchar(255) DEFAULT NULL,
+  `orgid` varchar(255) NULL DEFAULT NULL,
   `public_db` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `force_canread` JSON NOT NULL,
   `force_canwrite` JSON NOT NULL,
   `do_force_canread` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `do_force_canwrite` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `visible` tinyint UNSIGNED NOT NULL DEFAULT 1,
+  `announcement` varchar(255) NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -38,6 +38,11 @@
   <div class='box form-group'>
     <h3>{{ 'Configure your Team'|trans }}</h3>
     <hr>
+
+    <label for='announcement'>{{ 'Announcement'|trans }}</label>
+    <p class='smallgray'>{{ "The following text will be displayed to all users on all pages while it's active."|trans }}</p>
+    <input class='form-control col-md-4' type='text' id='announcement' name='announcement' value='{{ teamConfigArr.announcement }}' />
+
     <label for='deletable_xp'>{{ 'Users can delete experiments:'|trans }}</label>
     <select class='form-control col-md-4' name='deletable_xp' id='deletable_xp'>
       <option value='1'{{ teamConfigArr.deletable_xp ? " selected='selected'" }}>{{ 'Yes'|trans }}</option>

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -226,8 +226,14 @@
 {% for warning in App.warning %}
   {{ warning|msg('warning') }}
 {% endfor %}
-<!-- ANNOUNCEMENT -->
+<!-- ANNOUNCEMENTS -->
+{# general sysconfig announcement #}
 {% if App.Config.configArr.announcement %}
   {{ App.Config.configArr.announcement|msg('warning') }}
+{% endif %}
+
+{# team level announcement #}
+{% if App.teamArr.announcement %}
+  {{ App.teamArr.announcement|msg('warning') }}
 {% endif %}
 <div id='output'></div>

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -43,8 +43,13 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
             'link_href' => 'https://example.com',
             'link_name' => 'Example',
             'name' => 'Another name',
+            'announcement' => '',
         );
         $this->Teams->setId(4);
+        $this->assertIsArray($this->Teams->patch(Action::Update, $params));
+        $params = array(
+            'announcement' => 'yep',
+        );
         $this->assertIsArray($this->Teams->patch(Action::Update, $params));
     }
 


### PR DESCRIPTION
So admins can put out announcement messages on top of every page.
