### PR TITLE
Consolidate test data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             sed -i 's/elab.local:3148/elabtmp/g' tests/docker-compose.yml
             sed -i 's/elab.local/elabtmp/g' tests/docker-compose.yml
             sed -i 's/elab.local:3148/elabtmp/g' cypress.config.ts
-            sed -i 's/elab.local:3148/elabtmp/g' tests/populate-config.yml
+            sed -i 's/elab.local:3148/elabtmp/g' src/tests/populate-config.yml.dist
       - run:
           name: Build elabtmp image and start containers
           command: |
@@ -114,7 +114,7 @@ jobs:
           command: docker exec -it elabtmp bin/init db:install -r
       - run:
           name: Populate the database
-          command: docker exec -it elabtmp bin/console dev:populate tests/populate-config.yml
+          command: docker exec -it elabtmp bin/console dev:populate src/tests/populate-config.yml.dist
       - run:
           name: Fix permissions
           command: |
@@ -142,7 +142,7 @@ jobs:
           command: docker cp elabtmp:/elabftw/phpdoc-html phpdoc-html
       - run:
           name: Reset database
-          command: docker exec -it elabtmp bin/console dev:populate tests/populate-config.yml
+          command: docker exec -it elabtmp bin/console dev:populate src/tests/populate-config.yml.dist
       - run:
           name: Fix permissions
           command: |
@@ -158,8 +158,8 @@ jobs:
           command: |
             docker exec -it elab-cypress cypress run
             cypressExitCode=$?
-            docker cp elab-cypress:/home/node/tests/cypress/screenshots cypress/screenshots
-            docker cp elab-cypress:/home/node/tests/cypress/videos cypress/videos
+            docker cp elab-cypress:/home/node/tests/cypress/screenshots/. cypress/screenshots
+            docker cp elab-cypress:/home/node/tests/cypress/videos/. cypress/videos
             exit "$cypressExitCode"
       - store_artifacts:
           path: phpdoc-html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             sed -i 's/elab.local:3148/elabtmp/g' tests/docker-compose.yml
             sed -i 's/elab.local/elabtmp/g' tests/docker-compose.yml
             sed -i 's/elab.local:3148/elabtmp/g' cypress.config.ts
-            sed -i 's/elab.local:3148/elabtmp/g' src/tests/populate-config.yml.dist
+            sed -i 's/elab.local:3148/elabtmp/g' src/tools/populate-config.yml.dist
       - run:
           name: Build elabtmp image and start containers
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           command: docker exec -it elabtmp bin/init db:install -r
       - run:
           name: Populate the database
-          command: docker exec -it elabtmp bin/console dev:populate src/tests/populate-config.yml.dist
+          command: docker exec -it elabtmp bin/console dev:populate src/tools/populate-config.yml.dist
       - run:
           name: Fix permissions
           command: |
@@ -142,7 +142,7 @@ jobs:
           command: docker cp elabtmp:/elabftw/phpdoc-html phpdoc-html
       - run:
           name: Reset database
-          command: docker exec -it elabtmp bin/console dev:populate src/tests/populate-config.yml.dist
+          command: docker exec -it elabtmp bin/console dev:populate src/tools/populate-config.yml.dist
       - run:
           name: Fix permissions
           command: |

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   fixturesFolder: 'tests/cypress/fixtures',
   screenshotsFolder: 'tests/cypress/screenshots',
   videosFolder: 'tests/cypress/videos',
+  //videoCompression: false,
+  viewportWidth: 1440,
+  viewportHeight: 900,
   e2e: {
     setupNodeEvents(on, config) {
       return require('./tests/cypress/plugins/index.js')(on, config)

--- a/src/tools/populate-config.yml.dist
+++ b/src/tools/populate-config.yml.dist
@@ -11,7 +11,7 @@
 # Copy this file to populate-config.yml and edit it if needed
 
 # set to true to skip confirmation
-skip_confirm: false
+skip_confirm: true
 
 # put some config options that fit with a dev env
 # so we don't have to put them back in again after a populate command
@@ -29,7 +29,8 @@ config:
   ldap_username: cn=admin,dc=example,dc=org
   # increase this a bit
   login_tries: 10
-
+  # the url of the dev install
+  url: "https://elab.local:3148"
 
 teams:
   - name: Alpha
@@ -44,6 +45,7 @@ teams:
 # unless a password is set here
 users:
   - email: toto@yopmail.com
+    password: totototo
     firstname: Toto
     lastname: Le sysadmin
     team: Alpha

--- a/src/tools/populate-config.yml.dist
+++ b/src/tools/populate-config.yml.dist
@@ -49,6 +49,7 @@ users:
     firstname: Toto
     lastname: Le sysadmin
     team: Alpha
+    orgid: internal_id_1
     api_key: apiKey4Test
     create_experiments: true
     create_items: true
@@ -70,7 +71,7 @@ users:
     create_mfa_secret: true
 
   - email: demo@elabftw.net
-    password: demodemo
+    password: testPassword
     team: Alpha
     create_experiments: true
     create_templates: false
@@ -82,6 +83,11 @@ users:
     create_templates: true
 
   - team: Bravo
+
+  - email: somesamluser@example.com
+    team: Bravo
+    create_experiments: false
+    orgid: internal_id_42
 
   - team: Charlie
 

--- a/tests/cypress/integration/admin_items_types.cy.js
+++ b/tests/cypress/integration/admin_items_types.cy.js
@@ -2,17 +2,28 @@ describe('Items Types', () => {
   beforeEach(() => {
     cy.login()
   })
+  const newname = 'New test item type'
 
-  it('Create and delete an item type', () => {
-    const newname = 'New test item type'
+  it('Create an item type', () => {
     cy.visit('/admin.php?tab=5')
+    cy.intercept('POST', '/api/v2/items_types', req => {
+      req.on('before:response', res => {
+          expect(res.statusCode).to.equal(201)
+          expect(res.headers.location).to.include('templateid=10')
+      })
+    })
     cy.window().then(win => {
       cy.stub(win, 'prompt').returns(newname)
       cy.get('[data-action="itemstypes-create"]').click()
     })
-    cy.url().should('contains', 'templateid')
+    cy.visit('/admin.php?tab=5&templateid=10')
     cy.get('#itemsTypesName').should('have.value', newname)
+  });
+
+  it('Delete an item type', () => {
+    cy.visit('/admin.php?tab=5&templateid=10')
     cy.get('[data-action="itemstypes-destroy"]').click()
     cy.url().should('contains', 'tab=5')
+    cy.get('[data-table="items_types"]').get('#itemstypes_10').should('not.exist');
   });
 });

--- a/tests/cypress/integration/entity.cy.js
+++ b/tests/cypress/integration/entity.cy.js
@@ -28,9 +28,9 @@ describe('Experiments', () => {
     cy.get('[title="View mode"]').click()
     cy.get('#commentsCreateArea').type('This is a very nice experiment')
     cy.get('[data-action="create-comment"]').click()
-    cy.contains('Phpunit TestUser commented').should('be.visible')
+    cy.contains('Toto Le Sysadmin commented').should('be.visible')
     cy.get('[data-action="destroy-comment"]').click()
-    cy.contains('Phpunit TestUser commented').should('not.exist')
+    cy.contains('Toto Le Sysadmin commented').should('not.exist')
     // go back in edit mode for destroy action
     cy.get('[title="Edit"]').click()
   }

--- a/tests/cypress/integration/entity.cy.js
+++ b/tests/cypress/integration/entity.cy.js
@@ -28,9 +28,9 @@ describe('Experiments', () => {
     cy.get('[title="View mode"]').click()
     cy.get('#commentsCreateArea').type('This is a very nice experiment')
     cy.get('[data-action="create-comment"]').click()
-    cy.contains('Toto Le Sysadmin commented').should('be.visible')
+    cy.contains('Toto Le sysadmin commented').should('be.visible')
     cy.get('[data-action="destroy-comment"]').click()
-    cy.contains('Toto Le Sysadmin commented').should('not.exist')
+    cy.contains('Toto Le sysadmin commented').should('not.exist')
     // go back in edit mode for destroy action
     cy.get('[title="Edit"]').click()
   }

--- a/tests/cypress/integration/login.cy.js
+++ b/tests/cypress/integration/login.cy.js
@@ -9,5 +9,8 @@ describe('Logging in', () => {
 
     // {enter} causes the form to submit
     cy.get('input[name=password]').type(`${password}{enter}`);
+    cy.getCookie('token').should('exist').then(cookie => {
+      expect(cookie.value).to.match(/^[0-9a-fA-F]{64}$/)
+    })
   });
 });

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -19,4 +19,39 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('before:browser:launch', (browser = {}, launchOptions) => {
+    console.log(
+      'launching browser %s is headless? %s',
+      browser.name,
+      browser.isHeadless,
+    )
+
+    // the browser width and height we want to get
+    // our screenshots and videos will be of that resolution
+    const width = 1920
+    const height = 1080
+
+    console.log('setting the browser window size to %d x %d', width, height)
+
+    if (browser.name === 'chrome' && browser.isHeadless) {
+      launchOptions.args.push(`--window-size=${width},${height}`)
+
+      // force screen to be non-retina and just use our given resolution
+      launchOptions.args.push('--force-device-scale-factor=1')
+    }
+
+    if (browser.name === 'electron' && browser.isHeadless) {
+      // might not work on CI for some reason
+      launchOptions.preferences.width = width
+      launchOptions.preferences.height = height
+    }
+
+    if (browser.name === 'firefox' && browser.isHeadless) {
+      launchOptions.args.push(`--width=${width}`)
+      launchOptions.args.push(`--height=${height}`)
+    }
+
+    // IMPORTANT: return the updated browser launch options
+    return launchOptions
+  })
 }

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -25,8 +25,8 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('login', () => {
-  const email = 'phpunit@example.com';
-  const password = 'phpunitftw';
+  const email = 'toto@yopmail.com';
+  const password = 'totototo';
   cy.request('/login.php')
     .its('body')
     .then((body) => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -62,7 +62,7 @@ const inExperiments = () => {
   cy.getCookie('token').should('exist');
   cy.getCookie('token_team').should('exist');
   // UI should reflect this user being logged in
-  cy.get('h6').should('contain', 'Phpunit');
+  cy.get('h6').should('contain', 'Toto');
 }
 
 /**

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -62,7 +62,7 @@ if ($ci); then
     docker exec -it elabtmp yarn static
 fi
 # populate the database
-docker exec -it elabtmp bin/console dev:populate tests/populate-config.yml
+docker exec -it elabtmp bin/console dev:populate src/tools/populate-config.yml.dist
 # RUN TESTS
 if ($ci); then
     # fix permissions on test output and cache folders
@@ -85,8 +85,8 @@ elif [ "${1:-}" = "cy" ]; then
     docker exec -it elab-cypress cypress run
     # copy the artifacts in cypress output folder
     mkdir -p tests/cypress/{videos,screenshots}
-    docker cp elab-cypress:/home/node/tests/cypress/videos ./tests/cypress/videos
-    docker cp elab-cypress:/home/node/tests/cypress/screenshots ./tests/cypress/screenshots
+    docker cp elab-cypress:/home/node/tests/cypress/videos/. ./tests/cypress/videos
+    docker cp elab-cypress:/home/node/tests/cypress/screenshots/. ./tests/cypress/screenshots
 else
     docker exec -it elabtmp php vendor/bin/codecept run --coverage --coverage-html --coverage-xml
 fi

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -36,7 +36,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
         );
         $this->serverParams = array(
             'auth_firstname' => 'Toto',
-            'auth_lastname' => 'Le Sysadmin',
+            'auth_lastname' => 'Le sysadmin',
             'auth_email' => 'toto@yopmail.com',
             'auth_team' => 'Alpha',
         );

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -35,9 +35,9 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
             'user_msg_need_local_account_created' => 'yep',
         );
         $this->serverParams = array(
-            'auth_firstname' => 'Phpunit',
-            'auth_lastname' => 'FTW',
-            'auth_email' => 'phpunit@example.com',
+            'auth_firstname' => 'Toto',
+            'auth_lastname' => 'Le Sysadmin',
+            'auth_email' => 'toto@yopmail.com',
             'auth_team' => 'Alpha',
         );
         $this->log = new Logger('elabftw');

--- a/tests/unit/Auth/LdapTest.php
+++ b/tests/unit/Auth/LdapTest.php
@@ -32,8 +32,8 @@ class LdapTest extends \PHPUnit\Framework\TestCase
             'hosts' => array('127.0.0.1'),
             'port' => 389,
             'base_dn' => $configArr['ldap_base_dn'],
-            'username' => 'phpunit',
-            'password' => 'phpunitftw',
+            'username' => 'toto',
+            'password' => 'totototo',
             'use_tls' => false,
         );
         $fake = new LdapFake();
@@ -43,7 +43,7 @@ class LdapTest extends \PHPUnit\Framework\TestCase
         ));
         $connection = new ConnectionFake($ldapConfig, $fake);
 
-        $this->AuthService = new Ldap($connection, new Entry(), $configArr, 'phpunit@example.com', 'phpunitftw');
+        $this->AuthService = new Ldap($connection, new Entry(), $configArr, 'toto@yopmail.com', 'totototo');
     }
 
     public function testTryAuth(): void

--- a/tests/unit/Auth/LdapTest.php
+++ b/tests/unit/Auth/LdapTest.php
@@ -32,7 +32,7 @@ class LdapTest extends \PHPUnit\Framework\TestCase
             'hosts' => array('127.0.0.1'),
             'port' => 389,
             'base_dn' => $configArr['ldap_base_dn'],
-            'username' => 'toto',
+            'username' => 'Toto',
             'password' => 'totototo',
             'use_tls' => false,
         );

--- a/tests/unit/Auth/LocalTest.php
+++ b/tests/unit/Auth/LocalTest.php
@@ -18,13 +18,13 @@ class LocalTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->AuthService = new Local('phpunit@example.com', 'phpunitftw');
+        $this->AuthService = new Local('toto@yopmail.com', 'totototo');
     }
 
     public function testEmptyPassword(): void
     {
         $this->expectException(QuantumException::class);
-        new Local('phpunit@example.com', '');
+        new Local('toto@yopmail.com', '');
     }
 
     public function testTryAuth(): void
@@ -42,7 +42,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
 
     public function testTryAuthWithInvalidPassword(): void
     {
-        $AuthService = new Local('phpunit@example.com', 'nopenope');
+        $AuthService = new Local('toto@yopmail.com', 'nopenope');
         $this->expectException(InvalidCredentialsException::class);
         $AuthService->tryAuth();
     }
@@ -52,7 +52,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->AuthService::isMfaEnforced(1, 3));
         $this->assertTrue($this->AuthService::isMfaEnforced(1, 1));
         $this->assertFalse($this->AuthService::isMfaEnforced(4, 1));
-        $this->assertTrue($this->AuthService::isMfaEnforced(4, 2));
+        $this->assertTrue($this->AuthService::isMfaEnforced(5, 2));
         $this->assertFalse($this->AuthService::isMfaEnforced(4, 0));
     }
 }

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -75,8 +75,8 @@ class SamlTest extends \PHPUnit\Framework\TestCase
 
         // create fake saml idp response
         $this->samlUserdata = array();
-        $this->samlUserdata['User.email'] = 'phpunit@example.com';
-        $this->samlUserdata['User.firstname'] = 'Phpunit';
+        $this->samlUserdata['User.email'] = 'toto@yopmail.com';
+        $this->samlUserdata['User.firstname'] = 'Toto';
         $this->samlUserdata['User.lastname'] = 'FTW';
         $this->samlUserdata['User.team'] = 'Alpha';
         $this->SamlAuthLib->method('getAttributes')->willReturn($this->samlUserdata);
@@ -182,7 +182,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
     public function testAssertIdpResponseEmailArrayResponse(): void
     {
         $samlUserdata = $this->samlUserdata;
-        $samlUserdata['User.email'] = array('phpunit@example.com');
+        $samlUserdata['User.email'] = array('toto@yopmail.com');
 
         $authResponse = $this->getAuthResponse($samlUserdata);
         $this->assertEquals(1, $authResponse->selectedTeam);
@@ -234,7 +234,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
         $config['saml_sync_email_idp'] = '1';
 
         $authResponse = $this->getAuthResponse($samlUserdata, $config);
-        $this->assertEquals(5, $authResponse->userid);
+        $this->assertEquals(7, $authResponse->userid);
     }
 
     /**

--- a/tests/unit/commands/CommandsTest.php
+++ b/tests/unit/commands/CommandsTest.php
@@ -33,7 +33,7 @@ class CommandsTest extends \PHPUnit\Framework\TestCase
         // use NullHandler because we don't care about logs here
         $Logger->pushHandler(new NullHandler());
         $MockMailer = $this->createMock(MailerInterface::class);
-        $this->Email = new Email($MockMailer, $Logger, 'phpunit@example.net');
+        $this->Email = new Email($MockMailer, $Logger, 'toto@yopmail.com');
     }
 
     public function testCheckTsBalance(): void

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -92,7 +92,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue($this->Users->isAdminOf(1));
         $this->assertTrue($this->Users->isAdminOf(2));
-        $this->assertFalse($this->Users->isAdminOf(4));
+        $this->assertFalse($this->Users->isAdminOf(5));
         $tata = new Users(4, 2);
         $this->assertFalse($tata->isAdminOf(2));
     }
@@ -133,19 +133,19 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     public function testUpdatePassword(): void
     {
         $Users = new Users(4, 2, new Users(4, 2));
-        $this->assertIsArray($Users->patch(Action::UpdatePassword, array('password' => 'newPassw0rd', 'current_password' => 'testPassword')));
+        $this->assertIsArray($Users->patch(Action::UpdatePassword, array('password' => 'demodemo', 'current_password' => 'testPassword')));
     }
 
     public function testResetPassword(): void
     {
         $Users = new Users(4, 2, new Users(4, 2));
-        $this->assertTrue($Users->resetPassword('newPassw0rd'));
+        $this->assertTrue($Users->resetPassword('demodemo'));
     }
 
     public function testUpdatePasswordAsSysadmin(): void
     {
         $Users = new Users(4, 2, new Users(1, 1));
-        $this->assertIsArray($Users->patch(Action::UpdatePassword, array('password' => 'newPassw0rd')));
+        $this->assertIsArray($Users->patch(Action::UpdatePassword, array('password' => 'demodemo')));
     }
 
     public function testTryToBecomeSysadmin(): void
@@ -169,8 +169,8 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     public function testToggleArchive(): void
     {
         // tata in bravo
-        $Admin = new Users(4, 2);
-        $Users = new Users(5, 2, $Admin);
+        $Admin = new Users(5, 2);
+        $Users = new Users(6, 2, $Admin);
         $this->assertIsArray($Users->patch(Action::Lock, array()));
     }
 
@@ -187,8 +187,8 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     public function testUnArchiveButAnotherUserExists(): void
     {
         // this user is archived already
-        $Admin = new Users(4, 2);
-        $Users = new Users(5, 2, $Admin);
+        $Admin = new Users(5, 2);
+        $Users = new Users(6, 2, $Admin);
         // create another active user with the same email
         ExistingUser::fromScratch($Users->userData['email'], array('Alpha'), 'f', 'l', 4, false, false);
         // try to unarchive
@@ -198,12 +198,12 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     public function testReadAllActiveFromTeam(): void
     {
-        $this->assertCount(6, $this->Users->readAllActiveFromTeam());
+        $this->assertCount(7, $this->Users->readAllActiveFromTeam());
     }
 
     public function testDestroy(): void
     {
-        $Admin = new Users(4, 2);
+        $Admin = new Users(5, 2);
         $id = $Admin->createOne('testdestroy@a.fr', array('Bravo'), 'Life', 'isShort', 'yololololol', 4, false, false);
         $Target = new Users($id, 2, $Admin);
         $this->assertTrue($Target->destroy());

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -44,7 +44,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $query = ' TEST TEST1 AND TEST2 OR TEST3 NOT TEST4 & TEST5';
         $query .= ' | TEST6 AND ! TEST7 (TEST8 or TEST9) "T E S T 1 0"';
         $query .= ' \'T E S T 1 1\' "chinese 汉语 漢語 中文" "japanese 日本語 ひらがな 平仮名 カタカナ 片仮名"';
-        $query .= ' attachment:0 author:"Phpunit TestUser" body:"some text goes here"';
+        $query .= ' attachment:0 author:"Toto Le sysadmin" body:"some text goes here"';
         $query .= ' elabid:7bebdd3512dc6cbee0b1 locked:yes rating:5 rating:unrated';
         $query .= ' status:"only meaningful with experiments but no error"';
         $query .= ' timestamped: timestamped:true title:"very cool experiment" visibility:%owner';

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -30,7 +30,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         // use NullHandler because we don't care about logs here
         $this->Logger->pushHandler(new NullHandler());
         $MockMailer = $this->createMock(MailerInterface::class);
-        $this->Email = new Email($MockMailer, $this->Logger, 'phpunit@example.net');
+        $this->Email = new Email($MockMailer, $this->Logger, 'toto@yopmail.com');
     }
 
     public function testTestemailSend(): void
@@ -58,8 +58,8 @@ class EmailTest extends \PHPUnit\Framework\TestCase
     public function testMassEmail(): void
     {
         $replyTo = new Address('sender@example.com', 'Sergent Garcia');
-        $this->assertEquals(16, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
-        $this->assertEquals(7, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
+        $this->assertEquals(17, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
+        $this->assertEquals(8, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(0, $this->Email->massEmail(EmailTarget::TeamGroup, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(6, $this->Email->massEmail(EmailTarget::Admins, null, 'Important message to admins', 'yep', $replyTo));
         $this->assertEquals(1, $this->Email->massEmail(EmailTarget::Sysadmins, null, 'Important message to sysadmins', 'yep', $replyTo));

--- a/tests/unit/services/ResetPasswordKeyTest.php
+++ b/tests/unit/services/ResetPasswordKeyTest.php
@@ -30,7 +30,7 @@ class ResetPasswordKeyTest extends \PHPUnit\Framework\TestCase
 
     public function testValidate(): void
     {
-        $key = $this->ResetPasswordKey->generate('phpunit@example.com');
+        $key = $this->ResetPasswordKey->generate('toto@yopmail.com');
 
         $Users = $this->ResetPasswordKey->validate($key);
         $this->assertInstanceOf(Users::class, $Users);
@@ -51,7 +51,7 @@ class ResetPasswordKeyTest extends \PHPUnit\Framework\TestCase
 
     public function testValidateExpiredKey(): void
     {
-        $key = $this->ResetPasswordKey->generate('phpunit@example.com');
+        $key = $this->ResetPasswordKey->generate('toto@yopmail.com');
 
         $ResetPasswordKey = new ResetPasswordKey(time() + 1337, $this->secretKey);
         $this->expectException(ImproperActionException::class);

--- a/web/app/controllers/ResetPasswordController.php
+++ b/web/app/controllers/ResetPasswordController.php
@@ -91,7 +91,7 @@ try {
 
         // log the IP for the sysadmin to know who requested it
         // it's also good to keep a trace of such requests
-        $App->Log->info(sprintf('Password reset was requested'), array('email' => $email));
+        $App->Log->info('Password reset was requested', array('email' => $email));
         // show the same message as if the email didn't exist in the db
         // this is done to prevent information disclosure
         throw new QuantumException(_('If the account exists, an email has been sent.'));


### PR DESCRIPTION
Hi Nico,

We talked about the consolidation of the fake demo/dev and test data (https://github.com/elabftw/elabftw/pull/4484#issuecomment-1647596873).
Still need to remove the populate.yml from tests folder but the tests all pass now (again).

I also increased the resolution of the videos created by cypress so one can actually see errors. Maybe we want to run the cypress tests twice, one run for desktop screens and one run for mobile screens?