### PR TITLE
Refactor admin assignment

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -628,7 +628,7 @@ components:
           type: string
         validated:
           type: integer
-        usergroup:
+        is_sysadmin:
           type: integer
         archived:
           type: integer
@@ -640,7 +640,19 @@ components:
           type: string
         auth_service:
           type: integer
-
+        teams:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              is_admin:
+                type: integer
+              is_owner:
+                type: integer
 
 security:
   - token:
@@ -1615,7 +1627,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/event'
-
   /events/{id}:
     parameters:
       - name: id

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@types/bootstrap": "^5.0.17",
+    "@types/bootstrap-select": "^1.13.4",
     "@types/dropzone": "^5.7.4",
     "@types/fancybox": "^3.5.2",
     "@types/file-saver": "^2.0.1",

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 111;
+    public const REQUIRED_SCHEMA = 112;
 
     private Db $Db;
 

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -274,7 +274,7 @@ class Apiv2Controller extends AbstractApiController
 
     private function applyRestrictions(): void
     {
-        if ($this->Model instanceof Config && $this->Users->userData['is_sysadmin'] !== 1) {
+        if ($this->Model instanceof Config && !$this->Users->userData['is_sysadmin']) {
             throw new IllegalActionException('Non sysadmin user tried to use a restricted api endpoint.');
         }
 

--- a/src/models/ExistingUser.php
+++ b/src/models/ExistingUser.php
@@ -37,12 +37,13 @@ class ExistingUser extends Users
         array $teams,
         string $firstname,
         string $lastname,
-        ?int $usergroup = null,
+        bool $isAdmin = false,
+        bool $isSysadmin = false,
         bool $forceValidation = false,
         bool $alertAdmin = true,
     ): Users {
         $Users = new self();
-        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $forceValidation, $alertAdmin);
+        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $isAdmin, $isSysadmin, $forceValidation, $alertAdmin);
         $fresh = new self($userid);
         // we need to report the needValidation flag into the new object
         $fresh->needValidation = $Users->needValidation;

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -103,7 +103,7 @@ class Items extends AbstractConcreteEntity
         // check if we can actually delete items (for non-admins)
         $Teams = new Teams($this->Users);
         $teamConfigArr = $Teams->readOne();
-        if ($teamConfigArr['deletable_item'] === 0 && $this->Users->userData['is_admin'] === 0) {
+        if ($teamConfigArr['deletable_item'] === 0 && !$this->Users->userData['is_admin']) {
             throw new ImproperActionException(_('Users cannot delete items.'));
         }
 

--- a/src/models/Scheduler.php
+++ b/src/models/Scheduler.php
@@ -395,7 +395,7 @@ class Scheduler implements RestInterface
 
         // if it's not, we need to be admin in the same team as the event/user
         $TeamsHelper = new TeamsHelper($event['team']);
-        return $TeamsHelper->isUserInTeam($this->Items->Users->userData['userid']) && $this->Items->Users->userData['usergroup'] <= 2;
+        return $TeamsHelper->isUserInTeam($this->Items->Users->userData['userid']) && $this->Items->Users->userData['is_admin'];
     }
 
     private function canWriteOrExplode(): void

--- a/src/models/Tags.php
+++ b/src/models/Tags.php
@@ -157,7 +157,7 @@ class Tags implements RestInterface
             // check if we can actually create tags (for non-admins)
             $Teams = new Teams($this->Entity->Users, (int) $this->Entity->Users->userData['team']);
             $teamConfigArr = $Teams->readOne();
-            if ($teamConfigArr['user_create_tag'] === 0 && $this->Entity->Users->userData['is_admin'] === 0) {
+            if ($teamConfigArr['user_create_tag'] === 0 && !$this->Entity->Users->userData['is_admin']) {
                 throw new ImproperActionException(_('Users cannot create tags.'));
             }
 

--- a/src/models/TeamTags.php
+++ b/src/models/TeamTags.php
@@ -119,7 +119,7 @@ class TeamTags implements RestInterface
 
     public function patch(Action $action, array $params): array
     {
-        if ($this->Users->userData['is_admin'] !== 1) {
+        if (!$this->Users->userData['is_admin']) {
             throw new IllegalActionException('Only an admin can do this!');
         }
         return match ($action) {
@@ -134,7 +134,7 @@ class TeamTags implements RestInterface
      */
     public function destroy(): bool
     {
-        if ($this->Users->userData['is_admin'] !== 1) {
+        if (!$this->Users->userData['is_admin']) {
             throw new IllegalActionException('Only an admin can delete a tag!');
         }
         // first unreference the tag

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -171,11 +171,11 @@ class Users implements RestInterface
     public function readFromQuery(string $query, int $teamId = 0): array
     {
         $teamFilterSql = '';
-        $rollColumns = '';
+        $roleColumns = '';
         if ($teamId > 0) {
             $teamFilterSql = ' AND u2t.teams_id = :team';
             // only one team is selected at a time so we can use MIN to get the values
-            $rollColumns = 'MIN(u2t.is_owner) as is_owner, MIN(u2t.is_admin) AS is_admin,';
+            $roleColumns = 'MIN(u2t.is_owner) as is_owner, MIN(u2t.is_admin) AS is_admin,';
         }
 
         // Side effect: User is shown in team with lowest id
@@ -184,7 +184,7 @@ class Users implements RestInterface
             users.validated, users.is_sysadmin, users.archived, users.last_login, users.valid_until,
             CONCAT(users.firstname, ' ', users.lastname) AS fullname,
             users.orcid, users.auth_service,
-            ". $rollColumns ."
+            ". $roleColumns ."
             JSON_ARRAYAGG(JSON_OBJECT('id', u2t.teams_id, 'name',
                 teams.name, 'is_owner', u2t.is_owner, 'is_admin', u2t.is_admin
             )) AS teams
@@ -366,7 +366,7 @@ class Users implements RestInterface
 
     private function updateWrapper(array $params): void
     {
-        // first handle user role changes and unset user roll related elements
+        // first handle user role changes and unset user role related elements
         (new UserUpdateRoles($this, $this->requester, $params))->update();
         unset($params['is_admin'], $params['admin_of_teams'], $params['is_sysadmin']);
 

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -24,7 +24,7 @@ use Elabftw\Services\TeamsHelper;
 use Elabftw\Services\UserArchiver;
 use Elabftw\Services\UserCreator;
 use Elabftw\Services\UsersHelper;
-use Elabftw\Services\UserUpdateRolls;
+use Elabftw\Services\UserUpdateRoles;
 use PDO;
 use Symfony\Component\HttpFoundation\Request;
 use function time;
@@ -367,7 +367,7 @@ class Users implements RestInterface
     private function updateWrapper(array $params): void
     {
         // first handle user role changes and unset user roll related elements
-        (new UserUpdateRolls($this, $this->requester, $params))->update();
+        (new UserUpdateRoles($this, $this->requester, $params))->update();
         unset($params['is_admin'], $params['admin_of_teams'], $params['is_sysadmin']);
 
         foreach ($params as $target => $content) {

--- a/src/models/ValidatedUser.php
+++ b/src/models/ValidatedUser.php
@@ -16,11 +16,17 @@ class ValidatedUser extends ExistingUser
 {
     public static function fromExternal(string $email, array $teams, string $firstname, string $lastname): Users
     {
-        return parent::fromScratch($email, $teams, $firstname, $lastname, null, true);
+        return parent::fromScratch($email, $teams, $firstname, $lastname, false, false, true);
     }
 
-    public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, int $usergroup): Users
-    {
-        return parent::fromScratch($email, $teams, $firstname, $lastname, $usergroup, true, false);
+    public static function fromAdmin(
+        string $email,
+        array $teams,
+        string $firstname,
+        string $lastname,
+        bool $isAdmin = false,
+        bool $isSysadmin = false,
+    ): Users {
+        return parent::fromScratch($email, $teams, $firstname, $lastname, $isAdmin, $isSysadmin, true, false);
     }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1075,7 +1075,7 @@ the form-control fails to do that so we do the border ourselves */
  */
 .far,
 .fas,
-.fab, {
+.fab {
     pointer-events: none;
 }
 

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -129,7 +129,7 @@ class Email
     private function getSysadminEmails(): array
     {
         $Db = Db::getConnection();
-        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users WHERE validated = 1 AND archived = 0 AND usergroup = 1';
+        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users WHERE validated = 1 AND archived = 0 AND is_sysadmin = 1';
         $req = $Db->prepare($sql);
         $Db->execute($req);
         $emails = array();

--- a/src/services/LoginHelper.php
+++ b/src/services/LoginHelper.php
@@ -136,7 +136,7 @@ class LoginHelper
 
         // NORMAL LOGIN
         // load the permissions
-        $Users = new Users($this->AuthResponse->userid);
+        $Users = new Users($this->AuthResponse->userid, $this->AuthResponse->selectedTeam);
         $this->Session->set('is_admin', $Users->userData['is_admin']);
         $this->Session->set('is_sysadmin', $Users->userData['is_sysadmin']);
     }

--- a/src/services/Populate.php
+++ b/src/services/Populate.php
@@ -123,7 +123,7 @@ class Populate
         $passwordHash = (new UserParams('password', $user['password'] ?? self::DEFAULT_PASSWORD))->getContent();
         $email = $user['email'] ?? $this->faker->safeEmail();
 
-        $userid = $Teams->Users->createOne($email, array($user['team']), $firstname, $lastname, $passwordHash, null, true, false);
+        $userid = $Teams->Users->createOne($email, array($user['team']), $firstname, $lastname, $passwordHash, false, false, true, false);
         $team = $Teams->getTeamsFromIdOrNameOrOrgidArray(array($user['team']));
         $Users = new Users($userid, (int) $team[0]['id']);
 

--- a/src/services/UserUpdateRoles.php
+++ b/src/services/UserUpdateRoles.php
@@ -146,7 +146,7 @@ final class UserUpdateRoles
     }
 
     /**
-     * Is user roll related value provided in params array
+     * Is user role related value provided in params array
      */
     private function paramExists(array $params, string $key, string $type): mixed
     {

--- a/src/services/UserUpdateRoles.php
+++ b/src/services/UserUpdateRoles.php
@@ -17,7 +17,7 @@ use PDO;
 use PDOStatement;
 use function settype;
 
-final class UserUpdateRolls
+final class UserUpdateRoles
 {
     protected Db $Db;
 

--- a/src/services/UserUpdateRolls.php
+++ b/src/services/UserUpdateRolls.php
@@ -1,0 +1,184 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use function array_key_exists;
+use Elabftw\Elabftw\Db;
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Users;
+use PDO;
+use PDOStatement;
+use function settype;
+
+final class UserUpdateRolls
+{
+    protected Db $Db;
+
+    private bool $isAdmin = false;
+
+    private bool $isSysadmin = false;
+
+    private bool $targetIsSysadmin = false;
+
+    private ?bool $inputIsAdmin = null;
+
+    private ?array $inputAdminOfTeams = null;
+
+    private ?bool $inputIsSysadmin = null;
+
+    public function __construct(private Users $User, private Users $Requester, array $params)
+    {
+        $this->Db = Db::getConnection();
+
+        $this->isSysadmin = (bool) $this->Requester->userData['is_sysadmin'];
+        $this->isAdmin = (bool) $this->Requester->userData['is_admin'];
+        $this->targetIsSysadmin = (bool) $this->User->userData['is_sysadmin'];
+
+        $this->inputIsAdmin = $this->paramExists($params, 'is_admin', 'bool');
+        $this->inputAdminOfTeams = $this->paramExists($params, 'admin_of_teams', 'array');
+        $this->inputIsSysadmin = $this->paramExists($params, 'is_sysadmin', 'bool');
+    }
+
+    // private function checkUserGroup(int $usergroup): int
+    // {
+    //     $usergroup = Check::usergroup($usergroup);
+    //     // a sysadmin can do what they want, no need to check further
+    //     if ($this->isSysadmin === 1) {
+    //         return $usergroup;
+    //     }
+    //     // prevent an admin from promoting a user to sysadmin
+    //     if ($this->isAdmin === 1 && $usergroup === 1) {
+    //         throw new ImproperActionException('Only a sysadmin can promote another user to sysadmin.');
+    //     }
+    //     // a non sysadmin cannot demote a sysadmin
+    //     if ($usergroup !== 1 && $this->targetIsSysadmin) {
+    //         throw new ImproperActionException('Only a sysadmin can demote another sysadmin.');
+    //     }
+    //     // if requester is not admin the only valid usergroup is 4 (user)
+    //     if ($this->isAdmin !== 1) {
+    //         return 4;
+    //     }
+    //     return $usergroup;
+    // }
+
+    public function update(): void
+    {
+        if (isset($this->inputIsSysadmin)) {
+            $this->updateSysadminStatus();
+        }
+
+        if (isset($this->inputAdminOfTeams)) {
+            $this->updateAdminStatusSeveralTeams();
+        }
+
+        if (isset($this->inputIsAdmin)) {
+            $this->canUpdateOneOrExplode();
+            $this->updateOneTeam($this->inputIsAdmin);
+        }
+    }
+
+    private function updateSysadminStatus(): void
+    {
+        if (!$this->isSysadmin) {
+            // a non sysadmin cannot promote a user to sysadmin
+            if ($this->inputIsSysadmin === true) {
+                throw new ImproperActionException('Only a sysadmin can promote another user to sysadmin.');
+            }
+
+            // a non sysadmin cannot demote a sysadmin
+            if ($this->inputIsSysadmin === false) {
+                throw new ImproperActionException('Only a sysadmin can demote another sysadmin.');
+            }
+        }
+
+        // sysadmins can pro-/demote other sysadmins
+        if ($this->inputIsSysadmin !== $this->targetIsSysadmin) {
+            $sql = 'UPDATE users SET is_sysadmin = :is_sysadmin WHERE userid = :userid';
+            $req = $this->Db->prepare($sql);
+            $req->bindValue(':is_sysadmin', $this->inputIsSysadmin, PDO::PARAM_INT);
+            $req->bindValue(':userid', $this->User->userid, PDO::PARAM_INT);
+            $this->Db->execute($req);
+        }
+    }
+
+    private function updateAdminStatusSeveralTeams(): void
+    {
+        if (!$this->isSysadmin) {
+            throw new ImproperActionException('Only a sysadmin can change the admin status of a user in several teams at once.');
+        }
+
+        $teamsOfUser = array_column($this->User->userData['teams'], 'id');
+        $currentlyAdminOfTeams = array_keys(array_column($this->User->userData['teams'], 'is_admin', 'id'), 1, true);
+        // check that input is list of teams which user is actually member of
+        /** @psalm-suppress PossiblyNullArgument */
+        $inputValidTeams = array_intersect($this->inputAdminOfTeams, $teamsOfUser);
+
+        $req = $this->getUpdateReq();
+
+        $addToTeams = array_diff($inputValidTeams, $currentlyAdminOfTeams);
+        foreach ($addToTeams as $team) {
+            $req->bindValue(':is_admin', 1);
+            $req->bindValue(':team', $team, PDO::PARAM_INT);
+            $this->Db->execute($req);
+        }
+
+        $removeFromTeams = array_diff($currentlyAdminOfTeams, $inputValidTeams);
+        foreach ($removeFromTeams as $team) {
+            $req->bindValue(':is_admin', 0);
+            $req->bindValue(':team', $team, PDO::PARAM_INT);
+            $this->Db->execute($req);
+        }
+    }
+
+    private function updateOneTeam(bool $value): void
+    {
+        $req = $this->getUpdateReq();
+        $req->bindValue(':is_admin', $value, PDO::PARAM_INT);
+        $req->bindValue(':team', $this->User->team, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    /**
+     * Is user roll related value provided in params array
+     */
+    private function paramExists(array $params, string $key, string $type): mixed
+    {
+        $value = null;
+        if (array_key_exists($key, $params)) {
+            $value = $params[$key];
+            if (!settype($value, $type)) {
+                throw new ImproperActionException(
+                    sprintf('Wrong value provided for parameter %s. Expect value of type %s', $key, $type)
+                );
+            }
+        }
+        return $value;
+    }
+
+    private function getUpdateReq(): PDOStatement
+    {
+        $sql = 'UPDATE users2teams SET is_admin = :is_admin
+            WHERE users_id = :users_id AND teams_id = :team';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':users_id', $this->User->userid, PDO::PARAM_INT);
+
+        return $req;
+    }
+
+    /**
+     * target and requester (admin) need to be in same team if not sysadmin
+     */
+    private function canUpdateOneOrExplode(): void
+    {
+        if (!$this->isSysadmin && !($this->isAdmin && $this->User->team === $this->Requester->team)) {
+            throw new ImproperActionException('You need to be an admin in the same team or a sysadmin to change a users admin status.');
+        }
+    }
+}

--- a/src/services/UsersHelper.php
+++ b/src/services/UsersHelper.php
@@ -73,8 +73,10 @@ class UsersHelper
      */
     public function getTeamsFromUserid(): array
     {
-        $sql = 'SELECT DISTINCT teams.id, teams.name FROM teams
-            CROSS JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = teams.id)';
+        $sql = 'SELECT teams.id, teams.name, users2teams.is_admin, users2teams.is_owner
+            FROM users2teams
+            LEFT JOIN teams ON (users2teams.teams_id = teams.id)
+            WHERE users2teams.users_id = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);

--- a/src/sql/schema112.sql
+++ b/src/sql/schema112.sql
@@ -1,0 +1,29 @@
+-- schema 112
+ALTER TABLE `users2teams` ADD `is_admin` TINYINT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE `users2teams` ADD `is_owner` TINYINT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE `users2teams`
+  ADD KEY `idx_users2teams_is_admin` (`is_admin`),
+  ADD KEY `idx_users2teams_is_owner` (`is_owner`);
+ALTER TABLE `users` ADD `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER `usergroup`;
+ALTER TABLE `users`
+  ADD KEY `idx_users_is_sysadmin` (`is_sysadmin`),
+  ADD KEY `idx_users_email` (`email`),
+  ADD KEY `idx_users_archived` (`archived`),
+  ADD KEY `idx_users_validated` (`validated`);
+UPDATE `users` SET `is_sysadmin` = 1 WHERE `usergroup` = 1;
+-- admin users become admins of all teams they are member of. Like it was until now but exclude archived users.
+UPDATE `users2teams` AS `u2t`,
+  (SELECT `users2teams`.`users_id`, `users2teams`.`teams_id`, `users`.`usergroup`, `users`.`archived`
+    FROM `users`
+    LEFT JOIN `users2teams`
+      ON (`users2teams`.`users_id` = `users`.`userid`)
+    WHERE `users`.`usergroup` IN (1, 2)
+      AND `users`.`archived` = 0
+  ) AS `tmp`
+  SET `u2t`.`is_admin` = 1
+  WHERE `u2t`.`users_id` = `tmp`.`users_id`
+    AND `u2t`.`teams_id` = `tmp`.`teams_id`;
+ALTER TABLE `users` DROP FOREIGN KEY `fk_users_groups_id`;
+ALTER TABLE `users` DROP COLUMN `usergroup`;
+DROP TABLE `groups`;
+UPDATE config SET conf_value = 112 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -309,29 +309,13 @@ CREATE TABLE `favtags2users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
 --
--- Table structure for table `groups`
+-- RELATIONSHIPS FOR TABLE `favtags2users`:
+--   `users_id`
+--       `users` -> `userid`
+--   `tag_id`
+--       `tags` -> `id`
 --
 
-CREATE TABLE `groups` (
-  `id` tinyint UNSIGNED NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `is_sysadmin` tinyint UNSIGNED NOT NULL,
-  `is_admin` tinyint UNSIGNED NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
-
---
--- RELATIONSHIPS FOR TABLE `groups`:
---
-
---
--- Dumping data for table `groups`
---
-
-INSERT INTO `groups` (`id`, `name`, `is_sysadmin`, `is_admin`) VALUES
-(1, 'Sysadmins', 1, '1'),
-(2, 'Admins', 0, '1'),
-(4, 'Users', 0, '0');
 
 -- --------------------------------------------------------
 
@@ -794,7 +778,7 @@ CREATE TABLE `users` (
   `password` varchar(255) NULL DEFAULT NULL,
   `password_hash` varchar(255) NULL DEFAULT NULL,
   `mfa_secret` varchar(32) DEFAULT NULL,
-  `usergroup` tinyint UNSIGNED NOT NULL,
+  `is_sysadmin` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `firstname` varchar(255) NOT NULL,
   `lastname` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
@@ -847,8 +831,6 @@ CREATE TABLE `users` (
 
 --
 -- RELATIONSHIPS FOR TABLE `users`:
---   `usergroup`
---       `groups` -> `id`
 --
 
 -- --------------------------------------------------------
@@ -879,6 +861,8 @@ CREATE TABLE `users2team_groups` (
 CREATE TABLE `users2teams` (
   `users_id` int(10) UNSIGNED NOT NULL,
   `teams_id` int(10) UNSIGNED NOT NULL,
+  `is_admin` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  `is_owner` tinyint UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`users_id`, `teams_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 --
@@ -1072,7 +1056,10 @@ ALTER TABLE `todolist`
 -- Indexes for table `users`
 --
 ALTER TABLE `users`
-  ADD KEY `fk_users_groups_id` (`usergroup`);
+  ADD KEY `idx_users_is_sysadmin` (`is_sysadmin`),
+  ADD KEY `idx_users_email` (`email`),
+  ADD KEY `idx_users_archived` (`archived`),
+  ADD KEY `idx_users_validated` (`validated`);
 
 --
 -- Indexes for table `experiments2experiments`
@@ -1291,7 +1278,9 @@ CREATE TABLE `experiments_templates_links` (
 --
 ALTER TABLE `users2teams`
   ADD KEY `fk_users2teams_teams_id` (`teams_id`),
-  ADD KEY `fk_users2teams_users_id` (`users_id`);
+  ADD KEY `fk_users2teams_users_id` (`users_id`),
+  ADD KEY `idx_users2teams_is_admin` (`is_admin`),
+  ADD KEY `idx_users2teams_is_owner` (`is_owner`);
 ALTER TABLE `users2teams`
   ADD CONSTRAINT `fk_users2teams_teams_id` FOREIGN KEY (`teams_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_users2teams_users_id` FOREIGN KEY (`users_id`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1305,12 +1294,6 @@ ALTER TABLE `users2team_groups`
 ALTER TABLE `users2team_groups`
   ADD CONSTRAINT `fk_users2team_groups_groupid` FOREIGN KEY (`groupid`) REFERENCES `team_groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_users2team_groups_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
-
---
--- Constraints for table `users`
---
-ALTER TABLE `users`
-  ADD CONSTRAINT `fk_users_groups_id` FOREIGN KEY (`usergroup`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `experiments2experiments`

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -138,8 +138,10 @@
 
     <!-- CREATE A GROUP -->
     <label for='teamGroupCreate'>{{ 'Create a group'|trans }}</label>
-    <input class='form-control col-md-4 custom-control-inline' id='teamGroupCreate' type='text' />
-    <button type='submit' data-action='create-teamgroup' data-teamid='{{ App.Users.userData.team }}' id='teamGroupCreateBtn' class='button btn btn-primary'>{{ 'Create'|trans }}</button>
+    <div class='form-inline'>
+      <input class='form-control col-md-4 mr-2' id='teamGroupCreate' type='text' />
+      <button type='submit' data-action='create-teamgroup' data-teamid='{{ App.Users.userData.team }}' id='teamGroupCreateBtn' class='button btn btn-primary'>{{ 'Create'|trans }}</button>
+    </div>
     <!-- END CREATE GROUP -->
 
     <!-- SHOW EXISTING GROUPS -->
@@ -397,10 +399,10 @@
     <h3>{{ 'Manage tags of the team'|trans }}</h3>
     <hr>
     <p>{{ 'From here you can add, edit or delete the tags for your team. Click the tag to edit it. Then click the deduplicate button to merge similar tags.'|trans }}</p>
-    <div class='form-group'>
     <label for='adminAddTagInput'>{{ 'Add a tag'|trans }}</label>
-    <input class='form-control col-md-4 custom-control-inline' id='adminAddTagInput'>
-    <button class='button btn btn-primary' data-teamid='{{ App.Users.userData.team }}' data-action='admin-add-tag'>{{ 'Save'|trans }}</button>
+    <div class='form-group form-inline'>
+      <input class='form-control col-md-4 mr-2' id='adminAddTagInput'>
+      <button class='button btn btn-primary' data-teamid='{{ App.Users.userData.team }}' data-action='admin-add-tag'>{{ 'Save'|trans }}</button>
     </div>
     <hr>
     <button class='button btn btn-primary' data-action='deduplicate-tag'><i class='fas fa-clone mr-1 text-white'></i>{{ 'Deduplicate'|trans }}</button>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -1,10 +1,11 @@
+{% set is_sysconfig = (App.Request.getScriptName|split('/')|last == 'sysconfig.php') %}
 <div class='box form-group'>
   <form class='form-inline' method='get' id ='userSearchForm'>
     <label for='searchUsers' class='mb-2'>{{ 'Search users'|trans }}</label>
     <input type='text' autocomplete='off' class='form-control col-md-4 mb-2' id='searchUsers' value='{{ App.Request.query.get('q') }}' name='q' />
-    <!-- stay on correct tab -->
+    {# stay on correct tab #}
     <input type='hidden' value='3' name='tab' />
-    {% if App.Request.getScriptName|split('/')|last == 'sysconfig.php' %}
+    {% if is_sysconfig %}
       <label for='teamFilter' class='ml-2 mb-2'>{{ 'limit to team'|trans }}</label>
       <select class='form-control mb-2' name='teamFilter' id='teamFilter'>
         <option value=''>{{ 'All teams'|trans }}</option>
@@ -20,85 +21,128 @@
 
 {% if isSearching %}
     <div id='editUsersBox' class='box'>
-        <h3>{{ 'Edit Users'|trans }}</h3>
-        <hr>
-        {% if usersArr %}
+      <h3>{{ 'Edit Users'|trans }}</h3>
+      <hr>
+      {% if usersArr %}
         <ul class='list-group'>
-
-            {% for user in usersArr %}
+          {% for user in usersArr %}
             <li class='list-group-item'>
+              <p class='float-right'>
+                {% if user.mfa_secret %}
+                  <span class='elab-tooltip'><span>{{ '2FA enabled'|trans }}</span><i title='' class='fas fa-user-shield'></i></span>
+                {% endif %}
+                <span class='elab-tooltip badge badge-secondary'><span>{{ 'User ID'|trans }}</span>{{ user.userid }}</span>
+              </p>
+              <p>Last login: {{ user.last_login ?? 'never' }}</p>
+              {# TEAM #}
               <ul class='list-inline'>
-                <p class='float-right'>
-                  {% if user.mfa_secret %}
-                    <span class='elab-tooltip'><span>{{ '2FA enabled'|trans }}</span><i title='' class='fas fa-user-shield'></i></span>
-                  {% endif %}
-                  <span class='elab-tooltip badge badge-secondary'><span>{{ 'User ID'|trans }}</span>{{ user.userid }}</span>
-                </p>
-                <p>Last login: {{ user.last_login ?? 'never' }}</p>
-                <!-- TEAM -->
                 <li class='list-inline-item mb-2'>
                   <label for='usersUpdateTeam_{{ user.userid }}'>{{ 'Team(s)'|trans }}</label>
                   {% for team in user.teams %}
-                  <span data-action='destroy-user2team' data-teamid='{{ team.id }}' data-userid='{{ user.userid }}' class='btn btn-secondary {{ App.Request.getScriptName|split('/')|last == 'sysconfig.php' ? 'hover-danger' }}'>{{ team.name }}</span>
+                  <span data-action='destroy-user2team' data-teamid='{{ team.id }}' data-userid='{{ user.userid }}' class='btn btn-secondary {{- is_sysconfig ? ' hover-danger' }}'>{{ team.name }}</span>
                   {% endfor %}
-                  {% if App.Session.get('is_sysadmin') and (App.Request.getScriptName|split('/')|last == 'sysconfig.php') %}
+                  {% if is_sysconfig %}
                     {% set addableToTeams = teamsArr|filter(v => v.id not in user.teams|column('id')) %}
                     {% if addableToTeams %}
-                      <span class='btn btn-primary' data-action='toggle-next'><i class='color-white fas fa-plus-circle'></i> {{ 'Add team'|trans }}</span>
+                      <span class='btn btn-primary' data-action='toggle-next'><i class='color-white fas fa-plus-circle'></i> {{ 'Add to team'|trans }}</span>
                       <span class='form-group form-inline mt-2' hidden>
-                        <select class='form-control'>
+                        <select class='form-control mr-2' id='addUser2Team_{{ user.userid }}'>
                           {% for team in addableToTeams %}
-                          <option value='{{ team.id }}'>{{ team.name }}</option>
-                        {% endfor %}
-                      </select>
-                      <button data-action='create-user2team' data-userid='{{ user.userid }}' class='btn btn-primary'>{{ 'Go'|trans }}</button>
+                            <option value='{{ team.id }}'>{{ team.name }}</option>
+                          {% endfor %}
+                        </select>
+                        <div class='form-check'>
+                          <input class='form-check-input' type='checkbox' id='addUser2TeamIsAdmin_{{ user.userid }}'>
+                          <label class='form-check-label' for='addUser2TeamIsAdmin_{{ user.userid }}'>
+                            {{ 'as admin'|trans }}
+                          </label>
+                        </div>
+                        <button data-action='create-user2team' data-userid='{{ user.userid }}' class='btn btn-primary'>{{ 'Go'|trans }}</button>
                       </span>
                     {% endif %}
                   {% endif %}
                 </li>
-
-
-                <div class='form-group'>
-                  <!-- you need to be sysadmin to edit things like firstname/lastname/email -->
-                  <!-- FIRSTNAME -->
+              </ul>
+              <div class='form-group'>
+                <ul class='list-inline'>
+                  {# you need to be sysadmin to edit things like firstname/lastname/email #}
+                  {#  FIRSTNAME #}
                   <li class='list-inline-item'>
                     {# add the userid in the for and id to prevent having more than one id on the page. Label wrapping wouldn't display nice #}
                     <label for='usersUpdateFirstname_{{ user.userid }}'>{{ 'Firstname'|trans }}</label>
-                    <input autocomplete='off' {{ App.Users.userData.usergroup != '1' ? 'disabled' }} class='form-control custom-control-inline' id='usersUpdateFirstname_{{ user.userid }}' type='text' value='{{ user.firstname|raw }}' name='firstname' />
+                    <input autocomplete='off' {{- not is_sysconfig ? ' disabled' }} class='form-control' id='usersUpdateFirstname_{{ user.userid }}' type='text' value='{{ user.firstname|raw }}' name='firstname' />
                   </li>
 
-                  <!-- LASTNAME -->
+                  {#  LASTNAME #}
                   <li class='list-inline-item'>
                     <label for='usersUpdateLastname_{{ user.userid }}'>{{ 'Lastname'|trans }}</label>
-                    <input autocomplete='off' {{ App.Users.userData.usergroup != '1' ? 'disabled' }} class='form-control custom-control-inline' id='usersUpdateLastname_{{ user.userid }}' type='text' value='{{ user.lastname|raw }}' name='lastname' />
+                    <input autocomplete='off' {{- not is_sysconfig ? ' disabled' }} class='form-control' id='usersUpdateLastname_{{ user.userid }}' type='text' value='{{ user.lastname|raw }}' name='lastname' />
                   </li>
 
-                  <!-- EMAIL -->
+                  {#  EMAIL #}
                   <li class='list-inline-item'>
                     <label for='usersUpdateEmail_{{ user.userid }}'>{{ 'Email'|trans }}</label>
-                    <input autocomplete='off' {{ App.Users.userData.usergroup != '1' ? 'disabled' }} class='form-control custom-control-inline' id='usersUpdateEmail_{{ user.userid }}' type='email' value='{{ user.email }}' name='email' />
+                    <input autocomplete='off' {{- not is_sysconfig ? ' disabled' }} class='form-control' id='usersUpdateEmail_{{ user.userid }}' type='email' value='{{ user.email }}' name='email' />
                   </li>
 
-                  <!-- PERMISSION GROUP -->
-                  <li class='list-inline-item'>
-                    <label for='usersUpdateUsergroup_{{ user.userid }}'>{{ 'Permission group'|trans }}</label>
-                    <select {{ App.Users.userData.usergroup != '1' and user.usergroup == '1' ? 'disabled' }} class='form-control custom-control-inline' name='usergroup' id='usersUpdateUsergroup_{{ user.userid }}'>
-                      {% if App.Users.userData.usergroup == '1' %}
-                        <option value='1' {{ user.usergroup == '1' ? " selected='selected'" }}>Sysadmins</option>
-                      {% endif %}
-                      <option value='2' {{ user.usergroup == '2' ? " selected='selected'" }}>Admins</option>
-                      <option value='4' {{ user.usergroup == '4' ? " selected='selected'" }}>Users</option>
-                    </select>
-                  </li>
-
-                  {% if App.Users.userData.usergroup == '1' %}
-                    <!-- RESET PASSWORD -->
+                  {% if not is_sysconfig %}
+                  {# OWNER #}
                     <li class='list-inline-item'>
-                      <label for='usersUpdatePassword_{{ user.userid }}'>{{ 'Reset user password'|trans }}
-                        <p class='smallgray'>({{ minPasswordLength() }} {{ 'characters minimum'|trans }})</p>
-                      </label>
-                      <!-- add empty input to prevent FF from putting password in field because autocomplete doesn't work. from http://stackoverflow.com/questions/17781077/autocomplete-off-is-not-working-on-firefox -->
-                      <!-- chrome will continue to behave badly. See crbug.com/468153 and crbug.com/587466 -->
+                      <label for='usersUpdateIsOwner_{{ user.userid }}'>{{ 'Is owner'|trans }}</label>
+                      <select class='form-control' autocomplete='off' name='is_owner' id='usersUpdateIsOwner_{{ user.userid }}' disabled>
+                        <option value='1' {{- user.is_owner ? ' selected' }}>{{ 'Yes'|trans }}</option>
+                        <option value='0' {{- not user.is_owner ? ' selected' }}>{{ 'No'|trans }}</option>
+                      </select>
+                    </li>
+
+                    {# IS ADMIN #}
+                    {# Admins can only promote users from same team to admins #}
+                    <li class='list-inline-item'>
+                      <label for='usersUpdateIsAdmin_{{ user.userid }}'>{{ 'Is admin'|trans }}</label>
+                      <select class='form-control' autocomplete='off' name='is_admin' id='usersUpdateIsAdmin_{{ user.userid }}'>
+                        <option value='1' {{- user.is_admin ? ' selected' }}>{{ 'Yes'|trans }}</option>
+                        <option value='0' {{- not user.is_admin ? ' selected' }}>{{ 'No'|trans }}</option>
+                      </select>
+                    </li>
+                  {% endif %}
+
+                  {% if is_sysconfig %}
+                    {# Owner OF TEMAS #}
+                    <li class='list-inline-item'>
+                      <label for='usersUpdateTeamOwner_{{ user.userid }}'>{{ 'Owner of team(s)'|trans }}</label>
+                      <select multiple name='owner_of_teams' id='usersUpdateTeamOwner_{{ user.userid }}' class='form-control selectpicker' data-show-subtext='true' data-live-search='true' data-showtick='true' data-actions-box='true' disabled>
+                        {% for team in user.teams %}
+                          <option value='{{ team.id }}' {{- team.is_owner ? ' selected' }}>{{ team.name }}</option>
+                        {% endfor %}
+                     </select>
+                    </li>
+
+                    {# ADMIN OF TEMAS #}
+                    {# Sysadmins can promote users to admins in all teams user is member of #}
+                    <li class='list-inline-item'>
+                      <label for='usersUpdateTeamAdmins_{{ user.userid }}'>{{ 'Admin of team(s)'|trans }}</label>
+                      <select multiple name='admin_of_teams' id='usersUpdateTeamAdmins_{{ user.userid }}' class='form-control selectpicker' data-show-subtext='true' data-live-search='true' data-showtick='true' data-actions-box='true'>
+                        {% for team in user.teams %}
+                          <option value='{{ team.id }}' {{- team.is_admin ? ' selected' }}>{{ team.name }}</option>
+                        {% endfor %}
+                     </select>
+                    </li>
+
+                    {# IS SYSADMIN #}
+                    <li class='list-inline-item'>
+                      <label for='usersUpdateIsSysadmin_{{ user.userid }}'>{{ 'Is sysadmin'|trans }}</label>
+                      <select class='form-control' autocomplete='off' name='is_sysadmin' id='usersUpdateIsSysadmin_{{ user.userid }}'>
+                        <option value='1' {{- user.is_sysadmin ? ' selected' }}>{{ 'Yes'|trans }}</option>
+                        <option value='0' {{- not user.is_sysadmin ? ' selected' }}>{{ 'No'|trans }}</option>
+                      </select>
+                    </li>
+
+                    {# RESET PASSWORD #}
+                    <li class='list-inline-item'>
+                      <label for='usersUpdatePassword_{{ user.userid }}'>{{ 'Reset user password'|trans }}</label><br>
+                      <span class='smallgray'>({{ minPasswordLength() }} {{ 'characters minimum'|trans }})</span>
+                      {# add empty input to prevent FF from putting password in field because autocomplete doesn't work. from http://stackoverflow.com/questions/17781077/autocomplete-off-is-not-working-on-firefox #}
+                      {# chrome will continue to behave badly. See crbug.com/468153 and crbug.com/587466 #}
                       <input type='text' data-ignore='1' hidden>
                       <input type='password' data-ignore='1' hidden>
                       {% set pattern = '.{' ~ minPasswordLength() ~ ',}' %}
@@ -111,27 +155,27 @@
                     </li>
                   {% endif %}
 
-                  <!-- ACTIVE ACCOUNT -->
+                  {# ACTIVE ACCOUNT #}
                   <li class='list-inline-item'>
                     <label for='usersUpdateValidated_{{ user.userid }}'>{{ 'Has an active account?'|trans }}</label>
-                    <select class='form-control custom-control-inline' autocomplete='off' name='validated' id='usersUpdateValidated_{{ user.userid }}'>
-                      <option value='1' {{ user.validated ? " selected='selected'" }}>{{ 'Yes'|trans }}</option>
-                      <option value='0' {{ not user.validated ? " selected='selected'" }}>{{ 'No'|trans }}</option>
+                    <select class='form-control' autocomplete='off' name='validated' id='usersUpdateValidated_{{ user.userid }}'>
+                      <option value='1' {{- user.validated ? ' selected' }}>{{ 'Yes'|trans }}</option>
+                      <option value='0' {{- not user.validated ? ' selected' }}>{{ 'No'|trans }}</option>
                     </select>
                   </li>
 
-                  <!-- VALID UNTIL -->
+                  {# VALID UNTIL #}
                   <li class='list-inline-item'>
                     <label for='usersUpdateValidUntil_{{ user.userid }}'>{{ 'Valid until'|trans }}</label>
-                    <input autocomplete='off' value='{{ user.valid_until ? user.valid_until|date('Y-m-d') }}' type='date' class='form-control custom-control-inline' name='valid_until' id='usersUpdateValidUntil_{{ user.userid }}'>
+                    <input autocomplete='off' value='{{ user.valid_until ? user.valid_until|date('Y-m-d') }}' type='date' class='form-control' name='valid_until' id='usersUpdateValidUntil_{{ user.userid }}'>
                   </li>
 
-                  <!-- SAVE -->
+                  {# SAVE #}
                   <li class='list-inline-item'>
                     <button data-action='update-user' data-userid='{{ user.userid }}' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
                   </li>
 
-                  <!-- ARCHIVE USER -->
+                  {# ARCHIVE USER #}
                   <li class='list-inline-item'>
                     {% if user.archived %}
                       <button class='button btn btn-neutral' data-action='toggle-archive-user' data-userid='{{ user.userid }}'>{{ 'Unarchive user'|trans }}</button>
@@ -140,71 +184,71 @@
                     {% endif %}
                   </li>
 
-                  {% if App.Users.userData.usergroup == '1' %}
-                    <!-- DESTROY USER -->
+                  {% if is_sysconfig %}
+                    {# DESTROY USER #}
                     <li class='list-inline-item'>
                       <button class='button btn btn-danger' data-action='destroy-user' data-userid='{{ user.userid }}'>{{ 'Delete user'|trans }}</button>
-                   </li>
-                 {% endif %}
-                <hr>
-              </ul>
+                    </li>
+                  {% endif %}
+                </ul>
+              </div>
             </li>
-            {% endfor %}
+          {% endfor %}
         </ul>
-    {% else %}
+      {% else %}
         <p>{{ 'No user found!'|trans }}</p>
-    {% endif %}
+      {% endif %}
     </div>
 {% endif %}
 
-{% if App.Config.configArr.admins_create_users or App.Users.userData.is_sysadmin %}
-<!-- CREATE USER ACCOUNT -->
+{% if App.Config.configArr.admins_create_users or is_sysconfig %}
+{# CREATE USER ACCOUNT #}
 <div class='box'>
   <h3>{{ 'Add account'|trans }}</h3>
   <p>{{ 'Note: new user will need to use the "Forgot password" button on the login page to set a password.'|trans }}</p>
   <div class='form-group'>
     <div class='row form-group'>
-      <!-- TEAM -->
+      {# TEAM #}
       <div class='col-md-2'>
         <label for='create-user-team'>{{ 'Team'|trans }}</label>
-        <select {{ App.Request.getScriptName|split('/')|last == 'admin.php' ? 'disabled' }} class='form-control custom-control-inline' name='team' id='create-user-team'>
+        <select {{- not is_sysconfig ? ' disabled' }} class='form-control' name='team' id='create-user-team'>
           {% for team in teamsArr %}
-            <option value='{{ team.id }}' {{ App.Users.userData.team == team.id ? " selected='selected'" }}>{{ team.name }}</option>
+            <option value='{{ team.id }}' {{- App.Users.userData.team == team.id ? ' selected' }}>{{ team.name }}</option>
           {% endfor %}
         </select>
       </div>
 
-      <!-- EMAIL -->
+      {# EMAIL #}
       <div class='col-md-2'>
         <label for='email'>{{ 'Email'|trans }}</label>
         <input name='email' class='form-control' type='email' id='email' required />
       </div>
 
-      <!-- FIRSTNAME -->
+      {# FIRSTNAME #}
       <div class='col-md-2'>
         <label for='firstname'>{{ 'Firstname'|trans }}</label>
         <input name='firstname' class='form-control' type='text' id='firstname' required />
       </div>
 
-      <!-- LASTNAME -->
+      {# LASTNAME #}
       <div class='col-md-2'>
         <label for='lastname'>{{ 'Lastname'|trans }}</label>
         <input name='lastname' class='form-control' type='text' id='lastname' required />
       </div>
 
-      <!-- GROUP -->
+      {# GROUP #}
       <div class='col-md-2'>
         <label for='create-user-group'>{{ 'Permission group'|trans }}</label>
-        <select class='form-control custom-control-inline' name='usergroup' id='create-user-group'>
-          {% if App.Session.get('is_sysadmin') %}
+        <select class='form-control' name='usergroup' id='create-user-group'>
+          {% if is_sysconfig %}
             <option value='1'>Sysadmins</option>
           {% endif %}
           <option value='2'>Admins</option>
-          <option value='4' selected='selected'>Users</option>
+          <option value='4' selected>Users</option>
         </select>
       </div>
 
-      <!-- SUBMIT -->
+      {# SUBMIT #}
       <div class='col-md-2'>
         <button style='margin-top: 26px' data-action='create-user' class='button btn btn-primary'>{{ 'create'|trans }}</button>
       </div>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -187,8 +187,10 @@ MySQL database structure version: {{ App.Config.configArr.schema }}</p>
         <div class='box'>
             <h3>{{ 'Add a New Team'|trans }}</h3>
             <hr>
-            <input class='form-control custom-control-inline col-md-4' required type='text' placeholder='Pasteur lab' id='teamsName' />
-            <button data-action='create-team' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
+            <div class='form-inline'>
+              <input class='form-control col-md-4 mr-2' required type='text' placeholder='Pasteur lab' id='teamsName' />
+              <button data-action='create-team' class='button btn btn-primary'>{{ 'Save'|trans }}</button>
+            </div>
         </div>
 
         <!-- DISPLAY TEAMS -->
@@ -203,32 +205,40 @@ MySQL database structure version: {{ App.Config.configArr.schema }}</p>
                   <li class='list-inline-item mb-2'>
                     {% set count = Teams.getStats(team.id) %}
                     <label for='teamName_{{ team.id }}'>{{ 'Team Name'|trans }}</label>
-                    <input autocomplete='off' data-id='{{ team.id }}' class='form-control custom-control-inline' id='teamName_{{ team.id }}' type='text' value='{{ team.name }}' />
+                    <input autocomplete='off' data-id='{{ team.id }}' class='form-control' id='teamName_{{ team.id }}' type='text' value='{{ team.name }}' />
                   </li>
 
                   <li class='list-inline-item mb-2'>
                     <label for='teamOrgid_{{ team.id }}'>{{ 'Team Organisation ID'|trans }}</label>
-                    <input autocomplete='off' data-id='{{ team.id }}' class='form-control custom-control-inline' id='teamOrgid_{{ team.id }}' type='text' value='{{ team.orgid }}' />
+                    <input autocomplete='off' data-id='{{ team.id }}' class='form-control' id='teamOrgid_{{ team.id }}' type='text' value='{{ team.orgid }}' />
+                  </li>
+
+                  <li class='list-inline-item mb-2'>
+                    <label for='teamOwner_{{ team.id }}'>{{ 'Team Owner'|trans }}</label>
+                    <select class='form-control' name='teamOwner' id='teamOwner_{{ team.id }}'>
+                      {% for user in users2teams.getUsersFromTeam(team.id) %}
+                        <option value='{{ user.userid }}' {{- user.is_owner ? ' selected' }}>{{ user.fullname }} {{- user.is_admin ? ' (admin)' }}</option>
+                      {% endfor %}
+                    </select>
                   </li>
 
                   <li class='list-inline-item mb-2'>
                     {% if count.totusers == 0 and team.id != App.Users.userData.team %}
-                    <button data-id='{{ team.id }}' id='teamsDestroyButton_{{ team.id }}' data-action='destroy-team' class='button btn btn-danger'>
+                      <button data-id='{{ team.id }}' id='teamsDestroyButton_{{ team.id }}' data-action='destroy-team' class='button btn btn-danger'>
                         {{ 'Delete'|trans }}
-                    </button>
+                      </button>
                     {% else %}
-                    <button data-id='{{ team.id }}' data-action='archive-team' class='button btn btn-neutral'>
-                      {{ 'Archive'|trans }}
-                    </button>
+                      <button data-id='{{ team.id }}' data-action='archive-team' class='button btn btn-neutral'>
+                        {{ 'Archive'|trans }}
+                      </button>
+                    {% endif %}
                   </li>
-
-                  {% endif %}
 
                   <li class='list-inline-item mb-2'>
                     <label for='teamVisible_{{ team.id }}'>{{ 'Visible on registration page'|trans }}</label>
                     <select class='form-control' name='teamsVisible' id='teamVisible_{{ team.id }}'>
-                      <option value='1'{{ team.visible ? " selected='selected'" }}>{{ 'Yes'|trans }}</option>
-                      <option value='0'{{ not team.visible ? " selected='selected'" }}>{{ 'No'|trans }}</option>
+                      <option value='1' {{- team.visible ? ' selected' }}>{{ 'Yes'|trans }}</option>
+                      <option value='0' {{- not team.visible ? ' selected' }}>{{ 'No'|trans }}</option>
                     </select>
                   </li>
 

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { collectForm, reloadElement } from './misc';
+import { collectForm, reloadElement, reloadEditUsersBox } from './misc';
 import { Api } from './Apiv2.class';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -19,27 +19,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = (event.target as HTMLElement);
     // CREATE USER
     if (el.matches('[data-action="create-user"]')) {
-      return ApiC.post('users', collectForm(el.closest('div.form-group'))).then(() => reloadElement('editUsersBox'));
+      return ApiC.post('users', collectForm(el.closest('div.form-group')))
+        .then(() => reloadEditUsersBox());
 
     // UPDATE USER
     } else if (el.matches('[data-action="update-user"]')) {
-      return ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElement('editUsersBox'));
+      return ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group')))
+        .then(() => reloadEditUsersBox());
 
     // ARCHIVE USER TOGGLE
     } else if (el.matches('[data-action="toggle-archive-user"]')) {
       // show alert
       if (confirm('Are you sure you want to archive/unarchive this user?\nAll experiments will be locked and user will not be able to login anymore.')) {
-        return ApiC.patch(`users/${el.dataset.userid}`, {'action': 'archive'}).then(() => reloadElement('editUsersBox'));
+        return ApiC.patch(`users/${el.dataset.userid}`, {'action': 'archive'})
+          .then(() => reloadEditUsersBox());
       }
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {
-      return ApiC.patch(`users/${el.dataset.userid}`, {'action': 'validate'}).then(() => reloadElement('unvalidatedUsersBox')).then(() => reloadElement('editUsersBox'));
+      return ApiC.patch(`users/${el.dataset.userid}`, {'action': 'validate'})
+        .then(() => reloadElement('unvalidatedUsersBox'))
+        .then(() => reloadEditUsersBox());
 
     // DESTROY USER
     } else if (el.matches('[data-action="destroy-user"]')) {
       if (confirm('Are you sure you want to remove permanently this user and all associated data?')) {
-        return ApiC.delete(`users/${el.dataset.userid}`).then(() => reloadElement('editUsersBox'));
+        return ApiC.delete(`users/${el.dataset.userid}`)
+          .then(() => reloadEditUsersBox());
       }
     }
   });

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -50,20 +50,25 @@ export function relativeMoment(): void {
  */
 export function collectForm(form: HTMLElement): object {
   let params = {};
-  ['input', 'select'].forEach(inp => {
-    form.querySelectorAll(inp).forEach((input: HTMLInputElement) => {
-      const el = input as HTMLInputElement;
-      if (el.reportValidity() === false) {
-        throw new Error('Invalid input found! Aborting.');
-      }
-      if (el.dataset.ignore !== '1' && el.disabled === false) {
-        params = Object.assign(params, {[input.name]: input.value});
-      }
-      if (el.name === 'password') {
-        // clear a password field once collected
-        el.value = '';
-      }
-    });
+  form.querySelectorAll('input, select').forEach((el: HTMLInputElement|HTMLSelectElement) => {
+    let value: string|string[] = el.value;
+    if (el instanceof HTMLSelectElement && el.multiple) {
+      value = Array.from(el.selectedOptions).map(v => v.value);
+    }
+    if (el.reportValidity() === false) {
+      throw new Error('Invalid input found! Aborting.');
+    }
+    // check name is 
+    if (el.dataset.ignore !== '1'
+      && el.disabled === false
+      && el.hasAttribute('name') === true
+    ) {
+      params = Object.assign(params, {[el.name]: value});
+    }
+    if (el.name === 'password') {
+      // clear a password field once collected
+      el.value = '';
+    }
   });
   // don't send an empty password
   if (params['password'] === '') {
@@ -256,6 +261,14 @@ export async function reloadElement(elementId: string): Promise<void> {
   }
   const html = await fetchCurrentPage();
   document.getElementById(elementId).innerHTML = html.getElementById(elementId).innerHTML;
+}
+
+export async function reloadEditUsersBox(): Promise<void> {
+  return reloadElement('editUsersBox')
+    .then(() => {
+      ($('#editUsersBox .selectpicker') as JQuery<HTMLSelectElement>).selectpicker();
+      return;
+    });
 }
 
 /**

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { collectForm, notif, reloadElement, removeEmpty } from './misc';
+import { collectForm, notif, reloadElement, reloadEditUsersBox, removeEmpty } from './misc';
 import { Action, Model } from './interfaces';
 import i18next from 'i18next';
 import tinymce from 'tinymce/tinymce';
@@ -102,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'name': (document.getElementById('teamName_' + id) as HTMLInputElement).value,
         'orgid': (document.getElementById('teamOrgid_' + id) as HTMLInputElement).value,
         'visible': (document.getElementById('teamVisible_' + id) as HTMLSelectElement).value,
+        'is_owner': (document.getElementById('teamOwner_' + id) as HTMLSelectElement).value,
       };
       ApiC.patch(`${Model.Team}/${id}`, removeEmpty(params));
     // ARCHIVE TEAM
@@ -112,16 +113,19 @@ document.addEventListener('DOMContentLoaded', () => {
       ApiC.delete(`${Model.Team}/${el.dataset.id}`).then(() => reloadElement('teamsDiv'));
     // ADD USER TO TEAM
     } else if (el.matches('[data-action="create-user2team"]')) {
-      const selectEl = (el.previousElementSibling as HTMLSelectElement);
-      const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       const userid = parseInt(el.dataset.userid, 10);
-      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team}).then(() => reloadElement('editUsersBox'));
+      const selectEl = document.getElementById(`addUser2Team_${userid}`) as HTMLSelectElement;
+      const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
+      const isAdmin = (document.getElementById(`addUser2TeamIsAdmin_${userid}`) as HTMLInputElement).checked;
+      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team, 'is_admin': isAdmin})
+        .then(() => reloadEditUsersBox());
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         const userid = parseInt(el.dataset.userid, 10);
         const team = parseInt(el.dataset.teamid, 10);
-        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team}).then(() => reloadElement('editUsersBox'));
+        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team})
+          .then(() => reloadEditUsersBox());
       }
     // DESTROY ts_password
     } else if (el.matches('[data-action="destroy-ts-password"]')) {

--- a/tests/unit/classes/UserParamsTest.php
+++ b/tests/unit/classes/UserParamsTest.php
@@ -13,11 +13,11 @@ use Elabftw\Exceptions\ImproperActionException;
 
 class UserParamsTest extends \PHPUnit\Framework\TestCase
 {
-    public function testUserGroup(): void
-    {
-        $params = new UserParams('usergroup', '4', 0, 1);
-        $this->assertEquals(4, $params->getContent());
-    }
+    //public function testUserGroup(): void
+    //{
+    //    $params = new UserParams('usergroup', '4');
+    //    $this->assertEquals(4, $params->getContent());
+    //}
 
     public function testValidUntilEmpty(): void
     {

--- a/tests/unit/models/TagsTest.php
+++ b/tests/unit/models/TagsTest.php
@@ -45,6 +45,7 @@ class TagsTest extends \PHPUnit\Framework\TestCase
         $Teams = new Teams($this->Users, (int) $this->Users->userData['team']);
         $Teams->patch(Action::Update, array('user_create_tag' => 0));
         $this->expectException(ImproperActionException::class);
+        // ToDo: the code below is not executed
         $Tags->postAction(Action::Create, array('tag' => 'tag2i222'));
         // bring back config
         $Teams->patch(Action::Update, array('user_create_tag' => 1));

--- a/tests/unit/models/ValidatedUserTest.php
+++ b/tests/unit/models/ValidatedUserTest.php
@@ -18,7 +18,6 @@ class ValidatedUserTest extends \PHPUnit\Framework\TestCase
             array('Alpha'),
             'valid',
             'user',
-            4,
         );
         $this->assertInstanceOf(ExistingUser::class, $User);
     }

--- a/tests/unit/services/ExternalAuthTest.php
+++ b/tests/unit/services/ExternalAuthTest.php
@@ -54,7 +54,7 @@ class ExternalAuthTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $authResponse->userid);
         $this->assertFalse($authResponse->isAnonymous);
         $this->assertEquals(1, $authResponse->selectedTeam);
-        $teams = array(array('id' => '1', 'name' => 'Alpha'));
+        $teams = array(array('id' => 1, 'name' => 'Alpha', 'is_admin' => 1, 'is_owner' => 1));
         $this->assertEquals($teams, $authResponse->selectableTeams);
     }
 

--- a/tests/unit/services/MakeReportTest.php
+++ b/tests/unit/services/MakeReportTest.php
@@ -11,6 +11,7 @@ namespace Elabftw\Services;
 
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users;
+use ReflectionClass;
 
 class MakeReportTest extends \PHPUnit\Framework\TestCase
 {
@@ -26,8 +27,26 @@ class MakeReportTest extends \PHPUnit\Framework\TestCase
         $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}-report.elabftw.csv/', $this->Make->getFileName());
     }
 
+    public function testHeaderMatchesColumnNames(): void
+    {
+        $header = $this->callMethod($this->Make, 'getHeader', array());
+        $rows = array_keys($this->callMethod($this->Make, 'getRows', array())[0]);
+        $this->assertEquals($header, $rows);
+    }
+
     public function testGetCsv(): void
     {
         $this->assertIsString($this->Make->getFileContent());
+    }
+
+    /**
+     * Helper method to call protected/private methods
+     */
+    protected function callMethod(mixed $obj, string $name, array $args): mixed
+    {
+        $class = new ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($obj, $args);
     }
 }

--- a/tests/unit/services/TeamsHelperTest.php
+++ b/tests/unit/services/TeamsHelperTest.php
@@ -22,13 +22,16 @@ class TeamsHelperTest extends \PHPUnit\Framework\TestCase
         $this->TeamsHelper = new TeamsHelper(1);
     }
 
-    public function testGetGroup(): void
+    public function testIsFirstUser(): void
     {
-        $this->assertEquals(4, $this->TeamsHelper->getGroup());
-        // now create a new team and try to get group
+        $this->assertFalse($this->TeamsHelper->isFirstUser());
+    }
+
+    public function testIsFirstUserInTeam(): void
+    {
         $Teams = new Teams(new Users(1));
         $team = $Teams->postAction(Action::Create, array('name' => 'New team'));
         $TeamsHelper = new TeamsHelper($team);
-        $this->assertEquals(2, $TeamsHelper->getGroup());
+        $this->assertTrue($TeamsHelper->isFirstUserInTeam());
     }
 }

--- a/tests/unit/services/UsersHelperTest.php
+++ b/tests/unit/services/UsersHelperTest.php
@@ -35,7 +35,7 @@ class UsersHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTeamsFromUserid(): void
     {
-        $expected = array(array('id' => '1', 'name' => 'Alpha'));
+        $expected = array(array('id' => 1, 'name' => 'Alpha', 'is_admin' => 1, 'is_owner' => 1));
         $this->assertEquals($expected, $this->UsersHelper->getTeamsFromUserid());
     }
 

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -19,6 +19,7 @@ use Elabftw\Models\AuthFail;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Idps;
 use Elabftw\Models\Teams;
+use Elabftw\Models\Users2Teams;
 use Elabftw\Services\UsersHelper;
 use Exception;
 use function file_get_contents;
@@ -47,6 +48,7 @@ try {
     $Idps = new Idps();
     $idpsArr = $Idps->readAll();
     $Teams = new Teams($App->Users);
+    $Users2Teams = new Users2Teams();
     $teamsArr = $Teams->readAll();
     $teamsStats = $Teams->getAllStats();
     $Experiments = new Experiments($App->Users);
@@ -97,6 +99,7 @@ try {
         'teamsStats' => $teamsStats,
         'timestampLastMonth' => $Experiments->getTimestampLastMonth(),
         'usersArr' => $usersArr,
+        'users2teams' => $Users2Teams,
     );
 } catch (IllegalActionException $e) {
     $renderArr['error'] = Tools::error(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,13 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/bootstrap-select@^1.13.4":
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/@types/bootstrap-select/-/bootstrap-select-1.13.4.tgz#b95e72a70ebadb1cc2c0630e86472c6156fe4d5e"
+  integrity sha512-jpmfCyF/DETb7P9Ob1htDoSGwSNvdddmBEe47iAbLttWGAGbEzE/Ks6/eGzKzEbDDLbL/melqSW8RkqTpa60Gw==
+  dependencies:
+    "@types/jquery" "*"
+
 "@types/bootstrap@^5.0.17":
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/@types/bootstrap/-/bootstrap-5.2.6.tgz#e861b3aa1f4a1434da0bf50fbaa372b6f7e64d2f"


### PR DESCRIPTION
As I wrote to @NicolasCARPi already:

I started to work on separating the user permission (`usergroup`) from the `users` table and into the `users2teams` table. The idea is that every user that can authenticate is a basic user. No need to define that role any longer. Admins are associated to teams and therefore no longer necessarily admin in all teams (This seems to be the important part). The sysadmin status is associated to individual users as they will have no restrictions anyways.

There was also a request to add an owner/multiple owners to a team (#3454). So this will be handled similarly to the admin status in the `users2teams` table but no additional privileges are granted but emails can be send to this limited user group. For now there will only be one owner per team.

This is still WIP but it is working. The mailing part is still missing.

@NicolasCARPi I would like to start to discuss if this is going in the right direction.