### PR TITLE
Tinymce plugin: Use locatorHash to get checksum

### DIFF
--- a/src/tools/yarn-plugin-tinymce.js
+++ b/src/tools/yarn-plugin-tinymce.js
@@ -35,7 +35,7 @@ module.exports = {
                 break;
               }
             };
-            const checksum = project.storedChecksums.get(tinymceLocator) ?? null;
+            const checksum = project.storedChecksums.get(tinymceLocator.locatorHash) ?? null;
             const path = cache.getLocatorPath(tinymceLocator, checksum);
 
             const extractFile = (filename) => {


### PR DESCRIPTION
... not the Locator object.
The Locator object would never match and therefore checksum would always be null.