### PR TITLE
Add archival possibilities

### DIFF
--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -74,9 +74,7 @@ class DisplayParams
         $this->sort = Sort::tryFrom($Users->userData['sort']) ?? $this->sort;
         $this->adjust();
         // we don't care about the value, so it can be 'on' from a checkbox or 1 or anything really
-        if ($this->Request->query->get('archived')) {
-            $this->includeArchived = true;
-        }
+        $this->includeArchived = $this->Request->query->has('archived');
     }
 
     public function appendFilterSql(FilterableColumn $column, int $value): void

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -60,9 +60,11 @@ class DisplayParams
     public array $metadataValuePath = array();
 
     public array $metadataValue = array();
+    // end metadata stuff
+
+    public bool $includeArchived = false;
 
     private array $metadataHaving = array();
-    // end metadata stuff
 
     public function __construct(Users $Users, private Request $Request, private string $entityType)
     {
@@ -71,6 +73,10 @@ class DisplayParams
         $this->orderby = Orderby::tryFrom($Users->userData['orderby']) ?? $this->orderby;
         $this->sort = Sort::tryFrom($Users->userData['sort']) ?? $this->sort;
         $this->adjust();
+        // we don't care about the value, so it can be 'on' from a checkbox or 1 or anything really
+        if ($this->Request->query->get('archived')) {
+            $this->includeArchived = true;
+        }
     }
 
     public function appendFilterSql(FilterableColumn $column, int $value): void

--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -48,6 +48,7 @@ class EntitySqlBuilder
                 entity.rating,
                 entity.userid,
                 entity.locked,
+                entity.state,
                 entity.canread,
                 entity.canwrite,
                 entity.modified_at,';

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -56,6 +56,10 @@ abstract class AbstractEntityController implements ControllerInterface
             $Templates = new Templates($this->Entity->Users);
             $this->templatesArr = $Templates->Pins->readAllSimple();
         }
+        if ($App->Request->query->has('archived') && $Entity instanceof AbstractConcreteEntity) {
+            $Entity->Uploads->includeArchived = true;
+        }
+
     }
 
     public function getResponse(): Response

--- a/src/controllers/ExperimentsController.php
+++ b/src/controllers/ExperimentsController.php
@@ -28,10 +28,6 @@ class ExperimentsController extends AbstractEntityController
     {
         parent::__construct($app, $entity);
 
-        if ($app->Request->query->get('archived') === '1') {
-            $entity->Uploads->includeArchived = true;
-        }
-
         $Category = new Status(new Teams($this->App->Users, $this->App->Users->team));
         $this->categoryArr = $Category->readAll();
     }

--- a/src/controllers/ExperimentsController.php
+++ b/src/controllers/ExperimentsController.php
@@ -28,6 +28,10 @@ class ExperimentsController extends AbstractEntityController
     {
         parent::__construct($app, $entity);
 
+        if ($app->Request->query->get('archived') === '1') {
+            $entity->Uploads->includeArchived = true;
+        }
+
         $Category = new Status(new Teams($this->App->Users, $this->App->Users->team));
         $this->categoryArr = $Category->readAll();
     }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -22,6 +22,8 @@ $lightred: #ffc1b7;
 $dangerred: #e6614c;
 $darkred: #dd1e00;
 
+$warningbg: #fff3cd;
+
 $green: #54aa08;
 
 $lightgold: #eddec6;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -281,7 +281,10 @@ label {
     background-color: $lightred;
     border-color: $darkred;
     color: $darkred;
-    transition-duration: 500ms;
+}
+
+.hover-warning:hover {
+    background-color: $warningbg;
 }
 
 .hover-action:hover {

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -46,6 +46,10 @@
       {% if item.timestamped %}
         <i style='color:#{{ item.color }}' class='far fa-calendar-check fa-fw'></i>
       {% endif %}
+      {# archived icon #}
+      {% if item.state == constant('Elabftw\\Enums\\State::Archived').value %}
+        <i class='fas fa-box-archive fa-fw'></i>
+      {% endif %}
       {# category #}
       <span class='item-category'><a style='color:#{{ item.color }}' href='?cat={{ item.category_id }}'>{{ item.category|raw }}</a></span>
     </div>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -128,6 +128,16 @@
               {% endfor %}
             </select>
             {# onBlur cannot work on bootstrap multiselect see https://stackoverflow.com/questions/42673800/bootstrap-multiselect-blur-event-not-triggering so add a button #}
+            {# ARCHIVED filter #}
+            <div class='input-group mr-1'>
+              <div class='input-group-prepend'>
+                <div class='input-group-text'>
+                  <input id='showArchivedBox' type='checkbox' {{ App.Request.query.get('archived') == 'on' ? 'checked' }} name='archived' aria-label='{{ 'Show archived'|trans }}'>
+                </div>
+              </div>
+              <label for='showArchivedBox' class='input-group-text brl-none'>{{ 'Show archived'|trans }}</label>
+            </div>
+
             <button class='btn btn-primary'>{{ 'Go'|trans }}</button>
 
           </div>

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -73,8 +73,12 @@
       <i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}</a>
 
   {% if not upload.immutable and not Entity.isReadOnly %}
-    <!-- DESTROY -->
+    {# ARCHIVE #}
     <div class='dropdown-divider'></div>
+    <a class='dropdown-item hover-warning' data-action='archive-upload' data-uploadid='{{ upload.id }}'>
+      <i class='fas fa-fw fa-box-archive fa-fw mr-1' title='{{ 'Archive/Unarchive'|trans }}'></i>{{ 'Archive/Unarchive'|trans }}
+    </a>
+    {# DESTROY #}
     <a class='dropdown-item hover-danger' data-action='destroy-upload' data-uploadid='{{ upload.id }}'>
       <i class='fas fa-fw fa-trash-alt fa-fw mr-1' title='{{ 'Delete'|trans }}'></i>{{ 'Delete'|trans }}
     </a>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -58,8 +58,11 @@
         <!-- DEFAULT LAYOUT (1) -->
         {% else %}
           <div class='col-md-4 col-sm-6'>
-            <div class='thumbnail box' data-type='{{ Entity.type }}' data-id='{{ Entity.id }}' style='overflow: visible'>
+            <div class='thumbnail box {{ upload.state == constant('Elabftw\\Enums\\State::Archived').value ? 'bg-light' }}' data-type='{{ Entity.type }}' data-id='{{ Entity.id }}' style='overflow: visible'>
               {% include('upload-dropdown-menu.html') %}
+              {% if upload.state == constant('Elabftw\\Enums\\State::Archived').value %}
+              <p class='mb-0'><i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Archived'|trans }}</p>
+              {% endif %}
 
               <!-- IMAGES -->
               {% if ext matches '/(jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg|heic)$/i' %}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -21,6 +21,7 @@
 
 <!-- UPLOADED FILES -->
 <div id='filesdiv'>
+  <a name='filesDiv'></a>
   {% if Entity.entityData.uploads %}
     <div class='d-flex justify-content-between'>
       <div><!-- necessary div for flex -->
@@ -32,9 +33,14 @@
       </div>
 
       {# id is used with data-toggle-target-extra #}
-      <div title='{{ 'Switch layout'|trans }}' id='uploadsViewToggler' class='hl-hover-gray rounded p-1' data-action='toggle-uploads-layout' data-target-layout='{{ App.Users.userData.uploads_layout ? 0 : 1 }}'>
-        <i class='fas fa-fw fa-list fa-flip-horizontal'></i>
-        <i class='fas fa-fw fa-table-cells'></i>
+      <div>
+        <span title='{{ 'Switch layout'|trans }}' id='uploadsViewToggler' class='hl-hover-gray rounded p-1' data-action='toggle-uploads-layout' data-target-layout='{{ App.Users.userData.uploads_layout ? 0 : 1 }}'>
+          <i class='fas fa-fw fa-list fa-flip-horizontal'></i>
+          <i class='fas fa-fw fa-table-cells'></i>
+        </span>
+        <span title='{{ 'Show archived'|trans }}' class='hl-hover-gray rounded p-1' data-action='toggle-uploads-show-archived'>
+          <i class='fas fa-fw fa-box-archive'></i>
+        </span>
       </div>
     </div>
 

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -176,6 +176,9 @@
         <!-- CHANGELOG -->
         <a class='dropdown-item' href='?id={{ Entity.id }}&mode=changelog'><i class='fas fa-list fa-fw'></i> {{ 'See changelog'|trans }}</a>
 
+        <a class='dropdown-item hover-warning' data-action='archive-entity'>
+          <i class='fas fa-fw fa-box-archive fa-fw mr-1' title='{{ 'Archive/Unarchive'|trans }}'></i>{{ 'Archive/Unarchive'|trans }}
+        </a>
         {% if App.Config.configArr.deletable_xp == '1' %}
           <div class='dropdown-divider'></div>
           {# DELETE #}

--- a/src/templates/view-edit.html
+++ b/src/templates/view-edit.html
@@ -33,6 +33,6 @@
 
 <div id='isArchivedDiv'>
 {% if Entity.entityData.state == constant('Elabftw\\Enums\\State::Archived').value %}
-  {{ 'This entry is archived'|trans|msg('ok', false) }}
+  {{ 'This entry is archived: it will not appear in the listings by default.'|trans|msg('ok', false) }}
 {% endif %}
 </div>

--- a/src/templates/view-edit.html
+++ b/src/templates/view-edit.html
@@ -30,3 +30,9 @@
     </div>
   </div>
 </div>
+
+<div id='isArchivedDiv'>
+{% if Entity.entityData.state == constant('Elabftw\\Enums\\State::Archived').value %}
+  {{ 'This entry is archived'|trans|msg('ok', false) }}
+{% endif %}
+</div>

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -58,6 +58,7 @@ enum Action {
 
   AccessKey = 'accesskey',
   Add = 'add',
+  Archive = 'archive',
   Bloxberg = 'bloxberg',
   Deduplicate = 'deduplicate',
   Duplicate = 'duplicate',

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -123,6 +123,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(() => reloadElement('filesdiv'))
         // remove overlay in all cases
         .finally(() => document.getElementById('container').removeChild(document.getElementById('loadingOverlay')));
+    // ARCHIVE ENTITY
+    } else if (el.matches('[data-action="archive-entity"]')) {
+      ApiC.patch(`${entity.type}/${entity.id}`, {action: Action.Archive}).then(() => reloadElement('isArchivedDiv'));
 
     // DESTROY ENTITY
     } else if (el.matches('[data-action="destroy"]')) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -98,6 +98,24 @@ document.addEventListener('DOMContentLoaded', () => {
         reloadElement('filesdiv');
       });
 
+    // TOGGLE SHOW ARCHIVED
+    } else if (el.matches('[data-action="toggle-uploads-show-archived"]')) {
+      const url = new URL(window.location.href);
+      const queryParams = new URLSearchParams(url.search);
+
+      // toggle "archived" query parameter
+      if (queryParams.has('archived')) {
+        queryParams.delete('archived');
+      } else {
+        queryParams.set('archived', 'on');
+      }
+
+      // Update the query parameters in the URL
+      url.search = queryParams.toString();
+      url.hash = 'filesDiv';
+      const modifiedUrl = url.toString();
+      window.location.replace(modifiedUrl);
+
     // REPLACE UPLOAD
     } else if (el.matches('[data-action="replace-upload"]')) {
       document.getElementById('replaceUploadForm_' + el.dataset.uploadid).hidden = false;

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -124,6 +124,11 @@ document.addEventListener('DOMContentLoaded', () => {
       };
       ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElement('filesdiv'));
 
+    // ARCHIVE UPLOAD
+    } else if (el.matches('[data-action="archive-upload"]')) {
+      const uploadid = parseInt(el.dataset.uploadid, 10);
+      ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive}).then(() => reloadElement('filesdiv'));
+
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -35,6 +35,10 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue((bool) Check::id($new));
         $this->Experiments->setId($new);
         $this->Experiments->canOrExplode('write');
+        // test archive too
+        $this->assertIsArray($this->Experiments->patch(Action::Archive, array()));
+        // two times to test unarchive branch
+        $this->assertIsArray($this->Experiments->patch(Action::Archive, array()));
         $this->Experiments->toggleLock();
         $this->Experiments->destroy();
         $Templates = new Templates($this->Users);


### PR DESCRIPTION
With these changes:

* Users can Archive/Unarchive an experiment or database item

![2023-06-12-142445_1920x1080_scrot](https://github.com/elabftw/elabftw/assets/3043706/aa39784d-691f-4c39-8541-224db2a29a0e)


* An archived entry will not get listed, unless the "Show archived" box is checked in the filters:

![2023-06-12-142428_306x82_scrot](https://github.com/elabftw/elabftw/assets/3043706/538f74dc-7349-44b9-940e-f1f3b09aba15)

* A message is shown to users:
![2023-06-12-142533_569x95_scrot](https://github.com/elabftw/elabftw/assets/3043706/eef521a4-d4f4-40a9-8f00-fb18777c8f68)

* Uploaded files can also be archived, and a new icon allow toggling their visibility:

![2023-06-12-142635_1920x1080_scrot](https://github.com/elabftw/elabftw/assets/3043706/3349f849-4fc9-4ffa-8d90-ec5ecb41b4e3)

(the background color will be slightly different from non archived uploads, too)
![2023-06-12-142651_468x307_scrot](https://github.com/elabftw/elabftw/assets/3043706/f140de74-59b4-4622-8a01-f7f5e239f91e)

