### PR TITLE
Add an `audit_logs` table

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -3,6 +3,7 @@ coverage:
     show_uncovered: true
     show_only_summary: true
     include:
+        - src/AuditEvent/*
         - src/Auth/*
         - src/classes/*
         - src/commands/*

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
   },
   "autoload": {
     "psr-4": {
+      "Elabftw\\AuditEvent\\": [
+        "src/AuditEvent"
+      ],
       "Elabftw\\Auth\\": [
         "src/Auth"
       ],

--- a/src/AuditEvent/AbstractAuditEvent.php
+++ b/src/AuditEvent/AbstractAuditEvent.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Interfaces\AuditEventInterface;
+
+abstract class AbstractAuditEvent implements AuditEventInterface
+{
+    public function __construct(private int $userid = 0)
+    {
+    }
+
+    public function getUserid(): int
+    {
+        return $this->userid;
+    }
+
+    abstract public function getBody(): string;
+
+    abstract public function getCategory(): int;
+}

--- a/src/AuditEvent/AbstractUsers2TeamsModifiedEvent.php
+++ b/src/AuditEvent/AbstractUsers2TeamsModifiedEvent.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+abstract class AbstractUsers2TeamsModifiedEvent extends AbstractAuditEvent
+{
+    public function getCategory(): int
+    {
+        return AuditCategory::Users2TeamsModified->value;
+    }
+}

--- a/src/AuditEvent/IsSysadminChanged.php
+++ b/src/AuditEvent/IsSysadminChanged.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class IsSysadminChanged extends AbstractAuditEvent
+{
+    public function __construct(private int $requesterUserid, private int $content, int $userid)
+    {
+        parent::__construct($userid);
+    }
+
+    public function getBody(): string
+    {
+        return sprintf(
+            'User sysadmin rights was changed to %d by user with id %d',
+            $this->content,
+            $this->requesterUserid,
+        );
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::AccountModified->value;
+    }
+}

--- a/src/AuditEvent/PasswordChanged.php
+++ b/src/AuditEvent/PasswordChanged.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class PasswordChanged extends AbstractAuditEvent
+{
+    public function getBody(): string
+    {
+        return 'Password was changed';
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::PasswordChanged->value;
+    }
+}

--- a/src/AuditEvent/PasswordResetRequested.php
+++ b/src/AuditEvent/PasswordResetRequested.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class PasswordResetRequested extends AbstractAuditEvent
+{
+    public function __construct(private string $email)
+    {
+    }
+
+    public function getBody(): string
+    {
+        return sprintf('Password reset was requested for account associated with: %s', $this->email);
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::PasswordResetRequested->value;
+    }
+}

--- a/src/AuditEvent/PasswordResetRequested.php
+++ b/src/AuditEvent/PasswordResetRequested.php
@@ -15,6 +15,7 @@ class PasswordResetRequested extends AbstractAuditEvent
 {
     public function __construct(private string $email)
     {
+        parent::__construct();
     }
 
     public function getBody(): string

--- a/src/AuditEvent/PermissionLevelChanged.php
+++ b/src/AuditEvent/PermissionLevelChanged.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\Usergroup;
+
+class PermissionLevelChanged extends AbstractUsers2TeamsModifiedEvent
+{
+    public function __construct(private int $requesterUserid, private int $group, int $userid, private int $teamid)
+    {
+        parent::__construct($userid);
+    }
+
+    public function getBody(): string
+    {
+        return sprintf(
+            'User permission level was changed to %s in team %d by user with id %d',
+            Usergroup::from($this->group)->toHuman(),
+            $this->teamid,
+            $this->requesterUserid,
+        );
+    }
+}

--- a/src/AuditEvent/TeamAddition.php
+++ b/src/AuditEvent/TeamAddition.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\Usergroup;
+
+class TeamAddition extends AbstractUsers2TeamsModifiedEvent
+{
+    public function __construct(private int $teamid, private int $group, int $userid)
+    {
+        parent::__construct($userid);
+    }
+
+    public function getBody(): string
+    {
+        return sprintf('User was associated with team %d and permission level %d', $this->teamid, Usergroup::from($this->group)->toHuman());
+    }
+}

--- a/src/AuditEvent/TeamRemoval.php
+++ b/src/AuditEvent/TeamRemoval.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+class TeamRemoval extends AbstractUsers2TeamsModifiedEvent
+{
+    public function __construct(private int $teamid, int $userid)
+    {
+        parent::__construct($userid);
+    }
+
+    public function getBody(): string
+    {
+        return sprintf('User was removed from team with id %d.', $this->teamid);
+    }
+}

--- a/src/AuditEvent/UserLogin.php
+++ b/src/AuditEvent/UserLogin.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class UserLogin extends AbstractAuditEvent
+{
+    public function getBody(): string
+    {
+        return 'User logged in';
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::Login->value;
+    }
+}

--- a/src/AuditEvent/UserLogout.php
+++ b/src/AuditEvent/UserLogout.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class UserLogout extends AbstractAuditEvent
+{
+    public function getBody(): string
+    {
+        return 'User logged out';
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::Logout->value;
+    }
+}

--- a/src/AuditEvent/UserRegister.php
+++ b/src/AuditEvent/UserRegister.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+
+class UserRegister extends AbstractAuditEvent
+{
+    public function getBody(): string
+    {
+        return 'New account created';
+    }
+
+    public function getCategory(): int
+    {
+        return AuditCategory::AccountCreated->value;
+    }
+}

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 132;
+    public const REQUIRED_SCHEMA = 133;
 
     private Db $Db;
 

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -28,7 +28,7 @@ use function sha1;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 133;
+    public const REQUIRED_SCHEMA = 134;
 
     private Db $Db;
 

--- a/src/enums/AuditCategory.php
+++ b/src/enums/AuditCategory.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Enums;
+
+enum AuditCategory: int
+{
+    case Login = 10;
+    case Logout = 11;
+    case AccountCreated = 20;
+    case AccountValidated = 21;
+    case AccountArchived = 22;
+    case AccountDeleted = 23;
+    case AccountModified = 24;
+    case PasswordChanged = 30;
+    case PasswordResetRequested = 31;
+    case Users2TeamsModified = 40;
+}

--- a/src/interfaces/AuditEventInterface.php
+++ b/src/interfaces/AuditEventInterface.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/**
+ * @package   Elabftw\Elabftw
+ * @author    Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @see       https://www.elabftw.net Official website
+ */
+
+namespace Elabftw\Interfaces;
+
+interface AuditEventInterface
+{
+    public function getBody(): string;
+
+    public function getUserid(): int;
+
+    public function getCategory(): int;
+}

--- a/src/models/AuditLogs.php
+++ b/src/models/AuditLogs.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Interfaces\AuditEventInterface;
+use PDO;
+
+/**
+ * Deal with auditable events stored in audit_logs table
+ */
+class AuditLogs
+{
+    public const DEFAULT_LIMIT = 50;
+
+    public static function create(AuditEventInterface $event): int
+    {
+        $Db = Db::getConnection();
+        $sql = 'INSERT INTO audit_logs(body, category, userid) VALUES(:body, :category, :userid)';
+        $req = $Db->prepare($sql);
+        $req->bindValue(':body', $event->getBody());
+        $req->bindValue(':category', $event->getCategory());
+        $req->bindValue(':userid', $event->getUserid());
+        $Db->execute($req);
+
+        return $Db->lastInsertId();
+    }
+
+    public static function read(int $limit = self::DEFAULT_LIMIT, int $offset = 0): array
+    {
+        $Db = Db::getConnection();
+        $sql = 'SELECT * FROM audit_logs ORDER BY created_at DESC LIMIT :limit OFFSET :offset';
+        $req = $Db->prepare($sql);
+        $req->bindParam(':limit', $limit, PDO::PARAM_INT);
+        $req->bindParam(':offset', $offset, PDO::PARAM_INT);
+        $Db->execute($req);
+
+        return $req->fetchAll();
+    }
+}

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -9,6 +9,9 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\AuditEvent\IsSysadminChanged;
+use Elabftw\AuditEvent\PasswordChanged;
+use Elabftw\AuditEvent\UserRegister;
 use Elabftw\Auth\Local;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\Tools;
@@ -178,6 +181,7 @@ class Users implements RestInterface
             // set a flag to show correct message to user
             $this->needValidation = true;
         }
+        AuditLogs::create(new UserRegister($userid));
         return $userid;
     }
 
@@ -320,7 +324,7 @@ class Users implements RestInterface
                     $team = (int) $params['team'];
                     $TeamsHelper = new TeamsHelper($team);
                     $permissions = $TeamsHelper->getPermissions($this->requester->userData['userid']);
-                    if ($permissions['is_admin'] !== 1) {
+                    if ($permissions['is_admin'] !== 1 && $this->requester->userData['is_sysadmin'] !== 1) {
                         throw new IllegalActionException('Only Admin can add a user to a team (where they are Admin)');
                     }
                     (new Users2Teams())->create($this->userData['userid'], $team);
@@ -538,8 +542,11 @@ class Users implements RestInterface
             Filter::email($params->getContent());
         }
         // special case for is_sysadmin: only a sysadmin can affect this column
-        if ($params->getTarget() === 'is_sysadmin' && $this->requester->userData['is_sysadmin'] === 0) {
-            throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin column of a user');
+        if ($params->getTarget() === 'is_sysadmin') {
+            if ($this->requester->userData['is_sysadmin'] === 0) {
+                throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin column of a user');
+            }
+            AuditLogs::create(new IsSysadminChanged($this->requester->userid, (int) $params->getContent(), $this->userData['userid']));
         }
 
         $sql = 'UPDATE users SET ' . $params->getColumn() . ' = :content WHERE userid = :userid';
@@ -568,7 +575,10 @@ class Users implements RestInterface
         $req = $this->Db->prepare($sql);
         $req->bindValue(':content', $params->getContent());
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
-        return $this->Db->execute($req);
+        $res = $this->Db->execute($req);
+        /** @psalm-suppress PossiblyNullArgument */
+        AuditLogs::create(new PasswordChanged($this->userid));
+        return $res;
     }
 
     /**

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -546,6 +546,7 @@ class Users implements RestInterface
             if ($this->requester->userData['is_sysadmin'] === 0) {
                 throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin column of a user');
             }
+            /** @psalm-suppress PossiblyNullArgument */
             AuditLogs::create(new IsSysadminChanged($this->requester->userid, (int) $params->getContent(), $this->userData['userid']));
         }
 

--- a/src/services/LoginHelper.php
+++ b/src/services/LoginHelper.php
@@ -9,14 +9,14 @@
 
 namespace Elabftw\Services;
 
+use Elabftw\AuditEvent\UserLogin;
 use Elabftw\Auth\CookieToken;
 use Elabftw\Elabftw\AuthResponse;
 use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\AuditLogs;
 use Elabftw\Models\Config;
 
-use Monolog\Handler\ErrorLogHandler;
-use Monolog\Logger;
 use PDO;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -49,9 +49,7 @@ class LoginHelper
         if ($this->Session->has('auth_service')) {
             $this->updateAuthService();
         }
-        $Log = new Logger('elabftw');
-        $Log->pushHandler(new ErrorLogHandler());
-        $Log->info('User is logging in', array('userid' => $this->AuthResponse->userid));
+        AuditLogs::create(new UserLogin($this->AuthResponse->userid));
     }
 
     /**

--- a/src/sql/schema133-down.sql
+++ b/src/sql/schema133-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 133
+DROP TABLE IF EXISTS `audit_logs`;
+UPDATE config SET conf_value = 132 WHERE conf_name = 'schema';

--- a/src/sql/schema133-down.sql
+++ b/src/sql/schema133-down.sql
@@ -1,3 +1,0 @@
--- revert schema 133
-DROP TABLE IF EXISTS `audit_logs`;
-UPDATE config SET conf_value = 132 WHERE conf_name = 'schema';

--- a/src/sql/schema133.sql
+++ b/src/sql/schema133.sql
@@ -1,0 +1,9 @@
+-- schema 133
+CREATE TABLE `audit_logs` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `body` TEXT NOT NULL,
+    `category` INT UNSIGNED NOT NULL,
+    `userid` INT UNSIGNED NOT NULL,
+    PRIMARY KEY (`id`));
+UPDATE config SET conf_value = 133 WHERE conf_name = 'schema';

--- a/src/sql/schema134-down.sql
+++ b/src/sql/schema134-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 133
+DROP TABLE IF EXISTS `audit_logs`;
+UPDATE config SET conf_value = 133 WHERE conf_name = 'schema';

--- a/src/sql/schema134.sql
+++ b/src/sql/schema134.sql
@@ -6,4 +6,4 @@ CREATE TABLE `audit_logs` (
     `category` INT UNSIGNED NOT NULL,
     `userid` INT UNSIGNED NOT NULL,
     PRIMARY KEY (`id`));
-UPDATE config SET conf_value = 133 WHERE conf_name = 'schema';
+UPDATE config SET conf_value = 134 WHERE conf_name = 'schema';

--- a/src/sql/schema134.sql
+++ b/src/sql/schema134.sql
@@ -1,4 +1,4 @@
--- schema 133
+-- schema 134
 CREATE TABLE `audit_logs` (
     `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -41,6 +41,19 @@ CREATE TABLE `api_keys` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
 --
+-- Table structure for table `audit_logs`
+--
+
+CREATE TABLE `audit_logs` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `body` TEXT NOT NULL,
+  `category` INT UNSIGNED NOT NULL,
+  `userid` INT UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+--
 -- Table structure for table `authfail`
 --
 

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -50,6 +50,7 @@
   <li data-action='switch-tab' data-tabtarget='10'>SAML</li>
   <li data-action='switch-tab' data-tabtarget='11'>LDAP</li>
   <li data-action='switch-tab' data-tabtarget='12'>{{ 'External auth'|trans }}</li>
+  <li data-action='switch-tab' data-tabtarget='13'>{{ 'Audit Logs'|trans }}</li>
 </ul>
 
 {# loading spinner #}
@@ -988,6 +989,31 @@
   </div>
 </div>
 
+<div data-tabcontent='13' hidden>
+  <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Audit Logs'|trans }}</h3>
+  <div class='pl-3 mb-5'>
+    <p>{{ 'This table lists the most recent events recorded in the application and worth keeping a trace of.'|trans }}</p>
+    <table id='auditLogsTable' class='table' aria-label='audit logs table' data-table-sort='true'>
+      <thead>
+        <tr>
+          <th scope='col'>{{ 'Category'|trans }}</th>
+          <th scope='col'>{{ 'Created at'|trans }}</th>
+          <th scope='col'>{{ 'Content'|trans }}</th>
+          <th scope='col'>{{ 'Userid'|trans }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for log in auditLogsArr %}
+          <tr>
+            <td>{{ log.category }}</td>
+            <td><span class='relative-moment' title='{{ log.created_at }}'></span></td>
+            <td>{{ log.body }}</td>
+            <td>{% if log.userid != 0 %}<a class='p-1 rounded hl-hover-gray' href='?tab=3&q=&userid={{ log.userid }}'>{{ log.userid }}</a>{% else %}<span class='p-1'>−</span>{% endif %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 
 <div id='info' data-page='sysconfig'></div>
 {% endblock body %}

--- a/tests/unit/models/AuditLogsTest.php
+++ b/tests/unit/models/AuditLogsTest.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2023 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+class AuditLogsTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRead(): void
+    {
+        $this->assertIsArray(AuditLogs::read());
+    }
+}

--- a/web/app/controllers/RegisterController.php
+++ b/web/app/controllers/RegisterController.php
@@ -42,7 +42,7 @@ try {
     }
 
     // Create user
-    $userid = $App->Users->createOne(
+    $App->Users->createOne(
         (new UserParams('email', (string) $Request->request->get('email')))->getContent(),
         array($Request->request->get('team')),
         (new UserParams('firstname', (string) $Request->request->get('firstname')))->getContent(),

--- a/web/app/controllers/RegisterController.php
+++ b/web/app/controllers/RegisterController.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Elabftw;
 
 use function dirname;
+
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Services\Check;
@@ -41,7 +42,7 @@ try {
     }
 
     // Create user
-    $App->Users->createOne(
+    $userid = $App->Users->createOne(
         (new UserParams('email', (string) $Request->request->get('email')))->getContent(),
         array($Request->request->get('team')),
         (new UserParams('firstname', (string) $Request->request->get('firstname')))->getContent(),
@@ -56,9 +57,6 @@ try {
     }
     // store the email here so we can put it in the login field
     $App->Session->set('email', $Request->request->get('email'));
-
-    // log user creation
-    $App->Log->info('New user created from register page.');
 } catch (ImproperActionException $e) {
     // show message to user
     $App->Session->getFlashBag()->add('ko', $e->getMessage());

--- a/web/app/controllers/UcpController.php
+++ b/web/app/controllers/UcpController.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Elabftw;
 
 use function dirname;
+
 use Elabftw\Auth\Local;
 use Elabftw\Controllers\LoginController;
 use Elabftw\Enums\Action;
@@ -46,7 +47,6 @@ try {
         // CHANGE PASSWORD (only for local accounts)
         if (!empty($Request->request->get('password')) && (int) $App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL) {
             $App->Users->patch(Action::UpdatePassword, $postData);
-            $App->Log->info('Password was changed for this user', array('userid' => $App->Users->userData['userid']));
         }
 
         // TWO FACTOR AUTHENTICATION

--- a/web/app/logout.php
+++ b/web/app/logout.php
@@ -9,8 +9,10 @@
 
 namespace Elabftw\Elabftw;
 
+use Elabftw\AuditEvent\UserLogout;
 use Elabftw\Auth\Saml as SamlAuth;
 use Elabftw\Exceptions\UnauthorizedException;
+use Elabftw\Models\AuditLogs;
 use Elabftw\Models\AuthenticatedUser;
 use Elabftw\Models\Idps;
 use Exception;
@@ -25,12 +27,12 @@ require_once 'init.inc.php';
 
 $redirectUrl = '/login.php';
 
-// add log line when user logs out
-$App->Log->info('User is logging out', array('userid' => $App->Users->userData['userid'] ?? 0));
 
 $destroySession = function () use ($App): void {
     if ($App->Users instanceof AuthenticatedUser) {
         $App->Users->invalidateToken();
+        // create an event in the audit log (only for authenticated users)
+        AuditLogs::create(new UserLogout($App->Users->userData['userid']));
     }
 
     // kill session


### PR DESCRIPTION
This new table will record events that might be interesting to keep a trace of such as:

- user login/logout (previously generated as an `eLabFTW.INFO` log entry in php error log
- change in team attribution and permission level
- account lifecycle (creation, validation, archiving, modification, deletion)
- password reset request + password change

It looks like this:
![2023-11-27-181243_910x563_scrot](https://github.com/elabftw/elabftw/assets/3043706/807b0dc8-3c22-4997-90eb-9e5f8019f269)

The userid column can be clicked to show the user in the Users tab. It is only accessible to the Sysadmin.

This PR contains:

- a bugfix for adding users to new teams as a Sysadmin
- a new MySQL table: `audit_logs`
- a new namespace `AuditEvents`
