### PR TITLE
Use a specific version of phpcov

### DIFF
--- a/tests/elabtmp.Dockerfile
+++ b/tests/elabtmp.Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE_VERSION=hypernext
 FROM elabftw/elabimg:$BASE_IMAGE_VERSION
 
 # install phpcov
-ADD --chmod=755 https://phar.phpunit.de/phpcov.phar /usr/bin/phpcov
+ADD --chmod=755 https://phar.phpunit.de/phpcov-9.0.2.phar /usr/bin/phpcov
 
 RUN yarn install
 # Install xdebug for coverage


### PR DESCRIPTION
Avoid [The Death Star Version Constraint](https://thephp.cc/articles/the-death-star-version-constraint)

```
^@^@PHP Parse error:  syntax error, unexpected token "readonly", expecting "abstract" or "final" or "class" in phar:///usr/bin/phpcov/sebastian/version/src/Version.php on line 23
PHP Parse error:  syntax error, unexpected token "readonly", expecting "abstract" or "final" or "class" in phar:///usr/bin/phpcov/sebastian/version/src/Version.php on line 23
Error response from daemon: Could not find the file /elabftw/tests/_output/merge_cov/coverage-merged.clover.xml in container elabtmp
Successfully copied 1.54kB to /home/circleci/elabftw/elabftw/.
```
from https://app.circleci.com/pipelines/github/elabftw/elabftw/7601/workflows/cef38b9b-db6b-475f-82a6-22279c7f88b2/jobs/11121/parallel-runs/0/steps/0-124