### PR TITLE
Fix orgid type

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2806,7 +2806,7 @@ paths:
                      lastname:
                        type: string
                      orgid:
-                       type: integer
+                       type: string
                        nullable: true
                      email:
                        type: string


### PR DESCRIPTION
Fix orgid type that caused `ValueError: invalid literal for int()` for string-type orgids in elabapi-python. 
elabapi-python issue: [https://github.com/elabftw/elabapi-python/issues/14](https://github.com/elabftw/elabapi-python/issues/14).
