### PR TITLE
Add custom_id to search query syntax

### DIFF
--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -84,9 +84,9 @@ FieldTimestamp
   }
 
 FieldId
-  = 'id'i ':' id:$(Digit19 Digit*)
+  = field:('custom_id'i / 'id'i) ':' id:$(Digit19 Digit*)
   {
-    return new Field('id', new SimpleValueWrapper($id));
+    return new Field(strtolower($field), new SimpleValueWrapper($id));
   }
 
 FieldDate

--- a/src/services/advancedSearchQuery/enums/Fields.php
+++ b/src/services/advancedSearchQuery/enums/Fields.php
@@ -16,6 +16,7 @@ enum Fields: string
     case Author = 'author';
     case Body = 'body';
     case Category = 'category';
+    case CustomId = 'custom_id';
     case Elabid = 'elabid';
     case Group = 'group';
     case Id = 'id';

--- a/src/services/advancedSearchQuery/readme.md
+++ b/src/services/advancedSearchQuery/readme.md
@@ -1,10 +1,12 @@
+## Overview
+
 The advanced search query converts user input to a valid SQL where clause. This is achieved with the help of a parser. The parser is generated programmatically with [Peggy](https://github.com/peggyjs/peggy) and the [PHPeggy](https://github.com/marcelbolten/phpeggy) plugin. Peggy uses [parsing expression grammar](http://en.wikipedia.org/wiki/Parsing_expression_grammar) (PEG) formalism.
 
 The grammar file `src/node/grammar/queryGrammar.pegjs` is the input for the parser compilation and uses [Peggy v.1.0.0 grammar syntax and semantics](https://github.com/peggyjs/peggy/tree/v1.0.0#grammar-syntax-and-semantics). The parser is compiled at build-time and located at `cache/advancedSearchQuery/Parser.php`.
 
-The parser will build an abstract syntax tree AST with the grammar elements (PHP classes) located in `src/services/advancedSearchQuery/grammar/`: `AndExpression`, `AndOperand`, `DateField`, `Field`, `NotExpression`, `OrExpression`, `OrOperand`, and `SimpleValueWrapper`. The grammar file defines the hierarchy of the grammar elements but additionally the hierarchy is reflected by the parameter type hinting.
+The parser will build an abstract syntax tree AST with the grammar elements (PHP classes) located in `src/services/advancedSearchQuery/grammar/`: `AndExpression`, `AndOperand`, `DateField`, `Field`, `NotExpression`, `OrExpression`, `OrOperand`, `SimpleValueWrapper`, and `TimestampField`. The grammar file defines the hierarchy of the grammar elements but additionally the hierarchy is reflected by the parameter type hinting.
 
-After the AST is build successfully (syntax errors are reported to the user) it can be visited. Here the visitor pattern is used and there are tree visitors located in `src/services/advancedSearchQuery/visitors`: `DepthValidatorVisitor`, `FieldValidatorVisitor`, and `QueryBuilderVisitor`. 
+After the AST is build successfully (syntax errors are reported to the user) it can be visited. Here the visitor pattern is used and there are tree visitors located in `src/services/advancedSearchQuery/visitors`: `DepthValidatorVisitor`, `FieldValidatorVisitor`, and `QueryBuilderVisitor`.
 
 1. `DepthValidatorVisitor` checks the complexity of the query. How deep it the AST? (Not used currently.)
 2. `FieldValidatorVisitor` checks if fields/values are allowed, e.g., the `timestamped` field is only meaningful for experiments. Feedback is given for illegal fields/values.
@@ -17,3 +19,15 @@ The `FieldValidatorVisitor` and `QueryBuilderVisitor` use collectors (`src/servi
 `src/services/AdvancedSearchQuery.php` brings together the three steps, parsing/AST building, validation, and SQL where clause generation.
 
 ![Query and AST example!](Query-AST-example.svg "Query and AST example")
+
+## How to add a field `new_field` to the grammar
+- modify the grammar file `src/node/grammar/queryGrammar.pegjs`
+- modify or add the necessary files in `src/services/advancedSearchQuery/`
+  - add `new_field` to `src/services/advancedSearchQuery/enums/Fields.php`
+  - add a class method named `visitFieldNew_field` to visitor `src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php` and maybe add some data validation steps
+  - add a class method named `visitFieldNew_field` to visitor `src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php` and add the necessary SQL `WHERE` fragment to it
+- reflect the changes of the grammar also in the highlighter `src/ts/prism-elabftwquery.ts`
+- add a user query fragment to the unit test `tests/unit/services/AdvancedSearchQueryTest.php`, e.g.: `new_field:"test query"`
+- update the search syntax documentation `src/templates/search-syntax-doc-modal.html` and perhaps the shortened field list in `src/templates/search.html`
+
+This is not a comprehensive set of instructions that will work for all fields. There can be more complex code changes like for example for the date or timestamp fields. In this cases the new grammar classes (`src/services/advancedSearchQuery/grammar`) and interfaces (`src/services/advancedSearchQuery/interfaces/`) also need to be added/extended.

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -179,6 +179,11 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
+    private function visitFieldCustom_id(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
+    {
+        return new InvalidFieldCollector();
+    }
+
     private function visitFieldElabid(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         return new InvalidFieldCollector();

--- a/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/FieldValidatorVisitor.php
@@ -11,6 +11,7 @@
 namespace Elabftw\Services\AdvancedSearchQuery\Visitors;
 
 use Elabftw\Services\AdvancedSearchQuery\Collectors\InvalidFieldCollector;
+use Elabftw\Services\AdvancedSearchQuery\Enums\Fields;
 use Elabftw\Services\AdvancedSearchQuery\Enums\TimestampFields;
 use Elabftw\Services\AdvancedSearchQuery\Grammar\AndExpression;
 use Elabftw\Services\AdvancedSearchQuery\Grammar\AndOperand;
@@ -94,10 +95,18 @@ class FieldValidatorVisitor implements Visitor
 
     public function visitField(Field $field, VisitorParameters $parameters): InvalidFieldCollector
     {
-        // Call class methods dynamically to avoid many if statements.
-        // This works because the parser and the Fields enum define the list of fields.
-        $method = 'visitField' . ucfirst($field->getFieldType()->value);
-        return $this->$method($field->getValue(), $field->getAffix(), $parameters);
+        // only add the class methods that are actually used
+        if ($field->getFieldType() === Fields::Visibility
+            || $field->getFieldType() === Fields::Timestamped
+            || $field->getFieldType() === Fields::Group
+        ) {
+            // Call class methods dynamically to avoid many if statements.
+            // This works because the parser and the Fields enum define the list of fields.
+            $method = 'visitField' . ucfirst($field->getFieldType()->value);
+            return $this->$method($field->getValue(), $field->getAffix(), $parameters);
+        }
+
+        return new InvalidFieldCollector();
     }
 
     public function visitNotExpression(NotExpression $notExpression, VisitorParameters $parameters): InvalidFieldCollector
@@ -159,36 +168,6 @@ class FieldValidatorVisitor implements Visitor
         ));
     }
 
-    private function visitFieldAttachment(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldAuthor(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldBody(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldCategory(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldCustom_id(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldElabid(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
     private function visitFieldGroup(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         $teamGroups = $parameters->getTeamGroups();
@@ -204,36 +183,11 @@ class FieldValidatorVisitor implements Visitor
         return new InvalidFieldCollector();
     }
 
-    private function visitFieldId(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldLocked(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldRating(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldStatus(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
-        return new InvalidFieldCollector();
-    }
-
     private function visitFieldTimestamped(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
     {
         if ($parameters->getEntityType() !== 'experiments') {
             return new InvalidFieldCollector(array('timestamped: is only allowed when searching in experiments.'));
         }
-        return new InvalidFieldCollector();
-    }
-
-    private function visitFieldTitle(string $searchTerm, string $affix, VisitorParameters $parameters): InvalidFieldCollector
-    {
         return new InvalidFieldCollector();
     }
 

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -42,7 +42,17 @@ class QueryBuilderVisitor implements Visitor
         // so '<', '>', '&' need to be converted to their htmlentities &lt;, &gt;, &amp;
         $param = $this->getUniqueID();
         $paramBody = $this->getUniqueID();
-        $query = sprintf('(entity.title LIKE %1$s OR entity.body LIKE %2$s OR entity.date LIKE %1$s OR entity.elabid LIKE %1$s)', $param, $paramBody);
+        $paramCustomId = $this->getUniqueID();
+        $query = sprintf(
+            '(entity.title LIKE %1$s
+                OR entity.body LIKE %2$s
+                OR entity.date LIKE %1$s
+                OR entity.elabid LIKE %1$s
+                OR entity.custom_id = %3$s)',
+            $param,
+            $paramBody,
+            $paramCustomId,
+        );
 
         $bindValues = array();
         $bindValues[] = array(
@@ -54,6 +64,11 @@ class QueryBuilderVisitor implements Visitor
             'param' => $paramBody,
             'value' => '%' . htmlspecialchars($simpleValueWrapper->getValue(), ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401) . '%',
             'type' => PDO::PARAM_STR,
+        );
+        $bindValues[] = array(
+            'param' => $paramCustomId,
+            'value' => $simpleValueWrapper->getValue(),
+            'type' => PDO::PARAM_INT,
         );
 
         return new WhereCollector($query, $bindValues);
@@ -178,6 +193,7 @@ class QueryBuilderVisitor implements Visitor
         // Author:       CONCAT(users.firstname, ' ', users.lastname)
         // Body:         entity.body
         // Category:     categoryt.title
+        // Custom_id:    entity.custom_id
         // ELabID:       entity.elabid
         // Id:           entity.id
         // Locked:       entity.locked
@@ -341,6 +357,15 @@ class QueryBuilderVisitor implements Visitor
             'categoryt.title LIKE ',
             $affix . $searchTerm . $affix,
             PDO::PARAM_STR,
+        );
+    }
+
+    private function visitFieldCustom_id(string $searchTerm, string $affix, VisitorParameters $parameters): WhereCollector
+    {
+        return $this->getWhereCollector(
+            'entity.custom_id = ',
+            $searchTerm,
+            PDO::PARAM_INT,
         );
     }
 

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -45,9 +45,9 @@ class QueryBuilderVisitor implements Visitor
         $paramCustomId = $this->getUniqueID();
         $query = sprintf(
             '(entity.title LIKE %1$s
-                OR entity.body LIKE %2$s
                 OR entity.date LIKE %1$s
                 OR entity.elabid LIKE %1$s
+                OR entity.body LIKE %2$s
                 OR entity.custom_id = %3$s)',
             $param,
             $paramBody,

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -38,8 +38,6 @@ class QueryBuilderVisitor implements Visitor
 
     public function visitSimpleValueWrapper(SimpleValueWrapper $simpleValueWrapper, VisitorParameters $parameters): WhereCollector
     {
-        // body is stored as html after htmlPurifier worked on it
-        // so '<', '>', '&' need to be converted to their htmlentities &lt;, &gt;, &amp;
         $param = $this->getUniqueID();
         $paramBody = $this->getUniqueID();
         $paramCustomId = $this->getUniqueID();
@@ -60,6 +58,8 @@ class QueryBuilderVisitor implements Visitor
             'value' => '%' . $simpleValueWrapper->getValue() . '%',
             'type' => PDO::PARAM_STR,
         );
+        // body is stored as html after htmlPurifier worked on it
+        // so '<', '>', '&' need to be converted to their htmlentities &lt;, &gt;, &amp;
         $bindValues[] = array(
             'param' => $paramBody,
             'value' => '%' . htmlspecialchars($simpleValueWrapper->getValue(), ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401) . '%',

--- a/src/templates/search-syntax-doc-modal.html
+++ b/src/templates/search-syntax-doc-modal.html
@@ -1,0 +1,194 @@
+<div class='modal fade' id='advancedSearchModal' tabindex='-1' role='dialog' aria-labelledby='advancedSearchModalLabel'>
+  <div class='modal-dialog modal-xl' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='advancedSearchModalLabel'>{{ 'Search Syntax'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
+        <h3>Search terms</h3>
+        <p>The search is performed against title, body, date, and elabid.<br>
+            The entire team will be searched unless there is an author field.</p>
+        <dl>
+          <dt>Term</dt>
+          <dd>A sequence of characters without space (<code>&blank;</code>),
+              <code><span class='token operator'>|</span></code>,
+              <code><span class='token operator'>&amp;</span></code>,
+              <code><span class='token operator'>!</span></code>,
+              <code><span class='token punctuation'>(</span></code>,
+              <code><span class='token punctuation'>)</span></code>,
+              <code><span class='token string'>'</span></code> and
+              <code><span class='token string'>"</span></code>.<br>
+              <em><code><span class='token string'>termA</span></code></em> or
+              <em><code><span class='token string'>termB</span></code></em> or
+              <em><code><span class='token string'>456</span></code></em>
+          </dd>
+          <dt>Quoted term</dt>
+          <dd>A sequence of characters including space (<code>&blank;</code>)
+              enclosed in single (<code><span class='token string'>'</span></code>)
+              or double (<code><span class='token string'>"</span></code>) quotation marks.<br>
+              <em><code><span class='token string'>'Hello world'</span></code></em> or
+              <em><code><span class='token string'>"I love eLabFTW!"</span></code></em>
+          </dd>
+        </dl>
+        <p>Two wildcards are available. The percent sign
+          (<code><span class='token important'>%</span></code>)
+          matches zero or more characters while the underscore
+          (<code><span class='token important'>_</span></code>)
+          matches exactly one character. To search for literal
+          <code><span class='token important'>%</span></code> or
+          <code><span class='token important'>_</span></code>
+          the characters need to be escaped with a backslash
+          <code><span class='token important'>\%</span></code> or
+          <code><span class='token important'>\_</span></code>.</p>
+        <h3>Term concatenation and grouping</h3>
+        <p>Terms can be connected in different ways:</p>
+        <ul>
+          <li>
+            <code><span class='token operator'>OR</span></code> or
+            <code><span class='token operator'>|</span></code>:
+            <em><code><span class='token string'>termA</span> <span class='token operator'>OR</span> <span class='token string'>termB</span></code></em> or
+            <em><code><span class='token string'>termA</span><span class='token operator'>|</span><span class='token string'>termB</span></code></em>
+          </li>
+          <li>
+            <code><span class='token operator'>AND</span></code>,
+            <code><span class='token operator'>&amp;</span></code> or
+            space (<code>&blank;</code>):
+            <em><code><span class='token string'>termA</span> <span class='token operator'>AND</span> <span class='token string'>termB</span></code></em> or
+            <em><code><span class='token string'>termA</span><span class='token operator'>&amp;</span><span class='token string'>termB</span></code></em> or
+            <em><code><span class='token string'>termA</span>&nbsp;<span class='token string'>termB</span></code></em>
+          </li>
+          <li>
+            <code><span class='token operator'>NOT</span></code>,
+            <code><span class='token operator'>!</span></code>:
+            <em><code><span class='token operator'>NOT</span> <span class='token string'>termA</span></code></em> or
+            <em><code><span class='token operator'>!</span><span class='token string'>termA</span></code></em>
+          </li>
+          <li>Parenthesis <code><span class='token punctuation'>()</span></code>: <em><code><span class='token punctuation'>(</span><span class='token string'>termA</span> <span class='token operator'>OR</span> <span class='token string'>termB</span><span class='token punctuation'>)</span> <span class='token operator'>AND</span> <span class='token operator'>!</span><span class='token string'>termC</span></code></em></li>
+        </ul>
+        <p>The operators are listed in increasing order of precedence. Note the whitespace around the operators.
+          <code><span class='token operator'>OR</span></code>,
+          <code><span class='token operator'>AND</span></code> and
+          <code><span class='token operator'>NOT</span></code>
+          require to be surrounded by whitespace while
+          <code><span class='token operator'>|</span></code>,
+          <code><span class='token operator'>&amp;</span></code> and
+          <code><span class='token operator'>!</span></code>
+          don't.<br>
+          <em><code><span class='token string'>termA</span> <span class='token string'>termB</span> <span class='token operator'>OR</span> <span class='token string'>termC</span></code></em>
+          is equivalent to
+          <em><code><span class='token punctuation'>(</span><span class='token simple-term string'>termA</span> <span class='token operator'>AND</span> <span class='token simple-term string'>termB</span><span class='token punctuation'>)</span> <span class='token operator'>OR</span> <span class='token simple-term string'>termC</span></code></em>.
+          To give priority to
+          <code><span class='token operator'>OR</span></code>
+          use parenthesis:
+          <em><code><span class='token simple-term string'>termA</span> <span class='token operator'>AND</span> <span class='token punctuation'>(</span><span class='token simple-term string'>termB</span> <span class='token operator'>OR</span> <span class='token simple-term string'>termC</span><span class='token punctuation'>)</span></code></em>.
+        </p>
+        <h3>Field/value pair searches</h3>
+        <p>Field/value pairs are also applicable in the quick search fields.</p>
+        <p>Basic syntax <code><span class='token keyword'>field</span><span class='token punctuation'>:</span><span class='token string'>value</span></code></p>
+        <p>By default wildcards are added to Terms and Quoted terms. The strict switch (<code><span class='token keyword'>field</span><span class='token punctuation'>:</span><span class='token keyword'>s</span><span class='token punctuation'>:</span><span class='token string'>value</span></code>) disables the wildcards.</p>
+        <dl>
+          <dt><span class='token keyword'>attachment</span></dt>
+          <dd><span class='token boolean'>yes</span> or <span class='token boolean'>no</span>,
+              <span class='token boolean'>true</span> or <span class='token boolean'>false</span>,
+              <span class='token number'>1</span> or <span class='token number'>0</span>,
+              <span class='token boolean'>on</span> or <span class='token boolean'>off</span>:<br>
+              search entries with/out attachments<br>
+              Term or Quoted term:<br>
+              search in filenames and comments of attachments</dd>
+          <dt><span class='token keyword'>author</span></dt>
+          <dd>
+            Term or Quoted term<br>
+            Without any author the entire team will be searched.
+          </dd>
+          <dt><span class='token keyword'>body</span></dt>
+          <dd>Term or Quoted term</dd>
+          <dt><span class='token keyword'>category</span></dt>
+          <dd>Term or Quoted term; Only if Database is selected.</dd>
+          <dt><span class='token keyword'>created_at</span></dt>
+          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
+          <dt><span class='token keyword'>custom_id</span></dt>
+          <dd>Custom ID (integer) of an experiment or item</dd>
+          <dt><span class='token keyword'>date</span></dt>
+          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
+          <dt><span class='token keyword'>elabid</span></dt>
+          <dd>Term or Quoted term</dd>
+          <dt><span class='token keyword'>group</span></dt>
+          <dd>Term or Quoted term</dd>
+          <dt><span class='token keyword'>id</span></dt>
+          <dd>Id (integer) of an experiment or item</dd>
+          <dt><span class='token keyword'>locked</span></dt>
+          <dd><span class='token boolean'>yes</span> or <span class='token boolean'>no</span>,
+              <span class='token boolean'>true</span> or <span class='token boolean'>false</span>,
+              <span class='token number'>1</span> or <span class='token number'>0</span>,
+              <span class='token boolean'>on</span> or <span class='token boolean'>off</span>
+          </dd>
+          <dt><span class='token keyword'>locked_at</span></dt>
+          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
+          <dt><span class='token keyword'>rating</span></dt>
+          <dd><span class='token number'>1</span>,
+              <span class='token number'>2</span>,
+              <span class='token number'>3</span>,
+              <span class='token number'>4</span>,
+              <span class='token number'>5</span>,
+              <span class='token constant'>unrated</span> or
+              <span class='token number'>0</span>
+          </dd>
+          <dt><span class='token keyword'>status</span></dt>
+          <dd>Term or Quoted term; Only if Experiment is selected.</dd>
+          <dt><span class='token keyword'>timestamped</span></dt>
+          <dd><span class='token boolean'>yes</span> or
+              <span class='token boolean'>no</span>,
+              <span class='token boolean'>true</span> or
+              <span class='token boolean'>false</span>,
+              <span class='token number'>1</span> or
+              <span class='token number'>0</span>,
+              <span class='token boolean'>on</span> or
+              <span class='token boolean'>off</span>
+          </dd>
+          <dt><span class='token keyword'>timestamped_at</span></dt>
+          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
+          <dt><span class='token keyword'>title</span></dt>
+          <dd>Term or Quoted term</dd>
+          <dt><span class='token keyword'>visibility</span></dt>
+          <dd>Term or Quoted term<br>
+              {# A group name (e.g., <span class='token string'>'Lab Heroes'</span>) or #}
+              <span class='token string'>public</span>,
+              <span class='token string'>organization</span>,
+              <span class='token string'>myteams</span>,
+              <span class='token string'>user</span>, or
+              <span class='token string'>useronly</span>.
+          </dd>
+        </dl>
+        <h3 id='dateFormats'>Date formats</h3>
+        <p>A date has to be provided in the following format: <code><span class='token number'>YYYYMMDD</span></code>,
+          i.e., four digit year, two digit month, and two digit day.
+          Year, month and day can&mdash;but don't have to&mdash;be separated by
+          hyphen (<code><span class='token operator'>-</span></code>),
+          slash (<code><span class='token operator'>/</span></code>),
+          period (<code><span class='token operator'>.</span></code>),
+          or comma (<code><span class='token operator'>,</span></code>).<br>
+          Either a <strong>single date</strong> or a <strong>date range</strong> can be used.</p>
+        <dl>
+          <dt>Single date: <span class='token operator'>operator</span><span class='token number'>date<span></dt>
+          <dd>operator: <code><span class='token operator'>&lt;</span></code>, <code><span class='token operator'>&lt;=</span></code>, <code><span class='token operator'>=</span></code>, <code><span class='token operator'>&gt;=</span></code>, <code><span class='token operator'>&gt;</span></code>, or <code><span class='token operator'>!=</span></code><br>
+            An operator is optional. default is <span class='token operator'>=</span><br>
+            e.g., <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token number'>17890714</span></span></code></em> or
+            <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token operator'>&gt;</span><span class='token number'>1909</span><span class='token punctuation'>-</span><span class='token number'>12</span><span class='token punctuation'>-</span><span class='token number'>12</span></span></code></em> or
+            <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token operator'>&gt;=</span><span class='token number'>1867</span><span class='token punctuation'>.</span><span class='token number'>11</span><span class='token punctuation'>.</span><span class='token number'>07</span></span></code></em>
+          </dd>
+          <dt>Date range: <span class='token number'>date</span><span class='token operator'>..</span><span class='token number'>date</span></dt>
+          <dd>Two dates separated by two periods (<code><span class='token operator'>..</span></code>)<br>
+            e.g., <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token number'>20200101</span><span class='token operator'>..</span><span class='token number'>20201231</span></span></code></em>
+          </dd>
+        </dl>
+        <p>Date fields ending with <span class='token keyword'>_at</span> only accept dates between <em><code><span class='token number'>1970</span><span class='token punctuation'>-</span><span class='token number'>01</span><span class='token punctuation'>-</span><span class='token number'>02</span></em></code> and <em><code><span class='token number'>2038</span><span class='token punctuation'>-</span><span class='token number'>01</span><span class='token punctuation'>-</span><span class='token number'>18</span></em></code>.</p>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -3,200 +3,7 @@
   <h1 id='pageTitle'>{{ App.pageTitle }}</h1>
 {% endblock %}
 
-{# Modal for advanced search #}
-<div class='modal fade' id='advancedSearchModal' tabindex='-1' role='dialog' aria-labelledby='advancedSearchModalLabel'>
-  <div class='modal-dialog modal-xl' role='document'>
-    <div class='modal-content'>
-      <div class='modal-header'>
-        <h5 class='modal-title' id='advancedSearchModalLabel'>{{ 'Search Syntax'|trans }}</h5>
-        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
-          <span aria-hidden='true'>&times;</span>
-        </button>
-      </div>
-      <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
-        <h3>Search terms</h3>
-        <p>The search is performed against title, body, date, and elabid.<br>
-            The entire team will be searched unless there is an author field.</p>
-        <dl>
-          <dt>Term</dt>
-          <dd>A sequence of characters without space (<code>&blank;</code>),
-              <code><span class='token operator'>|</span></code>,
-              <code><span class='token operator'>&amp;</span></code>,
-              <code><span class='token operator'>!</span></code>,
-              <code><span class='token punctuation'>(</span></code>,
-              <code><span class='token punctuation'>)</span></code>,
-              <code><span class='token string'>'</span></code> and
-              <code><span class='token string'>"</span></code>.<br>
-              <em><code><span class='token string'>termA</span></code></em> or
-              <em><code><span class='token string'>termB</span></code></em> or
-              <em><code><span class='token string'>456</span></code></em>
-          </dd>
-          <dt>Quoted term</dt>
-          <dd>A sequence of characters including space (<code>&blank;</code>)
-              enclosed in single (<code><span class='token string'>'</span></code>)
-              or double (<code><span class='token string'>"</span></code>) quotation marks.<br>
-              <em><code><span class='token string'>'Hello world'</span></code></em> or
-              <em><code><span class='token string'>"I love eLabFTW!"</span></code></em>
-          </dd>
-        </dl>
-        <p>Two wildcards are available. The percent sign
-          (<code><span class='token important'>%</span></code>)
-          matches zero or more characters while the underscore
-          (<code><span class='token important'>_</span></code>)
-          matches exactly one character. To search for literal
-          <code><span class='token important'>%</span></code> or
-          <code><span class='token important'>_</span></code>
-          the characters need to be escaped with a backslash
-          <code><span class='token important'>\%</span></code> or
-          <code><span class='token important'>\_</span></code>.</p>
-        <h3>Term concatenation and grouping</h3>
-        <p>Terms can be connected in different ways:</p>
-        <ul>
-          <li>
-            <code><span class='token operator'>OR</span></code> or
-            <code><span class='token operator'>|</span></code>:
-            <em><code><span class='token string'>termA</span> <span class='token operator'>OR</span> <span class='token string'>termB</span></code></em> or
-            <em><code><span class='token string'>termA</span><span class='token operator'>|</span><span class='token string'>termB</span></code></em>
-          </li>
-          <li>
-            <code><span class='token operator'>AND</span></code>,
-            <code><span class='token operator'>&amp;</span></code> or
-            space (<code>&blank;</code>):
-            <em><code><span class='token string'>termA</span> <span class='token operator'>AND</span> <span class='token string'>termB</span></code></em> or
-            <em><code><span class='token string'>termA</span><span class='token operator'>&amp;</span><span class='token string'>termB</span></code></em> or
-            <em><code><span class='token string'>termA</span>&nbsp;<span class='token string'>termB</span></code></em>
-          </li>
-          <li>
-            <code><span class='token operator'>NOT</span></code>,
-            <code><span class='token operator'>!</span></code>:
-            <em><code><span class='token operator'>NOT</span> <span class='token string'>termA</span></code></em> or
-            <em><code><span class='token operator'>!</span><span class='token string'>termA</span></code></em>
-          </li>
-          <li>Parenthesis <code><span class='token punctuation'>()</span></code>: <em><code><span class='token punctuation'>(</span><span class='token string'>termA</span> <span class='token operator'>OR</span> <span class='token string'>termB</span><span class='token punctuation'>)</span> <span class='token operator'>AND</span> <span class='token operator'>!</span><span class='token string'>termC</span></code></em></li>
-        </ul>
-        <p>The operators are listed in increasing order of precedence. Note the whitespace around the operators.
-          <code><span class='token operator'>OR</span></code>,
-          <code><span class='token operator'>AND</span></code> and
-          <code><span class='token operator'>NOT</span></code>
-          require to be surrounded by whitespace while
-          <code><span class='token operator'>|</span></code>,
-          <code><span class='token operator'>&amp;</span></code> and
-          <code><span class='token operator'>!</span></code>
-          don't.<br>
-          <em><code><span class='token string'>termA</span> <span class='token string'>termB</span> <span class='token operator'>OR</span> <span class='token string'>termC</span></code></em>
-          is equivalent to
-          <em><code><span class='token punctuation'>(</span><span class='token simple-term string'>termA</span> <span class='token operator'>AND</span> <span class='token simple-term string'>termB</span><span class='token punctuation'>)</span> <span class='token operator'>OR</span> <span class='token simple-term string'>termC</span></code></em>.
-          To give priority to
-          <code><span class='token operator'>OR</span></code>
-          use parenthesis:
-          <em><code><span class='token simple-term string'>termA</span> <span class='token operator'>AND</span> <span class='token punctuation'>(</span><span class='token simple-term string'>termB</span> <span class='token operator'>OR</span> <span class='token simple-term string'>termC</span><span class='token punctuation'>)</span></code></em>.
-        </p>
-        <h3>Field/value pair searches</h3>
-        <p>Field/value pairs are also applicable in the quick search fields.</p>
-        <p>Basic syntax <code><span class='token keyword'>field</span><span class='token punctuation'>:</span><span class='token string'>value</span></code></p>
-        <p>By default wildcards are added to Terms and Quoted terms. The strict switch (<code><span class='token keyword'>field</span><span class='token punctuation'>:</span><span class='token keyword'>s</span><span class='token punctuation'>:</span><span class='token string'>value</span></code>) disables the wildcards.</p>
-        <dl>
-          <dt><span class='token keyword'>attachment</span></dt>
-          <dd><span class='token boolean'>yes</span> or <span class='token boolean'>no</span>,
-              <span class='token boolean'>true</span> or <span class='token boolean'>false</span>,
-              <span class='token number'>1</span> or <span class='token number'>0</span>,
-              <span class='token boolean'>on</span> or <span class='token boolean'>off</span>:<br>
-              search entries with/out attachments<br>
-              Term or Quoted term:<br>
-              search in filenames and comments of attachments</dd>
-          <dt><span class='token keyword'>author</span></dt>
-          <dd>
-            Term or Quoted term<br>
-            Without any author the entire team will be searched.
-          </dd>
-          <dt><span class='token keyword'>body</span></dt>
-          <dd>Term or Quoted term</dd>
-          <dt><span class='token keyword'>category</span></dt>
-          <dd>Term or Quoted term; Only if Database is selected.</dd>
-          <dt><span class='token keyword'>created_at</span></dt>
-          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
-          <dt><span class='token keyword'>date</span></dt>
-          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
-          <dt><span class='token keyword'>elabid</span></dt>
-          <dd>Term or Quoted term</dd>
-          <dt><span class='token keyword'>group</span></dt>
-          <dd>Term or Quoted term</dd>
-          <dt><span class='token keyword'>id</span></dt>
-          <dd>Id (integer) of an experiment or item</dd>
-          <dt><span class='token keyword'>locked</span></dt>
-          <dd><span class='token boolean'>yes</span> or <span class='token boolean'>no</span>,
-              <span class='token boolean'>true</span> or <span class='token boolean'>false</span>,
-              <span class='token number'>1</span> or <span class='token number'>0</span>,
-              <span class='token boolean'>on</span> or <span class='token boolean'>off</span>
-          </dd>
-          <dt><span class='token keyword'>locked_at</span></dt>
-          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
-          <dt><span class='token keyword'>rating</span></dt>
-          <dd><span class='token number'>1</span>,
-              <span class='token number'>2</span>,
-              <span class='token number'>3</span>,
-              <span class='token number'>4</span>,
-              <span class='token number'>5</span>,
-              <span class='token constant'>unrated</span> or
-              <span class='token number'>0</span>
-          </dd>
-          <dt><span class='token keyword'>status</span></dt>
-          <dd>Term or Quoted term; Only if Experiment is selected.</dd>
-          <dt><span class='token keyword'>timestamped</span></dt>
-          <dd><span class='token boolean'>yes</span> or
-              <span class='token boolean'>no</span>,
-              <span class='token boolean'>true</span> or
-              <span class='token boolean'>false</span>,
-              <span class='token number'>1</span> or
-              <span class='token number'>0</span>,
-              <span class='token boolean'>on</span> or
-              <span class='token boolean'>off</span>
-          </dd>
-          <dt><span class='token keyword'>timestamped_at</span></dt>
-          <dd><a href='#dateFormats'>See accepted date formats below</a></dd>
-          <dt><span class='token keyword'>title</span></dt>
-          <dd>Term or Quoted term</dd>
-          <dt><span class='token keyword'>visibility</span></dt>
-          <dd>Term or Quoted term<br>
-              {# A group name (e.g., <span class='token string'>'Lab Heroes'</span>) or #}
-              <span class='token string'>public</span>,
-              <span class='token string'>organization</span>,
-              <span class='token string'>myteams</span>,
-              <span class='token string'>user</span>, or
-              <span class='token string'>useronly</span>.
-          </dd>
-        </dl>
-        <h3 id='dateFormats'>Date formats</h3>
-        <p>A date has to be provided in the following format: <code><span class='token number'>YYYYMMDD</span></code>,
-          i.e., four digit year, two digit month, and two digit day.
-          Year, month and day can&mdash;but don't have to&mdash;be separated by
-          hyphen (<code><span class='token operator'>-</span></code>),
-          slash (<code><span class='token operator'>/</span></code>),
-          period (<code><span class='token operator'>.</span></code>),
-          or comma (<code><span class='token operator'>,</span></code>).<br>
-          Either a <strong>single date</strong> or a <strong>date range</strong> can be used.</p>
-        <dl>
-          <dt>Single date: <span class='token operator'>operator</span><span class='token number'>date<span></dt>
-          <dd>operator: <code><span class='token operator'>&lt;</span></code>, <code><span class='token operator'>&lt;=</span></code>, <code><span class='token operator'>=</span></code>, <code><span class='token operator'>&gt;=</span></code>, <code><span class='token operator'>&gt;</span></code>, or <code><span class='token operator'>!=</span></code><br>
-            An operator is optional. default is <span class='token operator'>=</span><br>
-            e.g., <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token number'>17890714</span></span></code></em> or
-            <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token operator'>&gt;</span><span class='token number'>1909</span><span class='token punctuation'>-</span><span class='token number'>12</span><span class='token punctuation'>-</span><span class='token number'>12</span></span></code></em> or
-            <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token operator'>&gt;=</span><span class='token number'>1867</span><span class='token punctuation'>.</span><span class='token number'>11</span><span class='token punctuation'>.</span><span class='token number'>07</span></span></code></em>
-          </dd>
-          <dt>Date range: <span class='token number'>date</span><span class='token operator'>..</span><span class='token number'>date</span></dt>
-          <dd>Two dates separated by two periods (<code><span class='token operator'>..</span></code>)<br>
-            e.g., <em><code><span class='token field-date keyword'>date<span class='token punctuation'>:</span><span class='token number'>20200101</span><span class='token operator'>..</span><span class='token number'>20201231</span></span></code></em>
-          </dd>
-        </dl>
-        <p>Date fields ending with <span class='token keyword'>_at</span> only accept dates between <em><code><span class='token number'>1970</span><span class='token punctuation'>-</span><span class='token number'>01</span><span class='token punctuation'>-</span><span class='token number'>02</span></em></code> and <em><code><span class='token number'>2038</span><span class='token punctuation'>-</span><span class='token number'>01</span><span class='token punctuation'>-</span><span class='token number'>18</span></em></code>.</p>
-      </div>
-      <div class='modal-footer'>
-        <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
-      </div>
-    </div>
-  </div>
-</div>
-
+{% include 'search-syntax-doc-modal.html' %}
 
 {# SEARCH PAGE BEGIN #}
 <hr>
@@ -233,14 +40,15 @@
         <li class='mb-2'><kbd>author:</kbd> {{ 'simple or quoted term'|trans }}</li>
         <li class='mb-2'><kbd>body:</kbd> {{ 'simple or quoted term'|trans }}</li>
         <li class='mb-2'><kbd>category:</kbd> {{ 'simple or quoted term'|trans }}</li>
+        <li class='mb-2'><kbd>custom_id:</kbd> {{ 'number'|trans }}</li>
         <li class='mb-2'><kbd>date:</kbd> {{ 'see date format'|trans }}</li>
         <li class='mb-2'><kbd>elabid:</kbd> {{ 'simple or quoted term'|trans }}</li>
-        <li class='mb-2'><kbd>group:</kbd> {{ 'simple or quoted term'|trans }}</li>
       </ul>
     </div>
 
     <div class='col-md-6'>
       <ul class='list-unstyled'>
+        <li class='mb-2'><kbd>group:</kbd> {{ 'simple or quoted term'|trans }}</li>
         <li class='mb-2'><kbd>locked:</kbd> {{ 'yes or no'|trans }}</li>
         <li class='mb-2'><kbd>rating:</kbd> {{ '1, 2, 3, 4, 5, or unrated or 0'|trans }}</li>
         <li class='mb-2'><kbd>status:</kbd> {{ 'simple or quoted term'|trans }}</li>

--- a/src/ts/prism-elabftwquery.ts
+++ b/src/ts/prism-elabftwquery.ts
@@ -56,7 +56,7 @@ import Prism from 'prismjs';
         'punctuation': /:/,
         'number': /\d+/,
       },
-      pattern: /\bid\b:[1-9][0-9]*/i,
+      pattern: /\b(?:custom_id|id)\b:[1-9][0-9]*/i,
     },
     'field-rating': {
       alias: 'keyword',

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -14,6 +14,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Models\TeamGroups;
 use Elabftw\Models\Users;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
+use function implode;
 
 class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 {
@@ -41,7 +42,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
     public function testGetWhereClause(): void
     {
-        $queryParts = array(
+        $query = implode(' ', array(
             ' TEST TEST1 AND TEST2 OR TEST3 NOT TEST4 & TEST5',
             '| TEST6 AND ! TEST7 (TEST8 or TEST9) "T E S T 1 0"',
             '\'T E S T 1 1\' "chinese 汉语 漢語 中文" "japanese 日本語 ひらがな 平仮名 カタカナ 片仮名"',
@@ -59,8 +60,7 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
             'locked_at:<20221209',
             'id:1',
             'custom_id:123',
-        );
-        $query = implode(' ', $queryParts);
+        ));
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
@@ -111,29 +111,33 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $visInput = 'noValidInput';
         $from = '20210101';
         $to = '20200101';
-        $query = 'visibility:' . $visInput;
-        $query .= ' date:' . $from . '..' . $to;
-        $query .= ' timestamped_at:' . $from . '..' . $to;
-        $query .= ' created_at:19700101';
-        $query .= ' locked_at:20221209..20380119';
-        $query .= ' group:"does not exist"';
-        $query .= ' category:"only works for items"';
+        $query = implode(' ', array(
+            "visibility:$visInput",
+            "date:$from..$to",
+            "timestamped_at:$from..$to",
+            'created_at:19700101',
+            'locked_at:20221209..20380119',
+            'group:"does not exist"',
+            'category:"only works for items"',
+        ));
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',
             $this->groups,
         ));
         $advancedSearchQuery->getWhereClause();
-        $this->assertStringStartsWith('visibility:' . $visInput . '. Valid values are ', $advancedSearchQuery->getException());
-        $this->assertStringContainsString('date:' . $from . '..' . $to . '. Second date needs to be equal or greater than first date.', $advancedSearchQuery->getException());
-        $this->assertStringContainsString('timestamped_at:' . $from . '..' . $to . '. Second date needs to be equal or greater than first date.', $advancedSearchQuery->getException());
+        $this->assertStringStartsWith("visibility:$visInput. Valid values are ", $advancedSearchQuery->getException());
+        $this->assertStringContainsString("date:$from..$to. Second date needs to be equal or greater than first date.", $advancedSearchQuery->getException());
+        $this->assertStringContainsString("timestamped_at:$from..$to. Second date needs to be equal or greater than first date.", $advancedSearchQuery->getException());
         $this->assertStringContainsString('created_at: Date needs to be between 1970-01-02 and 2038-01-18.', $advancedSearchQuery->getException());
         $this->assertStringContainsString('locked_at: Date needs to be between 1970-01-02 and 2038-01-18.', $advancedSearchQuery->getException());
         $this->assertStringContainsString('group:', $advancedSearchQuery->getException());
 
-        $query = 'timestamped:true';
-        $query .= ' timestamped_at:20221209';
-        $query .= ' status:"Running"';
+        $query = implode(' ', array(
+            'timestamped:true',
+            'timestamped_at:20221209',
+            'status:"Running"',
+        ));
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'itmes',

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -41,22 +41,26 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 
     public function testGetWhereClause(): void
     {
-        $query = ' TEST TEST1 AND TEST2 OR TEST3 NOT TEST4 & TEST5';
-        $query .= ' | TEST6 AND ! TEST7 (TEST8 or TEST9) "T E S T 1 0"';
-        $query .= ' \'T E S T 1 1\' "chinese 汉语 漢語 中文" "japanese 日本語 ひらがな 平仮名 カタカナ 片仮名"';
-        $query .= ' attachment:0 author:"Toto Le sysadmin" body:"some text goes here"';
-        $query .= ' elabid:7bebdd3512dc6cbee0b1 locked:yes rating:5 rating:unrated';
-        $query .= ' status:"only meaningful with experiments but no error"';
-        $query .= ' timestamped: timestamped:true title:"very cool experiment" visibility:%owner';
-        $query .= ' date:>2020.06,21 date:2020/06-21..20201231';
-        $query .= ' group:"Group Name"';
-        $query .= ' attachment:"hello world"';
-        $query .= ' timestamped_at:2022.12.01..2022-12-31';
-        $query .= ' timestamped_at:2022/12/09';
-        $query .= ' timestamped_at:!=2022,12,09';
-        $query .= ' created_at:>2022,12.09';
-        $query .= ' locked_at:<20221209';
-        $query .= ' id:1';
+        $queryParts = array(
+            ' TEST TEST1 AND TEST2 OR TEST3 NOT TEST4 & TEST5',
+            '| TEST6 AND ! TEST7 (TEST8 or TEST9) "T E S T 1 0"',
+            '\'T E S T 1 1\' "chinese 汉语 漢語 中文" "japanese 日本語 ひらがな 平仮名 カタカナ 片仮名"',
+            'attachment:0 author:"Toto Le sysadmin" body:"some text goes here"',
+            'elabid:7bebdd3512dc6cbee0b1 locked:yes rating:5 rating:unrated',
+            'status:"only meaningful with experiments but no error"',
+            'timestamped: timestamped:true title:"very cool experiment" visibility:%owner',
+            'date:>2020.06,21 date:2020/06-21..20201231',
+            'group:"Group Name"',
+            'attachment:"hello world"',
+            'timestamped_at:2022.12.01..2022-12-31',
+            'timestamped_at:2022/12/09',
+            'timestamped_at:!=2022,12,09',
+            'created_at:>2022,12.09',
+            'locked_at:<20221209',
+            'id:1',
+            'custom_id:123',
+        );
+        $query = implode(' ', $queryParts);
 
         $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
             'experiments',


### PR DESCRIPTION
There might be a problem with the mention plugin:

Let's say we want to search a Custom ID = `12`.
The chances are very high that `12` will be in many other entries so the entry with custom id = 12 might not be listed.
To address this problem the `ORDER BY` part needs to change so a match for a custom id has higher priority. But this might also not be what users want because now the custom id will dominate the search for numbers.

Also note that all non numerical values e.g. "my test string" will be treated as 0. And while the "Get next" button will add 1 as the first value, users can add 0 manually.

Perhaps we need to check if the query term is an integer and only then add the custom_id to the WHERE clause.
This is only relevant for the quick search/mention plugin search. Not if `custom_id:42` is used.