### PR TITLE
Fix recently introduced issue with uploads

### DIFF
--- a/src/classes/App.php
+++ b/src/classes/App.php
@@ -44,7 +44,7 @@ class App
     use UploadTrait;
     use TwigTrait;
 
-    public const INSTALLED_VERSION = '5.0.0-alpha3';
+    public const INSTALLED_VERSION = '5.0.0-alpha4';
 
     public const WHATSNEWLINK = 'https://www.deltablot.com/posts/release-500/';
 

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -121,7 +121,7 @@
   <div class='pl-3 mt-2'>
     <label for='common_template'>{{ 'Common Experiment Template'|trans }}</label>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element : suppress errors from tinymce] -->
+      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, text-content: suppress errors from tinymce] -->
     {%- endif %}
     <textarea style='height:400px' class='mceditable' name='common_template' id='common_template'>
       {{ App.teamArr.common_template|raw }}

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -121,7 +121,7 @@
   <div class='pl-3 mt-2'>
     <label for='common_template'>{{ 'Common Experiment Template'|trans }}</label>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block element-permitted-content, no-deprecated-attr, prefer-native-element, text-content: suppress errors from tinymce] -->
+      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, text-content: suppress errors from tinymce] -->
     {%- endif %}
     <textarea style='height:400px' class='mceditable' name='common_template' id='common_template'>
       {{ App.teamArr.common_template|raw }}

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -120,8 +120,8 @@
 
   <div class='pl-3 mt-2'>
     <label for='common_template'>{{ 'Common Experiment Template'|trans }}</label>
-    {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, text-content: suppress errors from tinymce] -->
+    {% if App.Config.configArr.debug -%}{# set no-unused-disable and text-content because removing or leaving text-content brings up error #}
+      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, no-unused-disable, text-content: suppress errors from tinymce] -->
     {%- endif %}
     <textarea style='height:400px' class='mceditable' name='common_template' id='common_template'>
       {{ App.teamArr.common_template|raw }}

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -121,7 +121,7 @@
   <div class='pl-3 mt-2'>
     <label for='common_template'>{{ 'Common Experiment Template'|trans }}</label>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, text-content: suppress errors from tinymce] -->
+      <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element : suppress errors from tinymce] -->
     {%- endif %}
     <textarea style='height:400px' class='mceditable' name='common_template' id='common_template'>
       {{ App.teamArr.common_template|raw }}

--- a/src/templates/archive-user-modal.html
+++ b/src/templates/archive-user-modal.html
@@ -7,7 +7,7 @@
   {% set action = 'Archive user'|trans %}
   {% set description = 'Archiving a user means their account will be disabled. This action is reversible.'|trans %}
 {% endif %}
-<div class='modal fade' id='archiveUserModal_{{ user.userid }}' tabindex='-1' role='dialog' aria-labelledby='archiveUserModalLabel' aria-hidden='true'>
+<div class='modal fade' id='archiveUserModal_{{ user.userid }}' tabindex='-1' role='dialog' aria-labelledby='archiveUserModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/booking-params-modal.html
+++ b/src/templates/booking-params-modal.html
@@ -1,5 +1,5 @@
 {# Modal for booking parameters #}
-<div class='modal fade' id='bookingParamsModal' tabindex='-1' role='dialog' aria-labelledby='bookingParamsModalLabel' aria-hidden='true'>
+<div class='modal fade' id='bookingParamsModal' tabindex='-1' role='dialog' aria-labelledby='bookingParamsModalLabel'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/create-idp-modal.html
+++ b/src/templates/create-idp-modal.html
@@ -1,5 +1,5 @@
 {# Modal for IDP creation #}
-<div class='modal fade' id='createIdpModal' tabindex='-1' role='dialog' aria-labelledby='createidpModalLabel' aria-hidden='true'>
+<div class='modal fade' id='createIdpModal' tabindex='-1' role='dialog' aria-labelledby='createidpModalLabel'>
   <div class='modal-dialog modal-xl' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/create-idp-modal.html
+++ b/src/templates/create-idp-modal.html
@@ -55,7 +55,7 @@
         <div class='d-flex justify-content-between'>
           <div>
             <label for='x509_idp' class='col-form-label'>x509 Certificate</label>
-            <input type='file' data-action='load-file-on-change' data-target='x509_idp' class='form-control' />
+            <input type='file' data-action='load-file-on-change' data-target='x509_idp' class='form-control' aria-label='File upload: x509 Certificate in PEM format' />
           </div>
             <textarea class='form-control col-md-4' id='x509_idp' placeholder='-----BEGIN CERTIFICATE-----MIIELDCC...' name='x509' required></textarea>
         </div>
@@ -64,7 +64,7 @@
         <div class='d-flex justify-content-between'>
           <div>
             <label for='x509_new_idp' class='col-form-label'>x509 Certificate (additional for rollover)</label>
-            <input type='file' data-action='load-file-on-change' data-target='x509_new_idp' class='form-control' />
+            <input type='file' data-action='load-file-on-change' data-target='x509_new_idp' class='form-control' aria-label='File upload: Rollover x509 Certificate in PEM format' />
           </div>
           <textarea class='form-control col-md-4' id='x509_new_idp' name='x509_new' required></textarea>
         </div>

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -22,7 +22,7 @@
               <a style='border: 1px #ccc solid;' class='btn btn-light mt-1' href='#' data-action='create-entity' data-type='{{ entityType }}' data-tplid='0'>{{ 'Default template'|trans }}</a>
               <a style='border: 1px #ccc solid;' class='btn btn-light ml-1 mt-1' href='#' data-action='create-entity' data-type='{{ entityType }}' data-tplid=''>{{ 'Blank experiment'|trans }}</a>
             {% endif %}
-        <a style='border: 1px #ccc solid;' class='btn btn-light ml-auto mt-1' title='{{ 'Manage templates'|trans }}' href='/ucp.php?tab=3'><i class='fas fa-cog'></i></a>
+            <a style='border: 1px #ccc solid;' class='btn btn-light ml-auto mt-1' title='{{ 'Manage templates'|trans }}' aria-label='{{ 'Manage templates'|trans }}' href='/ucp.php?tab=3'><i class='fas fa-cog'></i></a>
           </div>
           <hr>
         {% endif %}

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -6,7 +6,7 @@
   {% set createNewCategoryArr = categoryArr|default(itemsCategoryArr) %}
 {% endif %}
 
-<div class='modal fade' id='createModal_{{ entityType }}' tabindex='-1' role='dialog' aria-labelledby='createModalLabel_{{ entityType }}' aria-hidden='true'>
+<div class='modal fade' id='createModal_{{ entityType }}' tabindex='-1' role='dialog' aria-labelledby='createModalLabel_{{ entityType }}'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/create-new.html
+++ b/src/templates/create-new.html
@@ -20,9 +20,7 @@
             <h6 class='dropdown-header'>{{ 'No pinned templates found'|trans }}</h6>
           {% endif %}
           <div class='dropdown-divider'></div>
-          <a href='ucp.php?tab=3' class='dropdown-item'><i class='fas fa-layer-group'></i>
-            {{ 'Manage templates'|trans }}
-          </a>
+          <a href='ucp.php?tab=3' class='dropdown-item'><i class='fas fa-layer-group' aria-hidden='true'></i> {{ 'Manage templates'|trans }}</a>
         {% else %}
           {% for category in itemsCategoryArr %}
             <button type='button' data-action='create-entity' data-type='items' data-tplid='{{ category.id }}' class='btn btn-dropdown-item dropdown-item' style='color:#{{ category.color }}'>

--- a/src/templates/create-statuslike-modal.html
+++ b/src/templates/create-statuslike-modal.html
@@ -1,5 +1,5 @@
 {# create a status or experiments category #}
-<div class='modal fade' id='create{{ target }}Modal' tabindex='-1' role='dialog' aria-labelledby='create{{ target }}ModalLabel' aria-hidden='true'>
+<div class='modal fade' id='create{{ target }}Modal' tabindex='-1' role='dialog' aria-labelledby='create{{ target }}ModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/edit-tags.html
+++ b/src/templates/edit-tags.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 <div class='d-none d-sm-block mb-2 align-items-center mathjax-ignore'>
-  <details open>
+  <details closed>
     <summary class='col-form-label mr-3 edit-mode-label'>{{ 'Suggested tags'|trans }}</summary>
     <div id='tags_div_suggestedtags_{{ Entity.id }}' class='mr-2 d-flex flex-wrap'>
       {% set filteredTags = [] %}

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -35,7 +35,7 @@
 
 {% include('view-edit-toolbar.html') %}
 
-<section id='main_section'>
+<section id='main_section' aria-label='main section'>
 
   {# DATE and RATING #}
   <div class='d-flex mb-2'>
@@ -91,7 +91,7 @@
         {% else %}
         {# do not display body if set in metadata, done via css to avoid delayed disappearance after JS is executed #}
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block element-permitted-content, no-deprecated-attr, prefer-native-element: suppress errors from tinymce] -->
+            <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element: suppress errors from tinymce] -->
           {%- endif %}
           <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='mceditable invisible' name='body'>{{ Entity.entityData.body }}</textarea>
         {% endif %}
@@ -178,7 +178,7 @@
   {# chemdoodle #}
   <div>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block deprecated, element-permitted-content, no-missing-references, prefer-native-element, wcag/h37, wcag/h67, text-content, no-implicit-button-type, no-redundant-role: suppress errors from sketcher] -->
+      <!-- [html-validate-disable-block deprecated, element-permitted-content, no-missing-references, prefer-native-element, wcag/h67, no-implicit-button-type, no-redundant-role: suppress errors from sketcher] -->
     {%- endif %}
     <canvas id='sketcher'></canvas>
   </div>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -1,7 +1,7 @@
 <h3 class='p-2 pl-3 section-title'>{{ 'Search users'|trans }}</h3>
 <div class='pl-3'>
   <div class='form-group'>
-    <form method='get' id='userSearchForm' aria-label='{{ 'Search'|trans }}'>
+    <form method='get' id='userSearchForm' aria-label='{{ 'Search users'|trans }}'>
       {# stay on correct tab #}
       <input type='hidden' value='3' name='tab' />
 

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -1,7 +1,7 @@
 <h3 class='p-2 pl-3 section-title'>{{ 'Search users'|trans }}</h3>
 <div class='pl-3'>
   <div class='form-group'>
-    <form method='get' id ='userSearchForm'>
+    <form method='get' id='userSearchForm' aria-label='{{ 'Search'|trans }}'>
       {# stay on correct tab #}
       <input type='hidden' value='3' name='tab' />
 
@@ -56,7 +56,7 @@
         {% for user in usersArr %}
           {% include('archive-user-modal.html') %}
           {# Modal for managing users to teams, generated for each user #}
-          <div class='modal fade' id='manageUsers2teamsModal_{{ user.userid }}' tabindex='-1' role='dialog' aria-labelledby='manageTeamsForUser' aria-hidden='true'>
+          <div class='modal fade' id='manageUsers2teamsModal_{{ user.userid }}' tabindex='-1' role='dialog' aria-labelledby='manageTeamsForUser'>
             <div class='modal-dialog modal-xl' role='document'>
               <div class='modal-content'>
                 <div class='modal-header'>

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -5,7 +5,7 @@
       {% if App.Config.configArr.debug -%}
         <!-- [html-validate-disable-next wcag/h32: no submit button for navbar search field] -->
       {%- endif %}
-      <form id ='newFieldForm' class='new-field-form'>
+      <form id ='newFieldForm' class='new-field-form' aria-label='new extra field'>
         <div class='modal-header'>
           <h5 class='modal-title' id='fieldBuilderLabel'><i class='fas fa-fw fa-trowel'></i> {{ 'Add an extra field'|trans }}</h5>
           <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -1,5 +1,5 @@
 {# Modal for field builder #}
-<div class='modal fade' id='fieldBuilderModal' tabindex='-1' role='dialog' aria-labelledby='fieldBuilderLabel' aria-hidden='true'>
+<div class='modal fade' id='fieldBuilderModal' tabindex='-1' role='dialog' aria-labelledby='fieldBuilderLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       {% if App.Config.configArr.debug -%}
@@ -147,7 +147,7 @@
   </div>
 </div>
 {# Modal for field loader #}
-<div class='modal fade' id='fieldLoaderModal' tabindex='-1' role='dialog' aria-labelledby='fieldLoaderLabel' aria-hidden='true'>
+<div class='modal fade' id='fieldLoaderModal' tabindex='-1' role='dialog' aria-labelledby='fieldLoaderLabel'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content new-field-form'>
       <div class='modal-header'>

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -66,7 +66,7 @@
 {% endif %}
 
 {# Modal for policies #}
-<div class='modal fade' id='policiesModal' tabindex='-1' role='dialog' aria-labelledby='policiesModalLabel' aria-hidden='true'>
+<div class='modal fade' id='policiesModal' tabindex='-1' role='dialog' aria-labelledby='policiesModalLabel'>
   <div class='modal-dialog modal-xl' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -41,7 +41,7 @@
 <div id='container' class='container-fluid'>
 
 {# begin main menu #}
-<nav class='navbar navbar-expand-lg navbar-dark'>
+<nav aria-label='{{ 'Main menu'|trans }}' class='navbar navbar-expand-lg navbar-dark'>
     {% if App.Session.has('is_auth') %}
     {# hamburger menu #}
     <button class='navbar-toggler' type='button' data-toggle='collapse' data-target='#main-nav' aria-controls='main-nav' aria-expanded='false' aria-label='{{ 'Toggle navigation'|trans }}'>
@@ -78,7 +78,7 @@
         {% if App.Config.configArr.debug -%}
           <!-- [html-validate-disable-next wcag/h32: no submit button for navbar search field] -->
         {%- endif %}
-        <form class='nav-item form-inline ml-auto' method='get' action='{{ actionPage }}'>
+        <form aria-label='{{ 'Search'|trans }}' class='nav-item form-inline ml-auto' method='get' action='{{ actionPage }}'>
           {# the id is for making it easy to find the element when focusing it with the keyboard shortcut #}
           <input id='quicksearchInput' class='form-control big-search' type='search' name='q' aria-label='{{ 'Search'|trans }}' size='20' value='{{ App.Request.query.get('q') }}' />
         </form>
@@ -173,7 +173,7 @@
 </noscript>
 
 {# Modal for help #}
-<div class='modal fade' id='helpModal' tabindex='-1' role='dialog' aria-labelledby='helpModalLabel' aria-hidden='true'>
+<div class='modal fade' id='helpModal' tabindex='-1' role='dialog' aria-labelledby='helpModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -78,7 +78,7 @@
         {% if App.Config.configArr.debug -%}
           <!-- [html-validate-disable-next wcag/h32: no submit button for navbar search field] -->
         {%- endif %}
-        <form aria-label='{{ 'Search'|trans }}' class='nav-item form-inline ml-auto' method='get' action='{{ actionPage }}'>
+        <form aria-label='{{ 'Quicksearch'|trans }}' class='nav-item form-inline ml-auto' method='get' action='{{ actionPage }}'>
           {# the id is for making it easy to find the element when focusing it with the keyboard shortcut #}
           <input id='quicksearchInput' class='form-control big-search' type='search' name='q' aria-label='{{ 'Search'|trans }}' size='20' value='{{ App.Request.query.get('q') }}' />
         </form>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -1,7 +1,7 @@
 {# JSON EDITOR #}
 {% include('field-builder-modal.html') %}
 
-<section id='json-editor'>
+<section id='json-editor' aria-label='json editor'>
   {# id for icon is used when focusing after loading from file #}
   <h3 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='false' aria-controls='jsonEditorDiv'><i id='jsonEditorIcon' class='fas fa-caret-right fa-fw mr-2'></i>{{ 'JSON Editor'|trans }}</h3>
 
@@ -65,7 +65,7 @@
     <button class='btn lh-normal border-0 px-0' type='button' data-action='toggle-next' aria-expanded='false' title='{{ 'Information'|trans }}' aria-label='{{ 'Information'|trans }}'><i class='fas fa-fw fa-info-circle'></i></button><span hidden><a target='_blank' rel='noopener' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>
     <h6 id='jsonEditorTitle'></h6>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block no-deprecated-attr, text-content: suppress errors from jsonEditor] -->
+      <!-- [html-validate-disable-block no-deprecated-attr : suppress errors from jsonEditor] -->
     {%- endif %}
     <div id='jsonEditorContainer' data-preload-json='1'></div>
   </div>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -3,7 +3,7 @@
 {% block body %}
 
 {# Modal for reset password #}
-<div class='modal fade' id='resetModal' tabindex='-1' role='dialog' aria-labelledby='resetModalLabel' aria-hidden='true'>
+<div class='modal fade' id='resetModal' tabindex='-1' role='dialog' aria-labelledby='resetModalLabel'>
   <div class='modal-dialog modal-dialog-centered' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>
@@ -13,7 +13,7 @@
         </button>
       </div>
       <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
-        <form name='resetPass' method='post' action='app/controllers/ResetPasswordController.php'>
+        <form name='resetPass' method='post' action='app/controllers/ResetPasswordController.php' aria-label='{{ 'Reset password'|trans }}'>
           {{ App.Session.get('csrf')|csrf }}
           <input class='form-control' placeholder='{{ 'Enter your email address'|trans }}' name='email' type='email' required />
           <div class='text-center'>
@@ -88,7 +88,7 @@
   {% elseif App.Request.server.get(App.Config.configArr.extauth_remote_user) %}
     <!-- user is already authed with external auth, so just present a continue button
       we don't autologin anymore -->
-      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off'>
+      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off' aria-label='{{ 'Continue'|trans }}'>
         {{ App.Session.get('csrf')|csrf }}
         <input type='hidden' name='auth_type' value='external'>
         <h2 class='mt-4'>{{ 'You are already authenticated'|trans }}</h2>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -15,7 +15,7 @@
       <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
         <form name='resetPass' method='post' action='app/controllers/ResetPasswordController.php' aria-label='{{ 'Reset password'|trans }}'>
           {{ App.Session.get('csrf')|csrf }}
-          <input class='form-control' placeholder='{{ 'Enter your email address'|trans }}' name='email' type='email' required />
+          <input class='form-control' aria-label='email address' placeholder='{{ 'Enter your email address'|trans }}' name='email' type='email' required />
           <div class='text-center'>
             <button class='btn btn-primary mt-2' type='submit' name='Submit'>{{ 'Send reset link'|trans }}</button>
           </div>
@@ -88,7 +88,7 @@
   {% elseif App.Request.server.get(App.Config.configArr.extauth_remote_user) %}
     <!-- user is already authed with external auth, so just present a continue button
       we don't autologin anymore -->
-      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off' aria-label='{{ 'Continue'|trans }}'>
+      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off' aria-label='autologin form'>
         {{ App.Session.get('csrf')|csrf }}
         <input type='hidden' name='auth_type' value='external'>
         <h2 class='mt-4'>{{ 'You are already authenticated'|trans }}</h2>
@@ -99,7 +99,7 @@
 
     {% if showLocal or App.Config.configArr.ldap_toggle %}
       {# Login form , the id is for an acceptance test #}
-      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off'>
+      <form method='post' id='login' action='app/controllers/LoginController.php' autocomplete='off' aria-label='local or ldap login'>
         {{ App.Session.get('csrf')|csrf }}
         <h1 class='my-4 '>{{ 'Login to your account'|trans }}</h1>
         <div class='col-md-4 mx-auto text-left form-group'>

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -1,5 +1,5 @@
 {# Modal for ownership transfer #}
-<div class='modal fade' id='ownerModal' tabindex='-1' role='dialog' aria-labelledby='ownerModalLabel' aria-hidden='true'>
+<div class='modal fade' id='ownerModal' tabindex='-1' role='dialog' aria-labelledby='ownerModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -22,7 +22,7 @@
   {% set modalTitle = 'Select who can book this entry'|trans %}
 {% endif %}
 {# Modal for permission edit #}
-<div class='modal fade' id='permModal-{{ identifier }}' tabindex='-1' role='dialog' aria-labelledby='permModalLabel_{{ identifier }}' aria-hidden='true'>
+<div class='modal fade' id='permModal-{{ identifier }}' tabindex='-1' role='dialog' aria-labelledby='permModalLabel_{{ identifier }}'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -6,7 +6,7 @@
 </a>
 
 {# Modal for privacy policy #}
-<div class='modal fade' id='policyModal' tabindex='-1' role='dialog' aria-labelledby='policyModalLabel' aria-hidden='true'>
+<div class='modal fade' id='policyModal' tabindex='-1' role='dialog' aria-labelledby='policyModalLabel'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -200,7 +200,7 @@
 
 {# SEARCH PAGE BEGIN #}
 <hr>
-<form method='get' action='search.php'>
+<form method='get' action='search.php' aria-label='Main search form'>
 {# MAIN TEXTAREA FOR EXTENDED QUERY #}
 <div class='row'>
   <div class='col-md-12 mb-2'>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -4,7 +4,7 @@
 {% endblock %}
 
 {# Modal for advanced search #}
-<div class='modal fade' id='advancedSearchModal' tabindex='-1' role='dialog' aria-labelledby='advancedSearchModalLabel' aria-hidden='true'>
+<div class='modal fade' id='advancedSearchModal' tabindex='-1' role='dialog' aria-labelledby='advancedSearchModalLabel'>
   <div class='modal-dialog modal-xl' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/show-item-table.html
+++ b/src/templates/show-item-table.html
@@ -1,5 +1,5 @@
 {% set randomId = random() %}
-<tr class='item' id='parent_{{ randomId }}'>
+<tr class='item' id='parent_{{ randomId }}' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
 
   {# DATE #}
   <td class='item-date'>

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -5,7 +5,7 @@
   {% set owner = "%s <a href='?owner=%s'>%s</a>"|format('by'|trans, item.userid, item.fullname) %}
 {% endif %}
 
-<section class='item pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};'>
+<section class='item pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
 
   {# left part, full height: checkbox #}
   <div class='d-flex align-items-center'>

--- a/src/templates/show-view-edit.html
+++ b/src/templates/show-view-edit.html
@@ -12,7 +12,7 @@
       </div>
       <div class='modal-body'>
         <p>{{ 'You can import data from a .eln archive, a .zip archive (created by eLabFTW) or a .csv file. %sSee documentation %s%s.'|trans|format("<a href='https://doc.elabftw.net/user-guide.html#importing-data' target='_blank' rel='noopener'>", "<i class='fas fa-arrow-up-right-from-square'></i>", '</a>')|raw }}</p>
-        <form class='form-group' enctype='multipart/form-data' action='app/controllers/ImportController.php' method='post'>
+        <form class='form-group' enctype='multipart/form-data' action='app/controllers/ImportController.php' method='post' aria-label='{{ 'Import file'|trans }}'>
           {{ App.Session.get('csrf')|csrf }}
           <label for='import_modal_target'>{{ '1. Select where to import:'|trans }}</label>
           <select class='form-control' id='import_modal_target' autocomplete='off' name='target'>

--- a/src/templates/show-view-edit.html
+++ b/src/templates/show-view-edit.html
@@ -1,7 +1,7 @@
 {% include 'create-new-item-modal.html' with {'entityType': 'experiments'} %}
 {% include 'create-new-item-modal.html' with {'entityType': 'items'} %}
 {# Modal for import #}
-<div class='modal fade' id='importModal' tabindex='-1' role='dialog' aria-labelledby='importModalLabel' aria-hidden='true'>
+<div class='modal fade' id='importModal' tabindex='-1' role='dialog' aria-labelledby='importModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -76,7 +76,7 @@
     {% else %}
       <form
     {% endif %}
-       class='form-group form-inline mb-2'>
+      class='form-group form-inline mb-2' aria-label='{{ 'Query filters'|trans }}'>
       {% if not searchPage %}
         <input type='hidden' name='q' value='{{ DisplayParams.query }}' />
       {% endif %}

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,6 +1,6 @@
 <div class='row mt-4'>
   {# STEPS #}
-  <section class='col-md-12'>
+  <div class='col-md-12'>
     <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }}</h4>
     {# ADD STEP #}
     <div id='stepsDiv' class='mt-2' data-save-hidden='stepsDiv'>
@@ -89,13 +89,13 @@
       </div>
     </div>
     <hr>
-  </section>
+  </div>
 
 
   {# LINKS #}
   {% if Entity.type == 'items' or Entity.type == 'experiments' %}
     {# EXPERIMENTS LINKS #}
-    <section class='col-md-12'>
+    <div class='col-md-12'>
       <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksExpDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{% trans %}
       Linked experiment
       {% plural 2 %}
@@ -151,12 +151,12 @@
         </div>
       </div>
       <hr>
-    </section>
+    </div>
 
   {% endif %}
 
   {# ITEMS LINKS #}
-  <section class='col-md-12'>
+  <div class='col-md-12'>
     <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Linked resources'|trans }}</h4>
     {# DISPLAY ITEMS LINKS #}
     <div class='mt-2' data-save-hidden='linksDiv' id='linksDiv'>
@@ -208,6 +208,6 @@
       </div>
     </div>
     <hr>
-  </section>
+  </div>
 </div>
 

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -453,7 +453,7 @@
         {{ 'Note: the text below is a template and must be edited and saved.'|trans|msg('ok', false) }}
       {% endif %}
       {% if configArr.debug -%}
-        <!-- [html-validate-disable-block element-permitted-content, no-deprecated-attr, prefer-native-element: suppress errors from tinymce] -->
+        <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element: suppress errors from tinymce] -->
       {%- endif %}
       <textarea id='{{ slug }}Input' class='mceditable'>
         {{ configArr[slug]|default('Set your text here.')|raw }}
@@ -618,7 +618,7 @@
     <div class='d-flex justify-content-between'>
       <div>
         <label for='x509' class='col-form-label'>x509 Certificate in PEM format</label>
-        <input type='file' data-action='load-file-on-change' data-target='x509' class='form-control' aria-label='File upload: x509 Certificate in PEM format'/>
+        <input type='file' data-action='load-file-on-change' data-target='x509' class='form-control' aria-label='File upload: x509 Certificate in PEM format' />
       </div>
       <textarea class='form-control col-md-3' id='x509' data-trigger='blur' data-model='config' data-target='saml_x509'>{{ App.Config.configArr.saml_x509 }}</textarea>
     </div>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -5,7 +5,7 @@
 {% include('create-idp-modal.html') %}
 
 {# Modal for team creation #}
-<div class='modal fade' id='createTeamModal' tabindex='-1' role='dialog' aria-labelledby='createTeamModalLabel' aria-hidden='true'>
+<div class='modal fade' id='createTeamModal' tabindex='-1' role='dialog' aria-labelledby='createTeamModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -758,7 +758,7 @@
             <div class='d-flex justify-content-between'>
               <div>
                 <label for='x509_{{ idp.id }}' class='col-form-label'>x509cert</label>
-                <input type='file' data-action='load-file-on-change' data-target='x509_{{ idp.id }}' class='form-control' />
+                <input type='file' data-action='load-file-on-change' data-target='x509_{{ idp.id }}' class='form-control'  aria-label='File upload: x509 Certificate in PEM format' />
               </div>
               <textarea class='form-control col-md-3' data-trigger='blur' data-model='idps/{{ idp.id }}' data-target='x509' id='x509_{{ idp.id }}'>{{ idp.x509 }}</textarea>
             </div>
@@ -767,7 +767,7 @@
             <div class='d-flex justify-content-between'>
               <div>
                 <label for='x509_new_{{ idp.id }}' class='col-form-label'>x509cert (additional for rollover)</label>
-                <input type='file' data-action='load-file-on-change' data-target='x509_new_{{ idp.id }}' class='form-control' />
+                <input type='file' data-action='load-file-on-change' data-target='x509_new_{{ idp.id }}' class='form-control' aria-label='File upload: Rollover x509 Certificate in PEM format' />
               </div>
               <textarea class='form-control col-md-3' data-trigger='blur' data-model='idps/{{ idp.id }}' data-target='x509_new' id='x509_new_{{ idp.id }}'>{{ idp.x509_new }}</textarea>
             </div>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -14,7 +14,7 @@
 </div>
 
 {# Modal for event click #}
-<div class='modal fade' id='eventModal' tabindex='-1' role='dialog' aria-labelledby='eventModalLabel' aria-hidden='true'>
+<div class='modal fade' id='eventModal' tabindex='-1' role='dialog' aria-labelledby='eventModalLabel'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -36,14 +36,14 @@
 
         {# BIND EXPERIMENT #}
         <div class='mt-2'>
-          <i class='fas fa-link mr-1'></i><h5 class='d-inline'>{{ 'Bind an experiment'|trans }}</h5>
+          <i class='fas fa-link mr-1'></i><h5 class='d-inline' id='bindExpInputLabel'>{{ 'Bind an experiment'|trans }}</h5>
           <div id='eventBoundExp'></div>
-          <button data-action='scheduler-rm-bind' data-type='experiment' data-eventid='' aria-hidden='true' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
+          <button data-action='scheduler-rm-bind' data-type='experiment' data-eventid='' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
             <div class='input-group mb-3'>
               <div class='input-group-prepend'>
                 <span class='input-group-text'>{{ 'Search'|trans }}</span>
               </div>
-              <input type='text' data-complete-target='experiments' data-identifier='binddivexp' class='form-control bindInput' />
+              <input type='text' data-complete-target='experiments' data-identifier='binddivexp' class='form-control bindInput' aria-labelledby='bindExpInputLabel' />
               <div class='input-group-append'>
                 <button class='btn btn-primary' data-input='bindexpinput' data-action='scheduler-bind-entity' data-type='experiment' type='button'>{{ 'Attach'|trans }}</button>
               </div>
@@ -52,14 +52,14 @@
         </div>
         {# BIND ITEM #}
         <div class='mt-2'>
-          <i class='fas fa-link mr-1'></i><h5 class='d-inline'>{{ 'Bind a resource'|trans }}</h5>
+          <i class='fas fa-link mr-1'></i><h5 class='d-inline' id='bindItemInputLabel'>{{ 'Bind a resource'|trans }}</h5>
           <div id='eventBoundDb'></div>
-          <button data-action='scheduler-rm-bind' data-type='item_link' data-eventid='' aria-hidden='true' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
+          <button data-action='scheduler-rm-bind' data-type='item_link' data-eventid='' class='btn btn-sm btn-danger mb-2' type='button'>{{ 'Unbind'|trans }}</button>
             <div class='input-group mb-3'>
               <div class='input-group-prepend'>
                 <span class='input-group-text'>{{ 'Search'|trans }}</span>
               </div>
-              <input type='text' data-complete-target='items' data-identifier='binddivdb' class='form-control bindInput' />
+              <input type='text' data-complete-target='items' data-identifier='binddivdb' class='form-control bindInput' aria-labelledby='bindItemInputLabel' />
               <div class='input-group-append'>
                 <button class='btn btn-primary' data-input='binddbinput' data-action='scheduler-bind-entity' data-type='item_link' type='button'>{{ 'Attach'|trans }}</button>
               </div>
@@ -71,7 +71,7 @@
         {% if bookableItemData.book_is_cancellable == 1 or App.Users.isAdmin %}
           <div>
             <h5>{{ 'Cancel booking slot'|trans }}</h5>
-            <h6>{{ 'Add a custom message'|trans }}</h6>
+            <h6><label for='cancelEventTextarea'>{{ 'Add a custom message'|trans }}</label></h6>
               <textarea id='cancelEventTextarea' class='form-control'></textarea>
               <label>{{ 'Send to'|trans }}</label>
               <div class='form-check'>
@@ -116,7 +116,7 @@
         {% if App.Config.configArr.debug -%}
           <!-- [html-validate-disable-next wcag/h32: no submit button] -->
         {%- endif %}
-        <form>
+        <form aria-label='{{ 'Filter by category'|trans }}'>
           {% if App.Config.configArr.debug -%}
             <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
           {%- endif %}
@@ -135,7 +135,7 @@
         {% if App.Config.configArr.debug -%}
           <!-- [html-validate-disable-next wcag/h32: no submit button] -->
         {%- endif %}
-        <form>
+        <form aria-label='{{ 'Select a resource'|trans }}'>
           {% if App.Config.configArr.debug -%}
             <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
           {%- endif %}
@@ -213,7 +213,7 @@
 {# TAB 4 EMAIL #}
 <div data-tabcontent='4' hidden>
   <h3 class='p-2 pl-3 mb-3 section-title'><i class='fas fa-envelope'></i> {{ 'Send an email to users'|trans }}</h3>
-  <form class='pl-3' method='post' action='app/controllers/TeamController.php'>
+  <form class='pl-3' method='post' action='app/controllers/TeamController.php' aria-label='{{ 'Mass email form'|trans }}'>
     {{ App.Session.get('csrf')|csrf }}
     <input type='hidden' name='emailUsers' />
     <label>{{ 'Send to'|trans }}</label>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -253,7 +253,7 @@
 
 {# TAB 2 - USER INFORMATION #}
 <div data-tabcontent='2' hidden>
-  <form class='form-group' method='post' action='app/controllers/UcpController.php'>
+  <form class='form-group' method='post' action='app/controllers/UcpController.php' aria-label='{{ 'User information'|trans }}'>
     {{ App.Session.get('csrf')|csrf }}
     {# only show the email/password fields for locally authenticated users #}
     {% if App.Users.userData.auth_service == constant('Elabftw\\Controllers\\LoginController::AUTH_LOCAL') %}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -177,19 +177,19 @@
                 <ul class='dropdown-menu clickable'>
                   {% set moldivId = '3Dmol_' ~ upload.id %}
                   <li class='dropdown-item'>
-                    <span class='3dmol-style' data-divid='{{ moldivId }}' data-style='cartoon'>{{ 'Cartoon (proteins only)'|trans }}</span>
+                    <span data-action='set-3dmol-style' data-divid='{{ moldivId }}' data-style='cartoon'>{{ 'Cartoon (proteins only)'|trans }}</span>
                   </li>
                   <li class='dropdown-item'>
-                    <span class='3dmol-style' data-divid='{{ moldivId }}' data-style='cross'>{{ 'Cross'|trans }}</span>
+                    <span data-action='set-3dmol-style' data-divid='{{ moldivId }}' data-style='cross'>{{ 'Cross'|trans }}</span>
                   </li>
                   <li class='dropdown-item'>
-                    <span class='3dmol-style' data-divid='{{ moldivId }}' data-style='line'>{{ 'Line'|trans }}</span>
+                    <span data-action='set-3dmol-style' data-divid='{{ moldivId }}' data-style='line'>{{ 'Line'|trans }}</span>
                   </li>
                   <li class='dropdown-item'>
-                    <span class='3dmol-style' data-divid='{{ moldivId }}' data-style='sphere'>{{ 'Sphere'|trans }}</span>
+                    <span data-action='set-3dmol-style' data-divid='{{ moldivId }}' data-style='sphere'>{{ 'Sphere'|trans }}</span>
                   </li>
                   <li class='dropdown-item'>
-                    <span class='3dmol-style' data-divid='{{ moldivId }}' data-style='stick'>{{ 'Stick'|trans }}</span>
+                    <span data-action='set-3dmol-style' data-divid='{{ moldivId }}' data-style='stick'>{{ 'Stick'|trans }}</span>
                   </li>
                 </ul>
               </div>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -51,7 +51,7 @@
         {% if App.Config.configArr.debug -%}
           <!-- [html-validate-disable-next wcag/h32: no submit button for dropzone input] -->
         {%- endif %}
-        <form action='api/v2/{{ Entity.type }}/{{ Entity.id }}/uploads' class='dropzone hl-hover-gray mt-2 rounded' id='elabftw-dropzone'></form>
+        <form action='api/v2/{{ Entity.type }}/{{ Entity.id }}/uploads' class='dropzone hl-hover-gray mt-2 rounded' id='elabftw-dropzone' aria-label='file attachment form'></form>
       </div>
     {% endif %}
 

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -1,5 +1,5 @@
 {# Modal to display plain text content #}
-<div class='modal fade' id='plainTextModal' tabindex='-1' role='dialog' aria-labelledby='plainTextModalLabel' aria-hidden='true'>
+<div class='modal fade' id='plainTextModal' tabindex='-1' role='dialog' aria-labelledby='plainTextModalLabel'>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -1,5 +1,5 @@
 {# Modal for timestamping #}
-<div class='modal fade' id='timestampModal' tabindex='-1' role='dialog' aria-labelledby='timestampModalLabel' aria-hidden='true'>
+<div class='modal fade' id='timestampModal' tabindex='-1' role='dialog' aria-labelledby='timestampModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -27,7 +27,7 @@
 </div>
 
 {# Modal for blockchain timestamping #}
-<div class='modal fade' id='blocktimestampModal' tabindex='-1' role='dialog' aria-labelledby='blocktimestampModalLabel' aria-hidden='true'>
+<div class='modal fade' id='blocktimestampModal' tabindex='-1' role='dialog' aria-labelledby='blocktimestampModalLabel'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -20,7 +20,7 @@
       <div class='timestamp-error'></div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
-        <button type='button' data-action='timestamp' class='btn btn-primary'>{{ 'Timestamp'|trans }}</button>
+        <button type='button' data-action='timestamp' data-dismiss='modal' class='btn btn-primary'>{{ 'Timestamp'|trans }}</button>
       </div>
     </div>
   </div>

--- a/src/ts/JsonEditorHelper.class.ts
+++ b/src/ts/JsonEditorHelper.class.ts
@@ -9,7 +9,7 @@ import { Metadata } from './Metadata.class';
 import JSONEditor from 'jsoneditor';
 import $ from 'jquery';
 import i18next from 'i18next';
-import { notif, notifSaved, reloadElement } from './misc';
+import { notif, notifSaved, reloadUploads } from './misc';
 import { Action, Entity, Model } from './interfaces';
 import { Api } from './Apiv2.class';
 import { ValidMetadata } from './metadataInterfaces';
@@ -173,7 +173,7 @@ export default class JsonEditorHelper {
     };
     this.api.post(`${this.entity.type}/${this.entity.id}/${Model.Upload}`, params).then(resp => {
       const location = resp.headers.get('location').split('/');
-      reloadElement('filesdiv');
+      reloadUploads();
       this.currentUploadId = String(location[location.length - 1]);
     });
   }

--- a/src/ts/doodle.ts
+++ b/src/ts/doodle.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { reloadElement } from './misc';
+import { reloadUploads } from './misc';
 import i18next from 'i18next';
 import { Action, Model } from './interfaces';
 import { Api } from './Apiv2.class';
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'real_name': realName,
       'content': image,
     };
-    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadElement('filesdiv'));
+    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadUploads());
   });
 
 

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getEntity, notif, reloadElement, updateCatStat, escapeRegExp, notifError } from './misc';
+import { getEntity, notif, updateCatStat, escapeRegExp, notifError, reloadUploads } from './misc';
 import { getTinymceBaseConfig, quickSave } from './tinymce';
 import { EntityType, Target, Upload, Model, Action } from './interfaces';
 import { DateTime } from 'luxon';
@@ -217,7 +217,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'real_name': realName,
         'content': content,
       };
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElement('filesdiv'));
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadUploads());
 
     // ANNOTATE IMAGE
     } else if (el.matches('[data-action="annotate-image"]')) {
@@ -361,7 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
               resolve(`app/download.php?f=${json.long_name}&storage=${json.storage}`);
               // save here because using the old real_name will not return anything from the db (status is archived now)
               updateEntityBody();
-              reloadElement('filesdiv');
+              reloadUploads();
             });
           });
         } else {
@@ -457,7 +457,7 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         body: formData,
       }).then(resp => {
-        reloadElement('filesdiv');
+        reloadUploads();
         // return early if longName is not found in body
         if ((editorCurrentContent.indexOf(searchPrefixSrc + formElement.dataset.longName) === -1)
           && (editorCurrentContent.indexOf(searchPrefixMd + formElement.dataset.longName) === -1)

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -213,8 +213,8 @@ export function displayMolFiles(): void {
 
 // this exists here because in the Observer of uploads.ts for filesdiv it makes the browser crash
 // FIXME
-export function reloadUploads(): void {
-  reloadElement('filesdiv').then(() => $3Dmol.autoload());
+export async function reloadUploads(): Promise<void> {
+  return reloadElement('filesdiv').then(() => $3Dmol.autoload());
 }
 
 // insert a get param in the url and reload the page

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -211,23 +211,10 @@ export function displayMolFiles(): void {
   });
 }
 
-// DISPLAY 3D MOL FILES
-export function display3DMolecules(autoload = false): void {
-  if (autoload) {
-    $3Dmol.autoload();
-  }
-  // Top left menu to change the style of the displayed molecule
-  $('.dropdown-item').on('click', '.3dmol-style', function() {
-    const targetStyle = $(this).data('style');
-    let options = {};
-    const style = {};
-    if (targetStyle === 'cartoon') {
-      options = { color: 'spectrum' };
-    }
-    style[targetStyle] = options;
-
-    $3Dmol.viewers[$(this).data('divid')].setStyle(style).render();
-  });
+// this exists here because in the Observer of uploads.ts for filesdiv it makes the browser crash
+// FIXME
+export function reloadUploads(): void {
+  reloadElement('filesdiv').then(() => $3Dmol.autoload());
 }
 
 // insert a get param in the url and reload the page

--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -16,7 +16,7 @@ declare global {
 import '@teselagen/ove';
 import '@teselagen/ove/style.css';
 import { anyToJson } from '@teselagen/bio-parsers';
-import { notif, reloadElement } from './misc';
+import { notif, reloadUploads } from './misc';
 import { Action, Model } from './interfaces';
 import { Api } from './Apiv2.class';
 
@@ -49,7 +49,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
           'real_name': realName + '.png',
           'content': reader.result,
         };
-        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadElement('filesdiv'));
+        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadUploads());
       };
     }
 
@@ -136,7 +136,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
         generatePng: true,
         handleFullscreenClose: function(): void { // event could be used as parameter
           editor[viewerID].close();
-          reloadElement('filesdiv');
+          reloadUploads();
         },
         onCopy: function(event, copiedSequenceData, editorState): void {
           // the copiedSequenceData is the subset of the sequence that has been copied in the teselagen sequence format

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -123,8 +123,14 @@ function doneTyping(): void {
 // options for tinymce to pass to tinymce.init()
 export function getTinymceBaseConfig(page: string): object {
   let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image link pagebreak codesample template mention visualblocks visualchars';
-  if (page !== 'admin') {
+  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap adddate | codesample | link | sort-table | save';
+  let removedMenuItems = 'newdocument, image, anchor';
+  if (page === 'edit') {
     plugins += ' autosave';
+    // add Image button in toolbar
+    toolbar1 = toolbar1.replace('link |', 'link image |');
+    // let Image in menu
+    removedMenuItems = 'newdocument, anchor';
   }
   const entity = getEntity();
 
@@ -142,8 +148,8 @@ export function getTinymceBaseConfig(page: string): object {
     plugins: plugins,
     pagebreak_split_block: true,
     pagebreak_separator: '<div class="page-break"></div>',
-    toolbar1: 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap adddate | codesample | link | sort-table | save',
-    removed_menuitems: 'newdocument, image, anchor',
+    toolbar1: toolbar1,
+    removed_menuitems: removedMenuItems,
     image_caption: true,
     images_reuse_filename: false, // if set to true the src url gets a date appended
     images_upload_credentials: true,

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -10,7 +10,6 @@ import { Api } from './Apiv2.class';
 import EntityClass from './Entity.class';
 import i18next from 'i18next';
 import { Action } from './interfaces';
-import $ from 'jquery';
 
 document.addEventListener('DOMContentLoaded', () => {
 

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getEntity, reloadElement } from './misc';
+import { getEntity, reloadElement, reloadUploads } from './misc';
 import { Api } from './Apiv2.class';
 import EntityClass from './Entity.class';
 import i18next from 'i18next';
@@ -78,8 +78,6 @@ document.addEventListener('DOMContentLoaded', () => {
       // prevent double click
       (event.target as HTMLButtonElement).disabled = true;
       EntityC.timestamp(entity.id).then(() => {
-        $('#timestampModal').modal('toggle');
-        reloadElement('filesdiv');
         reloadElement('isTimestampedByInfoDiv');
       });
 
@@ -102,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('container').append(overlay);
       ApiC.patch(`${entity.type}/${entity.id}`, {'action': Action.Bloxberg})
         // reload uploaded files on success
-        .then(() => reloadElement('filesdiv'))
+        .then(() => reloadUploads())
         // remove overlay in all cases
         .finally(() => document.getElementById('container').removeChild(document.getElementById('loadingOverlay')));
     // ARCHIVE ENTITY

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -60,7 +60,7 @@ export class Uploader
 
   init(): Dropzone {
     // the dz-clickable class is present if Dropzone is active on this element
-    if (document.getElementById('elabftw-dropzone').classList.contains('dz-clickable') === false) {
+    if (document.getElementById('elabftw-dropzone') && document.getElementById('elabftw-dropzone').classList.contains('dz-clickable') === false) {
       return new Dropzone(this.getElement(), this.getOptions());
     }
   }

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import Dropzone from '@deltablot/dropzone';
-import { reloadElement } from './misc';
+import { reloadUploads } from './misc';
 import i18next from 'i18next';
 
 export class Uploader
@@ -33,7 +33,7 @@ export class Uploader
         this.on('complete', function() {
           if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
             // reload the #filesdiv
-            reloadElement('filesdiv').then(() => {
+            reloadUploads().then(() => {
               // Now grab the url of the image to give it to tinymce if needed
               // first make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
               if (typeof that.tinyImageSuccess !== 'undefined' && that.tinyImageSuccess !== null) {

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import Dropzone from '@deltablot/dropzone';
-import { relativeMoment, reloadElement } from './misc';
+import { reloadElement } from './misc';
 import i18next from 'i18next';
 
 export class Uploader
@@ -59,7 +59,9 @@ export class Uploader
   }
 
   init(): Dropzone {
-    relativeMoment();
-    return new Dropzone(this.getElement(), this.getOptions());
+    // the dz-clickable class is present if Dropzone is active on this element
+    if (document.getElementById('elabftw-dropzone').classList.contains('dz-clickable') === false) {
+      return new Dropzone(this.getElement(), this.getOptions());
+    }
   }
 }

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'real_name': el.dataset.name + '.png',
         'content': (document.getElementById(el.dataset.canvasid) as HTMLCanvasElement).toDataURL(),
       };
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadUploads);
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadUploads());
 
     // CHANGE 3DMOL FILES VISUALIZATION STYLE
     } else if (el.matches('[data-action="set-3dmol-style"]')) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -7,9 +7,10 @@
  */
 import $ from 'jquery';
 import { Action as MalleAction, Malle } from '@deltablot/malle';
+import * as $3Dmol from '3dmol';
 import '@fancyapps/fancybox/dist/jquery.fancybox.js';
 import { Action, Model } from './interfaces';
-import { displayMolFiles, display3DMolecules, getEntity, reloadElement } from './misc';
+import { displayMolFiles, getEntity, reloadElement, relativeMoment, reloadUploads } from './misc';
 import { displayPlasmidViewer } from './ove';
 import i18next from 'i18next';
 import { Api } from './Apiv2.class';
@@ -30,7 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   displayMolFiles();
-  display3DMolecules();
+  ///display3DMolecules();
+    //$3Dmol.autoload();
   displayPlasmidViewer(about);
   const entity = getEntity();
   const ApiC = new Api();
@@ -97,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // TOGGLE DISPLAY
     } else if (el.matches('[data-action="toggle-uploads-layout"]')) {
       ApiC.notifOnSaved = false;
-      ApiC.patch(`${Model.User}/me`, {'uploads_layout': el.dataset.targetLayout}).then(() => reloadElement('filesdiv'));
+      ApiC.patch(`${Model.User}/me`, {'uploads_layout': el.dataset.targetLayout}).then(() => reloadUploads());
 
     // SHOW CONTENT OF TEXT FILES, MARKDOWN OR JSON
     } else if (el.matches('[data-action="toggle-modal"][data-target="plainTextModal"]')) {
@@ -167,12 +169,25 @@ document.addEventListener('DOMContentLoaded', () => {
         'real_name': el.dataset.name + '.png',
         'content': (document.getElementById(el.dataset.canvasid) as HTMLCanvasElement).toDataURL(),
       };
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElement('filesdiv'));
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadUploads);
+
+    // CHANGE 3DMOL FILES VISUALIZATION STYLE
+    } else if (el.matches('[data-action="set-3dmol-style"]')) {
+      const targetStyle = el.dataset.style;
+      let options = {};
+      const style = {};
+      if (targetStyle === 'cartoon') {
+        options = { color: 'spectrum' };
+      }
+      style[targetStyle] = options;
+
+      $3Dmol.viewers[el.dataset.divid].setStyle(style).render();
 
     // ARCHIVE UPLOAD
     } else if (el.matches('[data-action="archive-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);
-      ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive}).then(() => reloadElement('filesdiv'));
+      ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive})
+        .then(() => reloadUploads());
 
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {
@@ -189,9 +204,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // Observe "#filesdiv" and reload javascript stuff every time it changes
   new MutationObserver(() => {
     displayMolFiles();
-    display3DMolecules(true);
+    //display3DMolecules();
     displayPlasmidViewer(about);
     malleableFilecomment.listen();
+    //$3Dmol.autoload();
     (new Uploader()).init();
+    relativeMoment();
   }).observe(document.getElementById('filesdiv'), {childList: true, subtree: true});
 });

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -31,8 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   displayMolFiles();
-  ///display3DMolecules();
-  //$3Dmol.autoload();
   displayPlasmidViewer(about);
   const entity = getEntity();
   const ApiC = new Api();
@@ -204,10 +202,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Observe "#filesdiv" and reload javascript stuff every time it changes
   new MutationObserver(() => {
     displayMolFiles();
-    //display3DMolecules();
     displayPlasmidViewer(about);
     malleableFilecomment.listen();
-    //$3Dmol.autoload();
     (new Uploader()).init();
     relativeMoment();
   }).observe(document.getElementById('filesdiv'), {childList: true, subtree: true});

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -10,7 +10,7 @@ import { Action as MalleAction, Malle } from '@deltablot/malle';
 import * as $3Dmol from '3dmol';
 import '@fancyapps/fancybox/dist/jquery.fancybox.js';
 import { Action, Model } from './interfaces';
-import { displayMolFiles, getEntity, reloadElement, relativeMoment, reloadUploads } from './misc';
+import { displayMolFiles, getEntity, relativeMoment, reloadUploads } from './misc';
 import { displayPlasmidViewer } from './ove';
 import i18next from 'i18next';
 import { Api } from './Apiv2.class';
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   displayMolFiles();
   ///display3DMolecules();
-    //$3Dmol.autoload();
+  //$3Dmol.autoload();
   displayPlasmidViewer(about);
   const entity = getEntity();
   const ApiC = new Api();


### PR DESCRIPTION
Uploading a .pdb file or any file recognized by 3Dmol would consume all memory and crash the tab.

* make suggested tags closed by default
* improve 3dmol related code by using a data-action
* use data-dismiss on timestamp modal instead of calling the close action manually
* this removes the need for `display3dmolecules()`
* bring back Image menu and button in edit mode. see #4842
* fix html validation issues