### PR TITLE
Change behavior of extra fields of type Experiments, Resources or Users

### DIFF
--- a/src/classes/App.php
+++ b/src/classes/App.php
@@ -44,7 +44,7 @@ class App
     use UploadTrait;
     use TwigTrait;
 
-    public const INSTALLED_VERSION = '5.0.0-beta2';
+    public const INSTALLED_VERSION = '5.0.0-beta3';
 
     // this version format is used to compare with last_seen_version of users
     // major is untouched, and minor and patch are padded with one 0 each

--- a/src/classes/TwigFilters.php
+++ b/src/classes/TwigFilters.php
@@ -105,7 +105,7 @@ class TwigFilters
                     $id = (int) $field[MetadataEnum::Value->value];
                     $page = $field[MetadataEnum::Type->value] === 'items' ? 'database' : 'experiments';
                     $value = sprintf(
-                        '<a href="/%s.php?mode=view&amp;id=%d"%s><span data-replace-with-title="true" data-id=%d data-endpoint=%s>%s</span></a>',
+                        '<a href="/%s.php?mode=view&amp;id=%d"%s><span data-replace-with-title="true" data-id="%d" data-endpoint=%s>%s</span></a>',
                         $page,
                         $id,
                         $newTab,

--- a/src/classes/TwigFilters.php
+++ b/src/classes/TwigFilters.php
@@ -14,6 +14,8 @@ use Defuse\Crypto\Key;
 use Elabftw\Enums\Metadata as MetadataEnum;
 use Elabftw\Enums\Scope;
 use Elabftw\Models\Config;
+use Elabftw\Models\Users;
+
 use function is_array;
 use function sprintf;
 
@@ -85,12 +87,12 @@ class TwigFilters
                     ? sprintf('<span class="smallgray">%s</span>', Tools::eLabHtmlspecialchars($field[MetadataEnum::Description->value]))
                     : '';
                 $value = $field[MetadataEnum::Value->value];
-                // checkbox is a special case
+                // type:checkbox is a special case
                 if ($field[MetadataEnum::Type->value] === 'checkbox') {
                     $checked = $field[MetadataEnum::Value->value] === 'on' ? ' checked="checked"' : '';
                     $value = '<input class="d-block" disabled type="checkbox"' . $checked . '>';
                 }
-                // url is another special case
+                // type:url is another special case
                 elseif ($field[MetadataEnum::Type->value] === 'url') {
                     $value = sprintf(
                         '<a href="%1$s"%2$s>%1$s</a>',
@@ -98,17 +100,24 @@ class TwigFilters
                         $newTab,
                     );
                 }
-                // exp/items is another special case
+                // type:exp/items is another special case
                 elseif (in_array($field[MetadataEnum::Type->value], array('experiments', 'items'), true)) {
                     $id = (int) $field[MetadataEnum::Value->value];
                     $page = $field[MetadataEnum::Type->value] === 'items' ? 'database' : 'experiments';
                     $value = sprintf(
-                        '<a href="/%s.php?mode=view&amp;id=%d"%s>%s</a>',
+                        '<a href="/%s.php?mode=view&amp;id=%d"%s><span data-replace-with-title="true" data-id=%d data-endpoint=%s>%s</span></a>',
                         $page,
                         $id,
                         $newTab,
+                        $id,
+                        $field[MetadataEnum::Type->value],
                         Tools::eLabHtmlspecialchars($value),
                     );
+                }
+                // type:users is also a special case where we go fetch the name of the user
+                elseif ($field[MetadataEnum::Type->value] === 'users') {
+                    $linkedUser = new Users((int) $field[MetadataEnum::Value->value]);
+                    $value = $linkedUser->userData['fullname'];
                 }
                 // multi select will be an array of options
                 elseif (is_array($value)) {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -652,10 +652,10 @@ abstract class AbstractEntity implements RestInterface
     /**
      * Update only one field in the metadata json
      */
-    private function updateJsonField(string $key, string|array $value): bool
+    private function updateJsonField(string $key, string|array|int $value): bool
     {
         $Changelog = new Changelog($this);
-        $valueAsString = is_array($value) ? implode(', ', $value) : $value;
+        $valueAsString = is_array($value) ? implode(', ', $value) : (string) $value;
 
         // Either ExperimentsLinks or ItmesLinks could be used here
         if ($this->ExperimentsLinks->isSelfLinkViaMetadata($key, $valueAsString)) {

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -77,6 +77,10 @@ export class Metadata {
       // collect all the selected options, and the value will be an array
       value = [...el.selectedOptions].map(option => option.value);
     }
+    // special case for Experiment/Resource/User link
+    if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf(), ExtraFieldInputType.Users.valueOf()].includes(el.dataset.completeTarget)) {
+      value = parseInt(value.split(' ')[0], 10);
+    }
     const params = {};
     params['action'] = Action.UpdateMetadataField;
     params[el.dataset.field] = value;
@@ -175,7 +179,7 @@ export class Metadata {
 
     let valueEl: HTMLElement;
     // checkbox is special case
-    if (properties.type === 'checkbox') {
+    if (properties.type === ExtraFieldInputType.Checkbox) {
       valueEl = document.createElement('input');
       valueEl.setAttribute('type', 'checkbox');
       valueEl.classList.add('d-block');
@@ -192,7 +196,7 @@ export class Metadata {
       valueEl.innerText = value;
       // the link is generated with javascript so we can still use innerText and
       // not innerHTML with manual "<a href...>" which implicates security considerations
-      if (properties.type === 'url') {
+      if (properties.type === ExtraFieldInputType.Url) {
         valueEl.dataset.genLink = 'true';
       }
     }

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import { Action, Entity, EntityType } from './interfaces';
-import { adjustHiddenState, makeSortableGreatAgain, notifError } from './misc';
+import { adjustHiddenState, makeSortableGreatAgain, notifError, reloadElements } from './misc';
 import i18next from 'i18next';
 import { Api } from './Apiv2.class';
 import { ValidMetadata, ExtraFieldProperties, ExtraFieldsGroup, ExtraFieldInputType } from './metadataInterfaces';
@@ -80,6 +80,10 @@ export class Metadata {
     // special case for Experiment/Resource/User link
     if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf(), ExtraFieldInputType.Users.valueOf()].includes(el.dataset.completeTarget)) {
       value = parseInt(value.split(' ')[0], 10);
+      // also create a link automatically for experiments and resources
+      if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf()].includes(el.dataset.completeTarget)) {
+        this.api.post(`${this.entity.type}/${this.entity.id}/${el.dataset.completeTarget}_links/${value}`).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
+      }
     }
     const params = {};
     params['action'] = Action.UpdateMetadataField;

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -21,6 +21,7 @@ import {
   permissionsToJson,
   relativeMoment,
   reloadElement,
+  replaceWithTitle,
   togglePlusIcon,
 } from './misc';
 import i18next from 'i18next';
@@ -131,6 +132,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // show human friendly moments
   relativeMoment();
+
+  replaceWithTitle();
 
   // look for elements that should have focus
   const needFocus = (document.querySelector('[data-focus="1"]') as HTMLInputElement);

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getEntity, notifError, addAutocompleteToExtraFieldsKeyInputs } from './misc';
+import { getEntity, notifError } from './misc';
 import { Metadata } from './Metadata.class';
 import { ValidMetadata, ExtraFieldInputType } from './metadataInterfaces';
 import JsonEditorHelper from './JsonEditorHelper.class';
@@ -51,8 +51,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('fieldBuilderModal')) {
     return;
   }
-
-  addAutocompleteToExtraFieldsKeyInputs();
 
   function toggleContentDiv(key: string) {
     const keys = ['classic', 'select', 'selectradio', 'checkbox', 'number'];

--- a/src/ts/metadataInterfaces.ts
+++ b/src/ts/metadataInterfaces.ts
@@ -34,7 +34,7 @@ export enum ExtraFieldInputType {
 
 export interface ExtraFieldProperties {
   type?: ExtraFieldInputType;
-  value: string|string[];
+  value: string|string[]|number;
   group_id?: number;
   position?: number;
   options?: string[];

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -520,3 +520,12 @@ export function escapeExtendedQuery(searchTerm: string): string {
 
   return searchTerm.trim();
 }
+
+export function replaceWithTitle(): void {
+  document.querySelectorAll('[data-replace-with-title="true"]').forEach((el: HTMLElement) => {
+    const ApiC = new Api();
+    ApiC.getJson(`${el.dataset.endpoint}/${el.dataset.id}`).then(json => {
+      el.innerText = json.title;
+    });
+  });
+}

--- a/src/ts/search.ts
+++ b/src/ts/search.ts
@@ -7,14 +7,11 @@
  */
 declare let key: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 import { SearchSyntaxHighlighting } from './SearchSyntaxHighlighting.class';
-import { addAutocompleteToExtraFieldsKeyInputs } from './misc';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (window.location.pathname !== '/search.php') {
     return;
   }
-
-  addAutocompleteToExtraFieldsKeyInputs();
 
   // scroll to anchor if there is a search
   const params = new URLSearchParams(document.location.search.slice(1));

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -20,10 +20,8 @@ describe('Experiments', () => {
     cy.get('div.tags').contains('some tag').should('exist');
 
     // delete tag
-    cy.window().then(win => {
-      cy.stub(win, 'confirm').returns(true);
-      cy.contains('some tag').click();
-    });
+    cy.on('window:confirm', () => { return true; });
+    cy.contains('some tag').click();
     cy.get('div.tags').contains('some tag').should('not.exist');
 
     // create step

--- a/tests/unit/classes/TwigFiltersTest.php
+++ b/tests/unit/classes/TwigFiltersTest.php
@@ -68,7 +68,7 @@ class TwigFiltersTest extends \PHPUnit\Framework\TestCase
             },
             "experiments link": {
               "type": "experiments",
-              "value": "1",
+              "value": 1,
               "group_id": 1
             }
           },
@@ -83,7 +83,7 @@ class TwigFiltersTest extends \PHPUnit\Framework\TestCase
         }';
         $expected = sprintf(
             '<h4 data-action=\'toggle-next\' class=\'mt-4 d-inline togglable-section-title\'><i class=\'fas fa-caret-down fa-fw mr-2\'></i>Some &lt;&amp;&apos;&quot;&gt; group</h4><div>'
-                . '%1$sexperiments link</h5><h6><a href="/experiments.php?mode=view&amp;id=1" target="_blank" rel="noopener">1</a></h6></li>'
+                . '%1$sexperiments link</h5><h6><a href="/experiments.php?mode=view&amp;id=1" target="_blank" rel="noopener"><span data-replace-with-title="true" data-id="1" data-endpoint=experiments>1</span></a></h6></li>'
                 . '</div>'
                 . '<h4 data-action=\'toggle-next\' class=\'mt-4 d-inline togglable-section-title\'><i class=\'fas fa-caret-down fa-fw mr-2\'></i>Undefined group</h4><div>'
                 . '%1$sfirst one</h5><h6>first</h6></li>'


### PR DESCRIPTION
See discussion on #3857.

* add autolink upon save
* only save the id
* exp/items titles are displayed through js ajax calls
* users are displayed by php

Caveat: the pdf export currently will only display the ID for exp/items.