### PR TITLE
Add qrcode png format for export of one entry

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -902,7 +902,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: ['csv', 'eln', 'json', 'qrpdf', 'pdf', 'pdfa', 'zip', 'zipa']
+            enum: ['csv', 'eln', 'json', 'qrpdf', 'qrpng', 'pdf', 'pdfa', 'zip', 'zipa']
             default: json
           description: |
             Get the entity in a different format like csv, pdf, eln or zip. "pdfa" means archive pdf (PDF/A), same with "zipa".
@@ -1091,6 +1091,22 @@ paths:
       tags: ['Items']
       summary: Read an item
       operationId: get-item
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: ['csv', 'eln', 'json', 'qrpdf', 'qrpng', 'pdf', 'pdfa', 'zip', 'zipa']
+            default: json
+          description: |
+            Get the entity in a different format like csv, pdf, eln or zip. "pdfa" means archive pdf (PDF/A), same with "zipa".
+          examples:
+            first:
+              summary: Generate a pdf
+              value: pdf
+            second:
+              summary: Generate a csv
+              value: csv
       responses:
         '200':
           description: An item

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -182,6 +182,7 @@ class Apiv2Controller extends AbstractApiController
             ExportFormat::Csv,
             ExportFormat::Eln,
             ExportFormat::QrPdf,
+            ExportFormat::QrPng,
             ExportFormat::Pdf,
             ExportFormat::PdfA,
             ExportFormat::ZipA,

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -13,6 +13,7 @@ use function count;
 
 use Elabftw\Enums\EntityType;
 use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Interfaces\MpdfProviderInterface;
 use Elabftw\Interfaces\StringMakerInterface;
@@ -28,6 +29,7 @@ use Elabftw\Services\MakeJson;
 use Elabftw\Services\MakeMultiPdf;
 use Elabftw\Services\MakePdf;
 use Elabftw\Services\MakeQrPdf;
+use Elabftw\Services\MakeQrPng;
 use Elabftw\Services\MakeReport;
 use Elabftw\Services\MakeSchedulerReport;
 use Elabftw\Services\MakeStreamZip;
@@ -87,6 +89,10 @@ class MakeController implements ControllerInterface
             case 'qrpdf':
                 $this->populateIdArr();
                 return $this->makeQrPdf();
+
+            case 'qrpng':
+                $this->populateIdArr();
+                return $this->makeQrPng();
 
             case 'report':
                 if (!$this->Users->userData['is_sysadmin']) {
@@ -173,6 +179,15 @@ class MakeController implements ControllerInterface
     private function makeQrPdf(): Response
     {
         return $this->getFileResponse(new MakeQrPdf($this->getMpdfProvider(), $this->Entity, $this->idArr));
+    }
+
+    private function makeQrPng(): Response
+    {
+        // only works for 1 entry
+        if (count($this->idArr) !== 1) {
+            throw new ImproperActionException('QR PNG format is only suitable for one ID.');
+        }
+        return $this->getFileResponse(new MakeQrPng($this->Entity, (int) $this->idArr[0], $this->Request->query->getInt('size')));
     }
 
     private function makeReport(): Response

--- a/src/enums/ExportFormat.php
+++ b/src/enums/ExportFormat.php
@@ -16,6 +16,7 @@ enum ExportFormat: string
     case Eln = 'eln';
     case Json = 'json';
     case QrPdf = 'qrpdf';
+    case QrPng = 'qrpng';
     case Pdf = 'pdf';
     case PdfA = 'pdfa';
     case Zip = 'zip';

--- a/src/services/MakeQrPng.php
+++ b/src/services/MakeQrPng.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Interfaces\StringMakerInterface;
+use Elabftw\Models\AbstractEntity;
+use Imagick;
+use ImagickDraw;
+use ImagickPixel;
+use Mpdf\QrCode\Output;
+use Mpdf\QrCode\QrCode;
+
+/**
+ * Make a PNG from one or several experiments or db items showing only minimal info with QR codes
+ */
+class MakeQrPng extends AbstractMake implements StringMakerInterface
+{
+    private const DEFAULT_IMAGE_SIZE_PX = 250;
+
+    private const LINE_HEIGHT_PX = 20;
+
+    private const SPLIT_FACTOR = 8;
+
+    protected string $contentType = 'image/png';
+
+    private int $fontSize = 16;
+
+    public function __construct(
+        private AbstractEntity $entity,
+        private int $id,
+        private int $size,
+        private array $backgroundColor = array(255, 255, 255), // white
+        private array $foregroundColor = array(0, 0, 0), // black
+    ) {
+        $this->entity->setId($this->id);
+        // 0 means no query parameter for size
+        $this->size = $this->size > 0 ? $this->size : self::DEFAULT_IMAGE_SIZE_PX;
+    }
+
+    /**
+     * Get the name of the generated file
+     */
+    public function getFileName(): string
+    {
+        return sprintf(
+            '%s-qr-code.elabftw.png',
+            Filter::forFilesystem($this->entity->entityData['title']),
+        );
+    }
+
+    public function getFileContent(): string
+    {
+        $qrCode = new Imagick();
+        $qrCode->setBackgroundColor('white');
+        $qrCode->readImageBlob($this->getQrCode());
+        // Create a drawing object
+        $draw = new ImagickDraw();
+        $draw->setTextAlignment(Imagick::ALIGN_LEFT);
+        $draw->setFont(dirname(__DIR__, 2) . '/web/assets/fonts/lato-medium-webfont.ttf');
+        $draw->setFontSize($this->fontSize);
+
+        $splitTitle = mb_str_split($this->entity->entityData['title'], $this->getTitleSplitSize());
+        $fullHeight = $qrCode->getImageHeight() + (count($splitTitle) * self::LINE_HEIGHT_PX);
+
+        // Create a new image to hold the qrcode + text
+        $newImage = new Imagick();
+        $newImage->newImage($qrCode->getImageWidth(), $fullHeight, new ImagickPixel('white'));
+        // Copy the original image to the new image
+        $newImage->compositeImage($qrCode, Imagick::COMPOSITE_OVER, 0, 0);
+        // Draw the text on the new image
+        foreach ($splitTitle as $key => $line) {
+            $newImage->annotateImage($draw, 10, $qrCode->getImageHeight() + ($key * 20), 0, $line);
+        }
+        $newImage->setImageFormat('png');
+
+        return $newImage->getImageBlob();
+    }
+
+    /**
+     * @return positive-int
+     */
+    private function getTitleSplitSize(): int
+    {
+        $res = abs(intdiv($this->size, self::SPLIT_FACTOR));
+        if ($res < 1) {
+            return 1;
+        }
+        return $res;
+    }
+
+    private function getQrCode(): string
+    {
+        $qrCode = new QrCode($this->entity->entityData['sharelink']);
+        // save black on white PNG image 100 px wide to filename.png. Colors are RGB arrays.
+        $output = new Output\Png();
+        return $output->output($qrCode, $this->size, $this->backgroundColor, $this->foregroundColor);
+    }
+}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -138,6 +138,7 @@
             <a class='dropdown-item' href='api/v2/{{ Entity.type }}/{{ Entity.id }}?format=zipa'><i class='fas fa-file-archive fa-fw'></i> {{ 'Long term storage ZIP'|trans }}</a>
             <a class='dropdown-item' href='api/v2/{{ Entity.type }}/{{ Entity.id }}?format=eln'><i class='fas fa-box-archive fa-fw'></i> {{ 'ELN Archive'|trans }}</a>
             <a class='dropdown-item' href='api/v2/{{ Entity.type }}/{{ Entity.id }}?format=csv'><i class='fas fa-file-csv fa-fw'></i> {{ 'CSV File'|trans }}</a>
+            <a class='dropdown-item' href='api/v2/{{ Entity.type }}/{{ Entity.id }}?format=qrpng'><i class='fas fa-qrcode fa-fw'></i> {{ 'QR Code'|trans }}</a>
           </span>
         </div>
       </div>

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -94,7 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // check if there is some local data with this id to recover
   if ((localStorage.getItem('id') == String(entity.id)) && (localStorage.getItem('type') == entity.type)) {
     const bodyRecovery = $('<div></div>', {
-      'class' : 'alert alert-warning',
+      class : 'alert alert-warning',
+      id: 'recoveryDiv',
       html: 'Recovery data found (saved on ' + localStorage.getItem('date') + '). It was probably saved because your session timed out and it could not be saved in the database. Do you want to recover it?<br><button class="button btn btn-primary recover-yes">YES</button> <button class="button btn btn-danger recover-no">NO</button><br><br>Here is what it looks like: ' + localStorage.getItem('body'),
     });
     $('#main_section').before(bodyRecovery);
@@ -103,15 +104,16 @@ document.addEventListener('DOMContentLoaded', () => {
   // RECOVER YES
   $(document).on('click', '.recover-yes', function() {
     EntityC.update(entity.id, Target.Body, localStorage.getItem('body')).then(() => {
+      editor.replaceContent(localStorage.getItem('body'));
       localStorage.clear();
-      document.location.reload();
+      document.getElementById('recoveryDiv').remove();
     });
   });
 
   // RECOVER NO
   $(document).on('click', '.recover-no', function() {
     localStorage.clear();
-    document.location.reload();
+    document.getElementById('recoveryDiv').remove();
   });
 
   // END DATA RECOVERY

--- a/tests/unit/services/MakeQrPdfTest.php
+++ b/tests/unit/services/MakeQrPdfTest.php
@@ -19,7 +19,6 @@ class MakeQrPdfTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $Entity = new Experiments(new Users(1, 1), 1);
-        $Entity->canOrExplode('read');
         $MpdfProvider = new MpdfProvider('Toto');
         $this->MakePdf = new MakeQrPdf($MpdfProvider, $Entity, array('1', '2', '3'));
     }

--- a/tests/unit/services/MakeQrPngTest.php
+++ b/tests/unit/services/MakeQrPngTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Models\Experiments;
+use Elabftw\Models\Users;
+
+class MakeQrPngTest extends \PHPUnit\Framework\TestCase
+{
+    private MakeQrPng $Maker;
+
+    protected function setUp(): void
+    {
+        $Entity = new Experiments(new Users(1, 1), 1);
+        $this->Maker = new MakeQrPng($Entity, 1, 250);
+    }
+
+    public function testGetFileContent(): void
+    {
+        $this->assertIsString($this->Maker->getFileContent());
+    }
+
+    public function testGetFileContentSmallsize(): void
+    {
+        $Entity = new Experiments(new Users(1, 1), 1);
+
+        $Maker = new MakeQrPng($Entity, 1, 4);
+        $this->assertIsString($Maker->getFileContent());
+    }
+
+    public function testGetFileName(): void
+    {
+        $this->assertStringEndsWith('qr-code.elabftw.png', $this->Maker->getFileName());
+    }
+}


### PR DESCRIPTION
add qrcode png format for export of individual entry

also allow selecting the size with the size query parameter
and display the title below the qr code

fix #3840

Use the already existing mpdf/qr-code library, along with Imagick to write the title below the image.

example output:

![Test-QR-code-with-a-pretty-long-title-blah-blih-blouh-yep-yip-yop-qr-code elabftw](https://user-images.githubusercontent.com/3043706/221047411-999b3bea-83c5-4c93-83be-96c2a064cf33.png)

