### PR TITLE
Fix tinyMCE mention plugin second try

### DIFF
--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -146,8 +146,10 @@ class Apiv2Controller extends AbstractApiController
                 throw new ImproperActionException('Incorrect format value.');
             }
             // fit the request with what makecontroller expects
-            $this->Request->query->set('type', $this->Model->type);
-            $this->Request->query->set('id', $this->id);
+            if ($this->Model instanceof AbstractEntity) {
+                $this->Request->query->set('type', $this->Model->type);
+                $this->Request->query->set('id', $this->id);
+            }
         }
         if ($this->Request->getContent()) {
             try {

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -16,7 +16,6 @@ use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\RestInterface;
-use Elabftw\Models\AbstractConcreteEntity;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\ApiKeys;
 use Elabftw\Models\Comments;

--- a/src/js/tinymce-plugins/mention/plugin.js
+++ b/src/js/tinymce-plugins/mention/plugin.js
@@ -161,7 +161,7 @@ class AutoComplete {
   }
 
   matcher(item) {
-    return ~item[this.options.queryBy].toLowerCase().indexOf(this.query.toLowerCase());
+    return this.query.toLowerCase().split(' ').every(word => item[this.options.queryBy].toLowerCase().includes(word));
   }
 
   sorter(items) {
@@ -185,8 +185,16 @@ class AutoComplete {
 
   highlighter(text) {
     if (this.query.length > 0) {
-      return text.replace(new RegExp('(' + this.query.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1') + ')', 'ig'), function(match) {
-        return '<strong>' + match + '</strong>';
+      const re = new RegExp(this.query.split(' ').map(word => {
+        word.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+      }).join('|'), 'igd');
+      let result;
+      const positions = [];
+      while ((result = re.exec(text)) !== null) {
+        positions.push(result.indices[0]);
+      }
+      positions.reverse().forEach(([start, stop]) => {
+        text = text.substring(0, start) + '<strong>' + text.substring(start, stop) + '</strong>' + text.substring(stop);
       });
     }
     return text;

--- a/src/js/tinymce-plugins/mention/plugin.js
+++ b/src/js/tinymce-plugins/mention/plugin.js
@@ -184,10 +184,16 @@ class AutoComplete {
   }
 
   highlighter(text) {
-    if (this.query.length > 0) {
-      const re = new RegExp(this.query.split(' ').map(word => {
-        word.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
-      }).join('|'), 'igd');
+    if (this.query.trim() && this.query.length > 0) {
+      const re = new RegExp(
+        this.query.split(' ')
+          // escape regex special chars
+          .map(word => word.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1'))
+          // remove empty strings
+          .filter(word => word)
+          .join('|'),
+        'igd',
+      );
       let result;
       const positions = [];
       while ((result = re.exec(text)) !== null) {
@@ -224,8 +230,8 @@ class AutoComplete {
 
     $.each(items, (i, item) => {
       const $element = $(this.render(item));
-
       $element.html($element.html().replace($element.text(), this.highlighter($element.text())));
+      $element.find('a').prepend(this.addCategory(item));
 
       $.each(items[i], (key, val) => {
         $element.attr('data-' + key, val);
@@ -246,10 +252,13 @@ class AutoComplete {
   }
 
   render(item) {
-    const category = item.category_title
-      ? `${item.category_title} - `
+    return `<li><a href="javascript:;"><span>${item[this.options.queryBy]}</span></a></li>`;
+  }
+
+  addCategory(item){
+    return item.category_title
+      ? `<span style='color:#${item.category_color}'>${item.category_title}</span> - `
       : '';
-    return `<li><a href="javascript:;"><span>${category}${item[this.options.queryBy]}</span></a></li>`;
   }
 
   autoCompleteClick(e) {

--- a/src/js/tinymce-plugins/mention/plugin.js
+++ b/src/js/tinymce-plugins/mention/plugin.js
@@ -1,345 +1,327 @@
 class AutoComplete {
 
-    constructor(ed, options) {
-      this.editor = ed;
+  constructor(ed, options) {
+    this.editor = ed;
 
-      this.options = $.extend({}, {
-          source: [],
-          delay: 500,
-          queryBy: 'title',
-          items: 10
-      }, options);
+    this.options = $.extend({}, {
+      source: [],
+      delay: 500,
+      queryBy: 'title',
+      items: 10,
+    }, options);
 
-      this.matcher = this.options.matcher || this.matcher;
-      this.renderDropdown = this.options.renderDropdown || this.renderDropdown;
-      this.render = this.options.render || this.render;
-      this.insert = this.options.insert || this.insert;
-      this.highlighter = this.options.highlighter || this.highlighter;
+    this.matcher = this.options.matcher || this.matcher;
+    this.renderDropdown = this.options.renderDropdown || this.renderDropdown;
+    this.$dropdown;
+    this.render = this.options.render || this.render;
+    this.insert = this.options.insert || this.insert;
+    this.highlighter = this.options.highlighter || this.highlighter;
 
-      this.query = '';
-      this.hasFocus = true;
-      // joiner should be an invisible character and functions as glue between delimiter and search text typed by user
-      // compare to https://stackoverflow.com/a/28405917 for potential characters
-      // e.g. \uFEF, \u2007, \u202F, \u2060, \u200B
-      // \uFEFF can not be used any longer as of tinymce version 5.10.9 - 2023-11-14 and 6.7.3 - 2023-11-15
-      this.joiner = '\u2060';
+    this.query = '';
+    this.hasFocus = true;
+    // joiner should be an invisible character and functions as glue between delimiter and search text typed by user
+    // compare to https://stackoverflow.com/a/28405917 for potential characters
+    // e.g. \uFEF, \u2007, \u202F, \u2060, \u200B
+    // \uFEFF can not be used any longer as of tinymce version 5.10.9 - 2023-11-14 and 6.7.3 - 2023-11-15
+    this.joiner = '\u2060';
 
-      this.renderInput();
+    this.renderInput();
 
-      this.bindEvents();
+    this.bindEvents();
+  }
+
+  renderInput() {
+    // for some reason the id attribute of the first span gets removed during insert, so we use a data attribute instead
+    // don't add any additional characters that would be part of rawHtml.innerText unless it is reflected in the lookup method
+    const rawHtml = '<span data-tiny-complete="1">'
+        + `<span id="autocomplete-delimiter">${this.options.delimiter}</span>`
+        + `<span data-tiny-complete-searchtext="1"><span class="dummy">${this.joiner}</span></span>`
+        + '</span>';
+    this.editor.execCommand('mceInsertContent', false, rawHtml);
+    this.editor.focus();
+    this.editor.selection.select(this.editor.selection.dom.select('span[data-tiny-complete-searchtext="1"] span')[0]);
+    this.editor.selection.collapse(0);
+  }
+
+  bindEvents() {
+    this.editor.on('keyup', this.editorKeyUpProxy = this.rteKeyUp.bind(this));
+    this.editor.on('keydown', this.editorKeyDownProxy = this.rteKeyDown.bind(this), true);
+    this.editor.on('click', this.editorClickProxy = this.rteClicked.bind(this));
+
+    $('body').on('click', this.bodyClickProxy = this.rteLostFocus.bind(this));
+
+    $(this.editor.getWin()).on('scroll', this.rteScroll = (function() { this.cleanUp(true); }).bind(this));
+  }
+
+  unbindEvents() {
+    this.editor.off('keyup', this.editorKeyUpProxy);
+    this.editor.off('keydown', this.editorKeyDownProxy);
+    this.editor.off('click', this.editorClickProxy);
+
+    $('body').off('click', this.bodyClickProxy);
+
+    $(this.editor.getWin()).off('scroll', this.rteScroll);
+  }
+
+  rteKeyUp(e) {
+    switch (e.which || e.keyCode) {
+    case 40: // DOWN ARROW
+    case 38: // UP ARROW
+    case 16: // SHIFT
+    case 17: // CTRL
+    case 18: // ALT
+      break;
+
+    case 8:  // BACKSPACE
+      if (this.query === '') {
+        this.cleanUp(true);
+      } else {
+        this.lookup();
+      }
+      break;
+
+    case 9:  // TAB
+    case 13: // ENTER
+      var item = (this.$dropdown !== undefined) ? this.$dropdown.find('li.active') : [];
+      if (item.length) {
+        this.select(item.data());
+        this.cleanUp(false);
+      } else {
+        this.cleanUp(true);
+      }
+      break;
+
+    case 27: // ESC
+      this.cleanUp(true);
+      break;
+
+    default:
+      this.lookup();
+    }
+  }
+
+  rteKeyDown(e) {
+    switch (e.which || e.keyCode) {
+    case 9:  // TAB
+    case 13: // ENTER
+    case 27: // ESC
+      e.preventDefault();
+      break;
+
+    case 38: // UP ARROW
+      e.preventDefault();
+      if (this.$dropdown !== undefined) {
+        this.highlightPreviousResult();
+      }
+      break;
+      
+    case 40: //DOWN ARROW
+      e.preventDefault();
+      if (this.$dropdown !== undefined) {
+        this.highlightNextResult();
+      }
+      break;
     }
 
-    renderInput() {
-        // for some reason the id attribute of the first span gets removed during insert, so we use a data attribute instead
-        // don't add any additional characters that would be part of rawHtml.innerText unless it is reflected in the lookup method
-        const rawHtml = '<span data-tiny-complete="1">'
-            + `<span id="autocomplete-delimiter">${this.options.delimiter}</span>`
-            + `<span data-tiny-complete-searchtext="1"><span class="dummy">${this.joiner}</span></span>`
-            + '</span>';
-        this.editor.execCommand('mceInsertContent', false, rawHtml);
-        this.editor.focus();
-        this.editor.selection.select(this.editor.selection.dom.select('span[data-tiny-complete-searchtext="1"] span')[0]);
-        this.editor.selection.collapse(0);
+    e.stopPropagation();
+  }
+
+  rteClicked(e) {
+    const $target = $(e.target);
+
+    if (this.hasFocus && $target.parent().attr('id') !== 'autocomplete-searchtext') {
+      this.cleanUp(true);
+    }
+  }
+
+  rteLostFocus() {
+    if (this.hasFocus) {
+      this.cleanUp(true);
+    }
+  }
+
+  lookup() {
+    // the text to be replaced has to match exactly what would be the result of rawHtml.innerText of the renderInput method
+    this.query = this.editor.getBody().querySelector('span[data-tiny-complete-searchtext="1"]').innerText.trim().replace(this.joiner, '');
+
+    if (this.$dropdown === undefined) {
+      this.show();
     }
 
-    bindEvents() {
-        this.editor.on('keyup', this.editorKeyUpProxy = $.proxy(this.rteKeyUp, this));
-        this.editor.on('keydown', this.editorKeyDownProxy = $.proxy(this.rteKeyDown, this), true);
-        this.editor.on('click', this.editorClickProxy = $.proxy(this.rteClicked, this));
+    clearTimeout(this.searchTimeout);
+    this.searchTimeout = setTimeout((function() {
+      // Added delimiter parameter as last argument for backwards compatibility.
+      const items = typeof this.options.source === 'function'
+        ? this.options.source(this.query, this.process.bind(this), this.options.delimiter)
+        : this.options.source;
+      if (items) {
+        this.process(items);
+      }
+    }).bind(this), this.options.delay);
+  }
 
-        $('body').on('click', this.bodyClickProxy = $.proxy(this.rteLostFocus, this));
+  matcher(item) {
+    return ~item[this.options.queryBy].toLowerCase().indexOf(this.query.toLowerCase());
+  }
 
-        $(this.editor.getWin()).on('scroll', this.rteScroll = $.proxy(function () { this.cleanUp(true); }, this));
+  sorter(items) {
+    const beginswith = [];
+    const caseSensitive = [];
+    const caseInsensitive = [];
+    let item;
+
+    while ((item = items.shift()) !== undefined) {
+      if (!item[this.options.queryBy].toLowerCase().indexOf(this.query.toLowerCase())) {
+        beginswith.push(item);
+      } else if (~item[this.options.queryBy].indexOf(this.query)) {
+        caseSensitive.push(item);
+      } else {
+        caseInsensitive.push(item);
+      }
     }
 
-    unbindEvents() {
-        this.editor.off('keyup', this.editorKeyUpProxy);
-        this.editor.off('keydown', this.editorKeyDownProxy);
-        this.editor.off('click', this.editorClickProxy);
+    return beginswith.concat(caseSensitive, caseInsensitive);
+  }
 
-        $('body').off('click', this.bodyClickProxy);
+  highlighter(text) {
+    if (this.query.length > 0) {
+      return text.replace(new RegExp('(' + this.query.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1') + ')', 'ig'), function(match) {
+        return '<strong>' + match + '</strong>';
+      });
+    }
+    return text;
+  }
 
-        $(this.editor.getWin()).off('scroll', this.rteScroll);
+  show() {
+    const offset = this.editor.inline ? this.offsetInline() : this.offset();
+
+    this.$dropdown = $(this.renderDropdown())
+      .css({
+        'top': offset.top,
+        'left': offset.left,
+      });
+
+    $('body').append(this.$dropdown);
+
+    this.$dropdown.on('click', (this.autoCompleteClick.bind(this)));
+  }
+
+  process(data) {
+    if (!this.hasFocus) {
+      return;
     }
 
-    rteKeyUp(e) {
-        switch (e.which || e.keyCode) {
-        //DOWN ARROW
-        case 40:
-        //UP ARROW
-        case 38:
-        //SHIFT
-        case 16:
-        //CTRL
-        case 17:
-        //ALT
-        case 18:
-            break;
+    const result = [];
+    const items = this.sorter(data.filter(item => this.matcher(item))).slice(0, this.options.items);
 
-        //BACKSPACE
-        case 8:
-            if (this.query === '') {
-                this.cleanUp(true);
-            } else {
-                this.lookup();
-            }
-            break;
+    $.each(items, (i, item) => {
+      const $element = $(this.render(item));
 
-        //TAB
-        case 9:
-        //ENTER
-        case 13:
-            var item = (this.$dropdown !== undefined) ? this.$dropdown.find('li.active') : [];
-            if (item.length) {
-                this.select(item.data());
-                this.cleanUp(false);
-            } else {
-                this.cleanUp(true);
-            }
-            break;
+      $element.html($element.html().replace($element.text(), this.highlighter($element.text())));
 
-        //ESC
-        case 27:
-            this.cleanUp(true);
-            break;
+      $.each(items[i], (key, val) => {
+        $element.attr('data-' + key, val);
+      });
 
-        default:
-            this.lookup();
-        }
+      result.push($element[0].outerHTML);
+    });
+
+    if (result.length) {
+      this.$dropdown.html(result.join('')).show();
+    } else {
+      this.$dropdown.hide();
+    }
+  }
+
+  renderDropdown() {
+    return '<ul class="rte-autocomplete dropdown-menu"><li class="loading"></li></ul>';
+  }
+
+  render(item) {
+    const category = item.category_title
+      ? `${item.category_title} - `
+      : '';
+    return `<li><a href="javascript:;"><span>${category}${item[this.options.queryBy]}</span></a></li>`;
+  }
+
+  autoCompleteClick(e) {
+    const item = $(e.target).closest('li').data();
+    if (!$.isEmptyObject(item)) {
+      this.select(item);
+      this.cleanUp(false);
+    }
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
+  highlightPreviousResult() {
+    let currentIndex = this.$dropdown.find('li.active').index(),
+      index = (currentIndex === 0) ? this.$dropdown.find('li').length - 1 : --currentIndex;
+
+    this.$dropdown.find('li').removeClass('active').eq(index).addClass('active');
+  }
+
+  highlightNextResult() {
+    let currentIndex = this.$dropdown.find('li.active').index(),
+      index = (currentIndex === this.$dropdown.find('li').length - 1) ? 0 : ++currentIndex;
+
+    this.$dropdown.find('li').removeClass('active').eq(index).addClass('active');
+  }
+
+  select(item) {
+    this.editor.focus();
+    const selection = this.editor.dom.select('span[data-tiny-complete="1"]')[0];
+    this.editor.dom.remove(selection);
+    this.editor.insertContent(this.insert(item));
+  }
+
+  // Note: not used, overridden in options
+  insert(item) {
+    return '<span>' + item.category + ' ' + item[this.options.queryBy] + '</span>&nbsp;';
+  }
+
+  cleanUp(rollback) {
+    this.unbindEvents();
+    this.hasFocus = false;
+
+    if (this.$dropdown !== undefined) {
+      this.$dropdown.remove();
+      delete this.$dropdown;
     }
 
-    rteKeyDown(e) {
-        switch (e.which || e.keyCode) {
-         //TAB
-        case 9:
-        //ENTER
-        case 13:
-        //ESC
-        case 27:
-            e.preventDefault();
-            break;
+    if (rollback) {
+      const text = this.query;
+      const $selection = $(this.editor.dom.select('span[data-tiny-complete="1"]'));
+      const replacement = $('<p>' + this.options.delimiter + text + '</p>')[0].firstChild;
+      const focus = $(this.editor.selection.getNode()).offset()?.top === ($selection.offset().top + (($selection.outerHeight() - $selection.height()) / 2));
 
-        //UP ARROW
-        case 38:
-            e.preventDefault();
-            if (this.$dropdown !== undefined) {
-                this.highlightPreviousResult();
-            }
-            break;
-        //DOWN ARROW
-        case 40:
-            e.preventDefault();
-            if (this.$dropdown !== undefined) {
-                this.highlightNextResult();
-            }
-            break;
-        }
+      this.editor.dom.replace(replacement, $selection[0]);
 
-        e.stopPropagation();
+      if (focus) {
+        this.editor.selection.select(replacement);
+        this.editor.selection.collapse();
+      }
     }
+  }
 
-    rteClicked(e) {
-        var $target = $(e.target);
+  offset() {
+    const contentAreaPosition = $(this.editor.getContentAreaContainer()).offset();
+    const nodePosition = $(this.editor.dom.select('span[data-tiny-complete="1"]')).offset();
 
-        if (this.hasFocus && $target.parent().attr('id') !== 'autocomplete-searchtext') {
-            this.cleanUp(true);
-        }
-    }
+    return {
+      top: contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() - $(this.editor.getDoc()).scrollTop() + 5,
+      left: contentAreaPosition.left + nodePosition.left,
+    };
+  }
 
-    rteLostFocus() {
-        if (this.hasFocus) {
-            this.cleanUp(true);
-        }
-    }
+  offsetInline() {
+    const nodePosition = $(this.editor.dom.select('span[data-tiny-complete="1"]')).offset();
 
-    lookup() {
-        // the text to be replaced has to match exactly what would be the result of rawHtml.innerText of the renderInput method
-        this.query = this.editor.getBody().querySelector('[data-tiny-complete="1"]').innerText.replace(`${this.options.delimiter}${this.joiner}`, '');
-
-        if (this.$dropdown === undefined) {
-            this.show();
-        }
-
-        clearTimeout(this.searchTimeout);
-        this.searchTimeout = setTimeout($.proxy(function () {
-            // Added delimiter parameter as last argument for backwards compatibility.
-            var items = $.isFunction(this.options.source) ? this.options.source(this.query, $.proxy(this.process, this), this.options.delimiter) : this.options.source;
-            if (items) {
-                this.process(items);
-            }
-        }, this), this.options.delay);
-    }
-
-    matcher(item) {
-        return ~item[this.options.queryBy].toLowerCase().indexOf(this.query.toLowerCase());
-    }
-
-    sorter(items) {
-        var beginswith = [],
-            caseSensitive = [],
-            caseInsensitive = [],
-            item;
-
-        while ((item = items.shift()) !== undefined) {
-            if (!item[this.options.queryBy].toLowerCase().indexOf(this.query.toLowerCase())) {
-                beginswith.push(item);
-            } else if (~item[this.options.queryBy].indexOf(this.query)) {
-                caseSensitive.push(item);
-            } else {
-                caseInsensitive.push(item);
-            }
-        }
-
-        return beginswith.concat(caseSensitive, caseInsensitive);
-    }
-
-    highlighter(text) {
-        if (this.query.length > 0) {
-            return text.replace(new RegExp('(' + this.query.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1') + ')', 'ig'), function (match) {
-                return '<strong>' + match + '</strong>';
-            });
-        }
-        return text;
-    }
-
-    show() {
-        var offset = this.editor.inline ? this.offsetInline() : this.offset();
-
-        this.$dropdown = $(this.renderDropdown())
-            .css({
-                'top': offset.top,
-                'left': offset.left
-            });
-
-        $('body').append(this.$dropdown);
-
-        this.$dropdown.on('click', $.proxy(this.autoCompleteClick, this));
-    }
-
-    process(data) {
-        if (!this.hasFocus) {
-            return;
-        }
-
-        var _this = this,
-            result = [],
-            items = $.grep(data, function (item) {
-                return _this.matcher(item);
-            });
-
-        items = _this.sorter(items);
-
-        items = items.slice(0, this.options.items);
-
-        $.each(items, function (i, item) {
-            var $element = $(_this.render(item));
-
-            $element.html($element.html().replace($element.text(), _this.highlighter($element.text())));
-
-            $.each(items[i], function (key, val) {
-                $element.attr('data-' + key, val);
-            });
-
-            result.push($element[0].outerHTML);
-        });
-
-        if (result.length) {
-            this.$dropdown.html(result.join('')).show();
-        } else {
-            this.$dropdown.hide();
-        }
-    }
-
-    renderDropdown() {
-        return '<ul class="rte-autocomplete dropdown-menu"><li class="loading"></li></ul>';
-    }
-
-    render(item) {
-        let category = '';
-        if (item.category_title) {
-          category = `${item.category_title} - `;
-        }
-        return `<li><a href="javascript:;"><span>${category}${item[this.options.queryBy]}</span></a></li>`;
-    }
-
-    autoCompleteClick(e) {
-        const item = $(e.target).closest('li').data();
-        if (!$.isEmptyObject(item)) {
-            this.select(item);
-            this.cleanUp(false);
-        }
-        e.stopPropagation();
-        e.preventDefault();
-    }
-
-    highlightPreviousResult() {
-        var currentIndex = this.$dropdown.find('li.active').index(),
-            index = (currentIndex === 0) ? this.$dropdown.find('li').length - 1 : --currentIndex;
-
-        this.$dropdown.find('li').removeClass('active').eq(index).addClass('active');
-    }
-
-    highlightNextResult() {
-        var currentIndex = this.$dropdown.find('li.active').index(),
-            index = (currentIndex === this.$dropdown.find('li').length - 1) ? 0 : ++currentIndex;
-
-        this.$dropdown.find('li').removeClass('active').eq(index).addClass('active');
-    }
-
-    select(item) {
-        this.editor.focus();
-        var selection = this.editor.dom.select('span[data-tiny-complete="1"]')[0];
-        this.editor.dom.remove(selection);
-        this.editor.insertContent(this.insert(item));
-    }
-
-    // Note: not used, overridden in options
-    insert(item) {
-        return '<span>' + item.category + ' ' + item[this.options.queryBy] + '</span>&nbsp;';
-    }
-
-    cleanUp(rollback) {
-        this.unbindEvents();
-        this.hasFocus = false;
-
-        if (this.$dropdown !== undefined) {
-            this.$dropdown.remove();
-            delete this.$dropdown;
-        }
-
-        if (rollback) {
-            var text = this.query,
-                $selection = $(this.editor.dom.select('span[data-tiny-complete="1"]')),
-                replacement = $('<p>' + this.options.delimiter + text + '</p>')[0].firstChild,
-                focus = $(this.editor.selection.getNode()).offset()?.top === ($selection.offset().top + (($selection.outerHeight() - $selection.height()) / 2));
-
-            this.editor.dom.replace(replacement, $selection[0]);
-
-            if (focus) {
-                this.editor.selection.select(replacement);
-                this.editor.selection.collapse();
-            }
-        }
-    }
-
-    offset() {
-        const contentAreaPosition = $(this.editor.getContentAreaContainer()).offset();
-        const nodePosition = $(this.editor.dom.select('span[data-tiny-complete="1"]')).offset();
-
-        return {
-            top: contentAreaPosition.top + nodePosition.top + $(this.editor.selection.getNode()).innerHeight() - $(this.editor.getDoc()).scrollTop() + 5,
-            left: contentAreaPosition.left + nodePosition.left
-        };
-    }
-
-    offsetInline() {
-        var nodePosition = $(this.editor.dom.select('span[data-tiny-complete="1"]')).offset();
-
-        return {
-            top: nodePosition.top + $(this.editor.selection.getNode()).innerHeight() + 5,
-            left: nodePosition.left
-        };
-    }
+    return {
+      top: nodePosition.top + $(this.editor.selection.getNode()).innerHeight() + 5,
+      left: nodePosition.left,
+    };
+  }
 }
 
 tinymce.PluginManager.add('mention', ed => {
@@ -357,10 +339,10 @@ tinymce.PluginManager.add('mention', ed => {
     const text = ed.selection.getRng(true).startContainer.data || '';
     const character = text.substr(start - 1, 1);
 
-    return (!!$.trim(character).length) ? false : true;
-  }
+    return character.trim().length ? false : true;
+  };
 
-  ed.on('keypress', function (e) {
+  ed.on('keypress', function(e) {
     if (autoCompleteData.delimiter.includes(e.key) && prevCharIsSpace()) {
       if (autoComplete === undefined || (autoComplete.hasFocus !== undefined && !autoComplete.hasFocus)) {
         e.preventDefault();

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -199,6 +199,11 @@ export function getTinymceBaseConfig(page: string): object {
       delimiter: ['#'],
       // get the source from json with get request
       source: function(query: string, process: (data) => void): void {
+        // need to use quotes around 'not', 'and', 'or' if individual words as they are used as operators
+        ['not', 'or', 'and'].forEach(word =>{
+          const re = new RegExp(`\\b${word}\\b`, 'g');
+          query = query.replace(re, `'${word}'`);
+        });
         // grab experiments and items
         const expjson = ApiC.getJson(`${EntityType.Experiment}?limit=100&q=${query}`);
         const itemjson = ApiC.getJson(`${EntityType.Item}?limit=100&q=${query}`);


### PR DESCRIPTION
Closes #4876

- spaces in a search term are working again
- the order of words in search term does not matter
- all words used in search term will be highlighted in the titles listed in the dropdown list
  even when they are separated by other text
- category will be shown with its color
- use of 'and', 'or', or 'not' as individual words will not result in an error message anymore nor will they alter the behavior of the query. However, '!' and '|' will result in an error message
- indentation of source code file was changed, better review ignoring whitespace 

![image](https://github.com/elabftw/elabftw/assets/65481677/aedf1cc9-c485-4767-b854-dcc79507c741)