### PR TITLE
maintenance: drop the old password and salt columns

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -29,7 +29,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const REQUIRED_SCHEMA = 144;
+    public const REQUIRED_SCHEMA = 145;
 
     private Db $Db;
 

--- a/src/sql/schema145-down.sql
+++ b/src/sql/schema145-down.sql
@@ -1,0 +1,4 @@
+-- revert schema 145
+ALTER TABLE `users` ADD `salt` varchar(255) NULL DEFAULT NULL;
+ALTER TABLE `users` ADD `password` varchar(255) NULL DEFAULT NULL;
+UPDATE config SET conf_value = 144 WHERE conf_name = 'schema';

--- a/src/sql/schema145.sql
+++ b/src/sql/schema145.sql
@@ -1,0 +1,4 @@
+-- schema 145 - drop old passwords with sha
+ALTER TABLE `users` DROP COLUMN `salt`;
+ALTER TABLE `users` DROP COLUMN `password`;
+UPDATE config SET conf_value = 145 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -859,8 +859,6 @@ CREATE TABLE `uploads` (
 
 CREATE TABLE `users` (
   `userid` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `salt` varchar(255) NULL DEFAULT NULL,
-  `password` varchar(255) NULL DEFAULT NULL,
   `password_hash` varchar(255) NULL DEFAULT NULL,
   `password_modified_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `mfa_secret` varchar(32) NULL DEFAULT NULL,


### PR DESCRIPTION
In 4.0.0 (June 16th 2021), modern password hashing algorithm was introduced. password_hash() is used instead of salted shasum. A mechanism to seamlessly update the old password to the new one was put in place.

Users who did not login since 4.0.0 will need to reset their password. It is safe to assume most users will not be impacted by this change.