### PR TITLE
added Entity.entityData.locked to duplication

### DIFF
--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -84,9 +84,11 @@
   {% if not App.Session.has('is_anon') %}
 
     {# DUPLICATE #}
-    <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' data-action='duplicate-entity' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
-      <i class='fas fa-copy fa-fw'></i>
-    </button>
+    {% if not (Entity.entityData.locked) %}
+      <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' data-action='duplicate-entity' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
+        <i class='fas fa-copy fa-fw'></i>
+      </button>
+    {% endif %}
 
     {% if Entity.type == 'items' and Entity.canBook and Entity.entityData.is_bookable %}
       <a class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' title='{{ 'Book item'|trans }}' aria-label='{{ 'Book item'|trans }}' href='team.php?tab=1&amp;item={{ Entity.id }}'>


### PR DESCRIPTION
In my institution I have the problem that some users tend to overlook the booking icon and accidentally click on the duplicate icon, creating a lot of duplicates that I have to delete regularly to prevent double booking.
To mitigate that I wrapped the [duplicate button ](https://github.com/elabftw/elabftw/blob/f67d2d43139782d78a549332d56b595bbc8fa562/src/templates/view-edit-toolbar.html#L86-L89) with a ``{% if not (Entity.entityData.locked) %}`` conditional to prevent accidental duplication of an item by mis-clicking the booking icon as long as the item is locked.

Changing write permissions altogether would probably be a better implementation but also quite a lot of work.
I hope the small PR is valid, and you like the idea.

Thank you
