### PR TITLE
Use correct helper class in apiv2 test suite

### DIFF
--- a/tests/apiv2.suite.yml
+++ b/tests/apiv2.suite.yml
@@ -9,7 +9,7 @@ coverage:
       allow_self_signed: true
 modules:
     enabled:
-        - \Helper\Api
+        - \Helper\Apiv2
         - REST:
             url: https://elabtmp/api/v2/
             depends: PhpBrowser


### PR DESCRIPTION
I don't understand why it fixes the coverage of `Users->disable2fa()` as the helper classes are identical on a quick glimpse but it does.
Seems like this was no problem when both v1 and v2 were tested but now that v1 is skipped this issue comes forward.

Edit: OK, it works locally but not on circle ci. 🤔

Edit: It only works locally after the second run if `tests/_output/coverage.serialized` is deleted before the first run.