### PR TITLE
Fix copy behaviour in plasmid viewer

### DIFF
--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -136,7 +136,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
         onCopy: function(event, copiedSequenceData, editorState): void {
           // the copiedSequenceData is the subset of the sequence that has been copied in the teselagen sequence format
           const clipboardData = event.clipboardData;
-          clipboardData.setData('text/plain', copiedSequenceData.sequence);
+          clipboardData.setData('text/plain', copiedSequenceData.textToCopy);
           data.selection = editorState.selectionLayer;
           data.openVECopied = copiedSequenceData;
           convertToFeaturedDNASequence(editorState.sequenceData);


### PR DESCRIPTION
It turned out to be a bug.
I initially used the wrong property. See commit message for more details.

Fix #4261