### PR TITLE
Remove `format: date-time`

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -25,7 +25,6 @@ components:
           type: string
         created_at:
           type: string
-          format: date-time
         hash:
           type: string
         can_write:
@@ -37,7 +36,6 @@ components:
           type: integer
         created_at:
           type: string
-          format: date-time
         item_id:
           type: integer
         comment:
@@ -46,7 +44,6 @@ components:
           type: integer
         modified_at:
           type: string
-          format: date-time
         fullname:
           type: string
         firstname:
@@ -272,7 +269,6 @@ components:
           description: How the body is stored. 1 for HTML, 2 for Markdown. If you plan on creating an entity with markdown, make sure to set it to 2.
         created_at:
           type: string
-          format: date-time
         date:
           type: string
         elabid:
@@ -305,7 +301,6 @@ components:
           type: string
         modified_at:
           type: string
-          format: date-time
         next_step:
           type: string
         orcid:
@@ -502,7 +497,6 @@ components:
           type: integer
         created_at:
           type: string
-          format: date-time
         userid:
           type: integer
         send_email:
@@ -526,7 +520,6 @@ components:
           type: integer
         created_at:
           type: string
-          format: date-time
         userid:
           type: integer
         metadata:
@@ -593,7 +586,6 @@ components:
           type: string
         created_at:
           type: string
-          format: date-time
         orgid:
           type: string
         public_db:
@@ -678,7 +670,6 @@ components:
           type: string
         created_at:
           type: string
-          format: date-time
         hash:
           type: string
         hash_algorithm:
@@ -2551,11 +2542,9 @@ paths:
                        type: integer
                      last_login:
                        type: string
-                       format: date-time
                        nullable: true
                      valid_until:
                        type: string
-                       format: date-time
                        nullable: true
                      is_sysadmin:
                        type: integer
@@ -2748,7 +2737,6 @@ paths:
                     type: integer
                   created_at:
                     type: string
-                    format: date-time
                   userid:
                     type: integer
     delete:
@@ -3409,7 +3397,6 @@ paths:
                       type: integer
                     created_at:
                       type: string
-                      format: date-time
                     fullname:
                       type: string
   /{entity_type}/{id}/revisions/{subid}:


### PR DESCRIPTION
Fixes #4542 

This PR remove `format: date-time` that was added in [`32b8b4a`](https://github.com/elabftw/elabftw/commit/32b8b4a067244e1668db43ace11ddb5e48c9a95e#diff-b19a313603d9d6db27db6f8650c81e4e30294de8272980e03c530778bc678b87). This will result in date-time type outputs (e.g., `last_login`) to be pure strings.

## Rationale

date-time like fields from API response already converted in`datetime.datetime` object should make things more convenient. However, that is not the case. Consider the following use-case:
```py
api_configuration = elabapi_python.Configuration()
# then other parameters like token, url are defined

# client handler object
api_client = elabapi_python.ApiClient(api_configuration)
```
Now we inspect one user from the default response of list of all users:
```py
>>> elabapi_python.UsersApi(api_client).read_users()[0]  # first index (user) of the returned list
{'archived': 0,
 'auth_service': 10,
 'email': '<email>',
 'firstname': 'John',
 'fullname': 'John Doe',
 'is_sysadmin': 1,
 'last_login': datetime.datetime(2023, 7, 6, 9, 4, 43),  # <-- Python datetime.datetime
 'lastname': 'Doe',
 'orcid': None,
 'orgid': None,
 'userid': 8,
 'valid_until': None,
 'validated': 1}
```
This user output contains `'last_login'` which is a `datetime.datetime`. Now if we wish to save the output as JSON, or serialize it to some other data format, or try to access one of its keys, we get `TypeError`.
```py
>>> json.dumps(elabapi_python.UsersApi(api_client).read_users()[0])
TypeError: Object of type InlineResponse2005 is not JSON serializable
```
```py
>>> elabapi_python.UsersApi(api_client).read_users()[0]["fullname"]
TypeError: 'InlineResponse2005' object is not subscriptable
```
The obvious reason is `elabapi_python` returns a very custom object. And it's not so easily convertible to hash map types like Python dictionaries, defeating the purpose of having `datetime.datetime` object in the output. 
```py
>>> elabapi_python.UsersApi(api_client).read_users()[0].__class__
<class 'elabapi_python.models.inline_response2005.InlineResponse2005'>
>>> elabapi_python.UsersApi(api_client).read_users()[0].__class__.__class__
<class 'type'>  # I was expecting something from urllib3 or dict
>>> elabapi_python.UsersApi(api_client).read_user(id=<user id>).__class__
<class 'elabapi_python.models.users.Users'>
```

We can try to convert the output to strings, and then to `dict` through `ast`.
```py
>>> import ast
>>> data = elabapi_python.UsersApi(api_client).read_users()[0]
>>> ast.literal_eval(str(data))
ValueError: malformed node or string on line 7: <ast.Call object at 0x105941d80>
```
We get this error because `ast` [can't](https://docs.python.org/3/library/ast.html#ast.literal_eval) (and shouldn't) parse the `datetime.datetime` object in `last_login`. This error with `ast` doesn't occur with `elabapi-python` v0.2.4 because the date-times are strings.

The **bottom line** is the more custom (like `datetime.datetime`) the response is the more loops we have to go through to properly be able to use/serialize the response. The more string-like the response the easier it is to dump it into a parser and have the data structured.

**Note:** Swagger generated `elabapi-python` uses `urllib3` to make and get the responses. In general, it is possible to ask `urllib3` to return specific types of data (like `JSON`) so it is easily serializable. However, as far as I have looked `elabapi-python` doesn't provide that option. I could be wrong, and then of course that would solve the problem if it did. I.e., if the following was possible:
```py
>>> elabapi_python.UsersApi(api_client).read_users().json() # <-- .json()
# so the all fields are in JSON-ready format which is possible from most Python HTTP-client libraries
```
In fact, this would be a much **better solution** than removing `format: date-time`. 

### Further improvement

If this PR is considered, I'd be also willing to add an example to `elabapi-python` explaining how to get Python `datetime.datetime` from string data for users looking for `datetime.datetime`.


Thank you for reading and all the hard work making elabftw!