### PR TITLE
Fix api test coverage

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -2,18 +2,19 @@ coverage:
     enabled: true
     show_uncovered: true
     show_only_summary: true
-    whitelist:
-        include:
-            - src/Auth/*
-            - src/commands/*
-            - src/models/*
-            - src/classes/*
-            - src/Make/*
-            - src/Import/*
-            - src/services/*
-            - src/Storage/*
-            - src/traits/*
-            - src/controllers/*
+    include:
+        - src/Auth/*
+        - src/classes/*
+        - src/controllers/*
+        - src/enums/*
+        - src/exceptions/*
+        - src/factories/*
+        - src/Import/*
+        - src/Make/*
+        - src/models/*
+        - src/services/*
+        - src/Storage/*
+        - src/traits/*
 actor: Tester
 paths:
     tests: tests

--- a/codeception.yml
+++ b/codeception.yml
@@ -5,6 +5,7 @@ coverage:
     include:
         - src/Auth/*
         - src/classes/*
+        - src/commands/*
         - src/controllers/*
         - src/enums/*
         - src/exceptions/*
@@ -15,6 +16,7 @@ coverage:
         - src/services/*
         - src/Storage/*
         - src/traits/*
+        - web/*
 actor: Tester
 paths:
     tests: tests

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "srcdoc": "phpDocumentor run --cache-folder /tmp -i ./cache -i ./uploads -d src/classes -d src/controllers -d src/exceptions -d src/interfaces -d src/models -d src/services -d src/traits -d web/app/controllers -t _srcdoc --setting=graphs.enabled=true",
     "static": "yarn psalm && yarn phpstan",
     "test": "tests/run.sh",
-    "test:clean": "php vendor/bin/codecpt clean",
+    "test:clean": "php vendor/bin/codecept clean",
     "tinymce": "cp node_modules/tinymce/skins/ui/oxide/fonts/tinymce-mobile.woff web/app/css/tinymce/fonts/tinymce-mobile.woff && cp node_modules/tinymce/skins/ui/oxide/*.min.css web/app/css/tinymce/",
     "twigcs": "php vendor/bin/twigcs",
     "unit": "tests/run.sh unit",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "srcdoc": "phpDocumentor run --cache-folder /tmp -i ./cache -i ./uploads -d src/classes -d src/controllers -d src/exceptions -d src/interfaces -d src/models -d src/services -d src/traits -d web/app/controllers -t _srcdoc --setting=graphs.enabled=true",
     "static": "yarn psalm && yarn phpstan",
     "test": "tests/run.sh",
+    "test:clean": "php vendor/bin/codecpt clean",
     "tinymce": "cp node_modules/tinymce/skins/ui/oxide/fonts/tinymce-mobile.woff web/app/css/tinymce/fonts/tinymce-mobile.woff && cp node_modules/tinymce/skins/ui/oxide/*.min.css web/app/css/tinymce/",
     "twigcs": "php vendor/bin/twigcs",
     "unit": "tests/run.sh unit",

--- a/tests/_support/Helper/Apiv2.php
+++ b/tests/_support/Helper/Apiv2.php
@@ -7,4 +7,13 @@ namespace Helper;
 
 class Apiv2 extends \Codeception\Module
 {
+
+    // HOOK: after suite
+    // wait a bit for the remote merge to finish before requesting the reports
+    // This will avoid a truncated report which can happen when a report is requested
+    // before the shutdown function is completed and/or the report generation is requested before each test is finished
+    public function _afterSuite()
+    {
+        sleep(5);
+    }
 }

--- a/tests/apiv2.suite.yml
+++ b/tests/apiv2.suite.yml
@@ -1,12 +1,15 @@
 actor: Apiv2Tester
 coverage:
-  enabled: true
-  c3_url: 'https://elabtmp'
-  remote_context_options:
-    ssl:
-      verify_peer: false
-      verify_peer_name: false
-      allow_self_signed: true
+    enabled: true
+    c3_url: 'https://elabtmp'
+    remote_context_options:
+        ssl:
+            verify_peer: false
+            verify_peer_name: false
+            allow_self_signed: true
+    include:
+        - web/app/init.inc.php
+        - web/app/controllers/ApiController.php
 modules:
     enabled:
         - \Helper\Apiv2

--- a/tests/apiv2.suite.yml
+++ b/tests/apiv2.suite.yml
@@ -7,9 +7,6 @@ coverage:
             verify_peer: false
             verify_peer_name: false
             allow_self_signed: true
-    include:
-        - web/app/init.inc.php
-        - web/app/controllers/ApiController.php
 modules:
     enabled:
         - \Helper\Apiv2

--- a/tests/cypress.suite.yml
+++ b/tests/cypress.suite.yml
@@ -8,5 +8,3 @@ coverage:
             verify_peer: false
             verify_peer_name: false
             allow_self_signed: true
-    include:
-        - web/*

--- a/tests/cypress.suite.yml
+++ b/tests/cypress.suite.yml
@@ -1,28 +1,12 @@
 actor: CypressTester
 coverage:
-  enabled: true
-  c3_url: 'https://elabtmp'
-  remote: true
-  remote_context_options:
-    ssl:
-      verify_peer: false
-      verify_peer_name: false
-      allow_self_signed: true
-  whitelist:
+    enabled: true
+    remote: true
+    c3_url: 'https://elabtmp'
+    remote_context_options:
+        ssl:
+            verify_peer: false
+            verify_peer_name: false
+            allow_self_signed: true
     include:
-      - src/Auth/*
-      - src/classes/*
-      - src/commands/*
-      - src/controllers/*
-      - src/enums/*
-      - src/exceptions/*
-      - src/factories/*
-      - src/Import/*
-      - src/Make/*
-      - src/models/*
-      - src/services/*
-      - src/Storage/*
-      - src/traits/*
-      - web/*
-    exclude:
-      - src/commands/*
+        - web/*

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -3,9 +3,6 @@
 # Suite for unit (internal) tests.
 
 class_name: UnitTester
-coverage:
-    include:
-        - src/commands/*
 modules:
     enabled:
         - Asserts

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -3,6 +3,9 @@
 # Suite for unit (internal) tests.
 
 class_name: UnitTester
+coverage:
+    include:
+        - src/commands/*
 modules:
     enabled:
         - Asserts


### PR DESCRIPTION
After dissecting c3.php and carefully evaluating the order of requests send by Codeception I found the reason why the code coverage of the test results are not correct (This took way to much time).

Codeception does send the requests and gets a response before the [shutdown function](https://github.com/Codeception/c3/blob/0b16f22ec0c46bc131063a3f704bdf9761192d6e/c3.php#L388) is executed. As a consequence, the next test request is send before the [file with the serialized data is stored](https://github.com/Codeception/c3/blob/0b16f22ec0c46bc131063a3f704bdf9761192d6e/c3.php#L417). However, this is addressed by [using portable advisory file locking](https://github.com/Codeception/c3/blob/0b16f22ec0c46bc131063a3f704bdf9761192d6e/c3.php#L239) (`flock()`). But there is no grantee that the access to the locked file is the same as the order of the incoming requests. This is no problem while performing the tests as [`CodeCoverage->merge()`](https://github.com/Codeception/c3/blob/0b16f22ec0c46bc131063a3f704bdf9761192d6e/c3.php#L411) does not care about the order. But this is a big issue when the report request gets access to the serialized file before all tests are merged because this results in truncated reports.
The sleep time might need to be adjusted depending on the number of test.

This is only a problem when multiple processes are running in parallel which is the case for our php-fpm setup.

