### PR TITLE
Change on the YAML specifications for the creation of the python API.

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1491,7 +1491,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              anyOf:
                 - type: object
                   properties:
                     action:


### PR DESCRIPTION
Change on experiement_templates. 

The PATCH method does not take into account the "body" parameter.  
This prevents the modification of an existing template.

 Changed the oneOf argument to anyOf allowing to take into account several argument schema of type: 

```function(id, body)```

