### PR TITLE
Allow an admin to add an existing user to their team

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 129;
+    public const REQUIRED_SCHEMA = 130;
 
     private Db $Db;
 

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -136,6 +136,7 @@ final class Config implements RestInterface
             ('support_url', 'https://github.com/elabftw/elabftw/issues'),
             ('deletable_xp', 1),
             ('allow_useronly', 1),
+            ('admins_import_users', 0),
             ('max_revisions', 10),
             ('min_delta_revisions', 100),
             ('min_days_revisions', 23),

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -311,6 +311,11 @@ class Users implements RestInterface
         match ($action) {
             Action::Add => (
                 function () use ($params) {
+                    // check instance config if admins are allowed to do that (if requestor is not sysadmin)
+                    $Config = Config::getConfig();
+                    if ($this->requester->userData['is_sysadmin'] !== 1 && $Config->configArr['admins_import_users'] !== '1') {
+                        throw new IllegalActionException('A non sysadmin user tried to import a user but admins_import_users is disabled in config.');
+                    }
                     // need to be admin to "import" a user in a team
                     $team = (int) $params['team'];
                     $TeamsHelper = new TeamsHelper($team);

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -311,7 +311,7 @@ class Users implements RestInterface
         match ($action) {
             Action::Add => (
                 function () use ($params) {
-                    // check instance config if admins are allowed to do that (if requestor is not sysadmin)
+                    // check instance config if admins are allowed to do that (if requester is not sysadmin)
                     $Config = Config::getConfig();
                     if ($this->requester->userData['is_sysadmin'] !== 1 && $Config->configArr['admins_import_users'] !== '1') {
                         throw new IllegalActionException('A non sysadmin user tried to import a user but admins_import_users is disabled in config.');

--- a/src/sql/schema130-down.sql
+++ b/src/sql/schema130-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 130
+DELETE FROM config WHERE conf_name = 'admins_import_users';
+UPDATE config SET conf_value = 129 WHERE conf_name = 'schema';

--- a/src/sql/schema130.sql
+++ b/src/sql/schema130.sql
@@ -1,0 +1,3 @@
+-- schema 130
+INSERT INTO config (conf_name, conf_value) VALUES ('admins_import_users', '0');
+UPDATE config SET conf_value = 130 WHERE conf_name = 'schema';

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -33,6 +33,11 @@
         </div>
         <div class='input-group-append'>
           <div class='input-group-text'>
+            <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeNotTeam') ? 'checked="checked"' }} name='includeNotTeam'>{{ 'Include users not in this team'|trans }}
+          </div>
+        </div>
+        <div class='input-group-append'>
+          <div class='input-group-text'>
             <input type='checkbox' class='mr-1' {{ App.Request.query.has('onlyAdmins') ? 'checked="checked"' }} name='onlyAdmins'>{{ 'Show only Admins'|trans }}
           </div>
         </div>
@@ -197,14 +202,22 @@
                       {# on admin page, allow promoting someone to admin of the same team #}
                       {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
                         {% set currentTeam = user.teams|filter(t => t.id == App.Users.userData.team)|first %}
+                        {# Promote to Admin #}
                         {% if currentTeam.usergroup == 4 %}
-                        <div class='dropdown-item' data-action='toggle-admin-user' data-promote='1' data-team='{{ App.Users.userData.team }}' data-userid='{{ user.userid }}'>
+                          <div class='dropdown-item' data-action='toggle-admin-user' data-promote='1' data-team='{{ App.Users.userData.team }}' data-userid='{{ user.userid }}'>
                             <i class='fas fa-fw fa-up-long mr-1'></i>{{ 'Promote to Admin'|trans }}
                           </div>
                         {% endif %}
+                        {# Demote from Admin #}
                         {% if currentTeam.usergroup == 2 %}
-                        <div class='dropdown-item' data-action='toggle-admin-user' data-promote='0' data-team='{{ App.Users.userData.team }}' data-userid='{{ user.userid }}'>
+                          <div class='dropdown-item' data-action='toggle-admin-user' data-promote='0' data-userid='{{ user.userid }}'>
                             <i class='fas fa-fw fa-down-long mr-1'></i>{{ 'Demote from Admin'|trans }}
+                          </div>
+                        {% endif %}
+                        {# Add to team #}
+                        {% if user.teams|filter(t => t.id == App.Users.userData.team) is empty %}
+                          <div class='dropdown-item' data-action='add-user-to-team' data-team='{{ App.Users.userData.team }}' data-userid='{{ user.userid }}'>
+                              <i class='fas fa-fw fa-user-plus mr-1'></i>{{ 'Add to team'|trans }}
                           </div>
                         {% endif %}
                       {% endif %}

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -216,7 +216,7 @@
                           </div>
                         {% endif %}
                         {# Add to team #}
-                        {% if user.teams|filter(t => t.id == App.Users.userData.team) is empty %}
+                        {% if user.teams|filter(t => t.id == App.Users.userData.team) is empty and App.Config.configArr.admins_import_users %}
                           <div class='dropdown-item' data-action='add-user-to-team' data-team='{{ App.Users.userData.team }}' data-userid='{{ user.userid }}'>
                               <i class='fas fa-fw fa-user-plus mr-1'></i>{{ 'Add to team'|trans }}
                           </div>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -31,11 +31,13 @@
             <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeArchived') ? 'checked="checked"' }} name='includeArchived'>{{ 'Include archived'|trans }}
           </div>
         </div>
-        <div class='input-group-append'>
-          <div class='input-group-text'>
-            <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeNotTeam') ? 'checked="checked"' }} name='includeNotTeam'>{{ 'Include users not in this team'|trans }}
+        {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
+          <div class='input-group-append'>
+            <div class='input-group-text'>
+              <input type='checkbox' class='mr-1' {{ App.Request.query.has('includeNotTeam') ? 'checked="checked"' }} name='includeNotTeam'>{{ 'Include users not in this team'|trans }}
+            </div>
           </div>
-        </div>
+        {% endif %}
         <div class='input-group-append'>
           <div class='input-group-text'>
             <input type='checkbox' class='mr-1' {{ App.Request.query.has('onlyAdmins') ? 'checked="checked"' }} name='onlyAdmins'>{{ 'Show only Admins'|trans }}

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -141,6 +141,8 @@
 
     {% include 'binary-setting.html' with {'label': 'Enable local account creation'|trans, 'slug': 'local_register'} %}
     {% include 'binary-setting.html' with {'label': 'Admins can create local accounts'|trans, 'slug': 'admins_create_users'} %}
+    {% include 'binary-setting.html' with {'label': 'Allow Admins to add existing users to their team'|trans, 'slug': 'admins_import_users'} %}
+
     {% include 'binary-setting.html' with {'label': 'Show local login form'|trans, 'slug': 'local_login', 'help': 'You can still show the local login form by appending ?letmein to the login page URL.'|trans} %}
 
     <div class='d-flex justify-content-between'>

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -9,7 +9,7 @@ import i18next from 'i18next';
 import { collectForm, reloadElement } from './misc';
 import { InputType, Malle } from '@deltablot/malle';
 import { Api } from './Apiv2.class';
-import { Action } from './interfaces';
+import { Action, Model } from './interfaces';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!['/sysconfig.php', '/admin.php'].includes(window.location.pathname)) {
@@ -57,7 +57,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
       const group = el.dataset.promote === '1' ? 2 : 4;
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElement('editUsersBox'));
+
+    // ADD TO TEAM
+    } else if (el.matches('[data-action="add-user-to-team"]')) {
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {'action': Action.Add, 'team': el.dataset.team}).then(() => reloadElement('editUsersBox'));
 
     // ARCHIVE USER TOGGLE
     } else if (el.matches('[data-action="toggle-archive-user"]')) {

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -32,6 +32,17 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         new Users(1337);
     }
 
+    public function testPostAction(): void
+    {
+        $this->assertIsInt($this->Users->postAction(Action::Create, array(
+            'team' => 1,
+            'firstname' => 'test',
+            'lastname' => 'post',
+            'email' => 'test@example.com',
+            'orgid' => 'XYZ123',
+        )));
+    }
+
     public function testAllowUntrustedLogin(): void
     {
         $this->assertFalse($this->Users->allowUntrustedLogin());
@@ -107,6 +118,15 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Users = new Users(4, 2, new Users(4, 2));
         $this->expectException(ImproperActionException::class);
         $Users->patch(Action::Update, array('password' => 'short'));
+    }
+
+    public function testDisable2fa(): void
+    {
+        $Users = new Users(4, 2, new Users(4, 2));
+        $this->assertIsArray($Users->patch(Action::Disable2fa, array()));
+        $Users = new Users(2, 1, new Users(4, 2));
+        $this->expectException(IllegalActionException::class);
+        $Users->patch(Action::Disable2fa, array());
     }
 
     public function testUpdatePasswordNoCurrentPasswordProvided(): void
@@ -198,7 +218,18 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     public function testReadAllActiveFromTeam(): void
     {
-        $this->assertCount(7, $this->Users->readAllActiveFromTeam());
+        $this->assertCount(8, $this->Users->readAllActiveFromTeam());
+    }
+
+    public function testAddUserToTeam(): void
+    {
+        // add a user from team bravo into team alpha
+        $Users = new Users(6, 2, new Users(1, 1));
+        $this->assertIsArray($Users->patch(Action::Add, array('team' => 1)));
+        // try the reverse
+        $Users = new Users(1, 1, new Users(6, 2));
+        $this->expectException(IllegalActionException::class);
+        $Users->patch(Action::Add, array('team' => 2));
     }
 
     public function testDestroy(): void

--- a/tests/unit/services/EmailNotificationsTest.php
+++ b/tests/unit/services/EmailNotificationsTest.php
@@ -52,7 +52,7 @@ class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
             'target' => 'team',
             'targetid' => 1,
         ));
-        $this->assertEquals(8, $targetCount);
+        $this->assertEquals(9, $targetCount);
         $this->assertIsArray($Notifications->readOne());
         $this->assertIsArray($Notifications->patch(Action::Update, array()));
         $this->assertIsString($Notifications->getPage());

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -58,8 +58,8 @@ class EmailTest extends \PHPUnit\Framework\TestCase
     public function testMassEmail(): void
     {
         $replyTo = new Address('sender@example.com', 'Sergent Garcia');
-        $this->assertEquals(17, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
-        $this->assertEquals(8, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
+        $this->assertEquals(18, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
+        $this->assertEquals(9, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(0, $this->Email->massEmail(EmailTarget::TeamGroup, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(6, $this->Email->massEmail(EmailTarget::Admins, null, 'Important message to admins', 'yep', $replyTo));
         $this->assertEquals(1, $this->Email->massEmail(EmailTarget::Sysadmins, null, 'Important message to sysadmins', 'yep', $replyTo));

--- a/web/admin.php
+++ b/web/admin.php
@@ -76,7 +76,7 @@ try {
         $isSearching = true;
         $usersArr = $App->Users->readFromQuery(
             filter_var($Request->query->get('q'), FILTER_SANITIZE_STRING),
-            $App->Users->userData['team'],
+            $App->Request->query->getBoolean('includeNotTeam') ? 0 : $App->Users->userData['team'],
             $App->Request->query->getBoolean('includeArchived'),
             $App->Request->query->getBoolean('onlyAdmins'),
         );


### PR DESCRIPTION
This adds a button to "import" an existing user in the current team if they are not part of it.
![2023-11-10-230632_3840x1080_scrot](https://github.com/elabftw/elabftw/assets/3043706/1ded04a1-123b-464b-9916-2928d363720c)


To show users from other teams, a checkbox must be checked in search input.
![2023-11-10-230747_252x65_scrot](https://github.com/elabftw/elabftw/assets/3043706/f4ba3b71-e698-420c-9592-a0fe222216d9)

Also add an instance setting to allow Admins to do that (disabled by default because it gives Admins power over any account, because they can import the user in their team, and then they have write access on that user)

![2023-11-10-233801_808x67_scrot](https://github.com/elabftw/elabftw/assets/3043706/a8ea26b9-7195-4275-9966-c1cea56ebe32)

