### PR TITLE
Improve code coverage acquisition method

### DIFF
--- a/tests/c3_wrapper.php
+++ b/tests/c3_wrapper.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/**
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ *
+ * This file is only used in test runs and will be included via auto_prepend_file.
+ * See elabtmp.Dockerfile
+ * Loading c3 this way ensures that the line coverage of all files is correctly
+ * annotated and no lines are missed which would happen in the files upstream of
+ * the file where c3.php is included. E.g. web/*.php web/app/init.inc.php
+ */
+
+if (PHP_SAPI === 'fpm-fcgi') {
+    require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+    if (file_exists(dirname(__DIR__) . '/c3.php')) {
+        require_once dirname(__DIR__) . '/c3.php';
+    }
+}

--- a/tests/elabtmp.Dockerfile
+++ b/tests/elabtmp.Dockerfile
@@ -30,3 +30,6 @@ RUN printf "zend_extension=xdebug.so\nxdebug.mode=coverage" > /etc/php81/conf.d/
 
 # add routes used by c3.php (codecoverage) into nginx config
 RUN sed -i '/# REST API v1/i #c3 codecoverage routes\nlocation ~ ^/c3/report/(clear|serialized|html|clover)/?$ {\n    rewrite /c3/report/.*$ /login.php last;\n}\n' /etc/nginx/common.conf
+
+# add c3_wrapper.php as auto_prepend_file; See c3_wrapper.php for details
+RUN sed -i 's|^auto_prepend_file =|& /elabftw/tests/c3_wrapper.php|' /etc/php81/php.ini

--- a/web/app/controllers/HeartBeat.php
+++ b/web/app/controllers/HeartBeat.php
@@ -16,10 +16,6 @@ use Symfony\Component\HttpFoundation\Session\Session;
  * Make sure that the user is still logged in
  */
 require_once dirname(__DIR__, 3) . '/vendor/autoload.php';
-// only used for tests in dev mode
-if (file_exists(dirname(__DIR__, 3) . '/c3.php')) {
-    require_once dirname(__DIR__, 3) . '/c3.php';
-}
 
 $Session = new Session();
 $Session->start();

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -17,7 +17,6 @@ use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Models\Config;
 use Elabftw\Services\LoginHelper;
 use Exception;
-use function file_exists;
 use function header;
 use function in_array;
 use Monolog\Logger;
@@ -38,10 +37,6 @@ use Symfony\Component\HttpFoundation\Session\Session;
  * It is the entrypoint of the app.
  */
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
-// only used for tests in dev mode
-if (file_exists(dirname(__DIR__, 2) . '/c3.php')) {
-    require_once dirname(__DIR__, 2) . '/c3.php';
-}
 
 $Request = Request::createFromGlobals();
 $Session = new Session();


### PR DESCRIPTION
Code coverage via Codeception is currently not taking into account all lines because `c3.php` is loaded too late in `web/app/init.inc.php`. Xdebug needs to know what it should do before a file is required/included (Compare to https://xdebug.org/docs/code_coverage#coverage-filter).

This PR makes use of [auto_prepend_file](https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file) and loads `c3_wrapper.php` before any eLabFTW code and only in the test environment. This allows for removal of `require_once c3.php` in the actual code and ensures correct line coverage detection of all source code files.