### PR TITLE
improve advanced search UX

### DIFF
--- a/src/classes/TwigFunctions.php
+++ b/src/classes/TwigFunctions.php
@@ -98,7 +98,7 @@ class TwigFunctions
     public static function extractJson(string $json, string $key): string|bool|int
     {
         $decoded = json_decode($json, true, 3, JSON_THROW_ON_ERROR);
-        if ($decoded[$key]) {
+        if (isset($decoded[$key])) {
             return (int) $decoded[$key];
         }
         return false;

--- a/src/classes/TwigFunctions.php
+++ b/src/classes/TwigFunctions.php
@@ -62,6 +62,18 @@ class TwigFunctions
         return memory_get_usage();
     }
 
+    public static function getExtendedSearchExample(): string
+    {
+        $examples = array(
+            '"search term in quotes"',
+            'termA AND date:>2023-01-01',
+            'title:something OR body:"something else"',
+            '(locked:yes OR timestamped:yes) AND author:"Firstname Lastname"',
+            '"western blot" AND rating:5',
+        );
+        return $examples[array_rand($examples)];
+    }
+
     public static function getNumberOfQueries(): int
     {
         $Db = Db::getConnection();

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -392,6 +392,7 @@
     <div class='row'>
       <div class='col-md-8 mb-2'>
         <h5><label for='extendedArea'><i class='fas fa-search'></i> {{ 'Search query'|trans }}</label></h5>
+        <p class='smallgray'>{{ 'Enter a term to search in title, body, date and elabid; or use advanced syntax, or a combination of both.'|trans }}</p>
         {# next div is wrapper to position pre below textarea #}
         <div style='position:relative;'>
           <textarea
@@ -399,9 +400,9 @@
             name='q'
             rows='10'
             class='form-control'
-            placeholder='author:"{{ App.Users.userData.fullname|raw }}" status:"Running"'
+            placeholder="{{ 'Enter search query, e.g.: %s'|trans|format(getExtendedSearchExample()) }}"
             spellcheck='false'
-          >{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim : 'author:"' ~ App.Users.userData.fullname ~ '" ' }}</textarea>
+          >{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim }}</textarea>
           <pre id='search-highlighting' class='form-control d-none' aria-hidden='true'><code></code></pre>
 
         </div>

--- a/src/traits/TwigTrait.php
+++ b/src/traits/TwigTrait.php
@@ -74,6 +74,8 @@ trait TwigTrait
         $minPasswordLength = new TwigFunction('minPasswordLength', '\Elabftw\Elabftw\TwigFunctions::getMinPasswordLength');
         $ext2icon = new TwigFunction('ext2icon', '\Elabftw\Elabftw\Extensions::getIconFromExtension');
         $sortIcon = new TwigFunction('sortIcon', '\Elabftw\Elabftw\TwigFunctions::getSortIcon');
+        $getExtendedSearchExample = new TwigFunction('getExtendedSearchExample', '\Elabftw\Elabftw\TwigFunctions::getExtendedSearchExample');
+
 
 
         // load the i18n extension for using the translation tag for twig
@@ -107,6 +109,7 @@ trait TwigTrait
         $TwigEnvironment->addFunction($minPasswordLength);
         $TwigEnvironment->addFunction($ext2icon);
         $TwigEnvironment->addFunction($sortIcon);
+        $TwigEnvironment->addFunction($getExtendedSearchExample);
 
         // use the image BUILD_ID to use as parameter for loading assets
         // this helps with busting the cache in browsers

--- a/tests/unit/classes/TwigFunctionsTest.php
+++ b/tests/unit/classes/TwigFunctionsTest.php
@@ -9,6 +9,8 @@
 
 namespace Elabftw\Elabftw;
 
+use Elabftw\Enums\BasePermissions;
+
 class TwigFunctionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetLimitOptions(): void
@@ -29,6 +31,11 @@ class TwigFunctionsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt(TwigFunctions::getMemoryUsage());
     }
 
+    public function testGetExtendedSearchExample(): void
+    {
+        $this->assertIsString(TwigFunctions::getExtendedSearchExample());
+    }
+
     public function testGetNumberOfQueries(): void
     {
         $this->assertIsInt(TwigFunctions::getNumberOfQueries());
@@ -37,5 +44,31 @@ class TwigFunctionsTest extends \PHPUnit\Framework\TestCase
     public function testGetMinPasswordLength(): void
     {
         $this->assertIsInt(TwigFunctions::getMinPasswordLength());
+    }
+
+    public function testToDatetime(): void
+    {
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', TwigFunctions::toDatetime('2023-02-01'));
+    }
+
+    public function testExtractJson(): void
+    {
+        $json = BasePermissions::Organization->toJson();
+        $key = 'base';
+        $this->assertEquals(BasePermissions::Organization->value, TwigFunctions::extractJson($json, $key));
+        $this->assertFalse(TwigFunctions::extractJson($json, 'unknown_key'));
+    }
+
+    public function testIsInJsonArray(): void
+    {
+        $json = '{"my_arr": [ 4, 5, 6 ]}';
+        $key = 'my_arr';
+        $this->assertTrue(TwigFunctions::isInJsonArray($json, $key, 5));
+        $this->assertFalse(TwigFunctions::isInJsonArray($json, $key, 7));
+    }
+
+    public function testCanToHuman(): void
+    {
+        $this->assertIsArray(TwigFunctions::canToHuman(BasePermissions::User->toJson()));
     }
 }


### PR DESCRIPTION
* Add a sentence on top to clarify what can be inputted
* Add a random search example
* Remove the default "author" search value fix #4181


