### PR TITLE
Event GUI: Keep button corners on right round

### DIFF
--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -73,12 +73,13 @@
             {% endfor %}
           </ul>
           {# add user to permissions input #}
-          <div id='autocompleteAnchorDiv_{{ identifier }}' class='input-group'>
+          <div class='input-group'>
             <input id='{{ identifier }}_select_users' data-identifier='{{ identifier }}' data-complete-target='users' class='form-control' placeholder='{{ 'Add user'|trans }}' autocomplete='off'>
             <div class='input-group-append'>
               <button class='btn btn-primary' data-rw='{{ rw }}' data-identifier='{{ identifier }}' data-action='add-user-to-permissions'>{{ 'Add'|trans }}</button>
             </div>
           </div>
+          <div id='autocompleteAnchorDiv_{{ identifier }}'></div>
         </div>
         {% if rw == 'canread' and App.Config.configArr.anon_users and not ucpPage %}
           <hr>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -38,30 +38,32 @@
           <i class='fas fa-link mr-1'></i><h5 class='d-inline'>{{ 'Bind an experiment'|trans }}</h5>
           <div id='eventBoundExp'></div>
           <button data-action='scheduler-rm-bind' data-type='experiment' data-eventid='' aria-hidden='true' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
-            <div id='autocompleteAnchorDiv_binddivexp' class='input-group mb-3'>
-                <div class='input-group-prepend'>
-                    <span class='input-group-text'>{{ 'Search'|trans }}</span>
-                </div>
-                <input type='text' data-complete-target='experiments' data-identifier='binddivexp' class='form-control bindInput' />
-                <div class='input-group-append'>
-                  <button class='btn btn-primary' data-input='bindexpinput' data-action='scheduler-bind-entity' data-type='experiment' type='button'>{{ 'Attach'|trans }}</button>
-                </div>
+            <div class='input-group mb-3'>
+              <div class='input-group-prepend'>
+                <span class='input-group-text'>{{ 'Search'|trans }}</span>
+              </div>
+              <input type='text' data-complete-target='experiments' data-identifier='binddivexp' class='form-control bindInput' />
+              <div class='input-group-append'>
+                <button class='btn btn-primary' data-input='bindexpinput' data-action='scheduler-bind-entity' data-type='experiment' type='button'>{{ 'Attach'|trans }}</button>
+              </div>
             </div>
+            <div id='autocompleteAnchorDiv_binddivexp'></div>
         </div>
         {# BIND ITEM #}
         <div class='mt-2'>
           <i class='fas fa-link mr-1'></i><h5 class='d-inline'>{{ 'Bind a resource'|trans }}</h5>
           <div id='eventBoundDb'></div>
           <button data-action='scheduler-rm-bind' data-type='item_link' data-eventid='' aria-hidden='true' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
-            <div id='autocompleteAnchorDiv_binddivdb' class='input-group mb-3'>
-                <div class='input-group-prepend'>
-                    <span class='input-group-text'>{{ 'Search'|trans }}</span>
-                </div>
-                <input type='text' data-complete-target='items' data-identifier='binddivdb' class='form-control bindInput' />
-                <div class='input-group-append'>
-                  <button class='btn btn-primary' data-input='binddbinput' data-action='scheduler-bind-entity' data-type='item_link' type='button'>{{ 'Attach'|trans }}</button>
-                </div>
+            <div class='input-group mb-3'>
+              <div class='input-group-prepend'>
+                <span class='input-group-text'>{{ 'Search'|trans }}</span>
+              </div>
+              <input type='text' data-complete-target='items' data-identifier='binddivdb' class='form-control bindInput' />
+              <div class='input-group-append'>
+                <button class='btn btn-primary' data-input='binddbinput' data-action='scheduler-bind-entity' data-type='item_link' type='button'>{{ 'Attach'|trans }}</button>
+              </div>
             </div>
+            <div id='autocompleteAnchorDiv_binddivdb'></div>
         </div>
 
         {# only show the cancel block if item is cancellable or user is admin #}


### PR DESCRIPTION
Initially the right button corners are round but as soon as one starts typing they become square. This is due to the new list element that gets added to show the results. If the list is moved into an independent div the button corners stay round.

![image](https://github.com/elabftw/elabftw/assets/65481677/a258ec28-243f-4dc1-846f-3d24cc0465d1)

![image](https://github.com/elabftw/elabftw/assets/65481677/bbf16a63-ca27-4aa8-9d4c-9398b47a2a6a)
