### PR TITLE
improvements for api keys. fix #4617

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -25,6 +25,8 @@ components:
           type: string
         created_at:
           type: string
+        last_used_at:
+          type: string
         hash:
           type: string
         can_write:

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 128;
+    public const REQUIRED_SCHEMA = 129;
 
     private Db $Db;
 

--- a/src/sql/schema129-down.sql
+++ b/src/sql/schema129-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 129
+ALTER TABLE `api_keys` DROP COLUMN `last_used_at`;
+UPDATE config SET conf_value = 128 WHERE conf_name = 'schema';

--- a/src/sql/schema129.sql
+++ b/src/sql/schema129.sql
@@ -1,0 +1,3 @@
+-- schema 129
+ALTER TABLE `api_keys` ADD `last_used_at` TIMESTAMP NULL DEFAULT NULL;
+UPDATE config SET conf_value = 129 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -33,6 +33,7 @@ CREATE TABLE `api_keys` (
   `name` varchar(255) NOT NULL,
   `hash` varchar(255) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_used_at` timestamp NULL DEFAULT NULL,
   `can_write` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `userid` int(10) UNSIGNED NOT NULL,
   `team` int(10) UNSIGNED NOT NULL,

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -405,20 +405,20 @@
   <table id='apiTable' class='table' aria-describedby='existingKeys' data-table-sort='true'>
     <thead>
       <tr>
-        <th scope='col'>#</th>
         <th scope='col'>{{ 'Name'|trans }}</th>
         <th scope='col'>{{ 'Permissions'|trans }}</th>
         <th scope='col'>{{ 'Creation date'|trans }}</th>
+        <th scope='col'>{{ 'Last used'|trans }}</th>
         <th scope='col'>{{ 'Action'|trans }}</th>
       </tr>
     </thead>
     <tbody>
       {% for key in apiKeysArr %}
         <tr>
-          <th scope='row'>{{ loop.index }}</th>
           <td>{{ key.name }}</td>
           <td>{{ key.can_write ? 'Read/Write'|trans : 'Read Only'|trans }}</td>
-          <td>{{ key.created_at }}</td>
+          <td><span class='relative-moment' title='{{ key.created_at }}'></span></td>
+          <td><span class='relative-moment' title='{{ key.last_used_at|default('never'|trans) }}'></span></td>
           <td><a data-action='destroy-apikey' title='{{ 'Delete'|trans }}' data-apikeyid='{{ key.id }}'><i class='fas fa-trash-alt'></i></a></td>
         </tr>
       {% endfor %}

--- a/tests/unit/models/ApiKeysTest.php
+++ b/tests/unit/models/ApiKeysTest.php
@@ -56,7 +56,7 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
     public function testInvalidKey(): void
     {
         $this->expectException(ImproperActionException::class);
-        $this->ApiKeys->readFromApiKey('unknown key');
+        $this->ApiKeys->readFromApiKey('666-unknown key');
     }
 
     public function testReadAll(): void

--- a/web/app/controllers/ApiController.php
+++ b/web/app/controllers/ApiController.php
@@ -35,10 +35,10 @@ try {
     if ($App->Request->server->has('HTTP_AUTHORIZATION') && !str_starts_with($App->Request->server->get('HTTP_AUTHORIZATION'), 'Basic')) {
         // verify the key and load user info
         $ApiKeys = new ApiKeys(new Users());
-        $keyArr = $ApiKeys->readFromApiKey($App->Request->server->get('HTTP_AUTHORIZATION') ?? '');
+        $key = $ApiKeys->readFromApiKey($App->Request->server->get('HTTP_AUTHORIZATION') ?? '');
         // replace the Users in App
-        $App->Users = new Users($keyArr['userid'], $keyArr['team']);
-        $canWrite = (bool) $keyArr['canWrite'];
+        $App->Users = new Users($key['userid'], $key['team']);
+        $canWrite = (bool) $key['can_write'];
     } else {
         if ($App->Session->get('is_auth') !== 1) {
             throw new UnauthorizedException();


### PR DESCRIPTION
* api keys now are presented as KEYID-KEY, where KEYID is the ID value in the database
* this was done to avoid having to lookup and test all the existing keys
* this change is backward compatible with old key format
* add `last_used_at` column to the key so we know when it was last used (and order listing with that)
