### PR TITLE
Let Storage/Memory be in memory

### DIFF
--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -30,7 +30,7 @@ abstract class AbstractStorage implements StorageInterface
      * @param string $relativePath A relative path or filename. e.g. folder/file.txt or file.txt
      * @return string The absolute path of a resource
      */
-    public function getPath(?string $relativePath=''): string
+    public function getPath(string $relativePath=''): string
     {
         return '/elabftw/' . static::FOLDER . ($relativePath !== '' ? '/' . $relativePath : '');
     }

--- a/src/Storage/AbstractStorage.php
+++ b/src/Storage/AbstractStorage.php
@@ -25,9 +25,14 @@ abstract class AbstractStorage implements StorageInterface
         return new Filesystem($this->getAdapter());
     }
 
-    public function getPath(): string
+    /**
+     * Get the absolute path of a resource
+     * @param string $relativePath A relative path or filename. e.g. folder/file.txt or file.txt
+     * @return string The absolute path of a resource
+     */
+    public function getPath(?string $relativePath=''): string
     {
-        return '/elabftw/' . static::FOLDER;
+        return '/elabftw/' . static::FOLDER . ($relativePath !== '' ? '/' . $relativePath : '');
     }
 
     abstract protected function getAdapter(): FilesystemAdapter;

--- a/src/Storage/Memory.php
+++ b/src/Storage/Memory.php
@@ -19,7 +19,8 @@ class Memory extends AbstractStorage
 {
     public function getPath(): string
     {
-        return '';
+        // compare to https://github.com/thephpleague/flysystem/issues/471#issuecomment-106231642
+        return 'php://memory';
     }
 
     protected function getAdapter(): FilesystemAdapter

--- a/src/Storage/Memory.php
+++ b/src/Storage/Memory.php
@@ -17,7 +17,7 @@ use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
  */
 class Memory extends AbstractStorage
 {
-    public function getPath(?string $relativePath=''): string
+    public function getPath(string $relativePath=''): string
     {
         // $path is not actually used here because php://memory does not provide a full file system
         // compare to https://github.com/thephpleague/flysystem/issues/471#issuecomment-106231642

--- a/src/Storage/Memory.php
+++ b/src/Storage/Memory.php
@@ -17,8 +17,9 @@ use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
  */
 class Memory extends AbstractStorage
 {
-    public function getPath(): string
+    public function getPath(?string $relativePath=''): string
     {
+        // $path is not actually used here because php://memory does not provide a full file system
         // compare to https://github.com/thephpleague/flysystem/issues/471#issuecomment-106231642
         return 'php://memory';
     }

--- a/src/classes/FsTools.php
+++ b/src/classes/FsTools.php
@@ -33,7 +33,7 @@ class FsTools
         $fs = $storage->getFs();
         $fs->createDirectory($folder);
         $fs->setVisibility($folder, Visibility::PRIVATE);
-        return sprintf('%s/%s', $storage->getPath(), $folder);
+        return $storage->getPath($folder);
     }
 
     /**

--- a/src/commands/ExportResources.php
+++ b/src/commands/ExportResources.php
@@ -47,8 +47,12 @@ class ExportResources extends Command
         $categoryId = (int) $input->getArgument('category_id');
         $userid = (int) $input->getArgument('userid');
         $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
-        $outputFilename = sprintf('export-%s-category_id-%d.eln', date('Y-m-d_H-i-s'), $categoryId);
-        $absolutePath = $this->Fs->getPath() . '/' . $outputFilename;
+        $absolutePath = sprintf(
+            '%s/export-%s-category_id-%d.eln',
+            $this->Fs->getPath(),
+            date('Y-m-d_H-i-s'),
+            $categoryId,
+        );
         if ($this->Fs instanceof Memory) {
             $absolutePath = $this->Fs->getPath();
         }
@@ -64,11 +68,13 @@ class ExportResources extends Command
 
         fclose($fileStream);
 
-        if (!$this->Fs instanceof Memory) {
-            $output->writeln(sprintf('Items of category with ID %d successfully exported as ELN archive.', $categoryId));
-            $output->writeln('Copy the generated archive from the container to the current directory with:');
-            $output->writeln(sprintf('docker cp elabftw:%s/%s .', $this->Fs->getPath(), $outputFilename));
+        if ($this->Fs instanceof Memory) {
+            return Command::SUCCESS;
         }
+
+        $output->writeln(sprintf('Items of category with ID %d successfully exported as ELN archive.', $categoryId));
+        $output->writeln('Copy the generated archive from the container to the current directory with:');
+        $output->writeln(sprintf('docker cp elabftw:%s .', $absolutePath));
 
         return Command::SUCCESS;
     }

--- a/src/commands/ExportResources.php
+++ b/src/commands/ExportResources.php
@@ -14,7 +14,6 @@ use Elabftw\Interfaces\StorageInterface;
 use Elabftw\Make\MakeEln;
 use Elabftw\Models\Users;
 use Elabftw\Services\UsersHelper;
-use Elabftw\Storage\Memory;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -47,15 +46,11 @@ class ExportResources extends Command
         $categoryId = (int) $input->getArgument('category_id');
         $userid = (int) $input->getArgument('userid');
         $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
-        $absolutePath = sprintf(
-            '%s/export-%s-category_id-%d.eln',
-            $this->Fs->getPath(),
+        $absolutePath = $this->Fs->getPath(sprintf(
+            'export-%s-category_id-%d.eln',
             date('Y-m-d_H-i-s'),
             $categoryId,
-        );
-        if ($this->Fs instanceof Memory) {
-            $absolutePath = $this->Fs->getPath();
-        }
+        ));
         $fileStream = fopen($absolutePath, 'wb');
         if ($fileStream === false) {
             throw new RuntimeException('Could not open output stream!');

--- a/src/commands/ExportResources.php
+++ b/src/commands/ExportResources.php
@@ -68,10 +68,6 @@ class ExportResources extends Command
 
         fclose($fileStream);
 
-        if ($this->Fs instanceof Memory) {
-            return Command::SUCCESS;
-        }
-
         $output->writeln(sprintf('Items of category with ID %d successfully exported as ELN archive.', $categoryId));
         $output->writeln('Copy the generated archive from the container to the current directory with:');
         $output->writeln(sprintf('docker cp elabftw:%s .', $absolutePath));

--- a/src/commands/ExportUser.php
+++ b/src/commands/ExportUser.php
@@ -64,10 +64,6 @@ class ExportUser extends Command
 
         fclose($fileStream);
 
-        if ($this->Fs instanceof Memory) {
-            return Command::SUCCESS;
-        }
-
         $output->writeln(sprintf('Experiments of user with ID %d successfully exported as ELN archive.', $userid));
         $output->writeln('Copy the generated archive from the container to the current directory with:');
         $output->writeln(sprintf('docker cp elabftw:%s .', $absolutePath));

--- a/src/commands/ExportUser.php
+++ b/src/commands/ExportUser.php
@@ -43,8 +43,12 @@ class ExportUser extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $userid = (int) $input->getArgument('userid');
-        $outputFilename = sprintf('export-%s-userid-%d.eln', date('Y-m-d_H-i-s'), $userid);
-        $absolutePath = $this->Fs->getPath() . '/' . $outputFilename;
+        $absolutePath = sprintf(
+            '%s/export-%s-userid-%d.eln',
+            $this->Fs->getPath(),
+            date('Y-m-d_H-i-s'),
+            $userid,
+        );
         if ($this->Fs instanceof Memory) {
             $absolutePath = $this->Fs->getPath();
         }
@@ -60,11 +64,13 @@ class ExportUser extends Command
 
         fclose($fileStream);
 
-        if (!$this->Fs instanceof Memory) {
-            $output->writeln(sprintf('Experiments of user with ID %d successfully exported as ELN archive.', $userid));
-            $output->writeln('Copy the generated archive from the container to the current directory with:');
-            $output->writeln(sprintf('docker cp elabftw:%s/%s .', $this->Fs->getPath(), $outputFilename));
+        if ($this->Fs instanceof Memory) {
+            return Command::SUCCESS;
         }
+
+        $output->writeln(sprintf('Experiments of user with ID %d successfully exported as ELN archive.', $userid));
+        $output->writeln('Copy the generated archive from the container to the current directory with:');
+        $output->writeln(sprintf('docker cp elabftw:%s .', $absolutePath));
 
         return Command::SUCCESS;
     }

--- a/src/commands/ExportUser.php
+++ b/src/commands/ExportUser.php
@@ -13,7 +13,6 @@ use Elabftw\Enums\EntityType;
 use Elabftw\Interfaces\StorageInterface;
 use Elabftw\Make\MakeEln;
 use Elabftw\Models\Users;
-use Elabftw\Storage\Memory;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -43,15 +42,11 @@ class ExportUser extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $userid = (int) $input->getArgument('userid');
-        $absolutePath = sprintf(
-            '%s/export-%s-userid-%d.eln',
-            $this->Fs->getPath(),
+        $absolutePath = $this->Fs->getPath(sprintf(
+            'export-%s-userid-%d.eln',
             date('Y-m-d_H-i-s'),
             $userid,
-        );
-        if ($this->Fs instanceof Memory) {
-            $absolutePath = $this->Fs->getPath();
-        }
+        ));
         $fileStream = fopen($absolutePath, 'wb');
         if ($fileStream === false) {
             throw new RuntimeException('Could not open output stream!');

--- a/src/commands/ImportResources.php
+++ b/src/commands/ImportResources.php
@@ -47,7 +47,7 @@ class ImportResources extends Command
     {
         $categoryId = (int) $input->getArgument('category_id');
         $userid = (int) $input->getArgument('userid');
-        $filePath = sprintf('%s/%s', $this->Fs->getPath(), $input->getArgument('file'));
+        $filePath = $this->Fs->getPath($input->getArgument('file'));
         $uploadedFile = new UploadedFile($filePath, 'input.eln', null, null, true);
         $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
         $Eln = new Eln(new Users($userid, $teamid), sprintf('items:%d', $categoryId), BasePermissions::MyTeams->toJson(), BasePermissions::User->toJson(), $uploadedFile, Storage::CACHE->getStorage()->getFs());

--- a/src/commands/ImportUser.php
+++ b/src/commands/ImportUser.php
@@ -45,7 +45,7 @@ class ImportUser extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $userid = (int) $input->getArgument('userid');
-        $filePath = sprintf('%s/%s', $this->Fs->getPath(), $input->getArgument('file'));
+        $filePath = $this->Fs->getPath((string) $input->getArgument('file'));
         $uploadedFile = new UploadedFile($filePath, 'input.eln', null, null, true);
         $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
         $Eln = new Eln(new Users($userid, $teamid), sprintf('experiments:%d', $userid), BasePermissions::User->toJson(), BasePermissions::User->toJson(), $uploadedFile, Storage::CACHE->getStorage()->getFs());

--- a/src/interfaces/StorageInterface.php
+++ b/src/interfaces/StorageInterface.php
@@ -18,5 +18,5 @@ interface StorageInterface
 {
     public function getFs(): Filesystem;
 
-    public function getPath(): string;
+    public function getPath(?string $relativePath=''): string;
 }

--- a/src/interfaces/StorageInterface.php
+++ b/src/interfaces/StorageInterface.php
@@ -18,5 +18,5 @@ interface StorageInterface
 {
     public function getFs(): Filesystem;
 
-    public function getPath(?string $relativePath=''): string;
+    public function getPath(string $relativePath=''): string;
 }


### PR DESCRIPTION
I had two unit tests in` CommandsTest` (`testExecuteExportResources()` and `testExecuteExportUser()`) that failed.
It is not possible to write files in the root directory in my dev setup.
However, why do we want to write the file to disk in the first place if we use the Storage\Memory class?

I changed the return value of `Memory->getPath()` to `php://memory` but that requires a bit of overhead to work properly.