### PR TITLE
Allow the browser to pass cookies when requesting the webapp manifest.

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -16,7 +16,7 @@
     <meta http-equiv='refresh' content='{{ App.Config.configArr.autologout_time }};url=app/logout.php' />
   {% endif %}
   <meta name='csrf-token' content='{{ App.Session.get('csrf') }}'/>
-  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials">
   <link rel="icon" href="/assets/images/favicon.ico" sizes="any"><!-- 32×32 -->
   <link rel="icon" href="/assets/images/favicon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="/assets/images/apple-touch-icon.png"><!-- 180×180 -->


### PR DESCRIPTION
Allow the browser to pass cookies when requesting the webapp manifest. Useful eg when a reverse proxy might otherwise provide a redirect that invalidates an existing session. This has been observed to cause issues for a reverse proxy running mod_auth_mellon. Users of Safari experienced issues, Firefox skips the manifest, while Chrome/Edge (sensibly) followed the redirect but blocked a subsequent CORS-violating redirect.

Why crossorigin, when we serve it from the same origin?
"If the manifest requires credentials to fetch, the crossorigin attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page." 
https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest