### PR TITLE
feat: add DGN.de timestamp service

### DIFF
--- a/src/Make/MakeDgnTimestamp.php
+++ b/src/Make/MakeDgnTimestamp.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Make;
+
+use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Key;
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Config;
+
+/**
+ * RFC3161 timestamping with DGN service
+ * https://www.dgn.de/dgn-zeitstempeldienst/
+ */
+class MakeDgnTimestamp extends AbstractMakeTrustedTimestamp
+{
+    protected const TS_URL = 'https://zeitstempel.dgn.de/tss';
+
+    protected const TS_HASH = 'sha512';
+
+    /**
+     * Return the needed parameters to request/verify a timestamp
+     *
+     * @return array<string,string>
+     */
+    public function getTimestampParameters(): array
+    {
+        $config = $this->configArr;
+
+        if (empty($config['ts_login'])) {
+            throw new ImproperActionException('DGN timestamping requires a login!');
+        }
+
+        if (empty($config['ts_password'])) {
+            throw new ImproperActionException('DGN timestamping requires a password!');
+        }
+        $password = Crypto::decrypt($config['ts_password'], Key::loadFromAsciiSafeString(Config::fromEnv('SECRET_KEY')));
+
+        return array(
+            'ts_login' => $config['ts_login'],
+            'ts_password' => $password,
+            // use static here so the dev class ts_url override is taken into account
+            'ts_url' => static::TS_URL,
+            'ts_hash' => self::TS_HASH,
+            // no need to verify for this provider
+            'ts_cert' => '',
+            'ts_chain' => '',
+            );
+    }
+}

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -20,6 +20,7 @@ use Elabftw\Interfaces\MakeTrustedTimestampInterface;
 use Elabftw\Make\MakeBloxberg;
 use Elabftw\Make\MakeCustomTimestamp;
 use Elabftw\Make\MakeDfnTimestamp;
+use Elabftw\Make\MakeDgnTimestamp;
 use Elabftw\Make\MakeDigicertTimestamp;
 use Elabftw\Make\MakeGlobalSignTimestamp;
 use Elabftw\Make\MakeSectigoTimestamp;
@@ -65,6 +66,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity implements CreateFr
     {
         return match ($config['ts_authority']) {
             'dfn' => new MakeDfnTimestamp($config, $this, $dataFormat),
+            'dgn' => new MakeDgnTimestamp($config, $this, $dataFormat),
             'universign' => $config['debug'] ? new MakeUniversignTimestampDev($config, $this, $dataFormat) : new MakeUniversignTimestamp($config, $this, $dataFormat),
             'digicert' => new MakeDigicertTimestamp($config, $this, $dataFormat),
             'sectigo' => new MakeSectigoTimestamp($config, $this, $dataFormat),

--- a/src/templates/ts-config.html
+++ b/src/templates/ts-config.html
@@ -4,6 +4,7 @@
   <select class='form-control col-md-3' data-trigger='change' data-model='config' data-target='ts_authority' id='ts_authority' autocomplete='off'>
     <option value='dfn' {{ App.Config.configArr.ts_authority == 'dfn' ? 'selected' }}>{{ 'DFN (free, no account required)'|trans }}</option>
     <option value='universign' {{ App.Config.configArr.ts_authority == 'universign' ? 'selected' }}>{{ 'Universign (requires account)'|trans }}</option>
+    <option value='dgn' {{ App.Config.configArr.ts_authority == 'dgn' ? 'selected' }}>{{ 'DGN.de Zeitstempel (requires account)'|trans }}</option>
     <option value='digicert' {{ App.Config.configArr.ts_authority == 'digicert' ? 'selected' }}>{{ 'Digicert (free, no account required)'|trans }}</option>
     <option value='sectigo' {{ App.Config.configArr.ts_authority == 'sectigo' ? 'selected' }}>{{ 'Sectigo (free, no account required)'|trans }}</option>
     <option value='globalsign' {{ App.Config.configArr.ts_authority == 'globalsign' ? 'selected' }}>{{ 'GlobalSign (free, no account required)'|trans }}</option>

--- a/src/templates/ts-config.html
+++ b/src/templates/ts-config.html
@@ -2,12 +2,12 @@
 <div class='d-flex justify-content-between'>
   <label for='ts_authority' class='col-form-label'>{{ 'Select timestamping authority (TSA)'|trans }}</label>
   <select class='form-control col-md-3' data-trigger='change' data-model='config' data-target='ts_authority' id='ts_authority' autocomplete='off'>
-    <option value='dfn' {{ App.Config.configArr.ts_authority == 'dfn' ? 'selected' }}>{{ 'DFN (free, no account required)'|trans }}</option>
-    <option value='universign' {{ App.Config.configArr.ts_authority == 'universign' ? 'selected' }}>{{ 'Universign (requires account)'|trans }}</option>
-    <option value='dgn' {{ App.Config.configArr.ts_authority == 'dgn' ? 'selected' }}>{{ 'DGN.de Zeitstempel (requires account)'|trans }}</option>
-    <option value='digicert' {{ App.Config.configArr.ts_authority == 'digicert' ? 'selected' }}>{{ 'Digicert (free, no account required)'|trans }}</option>
-    <option value='sectigo' {{ App.Config.configArr.ts_authority == 'sectigo' ? 'selected' }}>{{ 'Sectigo (free, no account required)'|trans }}</option>
-    <option value='globalsign' {{ App.Config.configArr.ts_authority == 'globalsign' ? 'selected' }}>{{ 'GlobalSign (free, no account required)'|trans }}</option>
+    <option value='dfn' {{ App.Config.configArr.ts_authority == 'dfn' ? 'selected' }}>DFN.de {{ '(free, no account required)'|trans }}</option>
+    <option value='universign' {{ App.Config.configArr.ts_authority == 'universign' ? 'selected' }}>Universign.com {{ '(requires account)'|trans }}</option>
+    <option value='dgn' {{ App.Config.configArr.ts_authority == 'dgn' ? 'selected' }}>DGN.de {{ '(requires account)'|trans }}</option>
+    <option value='digicert' {{ App.Config.configArr.ts_authority == 'digicert' ? 'selected' }}>Digicert.com {{ '(free, no account required)'|trans }}</option>
+    <option value='sectigo' {{ App.Config.configArr.ts_authority == 'sectigo' ? 'selected' }}>Sectigo.com {{ '(free, no account required)'|trans }}</option>
+    <option value='globalsign' {{ App.Config.configArr.ts_authority == 'globalsign' ? 'selected' }}>GlobalSign.com {{ '(free, no account required)'|trans }}</option>
     <option value='custom' {{ App.Config.configArr.ts_authority == 'custom' ? 'selected' }}>{{ 'Custom TSA'|trans }}</option>
   </select>
 </div>

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -254,7 +254,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // mask all
       document.getElementById('ts_loginpass').toggleAttribute('hidden', true);
       document.getElementById('ts_urldiv').toggleAttribute('hidden', true);
-    } else if (select.value === 'universign') {
+    } else if (select.value === 'universign' || select.value === 'dgn') {
       // only make loginpass visible
       document.getElementById('ts_loginpass').removeAttribute('hidden');
       document.getElementById('ts_urldiv').toggleAttribute('hidden', true);

--- a/tests/unit/Make/MakeTimestampTest.php
+++ b/tests/unit/Make/MakeTimestampTest.php
@@ -118,6 +118,16 @@ class MakeTimestampTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($Maker->getTimestampParameters());
     }
 
+    public function testDgn(): void
+    {
+        $config = array();
+        $config['ts_login'] = 'fakelogin@example.com';
+        // create a fake encrypted password
+        $config['ts_password'] = Crypto::encrypt('fakepassword', Key::loadFromAsciiSafeString(Config::fromEnv('SECRET_KEY')));
+        $Maker = new MakeDgnTimestamp($config, $this->getFreshTimestampableEntity(), $this->dataFormat);
+        $this->assertIsArray($Maker->getTimestampParameters());
+    }
+
     public function testSectigo(): void
     {
         $Maker = new MakeSectigoTimestamp(array(), $this->getFreshTimestampableEntity(), $this->dataFormat);


### PR DESCRIPTION
It's an eIDAS qualified timestamp service, with sha512 hash. Now it's easier to configure. Fix #4952
