### PR TITLE
Implement keeex support

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 113;
+    public const REQUIRED_SCHEMA = 114;
 
     private Db $Db;
 

--- a/src/services/make/AbstractMakeTimestamp.php
+++ b/src/services/make/AbstractMakeTimestamp.php
@@ -16,6 +16,7 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\MakeTimestampInterface;
 use Elabftw\Interfaces\TimestampResponseInterface;
 use Elabftw\Models\Experiments;
+use GuzzleHttp\Client;
 use ZipArchive;
 
 /**
@@ -79,6 +80,10 @@ abstract class AbstractMakeTimestamp extends AbstractMake implements MakeTimesta
             true, // PDF/A always for timestamp pdf
         );
         $MakePdf = new MakeTimestampPdf($MpdfProvider, $this->Entity);
+        if ($this->configArr['keeex_enabled'] === '1') {
+            $Keeex = new MakeKeeex(new Client());
+            return $Keeex->fromString($MakePdf->getFileContent());
+        }
         return $MakePdf->getFileContent();
     }
 

--- a/src/services/make/MakeKeeex.php
+++ b/src/services/make/MakeKeeex.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Elabftw\App;
+use Elabftw\Exceptions\ImproperActionException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7;
+
+/**
+ * Keeex a file
+ */
+class MakeKeeex
+{
+    private const REQUEST_TIMEOUT_SECONDS = 5;
+
+    private string $url;
+
+    public function __construct(
+        private ClientInterface $client,
+        private string $proxy = '',
+        string $host = 'keeex',
+        int $port = 8080,
+    ) {
+        $this->url = sprintf('http://%s:%d/keeex', $host, $port);
+    }
+
+    public function fromString(string $contents): string
+    {
+        return (string) $this->sendRequest($contents)->getBody();
+    }
+
+    private function sendRequest(string $contents): \Psr\Http\Message\ResponseInterface
+    {
+        $stream = Psr7\Utils::streamFor($contents);
+        $options = array(
+            'headers' => array(
+                // add user agent, because we're polite
+                'User-Agent' => 'Elabftw/' . App::INSTALLED_VERSION,
+                // Note: don't send the Content-Type header with 'multipart/form-data' as the boundary will not be properly set
+                // see: https://github.com/guzzle/guzzle/issues/1885
+            ),
+            // add proxy if there is one
+            'proxy' => $this->proxy,
+            // add a timeout, because if you need proxy, but don't have it, it will mess up things
+            'timeout' => self::REQUEST_TIMEOUT_SECONDS,
+            'multipart' => array(
+                array(
+                    'name'     => 'file',
+                    'contents' => $stream->getContents(),
+                    // without this parameter, it fails
+                    'filename' => 'osef.pdf',
+                ),
+                array(
+                    'name' => 'data',
+                    'contents' => '{"src":"-","dst":"-","mdata":{"identities":[{"type":"default"}]},"options":{"timestamp":true}}',
+                ),
+            ),
+        );
+
+        try {
+            return $this->client->request('POST', $this->url, $options);
+        } catch (ClientException | ServerException $e) {
+            throw new ImproperActionException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/sql/schema114.sql
+++ b/src/sql/schema114.sql
@@ -1,0 +1,5 @@
+-- schema 114
+INSERT INTO config (conf_name, conf_value) VALUES ('keeex_enabled', '0');
+INSERT INTO config (conf_name, conf_value) VALUES ('keeex_host', 'keeex');
+INSERT INTO config (conf_name, conf_value) VALUES ('keeex_port', '8080');
+UPDATE config SET conf_value = 114 WHERE conf_name = 'schema';

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -487,12 +487,34 @@
     {% include 'ts-config.html' %}
   </div>
 
+  {# BLOXBERG #}
   <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Blockchain timestamp configuration'|trans }}</h3>
   <div class='pl-3'>
 
     {% include 'binary-setting.html' with {'label': 'Enable blockchain timestamping with Bloxberg', 'slug': 'blox_enabled'} %}
     {% include 'binary-setting.html' with {'label': 'Anonymize author for GDPR compliance', 'slug': 'blox_anon'} %}
 
+  </div>
+
+  {# KEEEX #}
+  <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Keeex configuration'|trans }}</h3>
+  <div class='pl-3'>
+
+    {% include 'binary-setting.html' with {'label': 'Enable keeex', 'slug': 'keeex_enabled'} %}
+
+    <div class='d-flex justify-content-between'>
+      <label for='keeex_host' class='col-form-label'>{{ 'Keeex host'|trans }}</label>
+      <input class='form-control col-md-3' type='text' id='keeex_host' placeholder='' data-trigger='blur' data-model='config' data-target='keeex_host' value='{{ App.Config.configArr.keeex_host }}' />
+    </div>
+    <p class='smallgray'>{{ 'Address (hostname or IP) of the Keeex service.'|trans }}</p>
+    <hr>
+
+    <div class='d-flex justify-content-between'>
+      <label for='keeex_port' class='col-form-label'>{{ 'Keeex port'|trans }}</label>
+      <input class='form-control col-md-3' type='text' id='keeex_port' placeholder='' data-trigger='blur' data-model='config' data-target='keeex_port' value='{{ App.Config.configArr.keeex_port }}' />
+    </div>
+    <p class='smallgray'>{{ 'Default port is 8080.'|trans }}</p>
+    <hr>
   </div>
 </div>
 

--- a/tests/unit/services/MakeKeeexTest.php
+++ b/tests/unit/services/MakeKeeexTest.php
@@ -25,8 +25,6 @@ class MakeKeeexTest extends \PHPUnit\Framework\TestCase
             new Response(200, array(), 'fake keeexed content'),
             new Response(400, array(), 'fake keeexed content'),
             new Response(500, array(), 'fake keeexed content'),
-            //new RequestException('Invalid request', new Request('POST', 'test')),
-            //new RequestException('Server is down?', new Request('POST', 'test')),
         ));
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));

--- a/tests/unit/services/MakeKeeexTest.php
+++ b/tests/unit/services/MakeKeeexTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Exceptions\ImproperActionException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+class MakeKeeexTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFromString(): void
+    {
+        // don't use the real guzzle client, but use a mock
+        // https://docs.guzzlephp.org/en/stable/testing.html
+        $mock = new MockHandler(array(
+            new Response(200, array(), 'fake keeexed content'),
+            new Response(400, array(), 'fake keeexed content'),
+            new Response(500, array(), 'fake keeexed content'),
+            //new RequestException('Invalid request', new Request('POST', 'test')),
+            //new RequestException('Server is down?', new Request('POST', 'test')),
+        ));
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(array('handler' => $handlerStack));
+        $Maker = new MakeKeeex($client);
+        $this->assertIsString($Maker->fromString('source content'));
+        $this->expectException(ImproperActionException::class);
+        $Maker->fromString('trigger client error');
+        $this->expectException(ImproperActionException::class);
+        $Maker->fromString('trigger server error');
+    }
+}


### PR DESCRIPTION
Add support for using keeex web service running on-premise for timestamping/keeexing of the timestamped pdf.

This also opens the door to using FIDO2 signatures or other signatures schemes later on.
