### PR TITLE
Fix misspellings

### DIFF
--- a/src/controllers/DownloadController.php
+++ b/src/controllers/DownloadController.php
@@ -98,7 +98,7 @@ class DownloadController implements ControllerInterface
         }
 
         $disposition = HeaderUtils::DISPOSITION_INLINE;
-        // change the diposition to attachment
+        // change the disposition to attachment
         if ($this->forceDownload) {
             $disposition = HeaderUtils::DISPOSITION_ATTACHMENT;
         }

--- a/src/services/TimestampUtils.php
+++ b/src/services/TimestampUtils.php
@@ -53,7 +53,7 @@ class TimestampUtils
     }
 
     /**
-     * Delete all temporary files once the processus is completed
+     * Delete all temporary files once the process is completed
      */
     public function __destruct()
     {

--- a/tests/unit/services/UploadsCleanerTest.php
+++ b/tests/unit/services/UploadsCleanerTest.php
@@ -15,7 +15,7 @@ class UploadsCleanerTest extends \PHPUnit\Framework\TestCase
 {
     public function testCleanup(): void
     {
-        // create a non-persistant filesystem stored in memory
+        // create a non-persistent filesystem stored in memory
         $fs = Storage::MEMORY->getStorage()->getFs();
         // add a file to our filesystem so we can test removing it
         $fs->write('blah.txt', 'blih');

--- a/tests/unit/services/UploadsMigratorTest.php
+++ b/tests/unit/services/UploadsMigratorTest.php
@@ -15,7 +15,7 @@ class UploadsMigratorTest extends \PHPUnit\Framework\TestCase
 {
     public function testMigrate(): void
     {
-        // create a non-persistant filesystem stored in memory
+        // create a non-persistent filesystem stored in memory
         $sourceFs = Storage::LOCAL->getStorage()->getFs();
         $targetFs = Storage::MEMORY->getStorage()->getFs();
         $UploadsMigrator = new UploadsMigrator($sourceFs, $targetFs);

--- a/web/admin.php
+++ b/web/admin.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Administration panel of a team
  */
 require_once 'app/init.inc.php';
-$App->pageTitle = _('Admin panel'); // @phan-suppress PhanTypeExepectedObjectPropAccessButGotNull
+$App->pageTitle = _('Admin panel'); // @phan-suppress PhanTypeExpectedObjectPropAccessButGotNull
 $Response = new Response();
 $Response->prepare($Request);
 


### PR DESCRIPTION
| [**phan/phan/src/Phan/Issue.php**](https://github.com/phan/phan/blob/93c1c287d646d08249b4f5539bfe147550b163d7/src/Phan/Issue.php#L212) |
|-----|
|Line 212 in https://github.com/phan/phan/commit/93c1c28 |
```php
    public const TypeExpectedObjectPropAccessButGotNull = 'PhanTypeExpectedObjectPropAccessButGotNull';
```