### PR TITLE
add possibility for sysadmin to disable 2fa for a user

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2942,10 +2942,16 @@ paths:
                       type: integer
                       description: ID of the team
                 - type: object
+                  description: Disable 2FA (requires Sysadmin privilege or acting on ourself)
+                  properties:
+                    action:
+                      enum: ['disable2fa']
+                      type: string
+                - type: object
                   description: Change the password
                   properties:
                     action:
-                      const: 'updatepassword'
+                      enum: ['updatepassword']
                       type: string
                     current_password:
                       type: string

--- a/src/enums/Action.php
+++ b/src/enums/Action.php
@@ -18,6 +18,7 @@ enum Action: string
     case Create = 'create';
     case CreateFromString = 'createfromstring';
     case Deduplicate = 'deduplicate';
+    case Disable2fa = 'disable2fa';
     case Duplicate = 'duplicate';
     case Lock = 'lock';
     case Finish = 'finish';

--- a/src/models/ApiKeys.php
+++ b/src/models/ApiKeys.php
@@ -57,18 +57,19 @@ class ApiKeys implements RestInterface
      * Create a known key so we can test against it in dev mode
      * This function should only be called from the db:populate command
      */
-    public function createKnown(string $apiKey): void
+    public function createKnown(string $apiKey): int
     {
         $hash = password_hash($apiKey, PASSWORD_BCRYPT);
 
         $sql = 'INSERT INTO api_keys (name, hash, can_write, userid, team) VALUES (:name, :hash, :can_write, :userid, :team)';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':name', 'test key');
+        $req->bindValue(':name', 'known key used for tests');
         $req->bindParam(':hash', $hash);
         $req->bindValue(':can_write', 1, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $this->Db->execute($req);
+        return $this->Db->lastInsertId();
     }
 
     /**

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -42,7 +42,7 @@
 </div>
 
 {% if isSearching %}
-  <div id='editUsersBox'>
+  <div>
     <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Users list'|trans }}</h3>
     <div class='pl-3'>
       {% if usersArr %}
@@ -124,7 +124,8 @@
               <th scope='col'>{{ 'Actions'|trans }}</th>
             </tr>
           </thead>
-          <tbody>
+          {# this is the element to reload after a change, don't use the full div so we keep the js working in table headers #}
+          <tbody id='editUsersBox'>
             {% for user in usersArr %}
               <tr {{ user.archived ? "class='bg-medium'" }}>
                 <td><span title='{{ 'User ID'|trans }}' class='badge badge-secondary {{ user.archived ? 'alert-danger' }}'>{{ user.userid }}</span></td>
@@ -181,13 +182,13 @@
                       </div>
                     </div>
                   {% endif %}
+                  {# MORE OPTIONS MENU #}
                   <div class='dropdown'>
                     <div class='clickable p-2 hl-hover-gray text-center rounded' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}' role='button'>
                       <i class='fas fa-ellipsis-v'></i>
                     </div>
-                    {# Archive user #}
                     <div class='dropdown-menu dropdown-menu-right' aria-label='{{ 'More options'|trans }}'>
-                      {# Manage teams #}
+                      {# MANAGE TEAMS #}
                       {% if App.Users.userData.is_sysadmin and (App.Request.getScriptName|split('/')|last == 'sysconfig.php') %}
                         <div class='dropdown-item' data-action='toggle-modal' data-target='manageUsers2teamsModal_{{ user.userid }}'>
                           <i class='mr-1 fas fa-pencil fa-fw'></i>{{ 'Manage teams for user'|trans }}
@@ -207,6 +208,13 @@
                           </div>
                         {% endif %}
                       {% endif %}
+                      {# DISABLE 2FA: only for sysadmin if user has 2fa enabled #}
+                      {% if user.mfa_secret and App.Users.userData.is_sysadmin %}
+                        <div class='dropdown-item' data-action='remove-user-2fa' data-userid='{{ user.userid }}'>
+                          <i class='fas fa-fw fa-user-shield mr-1'></i>{{ 'Disable 2FA'|trans }}
+                        </div>
+                      {% endif %}
+                      {# ARCHIVE USER #}
                       {% if user.archived %}
                         <div class='dropdown-item' data-action='toggle-archive-user' data-userid='{{ user.userid }}'>
                           <i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Unarchive user'|trans }}

--- a/src/tools/populate-config.yml.dist
+++ b/src/tools/populate-config.yml.dist
@@ -80,6 +80,7 @@ users:
     create_experiments: true
     create_items: true
     create_templates: true
+    api_key: apiKey4Test_tata
 
   - team: Bravo
 

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -50,6 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="update-user"]')) {
       ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElement('editUsersBox'));
 
+    // REMOVE 2FA
+    } else if (el.matches('[data-action="remove-user-2fa"]')) {
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Disable2fa}).then(() => reloadElement('editUsersBox'));
+
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
       const group = el.dataset.promote === '1' ? 2 : 4;

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -61,6 +61,7 @@ enum Action {
   Archive = 'archive',
   Bloxberg = 'bloxberg',
   Deduplicate = 'deduplicate',
+  Disable2fa = 'disable2fa',
   Duplicate = 'duplicate',
   Lock = 'lock',
   PatchUser2Team = 'patchuser2team',

--- a/tests/apiv2/UsersCest.php
+++ b/tests/apiv2/UsersCest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * @package   Elabftw\Elabftw
+ * @author    Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @see       https://www.elabftw.net Official website
+ */
+
+use \Codeception\Util\HttpCode;
+
+class UsersCest
+{
+    public function _before(Apiv2Tester $I)
+    {
+        $I->haveHttpHeader('Authorization', 'apiKey4Test');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+    }
+
+    public function disableMfaTest(Apiv2Tester $I)
+    {
+        $I->wantTo('Disable mfa for a user');
+        // this user doesn't have 2fa but it's okay
+        $I->sendPATCH('/users/2');
+        $I->seeResponseCodeIs(HttpCode::OK); // 200
+        $I->seeResponseIsJson();
+    }
+
+    public function illegalDisableMfaTest(Apiv2Tester $I)
+    {
+        $I->haveHttpHeader('Authorization', 'apiKey4Test_tata');
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->wantTo('Disable mfa for a user but we should not be able to');
+        $I->sendPATCH('/users/2');
+        $I->seeResponseCodeIs(HttpCode::FORBIDDEN); // 403
+        $I->seeResponseIsJson();
+    }
+}

--- a/tests/apiv2/UsersCest.php
+++ b/tests/apiv2/UsersCest.php
@@ -8,6 +8,7 @@
  */
 
 use \Codeception\Util\HttpCode;
+use Elabftw\Enums\Action;
 
 class UsersCest
 {
@@ -21,17 +22,17 @@ class UsersCest
     {
         $I->wantTo('Disable mfa for a user');
         // this user doesn't have 2fa but it's okay
-        $I->sendPATCH('/users/2');
+        $I->sendPATCH('/users/2', array('action' => Action::Disable2fa->value));
         $I->seeResponseCodeIs(HttpCode::OK); // 200
         $I->seeResponseIsJson();
     }
 
     public function illegalDisableMfaTest(Apiv2Tester $I)
     {
+        // use Tata (Bravo team Admin) to try and disable 2fa for another user in their team
         $I->haveHttpHeader('Authorization', 'apiKey4Test_tata');
-        $I->haveHttpHeader('Content-Type', 'application/json');
         $I->wantTo('Disable mfa for a user but we should not be able to');
-        $I->sendPATCH('/users/2');
+        $I->sendPATCH('/users/6', array('action' => Action::Disable2fa->value));
         $I->seeResponseCodeIs(HttpCode::FORBIDDEN); // 403
         $I->seeResponseIsJson();
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -64,9 +64,6 @@ docker exec -it elabtmp mkdir -p cache/purifier/{HTML,CSS,URI} cache/{elab,mpdf,
 worker_user=$(docker exec -it elabtmp tail -n1 /etc/shadow |awk -F ":" '{print $1}')
 docker exec -it elabtmp chown -R "$worker_user":"$worker_user" cache
 
-# install the database
-echo "Initializing the database..."
-docker exec -it elabtmp bin/init db:install -r -q
 if ($ci); then
     docker exec -it elabtmp yarn static
 fi

--- a/tests/unit/models/ApiKeysTest.php
+++ b/tests/unit/models/ApiKeysTest.php
@@ -21,9 +21,12 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
         $this->ApiKeys = new ApiKeys(new Users(1, 1));
     }
 
-    public function testCreate(): void
+    public function testCreateAndDestroy(): void
     {
-        $this->assertIsInt($this->ApiKeys->postAction(Action::Create, array('name' => 'test key', 'canwrite' => 1)));
+        $id = $this->ApiKeys->postAction(Action::Create, array('name' => 'test key', 'canwrite' => 1));
+        $this->assertIsInt($id);
+        $this->ApiKeys->setId($id);
+        $this->assertTrue($this->ApiKeys->destroy());
     }
 
     public function testPatch(): void
@@ -48,6 +51,10 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
     {
         $this->ApiKeys->createKnown('phpunit');
         $this->assertIsArray($this->ApiKeys->readFromApiKey('phpunit'));
+    }
+
+    public function testInvalidKey(): void
+    {
         $this->expectException(ImproperActionException::class);
         $this->ApiKeys->readFromApiKey('unknown key');
     }
@@ -56,13 +63,7 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
     {
         $res = $this->ApiKeys->readAll();
         $this->assertIsArray($res);
-        $this->assertSame('test key', $res[1]['name']);
+        $this->assertSame('known key used for tests', $res[1]['name']);
         $this->assertSame(1, $res[1]['can_write']);
-    }
-
-    public function testDestroy(): void
-    {
-        $this->ApiKeys->setId(2);
-        $this->assertTrue($this->ApiKeys->destroy());
     }
 }

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -43,6 +43,17 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->Users->readAllFromTeam());
     }
 
+    public function testDisable2fa(): void
+    {
+        $this->assertIsArray($this->Users->patch(Action::Disable2fa, array()));
+    }
+
+    public function testIllegalDisable2fa(): void
+    {
+        $this->expectException(IllegalActionException::class);
+        (new Users(2, 1, new Users(3, 1)))->patch(Action::Disable2fa, array());
+    }
+
     public function testUpdateAccount(): void
     {
         $params = array(

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -43,17 +43,6 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->Users->readAllFromTeam());
     }
 
-    public function testDisable2fa(): void
-    {
-        $this->assertIsArray($this->Users->patch(Action::Disable2fa, array()));
-    }
-
-    public function testIllegalDisable2fa(): void
-    {
-        $this->expectException(IllegalActionException::class);
-        (new Users(2, 1, new Users(3, 1)))->patch(Action::Disable2fa, array());
-    }
-
     public function testUpdateAccount(): void
     {
         $params = array(


### PR DESCRIPTION
fix #4486

* implemented through a PATCH /users/ID Action: disable2fa
* also make the editusers listing be reloaded on the rows so table sorting header is not affected
