### PR TITLE
allow notifications on comments for resources too

### DIFF
--- a/src/factories/NotificationsFactory.php
+++ b/src/factories/NotificationsFactory.php
@@ -36,7 +36,7 @@ class NotificationsFactory
     public function getMailable(): MailableInterface
     {
         return match (Notifications::from($this->category)) {
-            Notifications::CommentCreated => new CommentCreated($this->body['experiment_id'], $this->body['commenter_userid']),
+            Notifications::CommentCreated => new CommentCreated($this->body['page'], $this->body['entity_id'], $this->body['commenter_userid']),
             Notifications::UserCreated => new UserCreated($this->body['userid'], $this->body['team']),
             Notifications::UserNeedValidation => new UserNeedValidation($this->body['userid'], $this->body['team']),
             Notifications::StepDeadline => new StepDeadline($this->body['step_id'], $this->body['entity_id'], $this->body['entity_page'], $this->body['deadline']),

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -33,7 +33,6 @@ use Elabftw\Interfaces\RestInterface;
 use Elabftw\Services\AccessKeyHelper;
 use Elabftw\Services\AdvancedSearchQuery;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
-use Elabftw\Services\Check;
 use Elabftw\Traits\EntityTrait;
 use function explode;
 use function implode;

--- a/src/models/Comments.php
+++ b/src/models/Comments.php
@@ -114,9 +114,7 @@ class Comments implements RestInterface
         $req->bindParam(':userid', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
 
         $this->Db->execute($req);
-        if ($this->Entity instanceof Experiments) {
-            $this->createNotification();
-        }
+        $this->createNotification();
 
         return $this->Db->lastInsertId();
     }
@@ -131,10 +129,9 @@ class Comments implements RestInterface
             return;
         }
 
-        // TODO: have a AbstractConcreteEntityWithId
         /** @psalm-suppress PossiblyNullArgument */
-        $Notif = new CommentCreated($this->Entity->id, (int) $this->Entity->Users->userData['userid']);
-        // target user is the owner of the experiment
+        $Notif = new CommentCreated($this->Entity->page, $this->Entity->id, (int) $this->Entity->Users->userData['userid']);
+        // target user is the owner of the entry
         $Notif->create($this->Entity->entityData['userid']);
     }
 }

--- a/src/models/notifications/CommentCreated.php
+++ b/src/models/notifications/CommentCreated.php
@@ -20,7 +20,7 @@ class CommentCreated extends AbstractNotifications implements MailableInterface
 
     protected Notifications $category = Notifications::CommentCreated;
 
-    public function __construct(private int $experimentId, private int $commenterId)
+    public function __construct(private string $page, private int $entityId, private int $commenterId)
     {
         parent::__construct();
     }
@@ -28,10 +28,10 @@ class CommentCreated extends AbstractNotifications implements MailableInterface
     public function getEmail(): array
     {
         $commenter = new Users($this->commenterId);
-        $url = sprintf('%s/experiments.php?mode=view&id=%d', Config::fromEnv('SITE_URL'), $this->experimentId);
+        $url = sprintf('%s/%s.php?mode=view&id=%d', Config::fromEnv('SITE_URL'), $this->page, $this->entityId);
 
         $body = sprintf(
-            _('Hi. %s left a comment on your experiment. Have a look: %s'),
+            _('Hi. %s left a comment on your entry. Have a look: %s'),
             $commenter->userData['fullname'],
             $url,
         );
@@ -44,7 +44,8 @@ class CommentCreated extends AbstractNotifications implements MailableInterface
     protected function getBody(): array
     {
         return array(
-            'experiment_id' => $this->experimentId,
+            'page' => $this->page,
+            'entity_id' => $this->entityId,
             'commenter_userid' => $this->commenterId,
         );
     }

--- a/src/services/Transform.php
+++ b/src/services/Transform.php
@@ -36,10 +36,11 @@ class Transform
         return match (Notifications::from($notif['category'])) {
             Notifications::CommentCreated =>
                 sprintf(
-                    '<span data-action="ack-notif" data-id="%d" data-href="experiments.php?mode=view&amp;id=%d">%s</span>' . $relativeMoment,
+                    '<span data-action="ack-notif" data-id="%d" data-href="%s.php?mode=view&amp;id=%d">%s</span>' . $relativeMoment,
                     (int) $notif['id'],
-                    (int) $notif['body']['experiment_id'],
-                    _('New comment on your experiment.'),
+                    $notif['body']['page'],
+                    (int) $notif['body']['entity_id'],
+                    _('New comment on your entry.'),
                     $notif['created_at'],
                 ),
             Notifications::EventDeleted =>

--- a/src/tools/mknotif.php
+++ b/src/tools/mknotif.php
@@ -15,7 +15,7 @@ use Elabftw\Models\Notifications\UserNeedValidation;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
-$Notifications = new CommentCreated(32, 2);
+$Notifications = new CommentCreated('experiments', 32, 2);
 $Notifications->create(1);
 $Notifications = new UserCreated(3, 'Some team name');
 $Notifications->create(1);

--- a/tests/unit/services/EmailNotificationsTest.php
+++ b/tests/unit/services/EmailNotificationsTest.php
@@ -26,7 +26,7 @@ class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
     public function testSendEmails(): void
     {
         // create a notification to fake send so there is something to process
-        $Notifications = new CommentCreated(1, 2);
+        $Notifications = new CommentCreated('experiments', 1, 2);
         $Notifications->create(1);
         $Notifications = new UserCreated(3, 'Some team name');
         $Notifications->create(1);


### PR DESCRIPTION
The CommentCreated notification type was only for experiments. This is due to Resources that used to miss having a stable userid (very long time ago the userid would change based on the last editor). So now this is aligned with experiments, like it should.

