### PR TITLE
Make Admin a role tied to a team, not a user

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -665,8 +665,6 @@ components:
           type: string
         validated:
           type: integer
-        usergroup:
-          type: integer
         archived:
           type: integer
         last_login:
@@ -679,6 +677,21 @@ components:
           type: string
         auth_service:
           type: integer
+        is_sysadmin:
+          type: integer
+        teams:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              usergroup:
+                type: integer
+              is_owner:
+                type: integer
 
 
 security:
@@ -2431,11 +2444,6 @@ paths:
                 email:
                   type: string
                   description: User's email address.
-                usergroup:
-                  type: string
-                  enum: ['1', '2', '4']
-                  description: |
-                    1: Sysadmin, 2: Admin, 4: regular user.
                 team:
                   type: integer
                   description: The team id.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "3dmol": "^2.0.2",
     "@deltablot/chemdoodle-web-mini": "^9.2.1",
-    "@deltablot/malle": "^2.1.0",
+    "@deltablot/malle": "^2.2.0",
     "@deltablot/open-vector-editor-umd": "^18.0.0",
     "@fancyapps/fancybox": "3.5.*",
     "@fullcalendar/bootstrap": "^6.1.5",

--- a/src/Auth/Cookie.php
+++ b/src/Auth/Cookie.php
@@ -42,12 +42,8 @@ class Cookie implements AuthInterface
     public function tryAuth(): AuthResponse
     {
         // compare the provided token with the token saved in SQL database
-        $sql = 'SELECT `users`.`userid`, `users`.`mfa_secret`, `users`.`auth_service`,
-                `groups`.`is_admin`, `groups`.`is_sysadmin`
-            FROM `users`
-            LEFT JOIN `groups` ON (`users`.`usergroup` = `groups`.`id`)
-            WHERE `token` = :token
-            LIMIT 1';
+        $sql = 'SELECT `users`.`userid`, `users`.`mfa_secret`, `users`.`auth_service`
+            FROM `users` WHERE `token` = :token LIMIT 1';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':token', $this->token);
         $this->Db->execute($req);
@@ -67,8 +63,6 @@ class Cookie implements AuthInterface
         $this->AuthResponse->userid = $userid;
         $this->AuthResponse->mfaSecret = $res['mfa_secret'];
         $this->AuthResponse->selectedTeam = $this->tokenTeam;
-        $this->AuthResponse->isAdmin = (bool) $res['is_admin'];
-        $this->AuthResponse->isSysAdmin = (bool) $res['is_sysadmin'];
 
         // Force user to login again to activate MFA if it is enforced for local auth and there is no mfaSecret
         if ($res['auth_service'] === LoginController::AUTH_LOCAL

--- a/src/Make/MakeJson.php
+++ b/src/Make/MakeJson.php
@@ -45,7 +45,7 @@ class MakeJson extends AbstractMake implements StringMakerInterface
             $this->Entity->setId((int) $id);
             try {
                 $all = $this->Entity->readOne();
-            } catch (IllegalActionException $e) {
+            } catch (IllegalActionException) {
                 continue;
             }
             // decode the metadata column because it's json
@@ -55,10 +55,7 @@ class MakeJson extends AbstractMake implements StringMakerInterface
             $res[] = $all;
         }
 
-        $json = json_encode($res);
-        if ($json === false) {
-            return '{"error": "Something went wrong!"}';
-        }
+        $json = json_encode($res, JSON_THROW_ON_ERROR);
         $this->contentSize = mb_strlen($json);
         return $json;
     }

--- a/src/Make/MakeReport.php
+++ b/src/Make/MakeReport.php
@@ -50,7 +50,6 @@ class MakeReport extends AbstractMakeCsv
             'lastname',
             'email',
             'validated',
-            'usergroup',
             'archived',
             'last_login',
             'valid_until',
@@ -80,6 +79,8 @@ class MakeReport extends AbstractMakeCsv
             // these columns can be null
             $unusedColumns = array(
                 'mfa_secret',
+                // TODO remove once we remove the column for good
+                'usergroup_old',
                 'orcid',
                 'auth_service',
                 'token',

--- a/src/Make/MakeReport.php
+++ b/src/Make/MakeReport.php
@@ -48,11 +48,13 @@ class MakeReport extends AbstractMakeCsv
             'userid',
             'firstname',
             'lastname',
+            'orgid',
             'email',
             'validated',
             'archived',
             'last_login',
             'valid_until',
+            'is_sysadmin',
             'full_name',
             'team(s)',
             'diskusage_in_bytes',
@@ -79,8 +81,6 @@ class MakeReport extends AbstractMakeCsv
             // these columns can be null
             $unusedColumns = array(
                 'mfa_secret',
-                // TODO remove once we remove the column for good
-                'usergroup_old',
                 'orcid',
                 'auth_service',
                 'token',

--- a/src/classes/AuthResponse.php
+++ b/src/classes/AuthResponse.php
@@ -36,10 +36,6 @@ class AuthResponse
 
     public ?string $mfaSecret = null;
 
-    public bool $isAdmin = false;
-
-    public bool $isSysAdmin = false;
-
     public bool $hasVerifiedMfa = false;
 
     public function setTeams(): void

--- a/src/classes/Permissions.php
+++ b/src/classes/Permissions.php
@@ -92,7 +92,7 @@ class Permissions
 
         // if the setting is 'user' (meaning user + admin(s)) check we are admin
         if ($this->canread['base'] === BasePermissions::User->value) {
-            if ($this->Users->userData['is_admin'] && $this->Teams->hasCommonTeamWithCurrent($this->item['userid'], (int) $this->Users->userData['team'])) {
+            if ($this->Users->isAdmin && $this->Teams->hasCommonTeamWithCurrent($this->item['userid'], (int) $this->Users->userData['team'])) {
                 return array('read' => true, 'write' => $write);
             }
         }
@@ -130,7 +130,7 @@ class Permissions
      */
     public function forItemType(): array
     {
-        if ($this->Users->userData['is_admin'] && ($this->item['team'] === $this->Users->userData['team'])) {
+        if ($this->Users->isAdmin && ($this->item['team'] === $this->Users->userData['team'])) {
             return array('read' => true, 'write' => true);
         }
         return array('read' => false, 'write' => false);
@@ -143,7 +143,7 @@ class Permissions
     {
         // locked entity cannot be written to
         // only the locker can unlock an entity
-        if ($this->item['locked'] && ($this->item['lockedby'] !== (int) $this->Users->userData['userid']) && !$this->Users->userData['is_admin']) {
+        if ($this->item['locked'] && ($this->item['lockedby'] !== (int) $this->Users->userData['userid']) && !$this->Users->isAdmin) {
             return false;
         }
 
@@ -205,7 +205,7 @@ class Permissions
 
         // it's not our entity, our last chance is to be admin in the same team as owner
         // also make sure that it's not in "useronly" mode
-        if ($this->Users->userData['is_admin'] && $this->canwrite['base'] !== BasePermissions::UserOnly->value) {
+        if ($this->Users->isAdmin && $this->canwrite['base'] !== BasePermissions::UserOnly->value) {
             // if it's an item (has team attribute), we need to be logged in in same team
             if (isset($this->item['team'])) {
                 if ($this->item['team'] === $this->Users->userData['team']) {

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 116;
+    public const REQUIRED_SCHEMA = 117;
 
     private Db $Db;
 

--- a/src/classes/UserParams.php
+++ b/src/classes/UserParams.php
@@ -21,11 +21,6 @@ use Elabftw\Services\Filter;
 
 final class UserParams extends ContentParams implements ContentParamsInterface
 {
-    public function __construct(string $target, string $content, private int $isSysadmin = 0, private int $isAdmin = 0, private int $targetIsSysadmin = 0)
-    {
-        parent::__construct($target, $content);
-    }
-
     public function getContent(): string
     {
         return match ($this->target) {
@@ -41,7 +36,6 @@ final class UserParams extends ContentParams implements ContentParamsInterface
                     return Filter::sanitize($this->content);
                 }
             )(),
-            'usergroup' => (string) $this->checkUserGroup((int) $this->content),
             // return the hash of the password
             'password' => password_hash(Check::passwordLength($this->content), PASSWORD_DEFAULT),
             'orcid' => $this->filterOrcid(),
@@ -50,7 +44,7 @@ final class UserParams extends ContentParams implements ContentParamsInterface
             'sort' => (Sort::tryFrom($this->content) ?? Sort::Desc)->value,
             'orderby' => (Orderby::tryFrom($this->content) ?? Orderby::Date)->value,
             'sc_create', 'sc_submit', 'sc_todo', 'sc_edit' => Filter::firstLetter($this->content),
-            'show_team', 'show_team_templates', 'show_public', 'uploads_layout', 'cjk_fonts', 'pdf_sig', 'use_markdown', 'use_isodate', 'inc_files_pdf', 'append_pdfs', 'validated', 'notif_comment_created', 'notif_comment_created_email', 'notif_step_deadline', 'notif_step_deadline_email', 'notif_user_created', 'notif_user_created_email', 'notif_user_need_validation', 'notif_user_need_validation_email', 'notif_event_deleted', 'notif_event_deleted_email' => (string) Filter::toBinary($this->content),
+            'is_sysadmin', 'show_team', 'show_team_templates', 'show_public', 'uploads_layout', 'cjk_fonts', 'pdf_sig', 'use_markdown', 'use_isodate', 'inc_files_pdf', 'append_pdfs', 'validated', 'notif_comment_created', 'notif_comment_created_email', 'notif_step_deadline', 'notif_step_deadline_email', 'notif_user_created', 'notif_user_created_email', 'notif_user_need_validation', 'notif_user_need_validation_email', 'notif_event_deleted', 'notif_event_deleted_email' => (string) Filter::toBinary($this->content),
             'lang' => (Language::tryFrom($this->content) ?? Language::English)->value,
             'default_read', 'default_write' => Check::visibility($this->content),
             'pdf_format' => (PdfFormat::tryFrom($this->content) ?? PdfFormat::A4)->value,
@@ -64,28 +58,6 @@ final class UserParams extends ContentParams implements ContentParamsInterface
             'password' => 'password_hash',
             default => $this->target,
         };
-    }
-
-    private function checkUserGroup(int $usergroup): int
-    {
-        $usergroup = Check::usergroup($usergroup);
-        // a sysadmin can do what they want, no need to check further
-        if ($this->isSysadmin === 1) {
-            return $usergroup;
-        }
-        // prevent an admin from promoting a user to sysadmin
-        if ($this->isAdmin === 1 && $usergroup === 1) {
-            throw new ImproperActionException('Only a sysadmin can promote another user to sysadmin.');
-        }
-        // a non sysadmin cannot demote a sysadmin
-        if ($usergroup !== 1 && $this->targetIsSysadmin) {
-            throw new ImproperActionException('Only a sysadmin can demote another sysadmin.');
-        }
-        // if requester is not admin the only valid usergroup is 4 (user)
-        if ($this->isAdmin !== 1) {
-            return 4;
-        }
-        return $usergroup;
     }
 
     private function filterOrcid(): string

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -308,7 +308,7 @@ abstract class AbstractEntityController implements ControllerInterface
             $deletableXp = false;
         }
         // an admin is able to delete
-        if ($this->App->Users->userData['is_admin']) {
+        if ($this->App->Users->isAdmin) {
             $deletableXp = true;
         }
         return $deletableXp;

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -101,7 +101,7 @@ class MakeController implements ControllerInterface
                 return $this->makeReport();
 
             case 'schedulerReport':
-                if (!$this->Users->userData['is_admin']) {
+                if (!$this->Users->isAdmin) {
                     throw new IllegalActionException('Non admin user tried to generate scheduler report.');
                 }
                 return $this->makeSchedulerReport();
@@ -126,7 +126,7 @@ class MakeController implements ControllerInterface
             $this->idArr = $this->Entity->getIdFromCategory((int) $this->Request->query->get('category'));
         } elseif ($this->Request->query->has('owner')) {
             // only admin can export a user, or it is ourself
-            if (!$this->Users->userData['is_admin'] && $this->Request->query->getInt('owner') !== $this->Users->userData['userid']) {
+            if (!$this->Users->isAdminOf($this->Request->query->getInt('owner'))) {
                 throw new IllegalActionException('User tried to export another user but is not admin.');
             }
             // being admin is good, but we also need to be in the same team as the requested user

--- a/src/enums/Action.php
+++ b/src/enums/Action.php
@@ -22,6 +22,7 @@ enum Action: string
     case Lock = 'lock';
     case Finish = 'finish';
     case Notif = 'notif';
+    case PatchUser2Team = 'patchuser2team';
     case Pin = 'pin';
     case Replace = 'replace';
     case Timestamp = 'timestamp';

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -151,13 +151,13 @@ abstract class AbstractEntity implements RestInterface
     public function toggleLock(): array
     {
         $this->getPermissions();
-        if (!$this->Users->userData['is_admin'] && $this->entityData['userid'] !== $this->Users->userData['userid']) {
+        if (!$this->Users->isAdmin && $this->entityData['userid'] !== $this->Users->userData['userid']) {
             throw new ImproperActionException(_("You don't have the rights to lock/unlock this."));
         }
         $locked = $this->entityData['locked'];
 
         // if we try to unlock something we didn't lock
-        if ($locked === 1 && !$this->Users->userData['is_admin'] && ($this->entityData['lockedby'] !== $this->Users->userData['userid'])) {
+        if ($locked === 1 && !$this->Users->isAdmin && ($this->entityData['lockedby'] !== $this->Users->userData['userid'])) {
             // Get the first name of the locker to show in error message
             $sql = 'SELECT firstname FROM users WHERE userid = :userid';
             $req = $this->Db->prepare($sql);
@@ -253,7 +253,7 @@ abstract class AbstractEntity implements RestInterface
         }
         $sql .= sprintf(" AND ( %s (JSON_EXTRACT(entity.canread, '$.base') = %d AND users2teams.users_id = entity.userid %s) OR (JSON_EXTRACT(entity.canread, '$.base') = %d ", $sqlPublicOrg, BasePermissions::MyTeams->value, $teamFilter, BasePermissions::User->value);
         // admin will see the experiments with visibility user for user of their team
-        if ($this->Users->userData['is_admin']) {
+        if ($this->Users->isAdmin) {
             $sql .= 'AND entity.userid = users2teams.users_id)';
         } else {
             $sql .= 'AND entity.userid = :userid)';
@@ -670,11 +670,11 @@ abstract class AbstractEntity implements RestInterface
         $Teams = new Teams($this->Users);
         $teamConfigArr = $Teams->readOne();
         if ($rw === 'canread') {
-            if ($teamConfigArr['do_force_canread'] === 1 && !$this->Users->userData['is_admin']) {
+            if ($teamConfigArr['do_force_canread'] === 1 && !$this->Users->isAdmin) {
                 throw new ImproperActionException(_('Read permissions enforced by admin. Aborting change.'));
             }
         } else {
-            if ($teamConfigArr['do_force_canwrite'] === 1 && !$this->Users->userData['is_admin']) {
+            if ($teamConfigArr['do_force_canwrite'] === 1 && !$this->Users->isAdmin) {
                 throw new ImproperActionException(_('Write permissions enforced by admin. Aborting change.'));
             }
         }

--- a/src/models/AnonymousUser.php
+++ b/src/models/AnonymousUser.php
@@ -36,7 +36,6 @@ final class AnonymousUser extends Users
         $this->userData['show_team_templates'] = 0;
         $this->userData['show_public'] = 0;
         $this->userData['fullname'] = 'Anon Ymous';
-        $this->userData['is_admin'] = 0;
         $this->userData['is_sysadmin'] = 0;
         $this->userData['lang'] = $this->lang;
         $this->userData['use_isodate'] = '0';

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -200,7 +200,7 @@ class Experiments extends AbstractConcreteEntity
         $Teams = new Teams($this->Users);
         $teamConfigArr = $Teams->readOne();
         $Config = Config::getConfig();
-        if ((!$teamConfigArr['deletable_xp'] && !$this->Users->userData['is_admin'])
+        if ((!$teamConfigArr['deletable_xp'] && !$this->Users->isAdmin)
             || $Config->configArr['deletable_xp'] === 0) {
             throw new ImproperActionException('You cannot delete experiments!');
         }

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -103,7 +103,7 @@ class Items extends AbstractConcreteEntity
         // check if we can actually delete items (for non-admins)
         $Teams = new Teams($this->Users);
         $teamConfigArr = $Teams->readOne();
-        if ($teamConfigArr['deletable_item'] === 0 && $this->Users->userData['is_admin'] === 0) {
+        if ($teamConfigArr['deletable_item'] === 0 && !$this->Users->isAdmin) {
             throw new ImproperActionException(_('Users cannot delete items.'));
         }
 

--- a/src/models/Scheduler.php
+++ b/src/models/Scheduler.php
@@ -350,7 +350,7 @@ class Scheduler implements RestInterface
         if ($date === false) {
             throw new ImproperActionException('Could not understand date format!');
         }
-        if ($this->Items->Users->userData['is_admin']) {
+        if ($this->Items->Users->isAdmin) {
             return;
         }
         $now = new DateTime();
@@ -394,7 +394,7 @@ class Scheduler implements RestInterface
 
         // if it's not, we need to be admin in the same team as the event/user
         $TeamsHelper = new TeamsHelper($event['team']);
-        return $TeamsHelper->isUserInTeam($this->Items->Users->userData['userid']) && $this->Items->Users->userData['usergroup'] <= 2;
+        return $TeamsHelper->isAdminInTeam($this->Items->Users->userData['userid']);
     }
 
     private function canWriteOrExplode(): void

--- a/src/models/Tags.php
+++ b/src/models/Tags.php
@@ -14,6 +14,7 @@ use Elabftw\Elabftw\TagParam;
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\RestInterface;
+use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\SetIdTrait;
 use function implode;
 use PDO;
@@ -157,7 +158,8 @@ class Tags implements RestInterface
             // check if we can actually create tags (for non-admins)
             $Teams = new Teams($this->Entity->Users, (int) $this->Entity->Users->userData['team']);
             $teamConfigArr = $Teams->readOne();
-            if ($teamConfigArr['user_create_tag'] === 0 && $this->Entity->Users->userData['is_admin'] === 0) {
+            $TeamsHelper = new TeamsHelper((int) $this->Entity->Users->userData['team']);
+            if ($teamConfigArr['user_create_tag'] === 0 && $TeamsHelper->isAdminInTeam($this->Entity->Users->userData['userid']) === false) {
                 throw new ImproperActionException(_('Users cannot create tags.'));
             }
 

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -302,7 +302,7 @@ class TeamGroups implements RestInterface
      */
     private function canWriteOrExplode(): void
     {
-        if (!$this->Users->userData['is_admin']) {
+        if (!$this->Users->isAdmin) {
             throw new IllegalActionException(Tools::error(true));
         }
     }

--- a/src/models/TeamTags.php
+++ b/src/models/TeamTags.php
@@ -119,7 +119,7 @@ class TeamTags implements RestInterface
 
     public function patch(Action $action, array $params): array
     {
-        if ($this->Users->userData['is_admin'] !== 1) {
+        if (!$this->Users->isAdmin) {
             throw new IllegalActionException('Only an admin can do this!');
         }
         return match ($action) {
@@ -134,7 +134,7 @@ class TeamTags implements RestInterface
      */
     public function destroy(): bool
     {
-        if ($this->Users->userData['is_admin'] !== 1) {
+        if (!$this->Users->isAdmin) {
             throw new IllegalActionException('Only an admin can delete a tag!');
         }
         // first unreference the tag

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -275,6 +275,7 @@ class Users implements RestInterface
     {
         $sql = 'SELECT users_id FROM users2teams WHERE users_id = :userid AND groups_id <= 2';
         $req = $this->Db->prepare($sql);
+        $req->bindParam(':userid', $this->userData['userid']);
         $this->Db->execute($req);
         return $req->rowCount() >= 1;
     }

--- a/src/models/Users2Teams.php
+++ b/src/models/Users2Teams.php
@@ -49,7 +49,7 @@ class Users2Teams
         $userid = (int) $params['userid'];
         $teamid = (int) $params['team'];
         if ($params['target'] === 'group') {
-            $group = Usergroup::from((int) $params['group']);
+            $group = Usergroup::from((int) $params['content']);
             return $this->patchTeamGroup($requester, $userid, $teamid, $group);
         }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1143,6 +1143,14 @@ input[type='color'] {
     &.ucp-align {
         margin-top: 0.5rem;
     }
+
+    &.disabled {
+        opacity: 0.7;
+
+        .slider {
+            cursor: default;
+        }
+    }
 }
 
 /* The slider */
@@ -1168,10 +1176,6 @@ input[type='color'] {
         transition: 355ms;
         width: 18px;
     }
-}
-
-.slider-label-deactivated {
-    color: $medium;
 }
 
 input:checked + .slider {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -956,15 +956,6 @@ the form-control fails to do that so we do the border ourselves */
     }
 }
 
-/* don't register clicks with the fontawesome icons
- * this way the click event is registered by the parent and all is well
- */
-.far,
-.fas,
-.fab, {
-    pointer-events: none;
-}
-
 .clickable:hover,
 .editable:hover,
 [data-action] {
@@ -977,11 +968,16 @@ the form-control fails to do that so we do the border ourselves */
     transition: color 0.8s ease;
 }
 
-/* font awesome icons color */
+/*
+ * font awesome icons color
+ * don't register clicks with the fontawesome icons
+ * this way the click event is registered by the parent and all is well
+ */
 .far,
 .fas,
 .fab {
     color: $medium;
+    pointer-events: none;
 }
 
 .fa-bell.active {

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -129,7 +129,7 @@ class Email
     private function getSysadminEmails(): array
     {
         $Db = Db::getConnection();
-        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users LEFT JOIN users2teams ON (users2teams.users_id = users.userid) WHERE validated = 1 AND archived = 0 AND MIN(users2teams.usergroup) = 1';
+        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users WHERE validated = 1 AND archived = 0 AND is_sysadmin = 1';
         $req = $Db->prepare($sql);
         $Db->execute($req);
         $emails = array();

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -129,7 +129,7 @@ class Email
     private function getSysadminEmails(): array
     {
         $Db = Db::getConnection();
-        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users WHERE validated = 1 AND archived = 0 AND usergroup = 1';
+        $sql = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users LEFT JOIN users2teams ON (users2teams.users_id = users.userid) WHERE validated = 1 AND archived = 0 AND MIN(users2teams.usergroup) = 1';
         $req = $Db->prepare($sql);
         $Db->execute($req);
         $emails = array();

--- a/src/services/LoginHelper.php
+++ b/src/services/LoginHelper.php
@@ -13,7 +13,6 @@ use function bin2hex;
 use Elabftw\Elabftw\AuthResponse;
 use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Models\Users;
 use function hash;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Logger;
@@ -112,7 +111,7 @@ class LoginHelper
     }
 
     /**
-     * Store userid and permissions in session
+     * Store userid in session
      */
     private function populateSession(): void
     {
@@ -128,16 +127,7 @@ class LoginHelper
         // ANON LOGIN
         if ($this->AuthResponse->isAnonymous) {
             $this->Session->set('is_anon', 1);
-            $this->Session->set('is_admin', 0);
-            $this->Session->set('is_sysadmin', 0);
-            return;
         }
-
-        // NORMAL LOGIN
-        // load the permissions
-        $Users = new Users($this->AuthResponse->userid);
-        $this->Session->set('is_admin', $Users->userData['is_admin']);
-        $this->Session->set('is_sysadmin', $Users->userData['is_sysadmin']);
     }
 
     /**

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Services;
 
 use Elabftw\Elabftw\Db;
+use Elabftw\Exceptions\ResourceNotFoundException;
 use PDO;
 
 class TeamsHelper
@@ -39,6 +40,45 @@ class TeamsHelper
         return 4;
     }
 
+    public function getPermissions(int $userid): array
+    {
+        $group = $this->getGroupInTeam($userid);
+        $sql = 'SELECT `is_admin` FROM `groups` WHERE `id` = :group';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':group', $group, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        try {
+            return $this->Db->fetch($req);
+        } catch (ResourceNotFoundException) {
+            return array('is_admin' => 0);
+        }
+    }
+
+    public function getUserInTeam(int $userid): array
+    {
+        $sql = 'SELECT `users_id`, `groups_id` FROM `users2teams` WHERE `teams_id` = :team AND `users_id` = :userid';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':team', $this->team, PDO::PARAM_INT);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        return $this->Db->fetch($req);
+    }
+
+    public function isAdminInTeam(int $userid): bool
+    {
+        return $this->getUserInTeam($userid)['groups_id'] <= 2;
+    }
+
+    public function isSysadminInTeam(int $userid): bool
+    {
+        return $this->getUserInTeam($userid)['groups_id'] === 1;
+    }
+
+    /**
+     * @deprecated
+     */
     public function isUserInTeam(int $userid): bool
     {
         $sql = 'SELECT `users_id` FROM `users2teams` WHERE `teams_id` = :team AND `users_id` = :userid';
@@ -50,11 +90,14 @@ class TeamsHelper
         return (bool) $req->fetchColumn();
     }
 
+    /**
+     * Get all the userid of active admins of the team
+     */
     public function getAllAdminsUserid(): array
     {
-        $sql = 'SELECT userid FROM users
-            CROSS JOIN users2teams ON (users2teams.users_id = users.userid)
-            WHERE validated = 1 AND archived = 0 AND users2teams.teams_id = :team AND (`usergroup` IN (1, 2))';
+        $sql = 'SELECT users_id FROM users2teams
+            LEFT JOIN users ON (users2teams.users_id = users.userid)
+            WHERE groups_id IN (1, 2) AND users.archived = 0 AND users2teams.teams_id = :team';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -76,6 +119,20 @@ class TeamsHelper
         $test = $req->fetch();
 
         return $test['usernb'] === 0;
+    }
+
+    /**
+     * @deprecated
+     */
+    private function getGroupInTeam(int $userid): int
+    {
+        $sql = 'SELECT `groups_id` FROM `users2teams` WHERE `teams_id` = :team AND `users_id` = :userid';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->team, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        return (int) $req->fetchColumn();
     }
 
     /**

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -28,6 +28,7 @@ class Transform
         return sprintf("<input type='hidden' name='csrf' value='%s' />", $token);
     }
 
+    // TODO not really used
     public static function usergroupToHuman(string $usergroup): string
     {
         return Usergroup::from((int) $usergroup)->toHuman();

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -10,7 +10,6 @@
 namespace Elabftw\Services;
 
 use Elabftw\Enums\Notifications;
-use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function sprintf;
@@ -26,12 +25,6 @@ class Transform
     public static function csrf(string $token): string
     {
         return sprintf("<input type='hidden' name='csrf' value='%s' />", $token);
-    }
-
-    // TODO not really used
-    public static function usergroupToHuman(string $usergroup): string
-    {
-        return Usergroup::from((int) $usergroup)->toHuman();
     }
 
     // generate html for a notification to show on web interface

--- a/src/services/UsersHelper.php
+++ b/src/services/UsersHelper.php
@@ -75,7 +75,7 @@ class UsersHelper
      */
     public function getTeamsFromUserid(): array
     {
-        $sql = 'SELECT DISTINCT teams.id, teams.name FROM teams
+        $sql = 'SELECT DISTINCT teams.id, teams.name, users2teams.groups_id AS usergroup, users2teams.is_owner FROM teams
             CROSS JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = teams.id)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);

--- a/src/sql/schema117-down.sql
+++ b/src/sql/schema117-down.sql
@@ -1,0 +1,6 @@
+-- revert schema 117
+ALTER TABLE `users2teams` DROP FOREIGN KEY fk_users2teams_groups_id;
+ALTER TABLE `users2teams` DROP COLUMN `groups_id`;
+ALTER TABLE `users2teams` DROP COLUMN `is_owner`;
+ALTER TABLE users RENAME COLUMN usergroup_old TO usergroup;
+UPDATE config SET conf_value = 116 WHERE conf_name = 'schema';

--- a/src/sql/schema117-down.sql
+++ b/src/sql/schema117-down.sql
@@ -2,5 +2,6 @@
 ALTER TABLE `users2teams` DROP FOREIGN KEY fk_users2teams_groups_id;
 ALTER TABLE `users2teams` DROP COLUMN `groups_id`;
 ALTER TABLE `users2teams` DROP COLUMN `is_owner`;
-ALTER TABLE users RENAME COLUMN usergroup_old TO usergroup;
+ALTER TABLE `users` RENAME COLUMN `usergroup_old` TO `usergroup`;
+ALTER TABLE `users` DROP COLUMN `is_sysadmin`;
 UPDATE config SET conf_value = 116 WHERE conf_name = 'schema';

--- a/src/sql/schema117.sql
+++ b/src/sql/schema117.sql
@@ -3,6 +3,8 @@ ALTER TABLE `users2teams` ADD `groups_id` TINYINT UNSIGNED NOT NULL DEFAULT 4;
 ALTER TABLE `users2teams` ADD CONSTRAINT `fk_users2teams_groups_id` FOREIGN KEY (`groups_id`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE `users2teams` ADD `is_owner` TINYINT UNSIGNED NOT NULL DEFAULT 0;
 UPDATE `users2teams` JOIN `users` ON (users.userid = users2teams.users_id) SET users2teams.groups_id = users.usergroup;
+-- make the previously sysadmins be admins in the teams for backward compatibility
+UPDATE `users2teams` JOIN `users` ON (users.userid = users2teams.users_id) SET users2teams.groups_id = 2 WHERE users2teams.groups_id = 1;
 ALTER TABLE users RENAME COLUMN usergroup TO usergroup_old;
 ALTER TABLE `users` ADD `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0;
 UPDATE `users` SET is_sysadmin = 1 WHERE usergroup_old = 1;

--- a/src/sql/schema117.sql
+++ b/src/sql/schema117.sql
@@ -6,4 +6,6 @@ UPDATE `users2teams` JOIN `users` ON (users.userid = users2teams.users_id) SET u
 ALTER TABLE users RENAME COLUMN usergroup TO usergroup_old;
 ALTER TABLE `users` ADD `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0;
 UPDATE `users` SET is_sysadmin = 1 WHERE usergroup_old = 1;
+-- add a default value for that column
+ALTER TABLE `users` CHANGE `usergroup_old` `usergroup_old` TINYINT UNSIGNED NOT NULL DEFAULT '4';
 UPDATE config SET conf_value = 117 WHERE conf_name = 'schema';

--- a/src/sql/schema117.sql
+++ b/src/sql/schema117.sql
@@ -1,0 +1,9 @@
+-- schema 117
+ALTER TABLE `users2teams` ADD `groups_id` TINYINT UNSIGNED NOT NULL DEFAULT 4;
+ALTER TABLE `users2teams` ADD CONSTRAINT `fk_users2teams_groups_id` FOREIGN KEY (`groups_id`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `users2teams` ADD `is_owner` TINYINT UNSIGNED NOT NULL DEFAULT 0;
+UPDATE `users2teams` JOIN `users` ON (users.userid = users2teams.users_id) SET users2teams.groups_id = users.usergroup;
+ALTER TABLE users RENAME COLUMN usergroup TO usergroup_old;
+ALTER TABLE `users` ADD `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0;
+UPDATE `users` SET is_sysadmin = 1 WHERE usergroup_old = 1;
+UPDATE config SET conf_value = 117 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -795,10 +795,10 @@ CREATE TABLE `users` (
   `password` varchar(255) NULL DEFAULT NULL,
   `password_hash` varchar(255) NULL DEFAULT NULL,
   `mfa_secret` varchar(32) NULL DEFAULT NULL,
-  `usergroup` tinyint UNSIGNED NOT NULL,
   `firstname` varchar(255) NOT NULL,
   `lastname` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
+  `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0,
   `orcid` varchar(19) NULL DEFAULT NULL,
   `orgid` varchar(255) NULL DEFAULT NULL,
   `register_date` bigint(20) UNSIGNED NOT NULL,
@@ -845,12 +845,6 @@ CREATE TABLE `users` (
   PRIMARY KEY (`userid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
---
--- RELATIONSHIPS FOR TABLE `users`:
---   `usergroup`
---       `groups` -> `id`
---
-
 -- --------------------------------------------------------
 
 --
@@ -879,6 +873,8 @@ CREATE TABLE `users2team_groups` (
 CREATE TABLE `users2teams` (
   `users_id` int(10) UNSIGNED NOT NULL,
   `teams_id` int(10) UNSIGNED NOT NULL,
+  `groups_id` TINYINT UNSIGNED NOT NULL DEFAULT 4,
+  `is_owner` TINYINT UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`users_id`, `teams_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 --
@@ -887,6 +883,8 @@ CREATE TABLE `users2teams` (
 --       `teams` -> `id`
 --   `users_id`
 --       `users` -> `userid`
+--   `groups_id`
+--       `groups` -> `id`
 --
 
 -- --------------------------------------------------------
@@ -1067,12 +1065,6 @@ ALTER TABLE `team_groups`
 --
 ALTER TABLE `todolist`
   ADD KEY `fk_todolist_users_userid` (`userid`);
-
---
--- Indexes for table `users`
---
-ALTER TABLE `users`
-  ADD KEY `fk_users_groups_id` (`usergroup`);
 
 --
 -- Indexes for table `experiments2experiments`
@@ -1291,10 +1283,12 @@ CREATE TABLE `experiments_templates_links` (
 --
 ALTER TABLE `users2teams`
   ADD KEY `fk_users2teams_teams_id` (`teams_id`),
-  ADD KEY `fk_users2teams_users_id` (`users_id`);
+  ADD KEY `fk_users2teams_users_id` (`users_id`),
+  ADD KEY `fk_users2teams_groups_id` (`groups_id`);
 ALTER TABLE `users2teams`
   ADD CONSTRAINT `fk_users2teams_teams_id` FOREIGN KEY (`teams_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  ADD CONSTRAINT `fk_users2teams_users_id` FOREIGN KEY (`users_id`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
+  ADD CONSTRAINT `fk_users2teams_users_id` FOREIGN KEY (`users_id`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_users2teams_groups_id` FOREIGN KEY (`groups_id`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Indexes and Constraints for table `users2team_groups`
@@ -1305,12 +1299,6 @@ ALTER TABLE `users2team_groups`
 ALTER TABLE `users2team_groups`
   ADD CONSTRAINT `fk_users2team_groups_groupid` FOREIGN KEY (`groupid`) REFERENCES `team_groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_users2team_groups_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
-
---
--- Constraints for table `users`
---
-ALTER TABLE `users`
-  ADD CONSTRAINT `fk_users_groups_id` FOREIGN KEY (`usergroup`) REFERENCES `groups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `experiments2experiments`

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -57,7 +57,10 @@
                     {% for team in user.teams %}
                       {% set currentTeam = user.teams|filter(t => t.id == team.id)|first %}
                       <div class='user-badge px-2 py-1 rounded mr-2 mt-2'>{{ team.name }}
-                        <span title='{{ 'Delete'|trans }}' class='hl-hover-gray p-1 rounded clickable m-1' data-action='destroy-user2team' data-userid='{{ user.userid }}' data-teamid='{{ team.id }}'><i class='fas fa-xmark' style='color:#29AEB9'></i></span>
+                        {# prevent deleting association of the team we are currently logged in #}
+                        {% if team.id != App.Users.userData.team %}
+                          <span title='{{ 'Delete'|trans }}' class='hl-hover-gray p-1 rounded clickable m-1' data-action='destroy-user2team' data-userid='{{ user.userid }}' data-teamid='{{ team.id }}'><i class='fas fa-xmark' style='color:#29AEB9'></i></span>
+                        {% endif %}
                         <div class='d-flex justify-content-between'>
                           <span class='form-group form-inline mt-2'>
                             <select class='form-control brr-none' autocomplete='off'>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -134,10 +134,10 @@
                   <span class='hl-hover-gray p-1 rounded malleableColumn' data-endpoint='users' data-id='{{ user.userid }}' data-target='lastname'>{{ user.lastname|raw }}</span>
                 </td>
                 <td>
-                  <span class='hl-hover-gray p-1 rounded malleableColumn' data-endpoint='users' data-id='{{ user.userid }}' data-target='email'>{{ user.email }}</span>
+                  <span class='hl-hover-gray p-1 rounded malleableColumn' data-ma-type='email' data-endpoint='users' data-id='{{ user.userid }}' data-target='email'>{{ user.email }}</span>
                 </td>
                 <td><span class='{{ not user.last_login ? 'font-italic' }}'>{{ user.last_login|default('never'|trans) }}</span></td>
-                <td>{{ user.valid_until ? user.valid_until|date('Y-m-d') : '3000-01-01' }}</td>
+                <td><span class='hl-hover-gray p-1 rounded malleableColumn' data-ma-type='date' data-endpoint='users' data-id='{{ user.userid }}' data-target='valid_until'>{{ user.valid_until ? user.valid_until|date('Y-m-d') : '3000-01-01' }}</span></td>
                 <td>
                   <span class='hl-hover-gray p-1 rounded malleableColumn {{ not user.orgid ? 'font-italic' }}' data-endpoint='users' data-id='{{ user.userid }}' data-target='orgid'>{{ user.orgid|default('unset') }}</span>
                 </td>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -41,6 +41,65 @@
     <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Users list'|trans }}</h3>
     <div class='pl-3'>
       {% if usersArr %}
+        {% for user in usersArr %}
+          {# Modal for managing users to teams, generated for each user #}
+          <div class='modal fade' id='manageUsers2teamsModal_{{ user.userid }}' tabindex='-1' role='dialog' aria-label='{{ 'Manage teams for user'|trans }}' aria-hidden='true'>
+            <div class='modal-dialog modal-xl' role='document'>
+              <div class='modal-content'>
+                <div class='modal-header'>
+                  <h5 class='modal-title'>{{ 'Manage teams for user'|trans }} - {{ user.fullname|raw }}</h5>
+                  <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+                    <span aria-hidden='true'>&times;</span>
+                  </button>
+                </div>
+                <div class='modal-body'>
+                  <div class='d-flex flex-row flex-wrap'>
+                    {% for team in user.teams %}
+                      {% set currentTeam = user.teams|filter(t => t.id == team.id)|first %}
+                      <div class='user-badge px-2 py-1 rounded mr-2 mt-2'>{{ team.name }}
+                        <span title='{{ 'Delete'|trans }}' class='hl-hover-gray p-1 rounded clickable m-1' data-action='destroy-user2team' data-userid='{{ user.userid }}' data-teamid='{{ team.id }}'><i class='fas fa-xmark' style='color:#29AEB9'></i></span>
+                        <div class='d-flex justify-content-between'>
+                          <span class='form-group form-inline mt-2'>
+                            <select class='form-control brr-none' autocomplete='off'>
+                              <option value='1' {{ currentTeam.usergroup == 1 ? 'selected' }}>{{ 'Admin'|trans }}</option>
+                              <option value='4' {{ currentTeam.usergroup == 4 ? 'selected' }}>{{ 'User'|trans }}</option>
+                            </select>
+                            <button data-action='patch-user2team-group' data-userid='{{ user.userid }}' data-team='{{ team.id }}' data-target='usergroup' class='btn btn-primary brl-none'>{{ 'Save'|trans }}</button>
+                          </span>
+                        </div>
+                        <div class='d-flex justify-content-between'>
+                          <label for='user_{{ user.id }}_isOwnerTeam_{{ team.id }}' class='col-form-label'>{{ 'Is Owner'|trans }}</label>
+                          <label class='switch ucp-align'>
+                            <input type='checkbox' autocomplete='off' data-trigger='change' data-custom-action='patch-user2team-is-owner' data-userid='{{ user.userid }}' data-team='{{ team.id }}' {{ currentTeam.is_owner ? 'checked="checked"' }} id='user_{{ user.id }}_isOwnerTeam_{{ team.id }}'>
+                            <span class='slider'></span>
+                          </label>
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                  {% set addableToTeams = teamsArr|filter(v => v.id not in user.teams|column('id')) %}
+                  {% if addableToTeams %}
+                    <hr>
+                    <span class='px-2 py-1 rounded mr-2 mt-2 btn btn-primary' data-action='toggle-next'><i class='text-light fas fa-plus-circle'></i> {{ 'Add team'|trans }}</span>
+                    <span class='form-group form-inline mt-2' hidden>
+                      <select class='form-control'>
+                        {% for team in addableToTeams %}
+                        <option value='{{ team.id }}'>{{ team.name }}</option>
+                        {% endfor %}
+                      </select>
+                      <button data-action='create-user2team' data-userid='{{ user.userid }}' class='btn btn-primary'>{{ 'Go'|trans }}</button>
+                    </span>
+                  {% endif %}
+                </div>
+                <div class='modal-footer'>
+                  <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          {# end modal #}
+        {% endfor %}
+
         <table id='usersTable' class='table' aria-label='users table' data-table-sort='true'>
           <thead>
             <tr>
@@ -52,7 +111,7 @@
               <th scope='col'>{{ 'Last login'|trans }}</th>
               <th scope='col'>{{ 'Valid until'|trans }}</th>
               <th scope='col'>{{ 'Internal ID'|trans }}</th>
-              <th scope='col'>{{ 'Permission group'|trans }}</th>
+              <th scope='col'>{{ 'Is Sysadmin'|trans }}</th>
               <th scope='col'>2FA</th>
               <th scope='col'>{{ 'Actions'|trans }}</th>
             </tr>
@@ -64,27 +123,9 @@
                 <td style='max-width: 270px'>
                   <div class='d-flex flex-row flex-wrap'>
                     {% for team in user.teams %}
-                      <div class='user-badge px-2 py-1 rounded mr-2 mt-2'>{{ team.name }}
-                      {% if App.Request.getScriptName|split('/')|last == 'sysconfig.php' %}
-                        <span title='{{ 'Delete'|trans }}' class='clickable m-1' data-action='destroy-user2team' data-userid='{{ user.userid }}' data-teamid='{{ team.id }}'><i class='fas fa-xmark' style='color:#29AEB9'></i></span>
-                      {% endif %}
-                      </div>
+                      <div class='user-badge px-2 py-1 rounded mr-2 mt-2'>{{ team.name }}</div>
                     {% endfor %}
                   </div>
-                  {% if App.Session.get('is_sysadmin') and (App.Request.getScriptName|split('/')|last == 'sysconfig.php') %}
-                    {% set addableToTeams = teamsArr|filter(v => v.id not in user.teams|column('id')) %}
-                    {% if addableToTeams %}
-                      <span class='px-2 py-1 rounded mr-2 mt-2 btn btn-primary' data-action='toggle-next'><i class='text-light fas fa-plus-circle'></i> {{ 'Add team'|trans }}</span>
-                      <span class='form-group form-inline mt-2' hidden>
-                        <select class='form-control'>
-                          {% for team in addableToTeams %}
-                          <option value='{{ team.id }}'>{{ team.name }}</option>
-                        {% endfor %}
-                      </select>
-                      <button data-action='create-user2team' data-userid='{{ user.userid }}' class='btn btn-primary'>{{ 'Go'|trans }}</button>
-                      </span>
-                    {% endif %}
-                  {% endif %}
                 </td>
                 <td>
                   <span class='hl-hover-gray p-1 rounded malleableColumn' data-endpoint='users' data-id='{{ user.userid }}' data-target='firstname'>{{ user.firstname|raw }}</span>
@@ -101,7 +142,12 @@
                   <span class='hl-hover-gray p-1 rounded malleableColumn {{ not user.orgid ? 'font-italic' }}' data-endpoint='users' data-id='{{ user.userid }}' data-target='orgid'>{{ user.orgid|default('unset') }}</span>
                 </td>
                 <td>
-                  <span class='malleableUsergroup hl-hover-gray rounded p-1' data-userid='{{ user.userid }}'>{{ user.usergroup|usergroupToHuman }}</span>
+                  <div class='d-flex justify-content-between'>
+                    <label class='switch ucp-align {{ App.Users.userData.is_sysadmin == 0 ? 'disabled' }}'>
+                      <input type='checkbox' autocomplete='off' {{ App.Users.userData.is_sysadmin == 0 ? "disabled='disabled'" }} data-trigger='change' data-model='users/{{ user.userid }}' data-target='is_sysadmin' {{ user.is_sysadmin ? 'checked="checked"' }}>
+                      <span class='slider'></span>
+                    </label>
+                  </div>
                 </td>
                 <td>{% if user.mfa_secret %}<span title='{{ '2FA enabled'|trans }}'><i title='{{ '2FA enabled'|trans }}' class='fas fa-user-shield'></i></span>{% endif %}</td>
                 <td>
@@ -124,8 +170,14 @@
                     <div class='clickable p-2 hl-hover-gray text-center rounded' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}' role='button'>
                       <i class='fas fa-ellipsis-v'></i>
                     </div>
-                    <!-- Archive user -->
+                    {# Archive user #}
                     <div class='dropdown-menu dropdown-menu-right' aria-label='{{ 'More options'|trans }}'>
+                      {# Manage teams #}
+                      {% if App.Users.userData.is_sysadmin and (App.Request.getScriptName|split('/')|last == 'sysconfig.php') %}
+                        <div class='dropdown-item' data-action='toggle-modal' data-target='manageUsers2teamsModal_{{ user.userid }}'>
+                          <i class='mr-1 fas fa-pencil fa-fw'></i>{{ 'Manage teams for user'|trans }}
+                        </div>
+                      {% endif %}
                       {% if user.archived %}
                         <div class='dropdown-item' data-action='toggle-archive-user' data-userid='{{ user.userid }}'>
                           <i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Unarchive user'|trans }}
@@ -171,7 +223,7 @@
       <div class='col-md-6'>
         <label for='create-user-group' class='col-form-label'>{{ 'Permission group'|trans }}</label>
         <select class='form-control custom-control-inline' name='usergroup' id='create-user-group'>
-          {% if App.Session.get('is_sysadmin') %}
+          {% if App.Users.userData.is_sysadmin %}
             <option value='1'>Sysadmins</option>
           {% endif %}
           <option value='2'>Admins</option>

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -135,10 +135,10 @@
               <a class='dropdown-item' href='profile.php'><i class='fas fa-user fa-fw'></i> {{ 'My profile'|trans }}</a>
               <a class='dropdown-item' data-action='toggle-todolist' href='#'><i class='fas fa-list fa-fw'></i> {{ 'Todolist'|trans }}</a>
               <a class='dropdown-item' href='ucp.php'><i class='fas fa-cogs fa-fw'></i> {{ 'User panel'|trans }}</a>
-              {% if App.Session.get('is_admin') %}
+              {% if App.Users.isAdmin %}
                 <a class='dropdown-item' href='admin.php'><i class='fas fa-tools fa-fw'></i> {{ 'Admin panel'|trans }}</a>
               {% endif %}
-              {% if App.Session.get('is_sysadmin') %}
+              {% if App.Users.userData.is_sysadmin %}
                 <a class='dropdown-item' href='sysconfig.php'><i class='fas fa-tools fa-fw' style='color:#e6614c'></i> {{ 'Sysadmin panel'|trans }}</a>
               {% endif %}
 

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -42,6 +42,7 @@
           <label for='team'>{{ 'Team'|trans }}</label>
           <select name='team' class='form-control selectpicker' id='team' required data-show-subtext='true' data-live-search='true'>
             <option value='' selected disabled>{{ 'Select a team'|trans }}</option>
+            {# on this page, only show the visible teams #}
             {% for team in teamsArr|filter(v => v.visible == 1) %}
               <option value='{{ team.id }}'>{{ team.name }}</option>
             {% endfor %}

--- a/src/templates/show-item-table.html
+++ b/src/templates/show-item-table.html
@@ -11,7 +11,7 @@
   {# TITLE #}
   <td class='title'>
     {# edit icon #}
-    {% if not item.locked and (item.userid == App.Users.userData.userid or Entity.type == 'items' or App.Session.get('is_admin')) %}
+    {% if not item.locked and (item.userid == App.Users.userData.userid or Entity.type == 'items' or App.Users.isAdmin) %}
       <span class='p-2 rounded hl-hover-gray'><a href='{{ Entity.page }}.php?mode=edit&id={{ item.id }}'><i class='fas fa-pencil-alt clickable link-like'></i></a></span>
     {% endif %}
     {# lock icon #}

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -20,7 +20,7 @@
         </div>
       {% else %}
         {# edit icon #}
-        {% if (item.userid == App.Users.userData.userid or Entity.type == 'items' or App.Session.get('is_admin')) %}
+        {% if (item.userid == App.Users.userData.userid or Entity.type == 'items' or App.Users.isAdmin) %}
           <a href='{{ Entity.page }}.php?mode=edit&id={{ item.id }}' title='{{ 'Edit'|trans }}'>
             <div class='left-icon rounded mr-3 my-1 bgnd-dark'>
               <i class='fas fa-pencil fa-fw'></i>

--- a/src/templates/show-view-edit.html
+++ b/src/templates/show-view-edit.html
@@ -40,7 +40,7 @@
             {% endfor %}
             <option disabled>{{ 'Import in experiments'|trans }}</option>
             {# if we are admin we can import in other users experiments, otherwise just for ourself #}
-            {% for user in usersArr|filter(u => App.Users.userData.is_admin ? true : u.userid == App.Users.userData.userid ? u) %}
+            {% for user in usersArr|filter(u => App.Users.isAdmin ? true : u.userid == App.Users.userData.userid ? u) %}
               <option value='experiments:{{ user.userid }}'>{{ user.fullname|raw }}</option>
             {% endfor %}
           </select>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -160,7 +160,7 @@
 
       <div class='dropdown-menu dropdown-menu-right' aria-label='{{ 'More options'|trans }}'>
         <!-- TRANSFER OWNERSHIP -->
-        {% if Entity.type == 'items' and (Entity.entityData.userid == App.Users.userData.userid or App.Session.get('is_admin')) %}
+        {% if Entity.type == 'items' and (Entity.entityData.userid == App.Users.userData.userid or App.Users.isAdmin) %}
           <a class='dropdown-item' data-action='toggle-modal' data-target='ownerModal'><i class='fas fa-people-arrows fa-fw' title='{{ 'Manage Permissions'|trans }}'></i> {{ 'Transfer ownership'|trans }}</a>
         {% endif %}
         {% if mode == 'edit' %}

--- a/src/traits/TwigTrait.php
+++ b/src/traits/TwigTrait.php
@@ -52,7 +52,6 @@ trait TwigTrait
         $metadataFilter = new TwigFilter('formatMetadata', '\Elabftw\Elabftw\TwigFilters::formatMetadata', $filterOptions);
         $csrfFilter = new TwigFilter('csrf', '\Elabftw\Services\Transform::csrf', $filterOptions);
         $notifWebFilter = new TwigFilter('notifWeb', '\Elabftw\Services\Transform::notif', $filterOptions);
-        $usergroupToHumanFilter = new TwigFilter('usergroupToHuman', '\Elabftw\Services\Transform::usergroupToHuman', $filterOptions);
         // |trans filter
         $transFilter = new TwigFilter(
             'trans',
@@ -100,7 +99,6 @@ trait TwigTrait
         $TwigEnvironment->addFilter($extractDisplayMainText);
         $TwigEnvironment->addFilter($isInJsonArray);
         $TwigEnvironment->addFilter($canToHuman);
-        $TwigEnvironment->addFilter($usergroupToHumanFilter);
         // functions
         $TwigEnvironment->addFunction($limitOptions);
         $TwigEnvironment->addFunction($generationTime);

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -10,7 +10,7 @@ import { Api } from './Apiv2.class';
 import { Malle } from '@deltablot/malle';
 import 'bootstrap-select';
 import 'bootstrap/js/src/modal.js';
-import { makeSortableGreatAgain, notifError, reloadElement, adjustHiddenState, getEntity, generateMetadataLink, permissionsToJson } from './misc';
+import { makeSortableGreatAgain, notifError, reloadElement, adjustHiddenState, getEntity, generateMetadataLink, listenTrigger, permissionsToJson } from './misc';
 import i18next from 'i18next';
 import EntityClass from './Entity.class';
 import { Metadata } from './Metadata.class';
@@ -105,43 +105,6 @@ document.addEventListener('DOMContentLoaded', () => {
   observer.observe(document.querySelector('footer'));
   // END BACK TO TOP BUTTON
 
-  // Add a listener for all elements triggered by an event
-  // and POST an update request
-  // select will be on change, text inputs on blur
-  function listenTrigger(): void {
-    document.querySelectorAll('[data-trigger]').forEach((el: HTMLInputElement) => {
-      el.addEventListener(el.dataset.trigger, event => {
-        event.preventDefault();
-        if (el.dataset.customAction === 'patch-user2team-is-owner') {
-          // currently only for modifying is_owner of a user in a given team
-          const team = parseInt(el.dataset.team, 10);
-          const userid = parseInt(el.dataset.userid, 10);
-          console.log(userid);
-          ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, userid: userid, team: team, target: 'is_owner', content: el.value});
-          return;
-        }
-
-        // for a checkbox element, look at the checked attribute, not the value
-        let value = el.type === 'checkbox' ? el.checked ? '1' : '0' : el.value;
-        if (el.dataset.transform === 'permissionsToJson') {
-          value = permissionsToJson(parseInt(value, 10), []);
-        }
-        if (el.dataset.value) {
-          value = el.dataset.value;
-        }
-        const params = {};
-        params[el.dataset.target] = value;
-        ApiC.patch(`${el.dataset.model}`, params).then(() => {
-          if (el.dataset.reload) {
-            reloadElement(el.dataset.reload).then(() => {
-              // make sure we listen to the new element too
-              listenTrigger();
-            });
-          }
-        });
-      });
-    });
-  }
   listenTrigger();
 
   adjustHiddenState();

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -112,6 +112,15 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-trigger]').forEach((el: HTMLInputElement) => {
       el.addEventListener(el.dataset.trigger, event => {
         event.preventDefault();
+        if (el.dataset.customAction === 'patch-user2team-is-owner') {
+          // currently only for modifying is_owner of a user in a given team
+          const team = parseInt(el.dataset.team, 10);
+          const userid = parseInt(el.dataset.userid, 10);
+          console.log(userid);
+          ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, userid: userid, team: team, target: 'is_owner', content: el.value});
+          return;
+        }
+
         // for a checkbox element, look at the checked attribute, not the value
         let value = el.type === 'checkbox' ? el.checked ? '1' : '0' : el.value;
         if (el.dataset.transform === 'permissionsToJson') {

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -62,6 +62,7 @@ enum Action {
   Deduplicate = 'deduplicate',
   Duplicate = 'duplicate',
   Lock = 'lock',
+  PatchUser2Team = 'patchuser2team',
   Pin = 'pin',
   Replace = 'replace',
   Timestamp = 'timestamp',

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -135,13 +135,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const selectEl = (el.previousElementSibling as HTMLSelectElement);
       const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       const userid = parseInt(el.dataset.userid, 10);
-      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team}).then(() => reloadElement(`manageUsers2teamsModal_${userid}`));
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         const userid = parseInt(el.dataset.userid, 10);
         const team = parseInt(el.dataset.teamid, 10);
-        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team}).then(() => reloadElement('editUsersBox'));
+        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team}).then(() => reloadElement(`manageUsers2teamsModal_${userid}`));
       }
     // MODIFY USER GROUP IN TEAM
     } else if (el.matches('[data-action="patch-user2team-group"]')) {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -150,7 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const group = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       const team = parseInt(el.dataset.team, 10);
       const userid = parseInt(el.dataset.userid, 10);
-      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: team, target: 'group', group: group});
+      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: team, target: 'group', content: group});
     // DESTROY ts_password
     } else if (el.matches('[data-action="destroy-ts-password"]')) {
       ApiC.patch('config', {'ts_password': ''}).then(() => reloadElement('ts_loginpass'));

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -143,6 +143,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const team = parseInt(el.dataset.teamid, 10);
         ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team}).then(() => reloadElement('editUsersBox'));
       }
+    // MODIFY USER GROUP IN TEAM
+    } else if (el.matches('[data-action="patch-user2team-group"]')) {
+      // will be 1 for Admin, 0 for user
+      const selectEl = (el.previousElementSibling as HTMLSelectElement);
+      const group = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
+      const team = parseInt(el.dataset.team, 10);
+      const userid = parseInt(el.dataset.userid, 10);
+      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: team, target: 'group', group: group});
     // DESTROY ts_password
     } else if (el.matches('[data-action="destroy-ts-password"]')) {
       ApiC.patch('config', {'ts_password': ''}).then(() => reloadElement('ts_loginpass'));

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -54,7 +54,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $authResponse->userid);
         $this->assertFalse($authResponse->isAnonymous);
         $this->assertEquals(1, $authResponse->selectedTeam);
-        $teams = array(array('id' => '1', 'name' => 'Alpha'));
+        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 1, 'is_owner' => 0));
         $this->assertEquals($teams, $authResponse->selectableTeams);
     }
 

--- a/tests/unit/Auth/LocalTest.php
+++ b/tests/unit/Auth/LocalTest.php
@@ -24,7 +24,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
     public function testEmptyPassword(): void
     {
         $this->expectException(QuantumException::class);
-        $AuthService = new Local('phpunit@example.com', '');
+        new Local('phpunit@example.com', '');
     }
 
     public function testTryAuth(): void
@@ -37,7 +37,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
     public function testTryAuthWithInvalidEmail(): void
     {
         $this->expectException(QuantumException::class);
-        $AuthService = new Local('invalid@example.com', 'nopenope');
+        new Local('invalid@example.com', 'nopenope');
     }
 
     public function testTryAuthWithInvalidPassword(): void
@@ -45,5 +45,14 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $AuthService = new Local('phpunit@example.com', 'nopenope');
         $this->expectException(InvalidCredentialsException::class);
         $AuthService->tryAuth();
+    }
+
+    public function testIsMfaEnforced(): void
+    {
+        $this->assertTrue($this->AuthService::isMfaEnforced(1, 3));
+        $this->assertTrue($this->AuthService::isMfaEnforced(1, 1));
+        $this->assertFalse($this->AuthService::isMfaEnforced(4, 1));
+        $this->assertTrue($this->AuthService::isMfaEnforced(4, 2));
+        $this->assertFalse($this->AuthService::isMfaEnforced(4, 0));
     }
 }

--- a/tests/unit/classes/UpdateTest.php
+++ b/tests/unit/classes/UpdateTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Exceptions\InvalidSchemaException;
+use League\Flysystem\Filesystem as Fs;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+
+class UpdateTest extends \PHPUnit\Framework\TestCase
+{
+    private Fs $Fs;
+
+    private Sql $Sql;
+
+    public function setUp(): void
+    {
+        $this->Fs = new Fs(new InMemoryFilesystemAdapter());
+        $this->Sql = new Sql($this->Fs);
+    }
+
+    public function testCheckSchema(): void
+    {
+        $Update = new Update(Update::REQUIRED_SCHEMA - 1, $this->Sql);
+        $this->expectException(InvalidSchemaException::class);
+        $Update->checkSchema();
+    }
+
+    public function testRunUpdateScript(): void
+    {
+        // create a fake schema file
+        $this->Fs->write(sprintf('schema%d.sql', Update::REQUIRED_SCHEMA), 'SELECT 1');
+        $Update = new Update(Update::REQUIRED_SCHEMA - 1, $this->Sql);
+        $this->assertIsArray($Update->runUpdateScript());
+    }
+
+    public function testOldAfInstance(): void
+    {
+        $Update = new Update(36, $this->Sql);
+        $this->expectException(ImproperActionException::class);
+        $Update->runUpdateScript();
+    }
+
+    public function testVersion2(): void
+    {
+        $Update = new Update(40, $this->Sql);
+        $this->expectException(ImproperActionException::class);
+        $Update->runUpdateScript();
+    }
+}

--- a/tests/unit/classes/UserParamsTest.php
+++ b/tests/unit/classes/UserParamsTest.php
@@ -13,12 +13,6 @@ use Elabftw\Exceptions\ImproperActionException;
 
 class UserParamsTest extends \PHPUnit\Framework\TestCase
 {
-    public function testUserGroup(): void
-    {
-        $params = new UserParams('usergroup', '4', 0, 1);
-        $this->assertEquals(4, $params->getContent());
-    }
-
     public function testValidUntilEmpty(): void
     {
         $params = new UserParams('valid_until', '');

--- a/tests/unit/models/AuthenticatedUserTest.php
+++ b/tests/unit/models/AuthenticatedUserTest.php
@@ -17,7 +17,5 @@ class AuthenticatedUserTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(AuthenticatedUser::class, $User);
         $this->assertEquals(1, $User->userData['team']);
         $this->assertEquals('en_GB', $User->userData['lang']);
-        $this->assertEquals(1, $User->userData['is_admin']);
-        $this->assertEquals(1, $User->userData['is_sysadmin']);
     }
 }

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -18,7 +18,7 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->Teams= new Teams(new Users(1, 1));
+        $this->Teams= new Teams(new Users(1, 1), 1);
     }
 
     public function testGetPage(): void
@@ -42,10 +42,8 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
         $params = array(
             'link_href' => 'https://example.com',
             'link_name' => 'Example',
-            'name' => 'Another name',
             'announcement' => '',
         );
-        $this->Teams->setId(4);
         $this->assertIsArray($this->Teams->patch(Action::Update, $params));
         $params = array(
             'announcement' => 'yep',
@@ -82,6 +80,7 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
     {
         $id = $this->Teams->postAction(Action::Create, array('name' => 'Destroy me'));
         $this->Teams->setId($id);
+        $this->Teams->bypassWritePermission = true;
         $this->assertTrue($this->Teams->destroy());
         // try to destroy a team with data
         $this->Teams->setId(1);

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -9,6 +9,7 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 
 class Users2TeamsTest extends \PHPUnit\Framework\TestCase
@@ -26,5 +27,29 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
         $this->Users2Teams->rmUserFromTeams(4, array(3));
         $this->expectException(ImproperActionException::class);
         $this->Users2Teams->rmUserFromTeams(4, array(2));
+    }
+
+    public function testPatchUser2TeamGroup(): void
+    {
+        $params = array(
+            'userid' => 2,
+            'team' => 1,
+            'target' => 'group',
+            'content' => 4,
+        );
+        $this->assertEquals(4, $this->Users2Teams->PatchUser2Team(new Users(1, 1), $params));
+    }
+
+    public function testPatchIsOwner(): void
+    {
+        $params = array(
+            'userid' => 3,
+            'team' => 1,
+            'target' => 'is_owner',
+            'content' => 'on',
+        );
+        $this->assertEquals(1, $this->Users2Teams->PatchUser2Team(new Users(1, 1), $params));
+        $this->expectException(IllegalActionException::class);
+        $this->Users2Teams->PatchUser2Team(new Users(2, 1), $params);
     }
 }

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -11,7 +11,6 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
-use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 
@@ -25,11 +24,13 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->Users= new Users(1, 1, $requester);
     }
 
+    /*
     protected function tearDown(): void
     {
         // make titi user again
         (new Users(2, 1, new Users(1, 1)))->patch(Action::Update, array('usergroup' => '4'));
     }
+     */
 
     public function testPopulate(): void
     {
@@ -69,6 +70,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         (new Users(4, 2, new Users(4, 2)))->patch(Action::Update, array('orcid' => 'blah'));
     }
 
+    /*
     public function testUpdateUsergroupToSysadmin(): void
     {
         $params = array(
@@ -86,7 +88,9 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->expectException(IllegalActionException::class);
         (new Users(2, 1, new Users(4, 2)))->patch(Action::Update, $params);
     }
+     */
 
+    /*
     public function testDemoteSysadmin(): void
     {
         // first make titi admin so we can use it to try and demote toto
@@ -95,6 +99,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ImproperActionException::class);
         (new Users(1, 1, new Users(2, 1)))->patch(Action::Update, array('usergroup' => '2'));
     }
+     */
 
     public function testUpdatePreferences(): void
     {
@@ -125,7 +130,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue($this->Users->isAdminOf(1));
         $this->assertTrue($this->Users->isAdminOf(2));
-        $this->assertTrue($this->Users->isAdminOf(4));
+        $this->assertFalse($this->Users->isAdminOf(4));
         $tata = new Users(4, 2);
         $this->assertFalse($tata->isAdminOf(2));
     }
@@ -155,6 +160,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     public function testToggleArchive(): void
     {
+        // tata in bravo
         $Admin = new Users(4, 2);
         $Users = new Users(5, 2, $Admin);
         $this->assertIsArray($Users->patch(Action::Lock, array()));
@@ -182,6 +188,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Users->patch(Action::Lock, array());
     }
 
+    /*
     public function testUserTryToPromoteToAdmin(): void
     {
         $Users = new Users(5, 2);
@@ -197,6 +204,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $res = $Target->patch(Action::Update, array('usergroup' => '4'));
         $this->assertEquals(4, $res['usergroup']);
     }
+     */
 
     public function testReadAllActiveFromTeam(): void
     {

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -24,14 +24,6 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->Users= new Users(1, 1, $requester);
     }
 
-    /*
-    protected function tearDown(): void
-    {
-        // make titi user again
-        (new Users(2, 1, new Users(1, 1)))->patch(Action::Update, array('usergroup' => '4'));
-    }
-     */
-
     public function testPopulate(): void
     {
         $this->assertTrue(is_array($this->Users->userData));
@@ -69,37 +61,6 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ImproperActionException::class);
         (new Users(4, 2, new Users(4, 2)))->patch(Action::Update, array('orcid' => 'blah'));
     }
-
-    /*
-    public function testUpdateUsergroupToSysadmin(): void
-    {
-        $params = array(
-            'usergroup' => '1',
-        );
-        $this->expectException(ImproperActionException::class);
-        (new Users(4, 2, new Users(4, 2)))->patch(Action::Update, $params);
-    }
-
-    public function testPatchFromOtherTeam(): void
-    {
-        $params = array(
-            'usergroup' => '2',
-        );
-        $this->expectException(IllegalActionException::class);
-        (new Users(2, 1, new Users(4, 2)))->patch(Action::Update, $params);
-    }
-     */
-
-    /*
-    public function testDemoteSysadmin(): void
-    {
-        // first make titi admin so we can use it to try and demote toto
-        (new Users(2, 1, new Users(1, 1)))->patch(Action::Update, array('usergroup' => '2'));
-        // now use titi to try and demote toto
-        $this->expectException(ImproperActionException::class);
-        (new Users(1, 1, new Users(2, 1)))->patch(Action::Update, array('usergroup' => '2'));
-    }
-     */
 
     public function testUpdatePreferences(): void
     {
@@ -188,24 +149,6 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Users->patch(Action::Lock, array());
     }
 
-    /*
-    public function testUserTryToPromoteToAdmin(): void
-    {
-        $Users = new Users(5, 2);
-        $Target = new Users(5, 2, $Users);
-        $res = $Target->patch(Action::Update, array('usergroup' => '2'));
-        $this->assertEquals(4, $res['usergroup']);
-    }
-
-    public function testUserPatchUsergroup(): void
-    {
-        $Users = new Users(5, 2);
-        $Target = new Users(5, 2, $Users);
-        $res = $Target->patch(Action::Update, array('usergroup' => '4'));
-        $this->assertEquals(4, $res['usergroup']);
-    }
-     */
-
     public function testReadAllActiveFromTeam(): void
     {
         $this->assertCount(6, $this->Users->readAllActiveFromTeam());
@@ -217,8 +160,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $id = $Admin->createOne('testdestroy@a.fr', array('Bravo'), 'Life', 'isShort', 'yololololol', 4, false, false);
         $Target = new Users($id, 2, $Admin);
         $this->expectException(ImproperActionException::class);
-        $Target->destroy();
-        // correct one $this->assertTrue($Target->destroy());
+        $this->assertTrue($Target->destroy());
     }
 
     public function testDestroyWithExperiments(): void

--- a/tests/unit/services/CheckTest.php
+++ b/tests/unit/services/CheckTest.php
@@ -38,22 +38,6 @@ class CheckTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(42, Check::id(42));
     }
 
-    public function testUsergroup(): void
-    {
-        $this->assertIsInt(Check::usergroup(1));
-        $this->assertIsInt(Check::usergroup(2));
-        $this->expectException(ImproperActionException::class);
-        Check::usergroup(3);
-        $this->assertIsInt(Check::usergroup(4));
-
-        $this->expectException(ImproperActionException::class);
-        Check::usergroup(-1337);
-        $this->expectException(ImproperActionException::class);
-        Check::usergroup(0);
-        $this->expectException(ImproperActionException::class);
-        Check::usergroup(5);
-    }
-
     public function testColor(): void
     {
         $this->assertEquals('AABBCC', Check::color('#AABBCC'));

--- a/tests/unit/services/CheckTest.php
+++ b/tests/unit/services/CheckTest.php
@@ -12,11 +12,13 @@ namespace Elabftw\Services;
 use function bin2hex;
 
 use Elabftw\Enums\BasePermissions;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Users;
+
 use function hash;
 use function random_bytes;
-use TypeError;
 
 class CheckTest extends \PHPUnit\Framework\TestCase
 {
@@ -29,9 +31,6 @@ class CheckTest extends \PHPUnit\Framework\TestCase
 
     public function testId(): void
     {
-        $this->expectException(TypeError::class);
-        // @phpstan-ignore-next-line
-        $this->assertFalse(Check::id('yep'));
         $this->assertFalse(Check::id(-42));
         $this->assertFalse(Check::id(0));
         $this->assertEquals(3, Check::id((int) 3.1415926535));
@@ -50,6 +49,18 @@ class CheckTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(BasePermissions::MyTeams->toJson(), Check::visibility(BasePermissions::MyTeams->toJson()));
         $this->expectException(ImproperActionException::class);
         Check::visibility('pwet');
+    }
+
+    public function testVisibilityIncorrectBase(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        Check::visibility('{"base": 12}');
+    }
+
+    public function testVisibilityIncorrectArray(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        Check::visibility('{"base": 10, "teams": "yep"}');
     }
 
     public function testToken(): void
@@ -74,5 +85,13 @@ class CheckTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(Check::digit('000000021825009', 7));
         $this->assertTrue(Check::digit('000000021694233', 10));
         $this->assertFalse(Check::digit('100000021825009', 7));
+    }
+
+    public function testUsergroup(): void
+    {
+        // simulate a non admin trying to set a usergroup level of admin
+        $requester = new Users(3, 2);
+        $usergroup = Usergroup::Admin;
+        $this->assertEquals(Usergroup::User, Check::usergroup($requester, $usergroup));
     }
 }

--- a/tests/unit/services/UserCreatorTest.php
+++ b/tests/unit/services/UserCreatorTest.php
@@ -41,12 +41,6 @@ class UserCreatorTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt($this->UserCreator->create());
     }
 
-    public function testCreateWithNonAdminUser(): void
-    {
-        $this->expectException(IllegalActionException::class);
-        new UserCreator(new Users(2, 1), array());
-    }
-
     public function testCreateFromAdminUser(): void
     {
         $UserCreator = new UserCreator(new Users(4, 2), array(

--- a/tests/unit/services/UsersHelperTest.php
+++ b/tests/unit/services/UsersHelperTest.php
@@ -35,7 +35,7 @@ class UsersHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTeamsFromUserid(): void
     {
-        $expected = array(array('id' => '1', 'name' => 'Alpha'));
+        $expected = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 1, 'is_owner' => 0));
         $this->assertEquals($expected, $this->UsersHelper->getTeamsFromUserid());
     }
 

--- a/web/admin.php
+++ b/web/admin.php
@@ -40,7 +40,7 @@ $template = 'error.html';
 $renderArr = array();
 
 try {
-    if (!$App->Session->get('is_admin')) {
+    if (!$App->Users->isAdmin) {
         throw new IllegalActionException('Non admin user tried to access admin controller.');
     }
 

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -42,13 +42,13 @@ $reqBody = json_decode((string) $App->Request->getContent(), true, 512, JSON_THR
 try {
     switch ($reqBody['table']) {
         case 'items_types':
-            if (!$App->Session->get('is_admin')) {
+            if (!$App->Users->isAdmin) {
                 throw new IllegalActionException('Non admin user tried to access admin controller.');
             }
             $Entity = new ItemsTypes($App->Users);
             break;
         case 'status':
-            if (!$App->Session->get('is_admin')) {
+            if (!$App->Users->isAdmin) {
                 throw new IllegalActionException('Non admin user tried to access admin controller.');
             }
             $Entity = new Status(new Teams($App->Users));

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -33,7 +33,7 @@ $Response->setData(array(
 ));
 
 try {
-    if (!$App->Session->get('is_sysadmin')) {
+    if (!$App->Users->userData['is_sysadmin']) {
         throw new IllegalActionException('Non sysadmin user tried to access sysadmin controller.');
     }
 

--- a/web/app/controllers/UcpController.php
+++ b/web/app/controllers/UcpController.php
@@ -79,8 +79,7 @@ try {
         } elseif (!$useMFA
             && $App->Users->userData['mfa_secret']
             && !Local::isMfaEnforced(
-                (bool) $App->Users->userData['is_admin'],
-                (bool) $App->Users->userData['is_sysadmin'],
+                $App->Users->userData['userid'],
                 (int) $App->Config->configArr['enforce_mfa'],
             )
         ) {

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -40,7 +40,7 @@ $template = 'error.html';
 $renderArr = array();
 
 try {
-    if (!$App->Session->get('is_sysadmin')) {
+    if (!$App->Users->userData['is_sysadmin']) {
         throw new IllegalActionException('Non sysadmin user tried to access sysconfig panel.');
     }
 

--- a/web/ucp.php
+++ b/web/ucp.php
@@ -75,7 +75,7 @@ try {
         ),
     );
 
-    if ($App->Users->userData['is_admin']) {
+    if ($App->Users->isAdmin) {
         $notificationsSettings[] =
             array(
                 'designation' => _('New user created'),
@@ -94,8 +94,7 @@ try {
     }
 
     $showMfa = !Local::isMfaEnforced(
-        (bool) $App->Users->userData['is_admin'],
-        (bool) $App->Users->userData['is_sysadmin'],
+        $App->Users->userData['userid'],
         (int) $App->Config->configArr['enforce_mfa'],
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,10 +87,10 @@
   resolved "https://registry.yarnpkg.com/@deltablot/chemdoodle-web-mini/-/chemdoodle-web-mini-9.2.6.tgz#8987050d8d1ceb6ba424d6556b92c2fe65646176"
   integrity sha512-Wk7AyGgI5pq1gHv9ipql+SB2ywahvEfBroAHfOSNXmBOlwuQp+pYlFxHzb+NX+Cn3Z6gNcPAZw8eaZziDXFqBA==
 
-"@deltablot/malle@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@deltablot/malle/-/malle-2.1.0.tgz#f2cfafc25c18f4374a6b30728268c24eba5f608b"
-  integrity sha512-CYUq2FdaPjmOVw6Sw6uT9E3gPoQfZeKHPmY2n5ZffDooVAMszC5gzsWuwylFHuthy6UykedS8jq9XY+EqXeD9w==
+"@deltablot/malle@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@deltablot/malle/-/malle-2.2.0.tgz#b238b2eb727d3327fca504f7f051e7e72ceed7bf"
+  integrity sha512-CydNYRiJCeFOOs71LwOqGxgZSyKXRnTtw1QI52avQM2VqEZFzutt1Z6+vn6iY44+jHeLSepI/75U2Zj3n9xc2w==
 
 "@deltablot/open-vector-editor-umd@^18.0.0":
   version "18.2.24"


### PR DESCRIPTION
In this PR:

* `usergroup` no longer exists on `users` table
* `is_sysadmin` appears on `users`: a user can be a sysadmin or not. This property is not linked to teams, so it is still something that is tied to the user.
* The `users2teams` table gains two columns: `groups_id` pointing to a row in the `groups` table, and `is_owner`, which currently is only informative. (fix #3454)
* When a `Users` object is loaded with a team, it gains the `isSysadmin` property, so we know easily if the user is Admin in the current team.
* Users can thus be Admin in a team and not another
* A Sysadmin user is no longer automatically Admin in all teams. You can be Sysadmin but not Admin in a team.
* The `usergroup` column of `users` table is renamed to `usergroups_old` so changes can be reverted thanks to the new `db:revert` command.
* New version of `@deltablot/malle` is used so the malleable column `email` in users listing table is a proper email input, and `valid_until` is malleable now.
* `is_admin` and `is_sysadmin` is removed from being stored in Session.
* new `Action` : `PatchUser2Team` to modify the users2teams attributes

Unrelated changes:

* Add tests for Update class
