### PR TITLE
New Sysadmin features

### DIFF
--- a/src/Auth/External.php
+++ b/src/Auth/External.php
@@ -54,7 +54,11 @@ class External implements AuthInterface
             // the user doesn't exist yet in the db
             // what do we do? Lookup the config setting for that case
             if ($this->configArr['saml_user_default'] === '0') {
-                throw new ImproperActionException('Could not find an existing user. Ask a Sysadmin to create your account.');
+                $msg = _('Could not find an existing user. Ask a Sysadmin to create your account.');
+                if ($this->configArr['user_msg_need_local_account_created']) {
+                    $msg = $this->configArr['user_msg_need_local_account_created'];
+                }
+                throw new ImproperActionException($msg);
             }
             // CREATE USER (and force validation of user)
             $Users = ValidatedUser::fromExternal($email, $teams, $firstname, $lastname);

--- a/src/Auth/Ldap.php
+++ b/src/Auth/Ldap.php
@@ -63,7 +63,11 @@ class Ldap implements AuthInterface
             // the user doesn't exist yet in the db
             // what do we do? Lookup the config setting for that case
             if ($this->configArr['saml_user_default'] === '0') {
-                throw new ImproperActionException('Could not find an existing user. Ask a Sysadmin to create your account.');
+                $msg = _('Could not find an existing user. Ask a Sysadmin to create your account.');
+                if ($this->configArr['user_msg_need_local_account_created']) {
+                    $msg = $this->configArr['user_msg_need_local_account_created'];
+                }
+                throw new ImproperActionException($msg);
             }
             // GET FIRSTNAME AND LASTNAME
             $firstname = $record[$this->configArr['ldap_firstname']][0] ?? 'Unknown';

--- a/src/Auth/Saml.php
+++ b/src/Auth/Saml.php
@@ -295,7 +295,11 @@ class Saml implements AuthInterface
             // the user doesn't exist yet in the db
             // what do we do? Lookup the config setting for that case
             if ($this->configArr['saml_user_default'] === '0') {
-                throw new ImproperActionException('Could not find an existing user. Ask a Sysadmin to create your account.');
+                $msg = _('Could not find an existing user. Ask a Sysadmin to create your account.');
+                if ($this->configArr['user_msg_need_local_account_created']) {
+                    $msg = $this->configArr['user_msg_need_local_account_created'];
+                }
+                throw new ImproperActionException($msg);
             }
 
             // now try and get the teams

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -69,6 +69,7 @@ final class Config implements RestInterface
             ('login_tries', '3'),
             ('mail_from', 'notconfigured@example.com'),
             ('proxy', ''),
+            ('user_msg_need_local_account_created', ''),
             ('smtp_address', 'mail.smtp2go.com'),
             ('smtp_encryption', 'ssl'),
             ('smtp_password', ''),

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -102,6 +102,11 @@ class Users implements RestInterface
 
         $isSysadmin = $group === 1 ? 1 : 0;
 
+        // transform group in 2 if it is 1 because users2teams.groups_id is 2 or 4, not 1
+        if ($group === 1) {
+            $group = 2;
+        }
+
         // will new user be validated?
         $validated = $Config->configArr['admin_validate'] && ($group === 4) ? 0 : 1;
         if ($forceValidation) {

--- a/src/services/Email.php
+++ b/src/services/Email.php
@@ -146,7 +146,7 @@ class Email
      */
     private function getAllEmails(string $targetType, ?int $targetId): array
     {
-        $select = 'SELECT email, CONCAT(firstname, " ", lastname) AS fullname FROM users';
+        $select = 'SELECT DISTINCT email, CONCAT(firstname, " ", lastname) AS fullname FROM users';
         switch($targetType) {
             case 'team':
                 $join = 'CROSS JOIN users2teams ON (users2teams.users_id = users.userid)';
@@ -155,6 +155,14 @@ class Email
             case 'teamgroup':
                 $join = 'CROSS JOIN users2team_groups ON (users2team_groups.userid = users.userid)';
                 $filter = 'AND users2team_groups.groupid = :id';
+                break;
+            case 'admins':
+                $join = 'CROSS JOIN users2teams ON (users2teams.users_id = users.userid)';
+                $filter = 'AND users2teams.groups_id = 2';
+                break;
+            case 'sysadmins':
+                $join = '';
+                $filter = 'AND users.is_sysadmin = 1';
                 break;
             default:
                 $join = '';

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -30,7 +30,11 @@ class TeamsHelper
      */
     public function getGroup(): int
     {
-        if ($this->isFirstUser() || $this->isFirstUserInTeam()) {
+        if ($this->isFirstUser()) {
+            return 1;
+        }
+
+        if ($this->isFirstUserInTeam()) {
             return 2;
         }
         return 4;

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -30,11 +30,7 @@ class TeamsHelper
      */
     public function getGroup(): int
     {
-        if ($this->isFirstUser()) {
-            return 1;
-        }
-
-        if ($this->isFirstUserInTeam()) {
+        if ($this->isFirstUser() || $this->isFirstUserInTeam()) {
             return 2;
         }
         return 4;

--- a/src/sql/schema123-down.sql
+++ b/src/sql/schema123-down.sql
@@ -1,3 +1,3 @@
 -- revert schema 123
-
+DELETE FROM config WHERE conf_name = 'user_msg_need_local_account_created';
 UPDATE config SET conf_value = 122 WHERE conf_name = 'schema';

--- a/src/sql/schema123-down.sql
+++ b/src/sql/schema123-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 123
+
+UPDATE config SET conf_value = 122 WHERE conf_name = 'schema';

--- a/src/sql/schema123.sql
+++ b/src/sql/schema123.sql
@@ -1,0 +1,3 @@
+-- schema 123
+UPDATE users2teams SET groups_id = 2 WHERE groups_id = 1;
+UPDATE config SET conf_value = 123 WHERE conf_name = 'schema';

--- a/src/sql/schema123.sql
+++ b/src/sql/schema123.sql
@@ -1,3 +1,4 @@
 -- schema 123
 UPDATE users2teams SET groups_id = 2 WHERE groups_id = 1;
+INSERT INTO config (conf_name, conf_value) VALUES ('user_msg_need_local_account_created', '');
 UPDATE config SET conf_value = 123 WHERE conf_name = 'schema';

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -31,6 +31,11 @@
             <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeArchived') ? 'checked="checked"' }} name='includeArchived'>{{ 'Include archived'|trans }}
           </div>
         </div>
+        <div class='input-group-append'>
+          <div class='input-group-text'>
+            <input type='checkbox' class='mr-1' {{ App.Request.query.has('onlyAdmins') ? 'checked="checked"' }} name='onlyAdmins'>{{ 'Show only Admins'|trans }}
+          </div>
+        </div>
       </div>
     </form>
   </div>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -27,7 +27,7 @@
           <button class='btn btn-secondary' id='editusersShowAll' type='button'>{{ 'Show all'|trans }}</button>
         </div>
         <div class='input-group-append'>
-          <div class="input-group-text">
+          <div class='input-group-text'>
             <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeArchived') ? 'checked="checked"' }} name='includeArchived'>{{ 'Include archived'|trans }}
           </div>
         </div>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -132,10 +132,9 @@
             <div class='input-group mr-1'>
               <div class='input-group-prepend'>
                 <div class='input-group-text'>
-                  <input id='showArchivedBox' type='checkbox' {{ App.Request.query.get('archived') == 'on' ? 'checked' }} name='archived' aria-label='{{ 'Show archived'|trans }}'>
+                  <input type='checkbox' {{ App.Request.query.get('archived') == 'on' ? 'checked' }} name='archived' class='mr-1' aria-label='{{ 'Show archived'|trans }}'>{{ 'Show archived'|trans }}
                 </div>
               </div>
-              <label for='showArchivedBox' class='input-group-text brl-none'>{{ 'Show archived'|trans }}</label>
             </div>
 
             <button class='btn btn-primary'>{{ 'Go'|trans }}</button>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -278,7 +278,20 @@
 
   <!-- MASS EMAIL -->
   <h3 class='p-2 pl-3 section-title'>{{ 'Send a Mass Email'|trans }}</h3>
-  <div class='pl-3 mt-2 mb-5'>
+  <div class='pl-3 mt-2 mb-5' id='massEmailDiv'>
+    <label>{{ 'Send to'|trans }}</label>
+
+    <div class='form-check'>
+      <input class='form-check-input' type='radio' name='target' value='all' id='targetAll' checked> <label class='form-check-label' for='targetAll'>{{ 'All active users'|trans }}</label>
+    </div>
+
+    <div class='form-check'>
+      <input class='form-check-input' type='radio' name='target' value='admins' id='targetAdmins'> <label class='form-check-label' for='targetAdmins'>{{ 'All active admins'|trans }}</label>
+    </div>
+
+    <div class='form-check'>
+      <input class='form-check-input' type='radio' name='target' value='sysadmins' id='targetSysadmins'> <label class='form-check-label' for='targetSysadmins'>{{ 'All active sysadmins'|trans }}</label>
+    </div>
     <label for='massSubject' class='col-form-label'>{{ 'Email Subject'|trans }}</label>
     <input class='form-control col-md-12' type='text' id='massSubject' size='45' />
 

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -142,6 +142,12 @@
     {% include 'binary-setting.html' with {'label': 'Enable local account creation'|trans, 'slug': 'local_register'} %}
     {% include 'binary-setting.html' with {'label': 'Admins can create local accounts'|trans, 'slug': 'admins_create_users'} %}
     {% include 'binary-setting.html' with {'label': 'Show local login form'|trans, 'slug': 'local_login', 'help': 'You can still show the local login form by appending ?letmein to the login page URL.'|trans } %}
+
+    <div class='d-flex justify-content-between'>
+      <label for='user_msg_need_local_account_created' class='col-form-label'>{{ 'Message shown to user after successful external auth but local account provisioning is required'|trans }}</label>
+      <input class='form-control col-md-3' data-trigger='blur' data-model='config' data-target='user_msg_need_local_account_created' type='text' autocomplete='off' value='{{ App.Config.configArr.user_msg_need_local_account_created }}' id='user_msg_need_local_account_created' />
+    </div>
+    <hr>
   </div>
 
   <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Remote directory configuration'|trans }}</h3>

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -191,6 +191,8 @@ document.addEventListener('DOMContentLoaded', () => {
         { 'testemailSend': '1', 'email': email }).then(resp => handleEmailResponse(resp, button));
     // MASS MAIL
     } else if (el.matches('[data-action="send-mass-email"]')) {
+      const massEmailDiv = document.getElementById('massEmailDiv');
+      const targetRadio = (massEmailDiv.querySelector('input[name="target"]:checked') as HTMLInputElement);
       const button = (el as HTMLButtonElement);
       button.disabled = true;
       button.innerText = 'Sending…';
@@ -198,7 +200,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const body = (document.getElementById('massBody') as HTMLInputElement).value;
       AjaxC.postForm(
         'app/controllers/SysconfigAjaxController.php',
-        { 'massEmail': '1', 'subject': subject, 'body': body }).then(resp => handleEmailResponse(resp, button));
+        { massEmail: '1', subject: subject, body: body, target: targetRadio.value }).then(resp => handleEmailResponse(resp, button));
     } else if (el.matches('[data-action="create-idp"]')) {
       const params = collectForm(document.getElementById('createIdpForm'));
       ApiC.post(Model.Idp, params).then(() => {

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -32,6 +32,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
             'extauth_teams' => 'auth_team',
             'saml_team_default' => '1',
             'saml_user_default' => '1',
+            'user_msg_need_local_account_created' => '',
         );
         $this->serverParams = array(
             'auth_firstname' => 'Phpunit',

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -54,7 +54,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $authResponse->userid);
         $this->assertFalse($authResponse->isAnonymous);
         $this->assertEquals(1, $authResponse->selectedTeam);
-        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 1, 'is_owner' => 0));
+        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 2, 'is_owner' => 0));
         $this->assertEquals($teams, $authResponse->selectableTeams);
     }
 

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -32,7 +32,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
             'extauth_teams' => 'auth_team',
             'saml_team_default' => '1',
             'saml_user_default' => '1',
-            'user_msg_need_local_account_created' => '',
+            'user_msg_need_local_account_created' => 'yep',
         );
         $this->serverParams = array(
             'auth_firstname' => 'Phpunit',

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -62,6 +62,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
             'saml_user_default' => '0',
             'saml_fallback_orgid' => '0',
             'saml_sync_email_idp' => '0',
+            'user_msg_need_local_account_created' => '',
         );
 
         // don't use the real saml lib but create a mock

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -62,7 +62,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
             'saml_user_default' => '0',
             'saml_fallback_orgid' => '0',
             'saml_sync_email_idp' => '0',
-            'user_msg_need_local_account_created' => '',
+            'user_msg_need_local_account_created' => 'yep',
         );
 
         // don't use the real saml lib but create a mock

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -59,6 +59,8 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(16, $this->Email->massEmail('instance', null, '', 'yep'));
         $this->assertEquals(7, $this->Email->massEmail('team', 1, 'Important message', 'yep'));
         $this->assertEquals(0, $this->Email->massEmail('teamgroup', 1, 'Important message', 'yep'));
+        $this->assertEquals(6, $this->Email->massEmail('admins', null, 'Important message to admins', 'yep'));
+        $this->assertEquals(1, $this->Email->massEmail('sysadmins', null, 'Important message to sysadmins', 'yep'));
     }
 
     public function testSendEmail(): void

--- a/tests/unit/services/UsersHelperTest.php
+++ b/tests/unit/services/UsersHelperTest.php
@@ -35,7 +35,7 @@ class UsersHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTeamsFromUserid(): void
     {
-        $expected = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 1, 'is_owner' => 0));
+        $expected = array(array('id' => 1, 'name' => 'Alpha', 'usergroup' => 2, 'is_owner' => 0));
         $this->assertEquals($expected, $this->UsersHelper->getTeamsFromUserid());
     }
 

--- a/web/admin.php
+++ b/web/admin.php
@@ -72,6 +72,7 @@ try {
             filter_var($Request->query->get('q'), FILTER_SANITIZE_STRING),
             $App->Users->userData['team'],
             $App->Request->query->getBoolean('includeArchived'),
+            $App->Request->query->getBoolean('onlyAdmins'),
         );
         foreach ($usersArr as &$user) {
             $UsersHelper = new UsersHelper((int) $user['userid']);

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -51,7 +51,7 @@ try {
 
     // SEND MASS EMAIL
     if ($Request->request->has('massEmail')) {
-        $Email->massEmail('instance', null, $Request->request->getString('subject'), $Request->request->getString('body'));
+        $Email->massEmail($Request->request->getString('target'), null, $Request->request->getString('subject'), $Request->request->getString('body'));
     }
 
     // DESTROY IDP

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -64,6 +64,7 @@ try {
             filter_var($App->Request->query->get('q'), FILTER_SANITIZE_STRING),
             (int) filter_var($App->Request->query->get('teamFilter'), FILTER_SANITIZE_NUMBER_INT),
             $App->Request->query->getBoolean('includeArchived'),
+            $App->Request->query->getBoolean('onlyAdmins'),
         );
         foreach ($usersArr as &$user) {
             $UsersHelper = new UsersHelper((int) $user['userid']);


### PR DESCRIPTION
* Allow Sysadmin or Admin to filter Admins on the users tab:

![2023-06-13-175750_1920x1080_scrot](https://github.com/elabftw/elabftw/assets/3043706/47c4b2e4-1d16-47a5-989f-1a700c48de4f)

* Allow Sysadmin to target different user levels for Mass Email function:

![2023-06-13-175938_343x403_scrot](https://github.com/elabftw/elabftw/assets/3043706/de4cdeb7-ac32-4c46-954a-64d442d54ee9)

* Allow Sysadmin to customize the error message sent to a user that authenticated successfully with an External auth provider (LDAP/SAML/External) but needs pre-provisioning of their (local) account beforehand.

![2023-06-13-180141_1124x84_scrot](https://github.com/elabftw/elabftw/assets/3043706/3ff5b8bd-bd83-4af9-811d-47eb702eb487)

