### PR TITLE
Create rudimentary mailmap to harmonize names and emails for Nicolas and Marcel

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Nicolas CARPi <nico-git@deltablot.email> <nicolas.carpi@curie.fr>
+Marcel Bolten <github@marcelbolten.de> <65481677+MarcelBolten@users.noreply.github.com>


### PR DESCRIPTION
So it looks like

	❯ git shortlog -sn | head
	  6766	Nicolas CARPi
	   214	Marcel Bolten
	   130	Alexander Minges
		96	Athemis
		47	PascalNOIRCi
		13	Scrutinizer Auto-Fixer
		10	timfalcucci
		 9	ManonStripes
		 5	Sherjeel Shabih
		 4	Minges, Alexander Ralph Michael (almin100)

instead of

    ❯ git shortlog -sn | head
      5864	Nicolas CARPi
       902	NicolasCARPi
       166	Marcel
       130	Alexander Minges
        96	Athemis
        48	Marcel Bolten
        47	PascalNOIRCi
        13	Scrutinizer Auto-Fixer
        10	timfalcucci
         9	ManonStripes