### PR TITLE
Improve Custom ID "get next" button

### DIFF
--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -62,7 +62,7 @@
       <div class='input-group-prepend'>
         <button class='btn btn-secondary' data-action='get-next-custom-id' data-endpoint='{{ Entity.type }}'>{{ 'Get next'|trans }}</button>
       </div>
-      <input id='custom_id_input' class='form-control' data-trigger='change' data-model='{{ Entity.type }}/{{ Entity.entityData.id }}' data-target='custom_id' type='number' value='{{ Entity.entityData.custom_id }}' />
+      <input id='custom_id_input' class='form-control' data-trigger='change' data-model='{{ Entity.type }}/{{ Entity.entityData.id }}' data-target='custom_id' type='number' min='0' value='{{ Entity.entityData.custom_id }}' />
     </div>
   </div>
 

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -195,17 +195,21 @@ document.addEventListener('DOMContentLoaded', () => {
         notifError(new Error(i18next.t('error-no-category')));
         return;
       }
+      // lock the button
       (el as HTMLButtonElement).disabled = true;
       // make sure the current id is null or it will increment this one
       EntityC.update(entity.id, Target.Customid, null).then(() => {
-        // get the entity with highest custom_id and add one to it
-        ApiC.getJson(`${el.dataset.endpoint}/?cat=${category}&order=customid&limit=1&sort=desc`).then(json => {
-          const next_id = json[0].custom_id + 1;
-          (document.getElementById('custom_id_input') as HTMLInputElement).value = next_id;
-          EntityC.update(entity.id, Target.Customid, next_id).then(() => {
-            (el as HTMLButtonElement).disabled = false;
-          });
-        });
+        // get the entity with highest custom_id
+        return ApiC.getJson(`${el.dataset.endpoint}/?cat=${category}&order=customid&limit=1&sort=desc`);
+      }).then(json => {
+        // add one to it
+        const next_id = json[0].custom_id + 1;
+        (document.getElementById('custom_id_input') as HTMLInputElement).value = next_id;
+        // update the db
+        return EntityC.update(entity.id, Target.Customid, next_id);
+      }).finally(() => {
+        // unlock the button
+        (el as HTMLButtonElement).disabled = false;
       });
 
     // CLICK the NOW button of a time or date extra field

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -195,13 +195,17 @@ document.addEventListener('DOMContentLoaded', () => {
         notifError(new Error(i18next.t('error-no-category')));
         return;
       }
+      (el as HTMLButtonElement).disabled = true;
       // make sure the current id is null or it will increment this one
-      EntityC.update(entity.id, Target.Customid, null);
-      // get the entity with highest custom_id and add one to it
-      ApiC.getJson(`${el.dataset.endpoint}/?cat=${category}&order=customid&limit=1&sort=desc`).then(json => {
-        const next_id = json[0].custom_id + 1;
-        (document.getElementById('custom_id_input') as HTMLInputElement).value = next_id;
-        EntityC.update(entity.id, Target.Customid, next_id);
+      EntityC.update(entity.id, Target.Customid, null).then(() => {
+        // get the entity with highest custom_id and add one to it
+        ApiC.getJson(`${el.dataset.endpoint}/?cat=${category}&order=customid&limit=1&sort=desc`).then(json => {
+          const next_id = json[0].custom_id + 1;
+          (document.getElementById('custom_id_input') as HTMLInputElement).value = next_id;
+          EntityC.update(entity.id, Target.Customid, next_id).then(() => {
+            (el as HTMLButtonElement).disabled = false;
+          });
+        });
       });
 
     // CLICK the NOW button of a time or date extra field


### PR DESCRIPTION
If the "get next" button for the custom id gets pressed twice or more often before all API requests are returned the ID can be increased by more than one.
This can be avoided by disabling the button after it has been pressed, and by chaining the promises.

Also, it is possible to use the decrease button of the number input to 'select' a value smaller than 0 which results in JavaScript errors and makes no sense from my point if view. The addition of the attribute `min='0'` to the input element avoids this.

Further more, I realized that so far there is no logic in place that will prevent using an ID several times. But as this is an ID this should not be possible, right?