### PR TITLE
Allow linking to experiments/users/resources from Extra Fields

### DIFF
--- a/src/classes/TwigFilters.php
+++ b/src/classes/TwigFilters.php
@@ -71,6 +71,10 @@ class TwigFilters
             $final .= sprintf("<h4 data-action='toggle-next' class='mt-4 d-inline togglable-section-title'><i class='fas fa-caret-down fa-fw mr-2'></i>%s</h4>", $group['name']);
             $final .= '<div>';
             foreach ($group['extra_fields'] as $field) {
+                $newTab = 'target="_blank" rel="noopener"';
+                if (($field['open_in_current_tab'] ?? false) === true) {
+                    $newTab = '';
+                }
                 $description = isset($field[MetadataEnum::Description->value])
                     ? sprintf('<span class="smallgray">%s</span>', $field[MetadataEnum::Description->value])
                     : '';
@@ -82,11 +86,13 @@ class TwigFilters
                 }
                 // url is another special case
                 if ($field[MetadataEnum::Type->value] === 'url') {
-                    $newTab = 'target="_blank" rel="noopener"';
-                    if (($field['open_in_current_tab'] ?? false) === true) {
-                        $newTab = '';
-                    }
                     $value = '<a href="' . $value . '" ' . $newTab . '>' . $value . '</a>';
+                }
+                // exp/items is another special case
+                if (in_array($field[MetadataEnum::Type->value], array('experiments', 'items'), true)) {
+                    $id = (int) $field[MetadataEnum::Value->value];
+                    $page = $field[MetadataEnum::Type->value] === 'items' ? 'database' : 'experiments';
+                    $value = sprintf("<a href='%s.php?mode=view&id=%d' %s>%s</a>", $page, $id, $newTab, $value);
                 }
 
                 // multi select will be an array

--- a/src/classes/TwigFilters.php
+++ b/src/classes/TwigFilters.php
@@ -92,7 +92,7 @@ class TwigFilters
                 if (in_array($field[MetadataEnum::Type->value], array('experiments', 'items'), true)) {
                     $id = (int) $field[MetadataEnum::Value->value];
                     $page = $field[MetadataEnum::Type->value] === 'items' ? 'database' : 'experiments';
-                    $value = sprintf("<a href='%s.php?mode=view&id=%d' %s>%s</a>", $page, $id, $newTab, $value);
+                    $value = sprintf("<a href='/%s.php?mode=view&id=%d' %s>%s</a>", $page, $id, $newTab, $value);
                 }
 
                 // multi select will be an array

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -163,7 +163,7 @@
     <div class='input-group'>
       <input type='text' id='teamGroupCreate' class='form-control' placeholder='{{ 'Add a group'|trans }}' aria-label='{{ 'Add a group'|trans }}'>
       <div class='input-group-append'>
-        <button class='btn btn-primary' data-action='create-teamgroup' data-teamid='{{ App.Users.userData.team }}' type='button'>{{ 'Create'|trans }}</button>
+        <button class='btn btn-primary' data-action='create-teamgroup' type='button'>{{ 'Create'|trans }}</button>
       </div>
     </div>
     <!-- END CREATE GROUP -->
@@ -178,11 +178,11 @@
           <a class='clickable teamGroupDelete float-right' data-id='{{ teamGroup.id }}' title='{{ 'Delete'|trans }}'>
             <i class='fas fa-trash-alt'></i>
           </a>
-          <h5><i class='fas fa-users'></i> <span data-teamid='{{ App.Users.userData.team }}' data-id='{{ teamGroup.id }}' class='malleableTeamgroupName hl-hover'>{{ teamGroup.name|raw }}</span></h5>
+          <h5><i class='fas fa-users'></i> <span data-id='{{ teamGroup.id }}' class='malleableTeamgroupName hl-hover'>{{ teamGroup.name|raw }}</span></h5>
           <hr>
           <div class='d-flex flex-wrap'>
             {% for user in teamGroup.users %}
-            <div class='user-badge rounded px-2 py-1 mr-2 mt-2'>{{ user.fullname|raw }} <span title='{{ 'Delete'|trans }}' class='clickable rmUserFromGroup m-1' data-user='{{ user.userid }}' data-teamid='{{ App.Users.userData.team }}' data-group='{{ teamGroup.id }}'><i class='fas fa-xmark' style='color:#29AEB9' ></i></span></div>
+            <div class='user-badge rounded px-2 py-1 mr-2 mt-2'>{{ user.fullname|raw }} <span title='{{ 'Delete'|trans }}' class='clickable rmUserFromGroup m-1' data-user='{{ user.userid }}' data-group='{{ teamGroup.id }}'><i class='fas fa-xmark' style='color:#29AEB9' ></i></span></div>
             {% endfor %}
           </div>
           <!-- ADD USER -->
@@ -192,7 +192,7 @@
             </div>
             <input type='text' class='form-control' data-complete-target='users' placeholder='{{ 'User name'|trans }}' aria-label='{{ 'User name'|trans }}'>
             <div class='input-group-append'>
-              <button class='btn btn-primary' data-action='adduser-teamgroup' data-teamid='{{ App.Users.userData.team }}' data-groupid='{{ teamGroup.id }}' type='button'>{{ 'Add user'|trans }}</button>
+              <button class='btn btn-primary' data-action='adduser-teamgroup' data-groupid='{{ teamGroup.id }}' type='button'>{{ 'Add user'|trans }}</button>
             </div>
           </div>
         </div>
@@ -245,11 +245,11 @@
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ cat.id }}' class='btn btn-primary' data-teamid='{{ App.Users.userData.team }}' data-target='expcat' data-action='update-status'>{{ 'Save'|trans }}</button>
+              <button data-id='{{ cat.id }}' class='btn btn-primary' data-target='expcat' data-action='update-status'>{{ 'Save'|trans }}</button>
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ cat.id }}' data-teamid='{{ App.Users.userData.team }}' data-target='experiments_categories' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
+              <button data-id='{{ cat.id }}' data-target='experiments_categories' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
             </li>
           </ul>
         </li>
@@ -361,11 +361,11 @@
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ status.id }}' class='btn btn-primary' data-teamid='{{ App.Users.userData.team }}' data-target='experiments' data-action='update-status'>{{ 'Save'|trans }}</button>
+              <button data-id='{{ status.id }}' class='btn btn-primary' data-target='experiments' data-action='update-status'>{{ 'Save'|trans }}</button>
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ status.id }}' data-teamid='{{ App.Users.userData.team }}' data-target='experiments_status' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
+              <button data-id='{{ status.id }}' data-target='experiments_status' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
             </li>
           </ul>
         </li>
@@ -408,11 +408,11 @@
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ status.id }}' class='btn btn-primary' data-teamid='{{ App.Users.userData.team }}' data-target='items' data-action='update-status'>{{ 'Save'|trans }}</button>
+              <button data-id='{{ status.id }}' class='btn btn-primary' data-target='items' data-action='update-status'>{{ 'Save'|trans }}</button>
             </li>
 
             <li class='list-inline-item'>
-              <button data-id='{{ status.id }}' data-teamid='{{ App.Users.userData.team }}' data-target='items_status' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
+              <button data-id='{{ status.id }}' data-target='items_status' data-action='destroy-catstat' class='btn btn-danger' >{{ 'Delete'|trans }}</button>
             </li>
           </ul>
         </li>
@@ -516,7 +516,7 @@
     <div class='input-group'>
       <input type='text' id='adminAddTagInput' class='form-control' placeholder='{{ 'Add a tag'|trans }}' aria-label='{{ 'Add a tag'|trans }}'>
       <div class='input-group-append'>
-        <button class='btn btn-primary' data-action='admin-add-tag' data-teamid='{{ App.Users.userData.team }}' type='button'>{{ 'Save'|trans }}</button>
+        <button class='btn btn-primary' data-action='admin-add-tag' type='button'>{{ 'Save'|trans }}</button>
       </div>
     </div>
   </div>

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -190,7 +190,7 @@
             <div class='input-group-prepend'>
               <span class='input-group-text'><i class='fas fa-magnifying-glass'></i></span>
             </div>
-            <input type='text' class='form-control autocompleteUsers' placeholder='{{ 'User name'|trans }}' aria-label='{{ 'User name'|trans }}'>
+            <input type='text' class='form-control' data-complete-target='users' placeholder='{{ 'User name'|trans }}' aria-label='{{ 'User name'|trans }}'>
             <div class='input-group-append'>
               <button class='btn btn-primary' data-action='adduser-teamgroup' data-teamid='{{ App.Users.userData.team }}' data-groupid='{{ teamGroup.id }}' type='button'>{{ 'Add user'|trans }}</button>
             </div>

--- a/src/templates/edit-tags.html
+++ b/src/templates/edit-tags.html
@@ -9,7 +9,7 @@
           <a class='tag margin-1px hover-danger {{ loop.last ? 'mr-2' }} {{ tag.is_favorite ? 'favorite' }}' data-action='unreference-tag' data-tagid='{{ tag.tag_id }}'>{{ tag.tag|raw }}</a>
         {%- endfor -%}
       </div>
-      <input type='text' id='createTagInput' data-teamid='{{ App.Users.userData.team }}' data-autocomplete='tags' class='createTagInput form-control' placeholder='{{ 'Add a tag'|trans }}' />
+      <input type='text' id='createTagInput' data-autocomplete='tags' class='createTagInput form-control' placeholder='{{ 'Add a tag'|trans }}' />
     </div>
   </div>
   <div class='d-flex mb-2 align-items-center mathjax-ignore'>

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -45,9 +45,9 @@
               <option value='time'>{{ 'Time'|trans }}</option>
               <option value='checkbox'>{{ 'Checkbox'|trans }}</option>
               <option value='number'>{{ 'Number'|trans }}</option>
-              <option value='experiments'>{{ 'Experiments'|trans }}</option>
-              <option value='items'>{{ 'Resources'|trans }}</option>
-              <option value='users'>{{ 'Users'|trans }}</option>
+              <option value='experiments'>{{ 'Experiment'|trans }}</option>
+              <option value='items'>{{ 'Resource'|trans }}</option>
+              <option value='users'>{{ 'User'|trans }}</option>
               <option value='url'>URL</option>
             </select>
 

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -45,6 +45,9 @@
               <option value='time'>{{ 'Time'|trans }}</option>
               <option value='checkbox'>{{ 'Checkbox'|trans }}</option>
               <option value='number'>{{ 'Number'|trans }}</option>
+              <option value='experiments'>{{ 'Experiments'|trans }}</option>
+              <option value='items'>{{ 'Resources'|trans }}</option>
+              <option value='users'>{{ 'Users'|trans }}</option>
               <option value='url'>URL</option>
             </select>
 

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -74,7 +74,7 @@
           </ul>
           <!-- add user to permissions input -->
           <div id='autocompleteUsersDiv{{ identifier }}' class='input-group'>
-            <input id='{{ identifier }}_select_users' data-identifier='{{ identifier }}' class='form-control autocompleteUsers autocompleteUsersPermissions' placeholder='{{ 'Add user'|trans }}' autocomplete='off'>
+            <input id='{{ identifier }}_select_users' data-identifier='{{ identifier }}' data-complete-target='users' class='form-control' placeholder='{{ 'Add user'|trans }}' autocomplete='off'>
             <div class='input-group-append'>
               <button class='btn btn-primary' data-rw='{{ rw }}' data-identifier='{{ identifier }}' data-action='add-user-to-permissions'>{{ 'Add'|trans }}</button>
             </div>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -46,7 +46,7 @@
   </div>
 
   {# TITLE #}
-  <h1 id='documentTitle' class='mb-4 title text-dark'>
+  <h1 id='documentTitle' class='mb-4 title text-dark malleableColumn hl-hover-gray py-1 rounded' data-target='title' data-endpoint='{{ Entity.type }}' data-id='{{ Entity.id }}'>
     {{ Entity.entityData.title|raw }}
   </h1>
 

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -118,7 +118,7 @@
 
 <hr>
 
-<!-- METADATA view -->
+{# METADATA view #}
 {% if Entity.entityData.metadata %}
   <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Extra fields'|trans }}</h3>
   <div class='mt-2 col-md-6' id='extraFieldsDiv' data-save-hidden='extraFieldsDiv'>

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -328,6 +328,26 @@ export class Metadata {
       return inputGroupDiv;
     }
 
+    // USERS/EXPERIMENTS/ITEMS input have a prepend to the input with a magnifying glass
+    if ([ExtraFieldInputType.Users, ExtraFieldInputType.Experiments, ExtraFieldInputType.Items].includes(properties.type)) {
+      // set the target for autocomplete function
+      element.dataset.completeTarget = properties.type;
+      const inputGroupDiv = document.createElement('div');
+      inputGroupDiv.classList.add('input-group');
+      const prependDiv = document.createElement('div');
+      prependDiv.classList.add('input-group-prepend');
+      const icon = document.createElement('i');
+      icon.classList.add('fas', 'fa-magnifying-glass');
+      const iconWrapper = document.createElement('span');
+      iconWrapper.classList.add('input-group-text');
+      iconWrapper.appendChild(icon);
+      prependDiv.appendChild(iconWrapper);
+      inputGroupDiv.appendChild(prependDiv);
+      inputGroupDiv.appendChild(element);
+
+      return inputGroupDiv;
+    }
+
     return element;
   }
 

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -7,7 +7,6 @@
  */
 import { notif, notifError, reloadElement, updateCatStat } from './misc';
 import $ from 'jquery';
-import 'jquery-ui/ui/widgets/autocomplete';
 import { Malle } from '@deltablot/malle';
 import i18next from 'i18next';
 import { MdEditor } from './Editor.class';

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
   $('#team_groups_div').on('click', '.rmUserFromGroup', function() {
     const user = $(this).data('user');
     const group = $(this).data('group');
-    ApiC.patch(`${Model.Team}/${$(this).data('teamid')}/${Model.TeamGroup}/${group}`, {'how': Action.Unreference, 'userid': user}).then(() => reloadElement('team_groups_div'));
+    ApiC.patch(`${Model.Team}/me/${Model.TeamGroup}/${group}`, {'how': Action.Unreference, 'userid': user}).then(() => reloadElement('team_groups_div'));
   });
 
   // edit the team group name
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     inputClasses: ['form-control'],
     formClasses: ['mb-3'],
     fun: async (value, original) => {
-      return ApiC.patch(`${Model.Team}/${original.dataset.teamid}/${Model.TeamGroup}/${original.dataset.id}`, {'name': value})
+      return ApiC.patch(`${Model.Team}/me/${Model.TeamGroup}/${original.dataset.id}`, {'name': value})
         .then(resp => resp.json()).then(json => json.name);
     },
     listenOn: '.malleableTeamgroupName',
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // CREATE TEAM GROUP
     } else if (el.matches('[data-action="create-teamgroup"]')) {
       const input = (document.getElementById('teamGroupCreate') as HTMLInputElement);
-      ApiC.post(`${Model.Team}/${input.dataset.teamid}/${Model.TeamGroup}`, {'name': input.value}).then(() => {
+      ApiC.post(`${Model.Team}/me/${Model.TeamGroup}`, {'name': input.value}).then(() => {
         reloadElement('team_groups_div');
         input.value = '';
       });
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
         notifError(new Error('Use the autocompletion menu to add users.'));
         return;
       }
-      ApiC.patch(`${Model.Team}/${el.dataset.teamid}/${Model.TeamGroup}/${el.dataset.groupid}`, {'how': Action.Add, 'userid': user}).then(() => reloadElement('team_groups_div'));
+      ApiC.patch(`${Model.Team}/me/${Model.TeamGroup}/${el.dataset.groupid}`, {'how': Action.Add, 'userid': user}).then(() => reloadElement('team_groups_div'));
     // CREATE STATUSLIKE
     } else if (el.matches('[data-action="create-statuslike"]')) {
       const holder = el.parentElement.parentElement;
@@ -143,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
         nameInput.style.borderColor = 'red';
         return;
       }
-      ApiC.post(`${Model.Team}/${el.dataset.teamid}/${el.dataset.target}`, {'name': name, 'color': colorInput.value}).then(() => {
+      ApiC.post(`${Model.Team}/me/${el.dataset.target}`, {'name': name, 'color': colorInput.value}).then(() => {
         $(`#create${el.dataset.target}Modal`).modal('hide');
         // clear the name
         nameInput.value = '';
@@ -167,11 +167,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const color = (holder.querySelector('input[type="color"]') as HTMLInputElement).value;
       const isDefault = (holder.querySelector('input[type="radio"]') as HTMLInputElement).checked;
       const params = {'title': title, 'color': color, 'is_default': Boolean(isDefault)};
-      ApiC.patch(`${Model.Team}/${el.dataset.teamid}/${target}/${id}`, params);
+      ApiC.patch(`${Model.Team}/me/${target}/${id}`, params);
     // DESTROY CATEGORY/STATUS
     } else if (el.matches('[data-action="destroy-catstat"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
-        ApiC.delete(`${Model.Team}/${el.dataset.teamid}/${el.dataset.target}/${el.dataset.id}`).then(() => reloadElement(`${el.dataset.target}Div`));
+        ApiC.delete(`${Model.Team}/me/${el.dataset.target}/${el.dataset.id}`).then(() => reloadElement(`${el.dataset.target}Div`));
       }
     // EXPORT CATEGORY
     } else if (el.matches('[data-action="export-category"]')) {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -255,7 +255,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // AUTOCOMPLETE
     } else if (el.matches('[data-complete-target]')) {
       // depending on the type of results, we will want different attributes and formatting
-      let transformer = entity => `${entity.id} - ${entity.mainattr_title} - ${entity.title}`;
+      let transformer = entity => {
+        const cat = entity.category_title ? `${entity.category_title} - ` : '';
+        const stat = entity.status_title ? `${entity.status_title} - ` : '';
+        return `${entity.id} - ${cat}${stat}${entity.title}`;
+      };
+      // useid data attribute is used in admin panel to grab the userid from input
       if (el.dataset.completeTarget === 'users') {
         transformer = user => `${user.userid} - ${user.fullname} (${user.email})`;
       }

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -176,25 +176,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // AUTOCOMPLETE input with users
-  $(document).on('focus', '.autocompleteUsers', function() {
-    if (!$(this).data('autocomplete')) {
-      $(this).autocomplete({
-        // necessary or the autocomplete will get under the modal
-        appendTo: '#autocompleteUsersDiv' + $(this).data('identifier'),
-        source: function(request: Record<string, string>, response: (data) => void): void {
-          ApiC.getJson(`${Model.User}/?q=${request.term}`).then(json => {
-            const res = [];
-            json.forEach(user => {
-              res.push(`${user.userid} - ${user.fullname} (${user.email})`);
-            });
-            response(res);
-          });
-        },
-      });
-    }
-  });
-
   /**
    * Make sure the icon for toggle-next is correct depending on the stored state in localStorage
    */
@@ -269,6 +250,24 @@ document.addEventListener('DOMContentLoaded', () => {
       document.documentElement.scrollTo({
         top: 0,
         behavior: 'smooth',
+      });
+
+    // AUTOCOMPLETE
+    } else if (el.matches('[data-complete-target]')) {
+      // depending on the type of results, we will want different attributes and formatting
+      let transformer = entity => `${entity.id} - ${entity.mainattr_title} - ${entity.title}`;
+      if (el.dataset.completeTarget === 'users') {
+        transformer = user => `${user.userid} - ${user.fullname} (${user.email})`;
+      }
+      // use autocomplete jquery-ui plugin
+      $(el).autocomplete({
+        // this option is necessary or the autocomplete box will get lost under the permissions modal
+        appendTo: el.dataset.identifier ? `#autocompleteUsersDiv${el.dataset.identifier}` : '',
+        source: function(request: Record<string, string>, response: (data: Array<string>) => void): void {
+          ApiC.getJson(`${el.dataset.completeTarget}/?q=${request.term}`).then(json => {
+            response(json.map(entry => transformer(entry)));
+          });
+        },
       });
 
     // TRANSFER OWNERSHIP

--- a/src/ts/metadataInterfaces.ts
+++ b/src/ts/metadataInterfaces.ts
@@ -20,11 +20,15 @@ export enum ExtraFieldInputType {
   Date = 'date',
   DateTime = 'datetime-local',
   Email = 'email',
+  Experiments = 'experiments',
   Number = 'number',
   Radio = 'radio',
+  Items = 'items',
   Select = 'select',
   Text = 'text',
   Time = 'time',
+  Uploads = 'uploads',
+  Users = 'users',
   Url = 'url',
 }
 


### PR DESCRIPTION
Implement request in #3857 

in this PR:

* allow creating extra fields of type 'users', 'experiments' or 'items'. It generates a field with autocomplete on users, experiments or resources. After selection, a string with the ID and title/name is saved.
* admin panel: remove the data-teamid on some elements because it is not needed as we can use `me` to target current team
* improve the autocompletion code by making it easier to add to an input, and make it work all the time by using a data-action
* make the title malleable, so editable in view mode

Uploads might come later.
