### PR TITLE
Refactor EntitySqlBuilder

### DIFF
--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -12,6 +12,7 @@ namespace Elabftw\Elabftw;
 use function array_column;
 use function array_unique;
 use Elabftw\Enums\BasePermissions;
+use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Scope;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Models\AbstractEntity;
@@ -35,11 +36,14 @@ class EntitySqlBuilder
      *
      * @param bool $getTags do we get the tags too?
      * @param bool $fullSelect select all the columns of entity
+     * @param bool $includeMetadata only include metadata if we really need it to avoid mysql out-of-sort-memory error
+     * @param null|EntityType $relatedOrigin Are we looking for related entries, what is the origin, experiments or items?
      */
     public function getReadSqlBeforeWhere(
         bool $getTags = true,
         bool $fullSelect = false,
-        bool $includeMetadata = false
+        bool $includeMetadata = false,
+        ?EntityType $relatedOrigin = null,
     ): string {
         $this->entity($fullSelect, $includeMetadata);
         $this->status();
@@ -52,7 +56,10 @@ class EntitySqlBuilder
             $this->teamEvents();
         }
         $this->steps();
-        $this->links();
+        // The links tables are only joined if we want to show related entities
+        if ($relatedOrigin !== null) {
+            $this->links($relatedOrigin);
+        }
         $this->usersTeams();
         $this->uploads();
 
@@ -228,10 +235,20 @@ class EntitySqlBuilder
                     AND uploads.type = \'%1$s\')';
     }
 
-    private function links(): void
+    private function links(EntityType $relatedOrigin): void
     {
-        $this->joinsSql[] = 'LEFT JOIN %1$s_links AS linkst
-            ON (linkst.item_id = entity.id)';
+        $table = 'items';
+        if ($this->entity->entityType === EntityType::Experiments) {
+            $table = 'experiments';
+        }
+
+        $related = '_links';
+        if ($relatedOrigin === EntityType::Experiments) {
+            $related = '2experiments';
+        }
+
+        $this->joinsSql[] = "LEFT JOIN $table$related AS linkst
+            ON (linkst.item_id = entity.id)";
     }
 
     private function steps(): void

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -14,6 +14,7 @@ use Elabftw\Elabftw\DisplayParams;
 use Elabftw\Elabftw\Metadata;
 use Elabftw\Elabftw\PermissionsHelper;
 use Elabftw\Elabftw\Tools;
+use Elabftw\Enums\SearchType;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Models\AbstractConcreteEntity;
@@ -126,7 +127,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'itemsArr' => $itemsArr,
             // generate light show page
             'searchPage' => $isSearchPage,
-            'searchType' => $isSearchPage ? 'something' : $DisplayParams->searchType,
+            'searchType' => $isSearchPage ? SearchType::SearchPage : $DisplayParams->searchType,
             'tagsArr' => $tagsArr,
             // get all the tags for the top search bar
             'tagsArrForSelect' => $TeamTags->readFull(),

--- a/src/enums/SearchType.php
+++ b/src/enums/SearchType.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Enums;
+
+enum SearchType
+{
+    case Category;
+    case Extended;
+    case Owner;
+    case Query;
+    case Related;
+    case Status;
+    case SearchPage;
+    case Tags;
+    case Undefined;
+}

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -23,6 +23,7 @@ use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Metadata as MetadataEnum;
+use Elabftw\Enums\SearchType;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\IllegalActionException;
@@ -209,6 +210,7 @@ abstract class AbstractEntity implements RestInterface
      * Only logged in users use this function
      * @param DisplayParams $displayParams display parameters like sort/limit/order by
      * @param bool $extended use it to get a full reply. used by API to get everything back
+     * @psalm-suppress UnusedForeachValue
      *
      *                   \||/
      *                   |  @___oo
@@ -223,7 +225,6 @@ abstract class AbstractEntity implements RestInterface
      *     \______(_______;;; __;;;
      *
      *          Here be dragons!
-     *  @psalm-suppress UnusedForeachValue
      */
     public function readShow(DisplayParams $displayParams, bool $extended = false, string $can = 'canread'): array
     {
@@ -233,7 +234,12 @@ abstract class AbstractEntity implements RestInterface
         }
 
         $EntitySqlBuilder = new EntitySqlBuilder($this);
-        $sql = $EntitySqlBuilder->getReadSqlBeforeWhere($extended, $extended, $displayParams->hasMetadataSearch);
+        $sql = $EntitySqlBuilder->getReadSqlBeforeWhere(
+            $extended,
+            $extended,
+            $displayParams->hasMetadataSearch,
+            $displayParams->searchType === SearchType::Related ? $displayParams->relatedOrigin : null,
+        );
 
         // first WHERE is the state, possibly including archived
         $stateSql = 'entity.state = :normal';

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -80,8 +80,9 @@
       {% if not searchPage %}
         <input type='hidden' name='q' value='{{ DisplayParams.query|e('html_attr') }}' />
       {% endif %}
-      {% if DisplayParams.searchType == 'related' %}
+      {% if DisplayParams.searchType == constant('Elabftw\\Enums\\SearchType::Related') %}
         <input type='hidden' name='related' value='{{ App.Request.query.get('related')|number_format }}' />
+        <input type='hidden' name='related_origin' value='{{ App.Request.query.getAlpha('related_origin') }}' />
       {% endif %}
 
       {# CATEGORY #}
@@ -171,7 +172,7 @@
 
   <div id='showModeContent'>
 
-  {% if count == 0 and searchType != '' %}
+  {% if count == 0 and searchType != constant('Elabftw\\Enums\\SearchType::Undefined') %}
     <div class='row display-flex' id='itemList'>
       {% set otherPage = Entity.type == 'experiments' ? 'database' : 'experiments' %}
       {% set otherCategory = Entity.type == 'experiments' ? 'items' : 'experiments' %}
@@ -182,7 +183,7 @@
         <button class='btn btn-primary' type='button'>{{ 'Search in %s'|trans|format(otherCategory) }}</button>
       </a>
     </div>
-  {% elseif count == 0 and searchType == '' and not App.Session.get('is_anon') and not App.Request.query.get('offset') %}
+  {% elseif count == 0 and searchType == constant('Elabftw\\Enums\\SearchType::Undefined') and not App.Session.get('is_anon') and not App.Request.query.get('offset') %}
     <div class='row display-flex' id='itemList'>
       {{ "Welcome to eLabFTW. Use the 'Create new' button to get started!"|trans|msg('ok', false) }}
     </div>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -120,12 +120,10 @@
       {% endfor %}
     </div>
 
-    {# TODO FIXME
     <div class='ml-3 mt-3'>
       <i class='fas fa-list mr-1 fa-fw'></i>
-      <a href='experiments.php?mode=show&amp;related={{ Entity.id }}'>{{ 'Show related experiments'|trans }}</a>
-    </div
-    #}
+      <a href='experiments.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}'>{{ 'Show related experiments'|trans }}</a>
+    </div>
     <hr>
   {% endif %}
 
@@ -157,12 +155,10 @@
       {% endfor %}
     </div>
 
-    {# TODO FIXME
     <div class='ml-3 mt-3'>
       <i class='fas fa-list mr-1 fa-fw'></i>
-      <a href='database.php?mode=show&amp;related={{ Entity.id }}'>{{ 'Show related items'|trans }}</a>
-    </div
-    #}
+      <a href='database.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}'>{{ 'Show related items'|trans }}</a>
+    </div>
     <hr>
   {% endif %}
 


### PR DESCRIPTION
I wanted to make some changes to the SQL queries in `EntitySqlBuilder` but did not understand with confidence what was happening in this class, so I refactored it first.

The idea is to disentangle the two long methods and split them into way smaller once with specific tasks. `getReadSqlBeforeWhere()` will call individual methods. Each is focused on one or two closely related `JOIN`s and the associated columns necessary in the `SELECT` statement. Similar for `getCanFilter()`, but here the split happens along the different permission levels.

There should be no changes in this PR that change the behavior of eLab.🤞
[`JSON_OVERLAPS`](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-overlaps) is used instead of `MEMBER OF()` in a loop.

Next in line are...
- fix show related items/experiments #4906
- add extra fields to eLab search query #4731
- transition from `GROUP_CONCAT` -> `JSON_ARRAYAGG`
