### PR TITLE
Avoid casting in favor of getString and get Int; harmonization of the use of App->Request

### DIFF
--- a/src/Make/AbstractMakeZip.php
+++ b/src/Make/AbstractMakeZip.php
@@ -76,7 +76,7 @@ abstract class AbstractMakeZip extends AbstractMake implements ZipMakerInterface
             $realName = $file['real_name'];
             // if we have a file with the same name, it shouldn't overwrite the previous one
             if (in_array($realName, $realNamesSoFar, true)) {
-                $realName = (string) $i . '_' . $realName;
+                $realName = sprintf('%d_%s', $i, $realName);
             }
             $realNamesSoFar[] = $realName;
             // modify the real_name in place

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -79,7 +79,7 @@ class Auth implements AuthInterface
                 );
             case 'access_key':
                 // now we need to know in which team we autologin the user
-                $TeamFinder = new TeamFinder($this->Request->getScriptName(), (string) ($this->Request->query->get('access_key') ?? ''));
+                $TeamFinder = new TeamFinder($this->Request->getScriptName(), $this->Request->query->getString('access_key'));
                 $team = $TeamFinder->findTeam();
 
                 if ($team === 0) {

--- a/src/classes/Csrf.php
+++ b/src/classes/Csrf.php
@@ -70,6 +70,6 @@ class Csrf
         if ($this->Request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
             return (string) $this->Request->headers->get('X-CSRF-Token');
         }
-        return (string) $this->Request->request->get('csrf');
+        return $this->Request->request->getString('csrf');
     }
 }

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -119,11 +119,11 @@ class DisplayParams
             $this->offset = $this->Request->query->getInt('offset');
         }
         if (!empty($this->Request->query->get('q'))) {
-            $this->query = trim((string) $this->Request->query->get('q'));
+            $this->query = trim($this->Request->query->getString('q'));
             $this->searchType = 'query';
         }
         if (!empty($this->Request->query->get('extended'))) {
-            $this->extendedQuery = trim((string) $this->Request->query->get('extended'));
+            $this->extendedQuery = trim($this->Request->query->getString('extended'));
             $this->searchType = 'extended';
         }
         // filter by user if we don't want to show the rest of the team, only for experiments

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -15,6 +15,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 use PDO;
 use function random_bytes;
 use function sha1;
+use function sprintf;
 
 /**
  * Use this to check for latest version or update the database schema
@@ -81,7 +82,7 @@ class Update
         // new style with SQL files instead of functions
         while ($this->currentSchema < self::REQUIRED_SCHEMA) {
             ++$this->currentSchema;
-            $this->Sql->execFile('schema' . (string) ($this->currentSchema) . '.sql', $force);
+            $this->Sql->execFile(sprintf('schema%d.sql', $this->currentSchema), $force);
             // schema57: add an elabid to existing database items
             if ($this->currentSchema === 57) {
                 $this->addElabidToItems();

--- a/src/controllers/AbstractApiController.php
+++ b/src/controllers/AbstractApiController.php
@@ -63,17 +63,17 @@ abstract class AbstractApiController implements ControllerInterface
          *   string(1) "4"
          *   }
          */
-        $req = explode('/', rtrim((string) $this->Request->query->get('req'), '/'));
+        $req = explode('/', rtrim($this->Request->query->getString('req'), '/'));
 
         // now parse the query string (part after ?)
         if ($this->Request->query->has('limit')) {
-            $this->limit = (int) $this->Request->query->get('limit');
+            $this->limit = $this->Request->query->getInt('limit');
         }
         if ($this->Request->query->has('offset')) {
-            $this->offset = (int) $this->Request->query->get('offset');
+            $this->offset = $this->Request->query->getInt('offset');
         }
         if ($this->Request->query->has('search')) {
-            $this->search = trim((string) $this->Request->query->get('search'));
+            $this->search = trim($this->Request->query->getString('search'));
         }
 
         // assign the endpoint (experiments, items, uploads, items_types, status)

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -161,7 +161,7 @@ abstract class AbstractEntityController implements ControllerInterface
         if ($this->App->Request->query->has('access_key') && $this->App->Request->query->get('access_key') !== $this->Entity->entityData['access_key']) {
             // for that we fetch the id not from the id param but from the access_key, so we will get a valid id that corresponds to an entity
             // with this access_key
-            $id = (new AccessKeyHelper($this->Entity))->getIdFromAccessKey((string) $this->App->Request->query->get('access_key'));
+            $id = (new AccessKeyHelper($this->Entity))->getIdFromAccessKey($this->App->Request->query->getString('access_key'));
             if ($id > 0) {
                 $this->Entity->bypassReadPermission = true;
             }
@@ -206,7 +206,7 @@ abstract class AbstractEntityController implements ControllerInterface
      */
     protected function edit(): Response
     {
-        $this->Entity->setId((int) $this->App->Request->query->get('id'));
+        $this->Entity->setId($this->App->Request->query->getInt('id'));
         // check permissions
         $this->Entity->canOrExplode('write');
         // a locked entity cannot be edited
@@ -259,7 +259,7 @@ abstract class AbstractEntityController implements ControllerInterface
 
     protected function changelog(): Response
     {
-        $this->Entity->setId((int) $this->App->Request->query->get('id'));
+        $this->Entity->setId($this->App->Request->query->getInt('id'));
         // check permissions
         $this->Entity->canOrExplode('read');
 

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -245,8 +245,8 @@ class Apiv2Controller extends AbstractApiController
                 return new Scheduler(
                     new Items($this->Users, $this->id),
                     null,
-                    (string) $this->Request->query->get('start', $defaultStart),
-                    (string) $this->Request->query->get('end', $defaultEnd),
+                    $this->Request->query->getString('start', $defaultStart),
+                    $this->Request->query->getString('end', $defaultEnd),
                     $this->Request->query->getInt('cat'),
                 );
             case 'favtags':

--- a/src/controllers/ImportController.php
+++ b/src/controllers/ImportController.php
@@ -21,7 +21,6 @@ use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Interfaces\ImportInterface;
 use Elabftw\Models\AuditLogs;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -31,7 +30,7 @@ class ImportController implements ControllerInterface
 {
     private const AUDIT_THRESHOLD = 12;
 
-    public function __construct(private App $app, private Request $request)
+    public function __construct(private App $App)
     {
     }
 
@@ -46,10 +45,10 @@ class ImportController implements ControllerInterface
             ngettext('item imported successfully.', 'items imported successfully.', $inserted),
         );
         if ($inserted > self::AUDIT_THRESHOLD) {
-            AuditLogs::create(new Import($this->app->Users->userid ?? 0, $inserted));
+            AuditLogs::create(new Import($this->App->Users->userid ?? 0, $inserted));
         }
-        $this->app->Session->getFlashBag()->add('ok', $msg);
-        if (str_starts_with((string) $this->request->request->get('target'), 'items')) {
+        $this->App->Session->getFlashBag()->add('ok', $msg);
+        if (str_starts_with($this->App->Request->request->getString('target'), 'items')) {
             return new RedirectResponse('/database.php?order=lastchange');
         }
         return new RedirectResponse('/experiments.php?order=lastchange');
@@ -57,19 +56,19 @@ class ImportController implements ControllerInterface
 
     private function getImporter(): ImportInterface
     {
-        $uploadedFile = $this->request->files->get('file');
+        $uploadedFile = $this->App->Request->files->get('file');
         $allowedExtensions = array('.eln', '.zip', '.csv');
 
         // the import menu only allows basic permission to be set, so translate this in proper json
-        $canread = BasePermissions::tryFrom($this->request->request->getInt('canread')) ?? BasePermissions::MyTeams;
-        $canwrite = BasePermissions::tryFrom($this->request->request->getInt('canwrite')) ?? BasePermissions::User;
+        $canread = BasePermissions::tryFrom($this->App->Request->request->getInt('canread')) ?? BasePermissions::MyTeams;
+        $canwrite = BasePermissions::tryFrom($this->App->Request->request->getInt('canwrite')) ?? BasePermissions::User;
 
         // figure out the filetype depending on file extension
         switch ($uploadedFile->getClientOriginalExtension()) {
             case 'eln':
                 return new Eln(
-                    $this->app->Users,
-                    (string) $this->request->request->get('target'),
+                    $this->App->Users,
+                    $this->App->Request->request->getString('target'),
                     $canread->toJson(),
                     $canwrite->toJson(),
                     $uploadedFile,
@@ -77,8 +76,8 @@ class ImportController implements ControllerInterface
                 );
             case 'zip':
                 return new Zip(
-                    $this->app->Users,
-                    (string) $this->request->request->get('target'),
+                    $this->App->Users,
+                    $this->App->Request->request->getString('target'),
                     $canread->toJson(),
                     $canwrite->toJson(),
                     $uploadedFile,
@@ -86,8 +85,8 @@ class ImportController implements ControllerInterface
                 );
             case 'csv':
                 return new Csv(
-                    $this->app->Users,
-                    (string) $this->request->request->get('target'),
+                    $this->App->Users,
+                    $this->App->Request->request->getString('target'),
                     $canread->toJson(),
                     $canwrite->toJson(),
                     $uploadedFile,

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -119,10 +119,10 @@ class MakeController implements ControllerInterface
 
     private function populateIdArr(): void
     {
-        $this->Entity = EntityType::from((string) $this->Request->query->get('type'))->toInstance($this->Users);
+        $this->Entity = EntityType::from($this->Request->query->getString('type'))->toInstance($this->Users);
         // generate the id array
         if ($this->Request->query->has('category')) {
-            $this->idArr = $this->Entity->getIdFromCategory((int) $this->Request->query->get('category'));
+            $this->idArr = $this->Entity->getIdFromCategory($this->Request->query->getInt('category'));
         } elseif ($this->Request->query->has('owner')) {
             // only admin can export a user, or it is ourself
             if (!$this->Users->isAdminOf($this->Request->query->getInt('owner'))) {
@@ -130,13 +130,13 @@ class MakeController implements ControllerInterface
             }
             // being admin is good, but we also need to be in the same team as the requested user
             $Teams = new Teams($this->Users);
-            $targetUserid = (int) $this->Request->query->get('owner');
+            $targetUserid = $this->Request->query->getInt('owner');
             if (!$Teams->hasCommonTeamWithCurrent($targetUserid, $this->Users->userData['team'])) {
                 throw new IllegalActionException('User tried to export another user but is not in same team.');
             }
             $this->idArr = $this->Entity->getIdFromUser($targetUserid);
         } elseif ($this->Request->query->has('id')) {
-            $this->idArr = explode(' ', (string) $this->Request->query->get('id'));
+            $this->idArr = explode(' ', $this->Request->query->getString('id'));
         }
         // generate audit log event if exporting more than $threshold entries
         $count = count($this->idArr);
@@ -202,8 +202,8 @@ class MakeController implements ControllerInterface
             new Scheduler(
                 new Items($this->Users),
                 null,
-                (string) $this->Request->query->get('start', $defaultStart),
-                (string) $this->Request->query->get('end', $defaultEnd),
+                $this->Request->query->getString('start', $defaultStart),
+                $this->Request->query->getString('end', $defaultEnd),
             ),
         ));
     }

--- a/src/services/DatabaseCleaner.php
+++ b/src/services/DatabaseCleaner.php
@@ -13,6 +13,7 @@ namespace Elabftw\Services;
 use function count;
 use Elabftw\Elabftw\Db;
 use Elabftw\Interfaces\CleanerInterface;
+use function sprintf;
 
 /**
  * Make sure the database is consistent with no leftover things
@@ -76,7 +77,7 @@ class DatabaseCleaner implements CleanerInterface
         $req->execute();
         $res = $req->fetchAll();
         if (!empty($res)) {
-            echo 'Found ' . (string) count($res) . ' rows to delete in ' . $table . "\n";
+            echo sprintf("Found %d rows to delete in %s\n", count($res), $table);
             $this->deleteFrom($table, $res);
         }
     }

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -120,7 +120,8 @@
 
   <div class='pl-3 mt-2'>
     <label for='common_template'>{{ 'Common Experiment Template'|trans }}</label>
-    {% if App.Config.configArr.debug -%}{# set no-unused-disable and text-content because removing or leaving text-content brings up error #}
+    {% if App.Config.configArr.debug -%}
+      {# set no-unused-disable and text-content because removing or leaving text-content brings up error #}
       <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, no-unused-disable, text-content: suppress errors from tinymce] -->
     {%- endif %}
     <textarea style='height:400px' class='mceditable' name='common_template' id='common_template'>

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -178,7 +178,8 @@
   {# chemdoodle #}
   <div>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block deprecated, element-permitted-content, no-missing-references, prefer-native-element, wcag/h67, no-implicit-button-type, no-redundant-role: suppress errors from sketcher] -->
+      {# set no-unused-disable and text-content and wcag/h37 because removing or leaving text-content and wcag/h37 brings up error #}
+      <!-- [html-validate-disable-block deprecated, element-permitted-content, no-missing-references, prefer-native-element, wcag/h37, wcag/h67, text-content, no-implicit-button-type, no-redundant-role, no-unused-disable: suppress errors from sketcher] -->
     {%- endif %}
     <canvas id='sketcher'></canvas>
   </div>

--- a/src/templates/json-editor.html
+++ b/src/templates/json-editor.html
@@ -65,7 +65,8 @@
     <button class='btn lh-normal border-0 px-0' type='button' data-action='toggle-next' aria-expanded='false' title='{{ 'Information'|trans }}' aria-label='{{ 'Information'|trans }}'><i class='fas fa-fw fa-info-circle'></i></button><span hidden><a target='_blank' rel='noopener' href='https://doc.elabftw.net/metadata.html'>{{ 'See documentation about extra fields.'|trans }} <i class='fas fa-fw fa-arrow-up-right-from-square'></i></a></span>
     <h6 id='jsonEditorTitle'></h6>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block no-deprecated-attr : suppress errors from jsonEditor] -->
+      {# set no-unused-disable and text-content because removing or leaving text-content brings up error #}
+      <!-- [html-validate-disable-block no-deprecated-attr, text-content, no-unused-disable: suppress errors from jsonEditor] -->
     {%- endif %}
     <div id='jsonEditorContainer' data-preload-json='1'></div>
   </div>

--- a/tests/unit/classes/CsrfTest.php
+++ b/tests/unit/classes/CsrfTest.php
@@ -23,32 +23,32 @@ class CsrfTest extends \PHPUnit\Framework\TestCase
 
     public function testValidateGet(): void
     {
-        $request = Request::create('/', 'GET');
-        $Csrf = new Csrf($request);
+        $Request = Request::create('/', 'GET');
+        $Csrf = new Csrf($Request);
         $Csrf->validate();
     }
 
     public function testValidateAjaxFail(): void
     {
-        $request = Request::create('/', 'POST');
-        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
-        $Csrf = new Csrf($request);
+        $Request = Request::create('/', 'POST');
+        $Request->headers->set('X-Requested-With', 'XMLHttpRequest');
+        $Csrf = new Csrf($Request);
         $this->expectException(InvalidCsrfTokenException::class);
         $Csrf->validate();
     }
 
     public function testValidateFormFail(): void
     {
-        $request = Request::create('/', 'POST');
-        $Csrf = new Csrf($request);
+        $Request = Request::create('/', 'POST');
+        $Csrf = new Csrf($Request);
         $this->expectException(InvalidCsrfTokenException::class);
         $Csrf->validate();
     }
 
     public function testValidateForm(): void
     {
-        $request = Request::create('/', 'POST', array('csrf' => 'fake-token'));
-        $Csrf = new Csrf($request);
+        $Request = Request::create('/', 'POST', array('csrf' => 'fake-token'));
+        $Csrf = new Csrf($Request);
         $Csrf->setToken('fake-token');
         $Csrf->validate();
     }

--- a/web/admin.php
+++ b/web/admin.php
@@ -36,7 +36,7 @@ use Symfony\Component\HttpFoundation\Response;
 require_once 'app/init.inc.php';
 $App->pageTitle = _('Admin panel'); // @phan-suppress PhanTypeExpectedObjectPropAccessButGotNull
 $Response = new Response();
-$Response->prepare($Request);
+$Response->prepare($App->Request);
 
 $template = 'error.html';
 $renderArr = array();
@@ -57,7 +57,7 @@ try {
     $itemsCategoryArr = $ItemsTypes->readAll();
     $ExperimentsCategories = new ExperimentsCategories($Teams);
     $experimentsCategoriesArr = $ExperimentsCategories->readAll();
-    if ($Request->query->has('templateid')) {
+    if ($App->Request->query->has('templateid')) {
         $ItemsTypes->setId($App->Request->query->getInt('templateid'));
     }
     $statusArr = $Status->readAll();
@@ -72,10 +72,10 @@ try {
     // Users search
     $isSearching = false;
     $usersArr = array();
-    if ($Request->query->has('q')) {
+    if ($App->Request->query->has('q')) {
         $isSearching = true;
         $usersArr = $App->Users->readFromQuery(
-            filter_var($Request->query->get('q'), FILTER_SANITIZE_STRING),
+            filter_var($App->Request->query->getString('q'), FILTER_SANITIZE_STRING),
             $App->Request->query->getBoolean('includeNotTeam') ? 0 : $App->Users->userData['team'],
             $App->Request->query->getBoolean('includeArchived'),
             $App->Request->query->getBoolean('onlyAdmins'),

--- a/web/app/controllers/ImportController.php
+++ b/web/app/controllers/ImportController.php
@@ -27,7 +27,7 @@ require_once dirname(__DIR__) . '/init.inc.php';
 
 // it might take some time and we don't want to be cut in the middle, so set time_limit to ∞
 set_time_limit(0);
-$Controller = new ImportController($App, $Request);
+$Controller = new ImportController($App);
 // default response
 $Response = new RedirectResponse('/database.php');
 

--- a/web/app/controllers/LoginController.php
+++ b/web/app/controllers/LoginController.php
@@ -42,13 +42,13 @@ try {
     // show message to user
     $App->Session->getFlashBag()->add('ko', $e->getMessage());
 } catch (IllegalActionException $e) {
-    $App->Log->notice('', array(array('ip' => $Request->server->get('REMOTE_ADDR')), array('IllegalAction' => $e)));
+    $App->Log->notice('', array(array('ip' => $App->Request->server->get('REMOTE_ADDR')), array('IllegalAction' => $e)));
     $App->Session->getFlashBag()->add('ko', Tools::error(true));
 } catch (DatabaseErrorException | FilesystemErrorException $e) {
-    $App->Log->error('', array(array('ip' => $Request->server->get('REMOTE_ADDR')), array('Error' => $e)));
+    $App->Log->error('', array(array('ip' => $App->Request->server->get('REMOTE_ADDR')), array('Error' => $e)));
     $App->Session->getFlashBag()->add('ko', $e->getMessage());
 } catch (Exception $e) {
-    $App->Log->error('', array(array('ip' => $Request->server->get('REMOTE_ADDR')), array('Exception' => $e)));
+    $App->Log->error('', array(array('ip' => $App->Request->server->get('REMOTE_ADDR')), array('Exception' => $e)));
     $App->Session->getFlashBag()->add('ko', Tools::error());
 } finally {
     $Response->send();

--- a/web/app/controllers/RegisterController.php
+++ b/web/app/controllers/RegisterController.php
@@ -29,25 +29,26 @@ try {
     }
 
     // Stop bot registration by checking if the (invisible to humans) bot input is filled
-    if (!empty($Request->request->get('bot'))) {
+    if (!empty($App->Request->request->get('bot'))) {
         throw new IllegalActionException('The bot field was filled on register page. Possible automated registration attempt.');
     }
 
-    if ((Check::id((int) $Request->request->get('team')) === false) ||
-        !$Request->request->get('firstname') ||
-        !$Request->request->get('lastname') ||
-        !$Request->request->get('email') ||
-        !filter_var($Request->request->get('email'), FILTER_VALIDATE_EMAIL)) {
+    if (Check::id($App->Request->request->getInt('team')) === false
+        || !$App->Request->request->getString('firstname')
+        || !$App->Request->request->getString('lastname')
+        || !$App->Request->request->getString('email')
+        || !filter_var($App->Request->request->get('email'), FILTER_VALIDATE_EMAIL)
+    ) {
         throw new ImproperActionException(_('A mandatory field is missing!'));
     }
 
     // Create user
     $App->Users->createOne(
-        (new UserParams('email', (string) $Request->request->get('email')))->getContent(),
-        array($Request->request->get('team')),
-        (new UserParams('firstname', (string) $Request->request->get('firstname')))->getContent(),
-        (new UserParams('lastname', (string) $Request->request->get('lastname')))->getContent(),
-        (new UserParams('password', (string) $Request->request->get('password')))->getContent(),
+        (new UserParams('email', $App->Request->request->getString('email')))->getContent(),
+        array($App->Request->request->getInt('team')),
+        (new UserParams('firstname', $App->Request->request->getString('firstname')))->getContent(),
+        (new UserParams('lastname', $App->Request->request->getString('lastname')))->getContent(),
+        (new UserParams('password', $App->Request->request->getString('password')))->getContent(),
     );
 
     if ($App->Users->needValidation) {
@@ -56,7 +57,7 @@ try {
         $App->Session->getFlashBag()->add('ok', _('Registration successful :)<br>Welcome to eLabFTW o/'));
     }
     // store the email here so we can put it in the login field
-    $App->Session->set('email', $Request->request->get('email'));
+    $App->Session->set('email', $App->Request->request->getString('email'));
 } catch (ImproperActionException $e) {
     // show message to user
     $App->Session->getFlashBag()->add('ko', $e->getMessage());

--- a/web/app/controllers/ResetPasswordController.php
+++ b/web/app/controllers/ResetPasswordController.php
@@ -47,8 +47,8 @@ try {
     );
 
     // PART 1: we receive the email from the login page/forgot password form
-    if ($Request->request->has('email')) {
-        $email = $Request->request->getString('email');
+    if ($App->Request->request->has('email')) {
+        $email = $App->Request->request->getString('email');
 
         // check email is valid. Input field is of type email so browsers should not let users send invalid email.
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -100,12 +100,12 @@ try {
     }
 
     // PART 2: update the password
-    if ($Request->request->has('password')) {
+    if ($App->Request->request->has('password')) {
         // verify the key received is valid
         // we get the Users object from the email encrypted in the key
-        $Users = $ResetPasswordKey->validate($Request->request->getString('key'));
+        $Users = $ResetPasswordKey->validate($App->Request->request->getString('key'));
         // Replace new password in database
-        $Users->resetPassword($Request->request->getString('password'));
+        $Users->resetPassword($App->Request->request->getString('password'));
         $App->Session->getFlashBag()->add('ok', _('New password inserted. You can now login.'));
     }
 } catch (QuantumException $e) {
@@ -120,7 +120,7 @@ try {
     $App->Log->error('', array(array('userid' => $App->Session->get('userid')), array('Error', $e)));
     $App->Session->getFlashBag()->add('ko', $e->getMessage());
 } catch (Exception $e) {
-    $App->Log->warning('Reset password failed attempt', array(array('ip' => $Request->server->get('REMOTE_ADDR')), array('exception' => $e)));
+    $App->Log->warning('Reset password failed attempt', array(array('ip' => $App->Request->server->get('REMOTE_ADDR')), array('exception' => $e)));
     $App->Session->getFlashBag()->add('ko', Tools::error());
 } finally {
     $Response->send();

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -48,31 +48,37 @@ try {
     );
 
     // SEND TEST EMAIL
-    if ($Request->request->has('testemailSend')) {
-        $Email->testemailSend($Request->request->getString('email'));
+    if ($App->Request->request->has('testemailSend')) {
+        $Email->testemailSend($App->Request->request->getString('email'));
     }
 
     // SEND MASS EMAIL
-    if ($Request->request->has('massEmail')) {
+    if ($App->Request->request->has('massEmail')) {
         $replyTo = new Address($App->Users->userData['email'], $App->Users->userData['fullname']);
-        $Email->massEmail(EmailTarget::from($Request->request->getString('target')), null, $Request->request->getString('subject'), $Request->request->getString('body'), $replyTo);
+        $Email->massEmail(
+            EmailTarget::from($App->Request->request->getString('target')),
+            null,
+            $App->Request->request->getString('subject'),
+            $App->Request->request->getString('body'),
+            $replyTo
+        );
     }
 
     // DESTROY IDP
-    if ($Request->request->has('idpsDestroy')) {
-        $Idps = new Idps($Request->request->getInt('id'));
+    if ($App->Request->request->has('idpsDestroy')) {
+        $Idps = new Idps($App->Request->request->getInt('id'));
         $Idps->destroy();
     }
 
     // CLEAR NOLOGIN
-    if ($Request->request->has('clear-nologinusers')) {
+    if ($App->Request->request->has('clear-nologinusers')) {
         // this is so simple and only used here it doesn't have its own function
         $Db = Db::getConnection();
         $Db->q('UPDATE users SET allow_untrusted = 1');
     }
 
     // CLEAR LOCKOUT DEVICES
-    if ($Request->request->has('clear-lockoutdevices')) {
+    if ($App->Request->request->has('clear-lockoutdevices')) {
         // this is so simple and only used here it doesn't have its own function
         $Db = Db::getConnection();
         $Db->q('DELETE FROM lockout_devices');

--- a/web/app/controllers/TeamController.php
+++ b/web/app/controllers/TeamController.php
@@ -36,8 +36,8 @@ try {
     }
 
     // EMAIL TEAM
-    if ($Request->request->has('emailUsers')) {
-        $target = (string) $Request->request->get('target');
+    if ($App->Request->request->has('emailUsers')) {
+        $target = $App->Request->request->getString('target');
         // default to team
         $targetId = $App->Users->userData['team'];
         $targetType = EmailTarget::Team;
@@ -54,8 +54,8 @@ try {
         $sent = $Email->massEmail(
             $targetType,
             $targetId,
-            $Request->request->getString('subject'),
-            $Request->request->getString('body'),
+            $App->Request->request->getString('subject'),
+            $App->Request->request->getString('body'),
             $replyTo,
         );
         $App->Session->getFlashBag()->add('ok', sprintf(_('Email sent to %d users'), $sent));

--- a/web/app/controllers/UcpController.php
+++ b/web/app/controllers/UcpController.php
@@ -30,14 +30,14 @@ require_once dirname(__DIR__) . '/init.inc.php';
 $tab = 1;
 $Response = new RedirectResponse(sprintf('/ucp.php?tab=%d', $tab));
 
-$postData = $Request->request->all();
+$postData = $App->Request->request->all();
 try {
     // TAB 2 : ACCOUNT
-    if ($Request->request->has('use_mfa')) {
+    if ($App->Request->request->has('use_mfa')) {
         $tab = 2;
         // if user is authenticated through external service we skip the password verification
         if ($App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL) {
-            $App->Users->checkCurrentPasswordOrExplode($Request->request->getString('current_password'));
+            $App->Users->checkCurrentPasswordOrExplode($App->Request->request->getString('current_password'));
             // update the email if necessary
             if (isset($postData['email']) && ($postData['email'] !== $App->Users->userData['email'])) {
                 $App->Users->patch(Action::Update, array('email' => $postData['email']));
@@ -45,7 +45,9 @@ try {
         }
 
         // CHANGE PASSWORD (only for local accounts)
-        if (!empty($Request->request->get('password')) && (int) $App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL) {
+        if (!empty($App->Request->request->getString('password'))
+            && (int) $App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL
+        ) {
             $App->Users->patch(Action::UpdatePassword, $postData);
         }
 

--- a/web/app/download.php
+++ b/web/app/download.php
@@ -45,8 +45,8 @@ try {
     $DownloadController = new DownloadController(
         $storageFs,
         $longName,
-        (string) $Request->query->get('name'),
-        $Request->query->has('forceDownload'),
+        $App->Request->query->getString('name'),
+        $App->Request->query->has('forceDownload'),
     );
     $Response = $DownloadController->getResponse();
     $Response->prepare($App->Request);

--- a/web/app/download.php
+++ b/web/app/download.php
@@ -29,12 +29,12 @@ try {
     set_time_limit(0);
 
     // Check for LONG_NAME
-    $longName = (string) $Request->query->get('f');
+    $longName = $App->Request->query->getString('f');
     if (strpos($longName, "\0") !== false) {
         throw new IllegalActionException('Missing parameter for download');
     }
 
-    $storage = (int) $Request->query->get('storage');
+    $storage = $App->Request->query->getInt('storage');
     // backward compatibility: the download links in body won't have the storage param
     if ($storage === 0) {
         // we fallback on the instance's configured storage

--- a/web/app/logout.php
+++ b/web/app/logout.php
@@ -91,10 +91,10 @@ if ($App->Request->query->has('sls') && ($App->Request->query->has('SAMLRequest'
     $IdpsHelper = new IdpsHelper($App->Config, new Idps());
     $tmpSettings = $IdpsHelper->getSettings(); // get temporary settings to decode message
     if ($App->Request->query->has('SAMLRequest')) {
-        $req = new SamlLogoutRequest(new SamlSettings($tmpSettings), (string) $App->Request->query->get('SAMLRequest'));
+        $req = new SamlLogoutRequest(new SamlSettings($tmpSettings), $App->Request->query->getString('SAMLRequest'));
         $entId = SamlLogoutRequest::getIssuer($req->getXML());
     } else {// if ($App->Request->query->has('SAMLResponse'))
-        $resp = new SamlLogoutResponse(new SamlSettings($tmpSettings), (string) $App->Request->query->get('SAMLResponse'));
+        $resp = new SamlLogoutResponse(new SamlSettings($tmpSettings), $App->Request->query->getString('SAMLResponse'));
         $entId = $resp->getIssuer();
     }
 

--- a/web/change-pass.php
+++ b/web/change-pass.php
@@ -30,16 +30,16 @@ $renderArr = array();
 
 try {
     // make sure this page is accessed with a key
-    if (!$Request->query->has('key')) {
+    if (!$App->Request->query->has('key')) {
         throw new IllegalActionException('Bad parameters in url.');
     }
 
     // validate the key to show error if the key is expired
     $ResetPasswordKey = new ResetPasswordKey(time(), Config::fromEnv('SECRET_KEY'));
-    $ResetPasswordKey->validate($Request->query->getAlnum('key'));
+    $ResetPasswordKey->validate($App->Request->query->getAlnum('key'));
 
     $template = 'change-pass.html';
-    $renderArr = array('key' => $Request->query->getAlnum('key'));
+    $renderArr = array('key' => $App->Request->query->getAlnum('key'));
 } catch (Exception $e) {
     $renderArr['error'] = $e->getMessage();
 } finally {

--- a/web/index.php
+++ b/web/index.php
@@ -32,7 +32,7 @@ try {
 
         $IdpsHelper = new IdpsHelper($App->Config, new Idps());
         $tmpSettings = $IdpsHelper->getSettings(); // get temporary settings to decode message
-        $resp = new SamlResponse(new SamlSettings($tmpSettings), (string) $App->Request->request->get('SAMLResponse'));
+        $resp = new SamlResponse(new SamlSettings($tmpSettings), $App->Request->request->getString('SAMLResponse'));
         $entId = $resp->getIssuers()[0]; // getIssuers returns always one or two entity ids
 
         $settings = $IdpsHelper->getSettingsByEntityId($entId);

--- a/web/login.php
+++ b/web/login.php
@@ -32,11 +32,11 @@ require_once 'app/init.inc.php';
 $App->pageTitle = _('Login');
 
 $Response = new Response();
-$Response->prepare($Request);
+$Response->prepare($App->Request);
 
 try {
     // if we are not in https, die saying we work only in https
-    if (!$Request->isSecure() && !$Request->server->has('HTTP_X_FORWARDED_PROTO')) {
+    if (!$App->Request->isSecure() && !$App->Request->server->has('HTTP_X_FORWARDED_PROTO')) {
         // get the url to display a link to click
         $url = Config::fromEnv('SITE_URL');
         $message = "eLabFTW works only in HTTPS. Please enable HTTPS on your server or ensure X-Forwarded-Proto header is correctly sent by the load balancer. Or follow this link : <a href='" .
@@ -44,7 +44,7 @@ try {
         throw new ImproperActionException($message);
     }
 
-    if ($Request->query->has('rm_teaminit')) {
+    if ($App->Request->query->has('rm_teaminit')) {
         $App->Session->remove('teaminit_done');
     }
 
@@ -70,7 +70,7 @@ try {
         exit;
     }
 
-    if ($Request->query->get('switch_team') === '1') {
+    if ($App->Request->query->get('switch_team') === '1') {
         $App->Session->set('team_selection_required', true);
         $App->Session->set('team_selection', $App->Users->userData['teams']);
         $App->Session->set('auth_userid', $App->Users->userData['userid']);
@@ -88,7 +88,7 @@ try {
     // don't show the local login form if it's disabled
     $showLocal = true;
     // if there is a ?letmein in the url, we still show it.
-    if (!$App->Config->configArr['local_login'] && !$Request->query->has('letmein')) {
+    if (!$App->Config->configArr['local_login'] && !$App->Request->query->has('letmein')) {
         $showLocal = false;
     }
 
@@ -99,7 +99,7 @@ try {
     $Teams->bypassReadPermission = true;
     $teamsArr = $Teams->readAll();
 
-    if ($Request->cookies->has('kickreason')) {
+    if ($App->Request->cookies->has('kickreason')) {
         // at the moment there is only one reason
         $App->ko[] = _('Your session expired.');
     }

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -57,8 +57,8 @@ try {
     if ($App->Request->query->has('q')) {
         $isSearching = true;
         $usersArr = $App->Users->readFromQuery(
-            filter_var($App->Request->query->get('q'), FILTER_SANITIZE_STRING),
-            (int) filter_var($App->Request->query->get('teamFilter'), FILTER_SANITIZE_NUMBER_INT),
+            filter_var($App->Request->query->getString('q'), FILTER_SANITIZE_STRING),
+            $App->Request->query->getInt('teamFilter'),
             $App->Request->query->getBoolean('includeArchived'),
             $App->Request->query->getBoolean('onlyAdmins'),
         );

--- a/web/ucp.php
+++ b/web/ucp.php
@@ -51,7 +51,7 @@ try {
     $changelogData = array();
     $metadataGroups = array();
     if ($App->Request->query->has('templateid')) {
-        $Templates->setId((int) $App->Request->query->get('templateid'));
+        $Templates->setId($App->Request->query->getInt('templateid'));
         $entityData = $Templates->readOne();
         $Metadata = new Metadata($Templates->entityData['metadata']);
         $metadataGroups = $Metadata->getGroups();


### PR DESCRIPTION
Hi Nico,

Because of your comment https://github.com/elabftw/elabftw/pull/4835#discussion_r1439154932 there is this PR now. It will
- Remove some casting and use `getString` or `getInt`. In some cases `sprintf` is used.
- Use of `App->Request` is preferred over `Request`, this should be the same no everywhere.
- Also there were some flaky cypress-html-validate tests again which will hopefully be resolved using your strategy: the addition of `no-unused-disable`.
