### PR TITLE
Proposed changes on #4920

### DIFF
--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -80,7 +80,8 @@ class EntitySqlBuilder
         $sql .= sprintf(
             ' AND (%s)',
             implode(' OR ', array(
-                $this->canBasePubOrg($can),
+                $this->canBasePub($can),
+                $this->canBaseOrg($can),
                 $this->canBaseTeam($can),
                 $this->canBaseUser($can),
                 $this->canBaseUserOnly($can),
@@ -291,15 +292,25 @@ class EntitySqlBuilder
     }
 
     /**
-     * base pub/org filter
+     * base pub filter
      */
-    private function canBasePubOrg(string $can): string
+    private function canBasePub(string $can): string
     {
         return sprintf(
-            '(entity.%1$s->\'$.base\' = %2$d
-                OR entity.%1$s->\'$.base\' = %3$d)',
+            "entity.%s->'$.base' = %d",
             $can,
             BasePermissions::Full->value,
+        );
+    }
+
+    /**
+     * base org filter
+     */
+    private function canBaseOrg(string $can): string
+    {
+        return sprintf(
+            "entity.%s->'$.base' = %d",
+            $can,
             BasePermissions::Organization->value,
         );
     }

--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -321,7 +321,8 @@ class EntitySqlBuilder
     private function canBaseTeam(string $can): string
     {
         return sprintf(
-            "(entity.%s->'$.base' = %d AND users2teams.teams_id = entity.team)",
+            "(entity.%s->'$.base' = %d
+                AND users2teams.teams_id = entity.team)",
             $can,
             BasePermissions::Team->value,
         );
@@ -335,7 +336,8 @@ class EntitySqlBuilder
     {
         return sprintf(
             "(entity.%s->'$.base' = %d
-                AND entity.userid = %s AND users2teams.teams_id = entity.team)",
+                AND entity.userid = %s
+                AND users2teams.teams_id = entity.team)",
             $can,
             BasePermissions::User->value,
             $this->entity->Users->isAdmin
@@ -352,7 +354,8 @@ class EntitySqlBuilder
     {
         return sprintf(
             "(entity.%s->'$.base' = %d
-                AND entity.userid = :userid AND users2teams.teams_id = entity.team)",
+                AND entity.userid = :userid
+                AND users2teams.teams_id = entity.team)",
             $can,
             BasePermissions::UserOnly->value,
         );

--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -316,7 +316,7 @@ class EntitySqlBuilder
     }
 
     /**
-     * base my teams filter
+     * base team filter
      */
     private function canBaseTeam(string $can): string
     {

--- a/src/classes/PermissionsHelper.php
+++ b/src/classes/PermissionsHelper.php
@@ -68,7 +68,7 @@ final class PermissionsHelper
         $englishBase = array(
             'public' => BasePermissions::Full->value,
             'organization' => BasePermissions::Organization->value,
-            'myteams' => BasePermissions::Team->value,
+            'myteam' => BasePermissions::Team->value,
             'user' => BasePermissions::User->value,
         );
         // add the only me setting only if it is allowed by main config

--- a/src/enums/PasswordComplexity.php
+++ b/src/enums/PasswordComplexity.php
@@ -24,19 +24,22 @@ enum PasswordComplexity: int
     {
         return match ($case) {
             PasswordComplexity::None => _('Minimum password length'),
-            PasswordComplexity::Weak => _('Must have at least one upper and one lower case letter'),
-            PasswordComplexity::Medium => _('Must have at least one digit, one upper and one lower case letter'),
-            PasswordComplexity::Strong => _('Must have at least one special character, one digit, one upper and one lower case letter'),
+            PasswordComplexity::Weak => _('Must have at least one upper and one lower case letter, if your alphabet allows'),
+            PasswordComplexity::Medium => _('Must have at least one upper and one lower case letter, if your alphabet allows, and one digit'),
+            PasswordComplexity::Strong => _('Must have at least one upper and one lower case letter, if your alphabet allows, one special character, and one digit'),
         };
     }
 
     public static function toPattern(self $case): string
     {
+        // we need Lo for unicase/unicameral alphabets like Chinese, Japanese, and Korean
+        $letters = '(?:(?=.*\p{Ll})(?=.*\p{Lu})|(?=.*\p{Lo}))';
+        $digits = '(?=.*\d)';
         return match ($case) {
             PasswordComplexity::None => '.*',
-            PasswordComplexity::Weak => '^(?=.*\p{Ll})(?=.*\p{Lu}).*$',
-            PasswordComplexity::Medium => '^(?=.*\p{Ll})(?=.*\p{Lu})(?=.*\d).*$',
-            PasswordComplexity::Strong => '^(?=.*\p{Ll})(?=.*\p{Lu})(?=.*\d)(?=.*[\p{P}\p{S}]).*$',
+            PasswordComplexity::Weak => "^$letters.*$",
+            PasswordComplexity::Medium => "^$letters$digits.*$",
+            PasswordComplexity::Strong => "^$letters$digits(?=.*[\p{P}\p{S}]).*$",
         };
     }
 

--- a/src/models/Teams.php
+++ b/src/models/Teams.php
@@ -134,17 +134,6 @@ class Teams implements RestInterface
         return $req->fetchAll();
     }
 
-    public function readMyTeams(): array
-    {
-        $this->canReadOrExplode();
-        $sql = 'SELECT teams.id, teams.name, teams.orgid FROM teams CROSS JOIN users2teams ON (users2teams.teams_id = teams.id AND users2teams.users_id = :userid) WHERE users2teams.users_id = :userid ORDER BY name ASC';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
-        $this->Db->execute($req);
-
-        return $req->fetchAll();
-    }
-
     public function readNamesFromIds(array $idArr): array
     {
         if (empty($idArr)) {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -206,12 +206,6 @@ select.form-control {
     color: $elabblue;
 }
 
-/* GENERAL */
-img {
-    margin-right: 3px;
-    vertical-align: -3px;
-}
-
 /* BLOCKQUOTE */
 blockquote {
     background: #f9f9f9;
@@ -380,10 +374,17 @@ button:disabled {
     transform: rotate(35deg);
 }
 
-#body_view p {
-    // break super long words, see #4169
-    overflow-wrap: break-word;
-    word-wrap: break-word;
+#body_view {
+    img {
+        height: auto;
+        max-width: 100%;
+    }
+
+    p {
+        // break super long words, see #4169
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+    }
 }
 
 /* fix for big images uploaded in the text */

--- a/src/sql/schema144.sql
+++ b/src/sql/schema144.sql
@@ -3,10 +3,17 @@ ALTER TABLE `experiments` ADD `team` INT UNSIGNED NOT NULL;
 -- try and find a team value for experiments, first assign it through status or category
 -- this should take care of most experiments
 UPDATE experiments e
-JOIN experiments_status es ON e.status = es.id
-JOIN experiments_categories ec ON e.category = ec.id
-JOIN users2teams ut ON e.userid = ut.users_id
-SET e.team = COALESCE(es.team, ec.team);
+INNER JOIN users2teams ut
+    ON (e.userid = ut.users_id)
+LEFT JOIN experiments_status es
+    ON (es.id = e.status
+        AND es.team = ut.teams_id)
+LEFT JOIN experiments_categories ec
+    ON (ec.id = e.category
+        AND ec.team = ut.teams_id)
+SET e.team = ut.teams_id
+WHERE es.team IS NOT NULL
+    OR ec.team IS NOT NULL;
 -- now for the ones that are still 0, fetch a team from the user
 UPDATE experiments e
 INNER JOIN (
@@ -14,5 +21,6 @@ INNER JOIN (
     FROM users2teams
     GROUP BY users_id
 ) ut ON e.userid = ut.users_id
-SET e.team = ut.team WHERE e.team = 0;
+SET e.team = ut.team
+WHERE e.team = 0;
 UPDATE config SET conf_value = 144 WHERE conf_name = 'schema';

--- a/src/templates/search-syntax-doc-modal.html
+++ b/src/templates/search-syntax-doc-modal.html
@@ -164,7 +164,7 @@
               {# A group name (e.g., <span class='token string'>'Lab Heroes'</span>) or #}
               <span class='token string'>public</span>,
               <span class='token string'>organization</span>,
-              <span class='token string'>myteams</span>,
+              <span class='token string'>myteam</span>,
               <span class='token string'>user</span>, or
               <span class='token string'>useronly</span>.
           </dd>

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -60,11 +60,6 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
         $this->Teams->patch(Action::Update, $params);
     }
 
-    public function testReadMyTeams(): void
-    {
-        $this->assertCount(1, $this->Teams->readMyTeams());
-    }
-
     public function testReadNamesFromIds(): void
     {
         $this->assertCount(3, $this->Teams->readNamesFromIds(array(1, 2, 3)));

--- a/tests/unit/services/PasswordValidatorTest.php
+++ b/tests/unit/services/PasswordValidatorTest.php
@@ -45,7 +45,7 @@ class PasswordValidatorTest extends \PHPUnit\Framework\TestCase
         $PasswordValidator = new PasswordValidator(6, PasswordComplexity::Weak);
         $this->assertTrue($PasswordValidator->validate('Abcdef'));
         // no capital letters but japanese characters
-        $this->assertTrue($this->PasswordValidator->validate('みうろねのけをけか'));
+        $this->assertTrue($PasswordValidator->validate('みうろねのけをけか'));
         $this->expectException(ImproperActionException::class);
         $PasswordValidator->validate('abcdefghijkl');
     }


### PR DESCRIPTION
- remove  unused code
- `myteams` -> `myteam` also in the UI
- Your `UPDATE` query is using a 3 (actually 4) way intersection but that will also eliminate all entries where only one of status and category is set.
  In my `UPDATE` query the intersection happens only on users2teams and status and category use a left join and additionally filter away results where both status AND category are null aka keep all where status OR category is set.
In a `SELECT` query on the db after running `yarn test` the result was 273 vs 309

![image](https://github.com/elabftw/elabftw/assets/65481677/d1db9201-5146-4491-b001-df493791748d)
