### PR TITLE
One exception per unit test

### DIFF
--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -241,12 +241,19 @@ class Apiv2Controller extends AbstractApiController
                 $this->Request->query->getString('end', Scheduler::EVENT_END),
                 $this->Request->query->getInt('cat'),
             ),
-            ApiEndpoint::ExtraFieldsKeys => new ExtraFieldsKeys($this->Users, trim($this->Request->query->getString('q')), $this->Request->query->getInt('limit')),
+            ApiEndpoint::ExtraFieldsKeys => new ExtraFieldsKeys(
+                $this->Users,
+                trim($this->Request->query->getString('q')),
+                $this->Request->query->getInt('limit'),
+            ),
             ApiEndpoint::FavTags => new FavTags($this->Users, $this->id),
             ApiEndpoint::TeamTags => new TeamTags($this->Users, $this->id),
             ApiEndpoint::Teams => new Teams($this->Users, $this->id),
             ApiEndpoint::Todolist => new Todolist($this->Users->userData['userid'], $this->id),
-            ApiEndpoint::UnfinishedSteps => new UnfinishedSteps($this->Users, $this->Request->query->get('scope') === 'team'),
+            ApiEndpoint::UnfinishedSteps => new UnfinishedSteps(
+                $this->Users,
+                $this->Request->query->get('scope') === 'team',
+            ),
             ApiEndpoint::Users => new Users($this->id, $this->Users->team, $this->Users),
         };
     }

--- a/tests/unit/Make/MakeKeeexTest.php
+++ b/tests/unit/Make/MakeKeeexTest.php
@@ -23,15 +23,37 @@ class MakeKeeexTest extends \PHPUnit\Framework\TestCase
         // https://docs.guzzlephp.org/en/stable/testing.html
         $mock = new MockHandler(array(
             new Response(200, array(), 'fake keeexed content'),
-            new Response(400, array(), 'fake keeexed content'),
-            new Response(500, array(), 'fake keeexed content'),
         ));
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $Maker = new MakeKeeex($client);
         $this->assertIsString($Maker->fromString('source content'));
+    }
+
+    public function testClientError(): void
+    {
+        // don't use the real guzzle client, but use a mock
+        // https://docs.guzzlephp.org/en/stable/testing.html
+        $mock = new MockHandler(array(
+            new Response(400, array(), 'fake keeexed content'),
+        ));
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(array('handler' => $handlerStack));
+        $Maker = new MakeKeeex($client);
         $this->expectException(ImproperActionException::class);
         $Maker->fromString('trigger client error');
+    }
+
+    public function testServerError(): void
+    {
+        // don't use the real guzzle client, but use a mock
+        // https://docs.guzzlephp.org/en/stable/testing.html
+        $mock = new MockHandler(array(
+            new Response(500, array(), 'fake keeexed content'),
+        ));
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(array('handler' => $handlerStack));
+        $Maker = new MakeKeeex($client);
         $this->expectException(ImproperActionException::class);
         $Maker->fromString('trigger server error');
     }

--- a/tests/unit/classes/UserParamsTest.php
+++ b/tests/unit/classes/UserParamsTest.php
@@ -26,14 +26,25 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($input, $params->getContent());
     }
 
-    public function testInvalidOrcid(): void
+    public function testOrcid(): void
     {
-        $invalidOrcid = '1234-5678-1212-000X';
-        $params = new UserParams('orcid', $invalidOrcid);
+        $orcid = '1234-5678-1212-0001';
+        $params = new UserParams('orcid', $orcid);
+        $this->assertEquals($orcid, $params->getContent());
+    }
+
+    public function testInvalidOrcidForamt(): void
+    {
+        $orcid = '1234-5678-1212-001';
+        $params = new UserParams('orcid', $orcid);
         $this->expectException(ImproperActionException::class);
         $params->getContent();
-        $invalidOrcid = '1234-5678-1212-0001';
-        $params = new UserParams('orcid', $invalidOrcid);
+    }
+
+    public function testInvalidOrcidChecksum(): void
+    {
+        $orcid = '1234-5678-1212-000X';
+        $params = new UserParams('orcid', $orcid);
         $this->expectException(ImproperActionException::class);
         $params->getContent();
     }

--- a/tests/unit/models/ApiKeysTest.php
+++ b/tests/unit/models/ApiKeysTest.php
@@ -29,10 +29,14 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->ApiKeys->destroy());
     }
 
-    public function testPatch(): void
+    public function testPatchInvalidUpdate(): void
     {
         $this->expectException(ImproperActionException::class);
         $this->ApiKeys->patch(Action::Update, array());
+    }
+
+    public function testPatchInvalidArchive(): void
+    {
         $this->expectException(ImproperActionException::class);
         $this->ApiKeys->patch(Action::Archive, array());
     }

--- a/tests/unit/models/SchedulerTest.php
+++ b/tests/unit/models/SchedulerTest.php
@@ -71,15 +71,26 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->Scheduler->readOne());
     }
 
-    public function testPatchEpoch(): void
+    public function testPatchEpoch(): Scheduler
     {
         $Items = new Items(new Users(1, 1), 1);
         $id = $this->testCreate();
         $Scheduler = new Scheduler($Items, $id, $this->start, $this->end);
         $this->assertIsArray($Scheduler->patch(Action::Update, array('target' => 'start_epoch', 'epoch' => date('U'))));
         $this->assertIsArray($Scheduler->patch(Action::Update, array('target' => 'end_epoch', 'epoch' => date('U'))));
+        return $Scheduler;
+    }
+
+    public function testPatchEpochInvalidTarget(): void
+    {
+        $Scheduler = $this->testPatchEpoch();
         $this->expectException(ImproperActionException::class);
         $Scheduler->patch(Action::Update, array('target' => 'oops', 'epoch' => date('U')));
+    }
+
+    public function testPatchEpochInvalidEpoch(): void
+    {
+        $Scheduler = $this->testPatchEpoch();
         $this->expectException(ImproperActionException::class);
         $Scheduler->patch(Action::Update, array('target' => 'end_epoch', 'epoch' => ''));
     }
@@ -288,7 +299,11 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     public function testDestroy(): void
     {
-        $id = $this->Scheduler->postAction(Action::Create, array('start' => '2016-07-22T19:42:00+02:00', 'end' => '2016-07-23T19:42:00+02:00', 'title' => 'Yep'));
+        $id = $this->Scheduler->postAction(Action::Create, array(
+            'start' => '2016-07-22T19:42:00+02:00',
+            'end' => '2016-07-23T19:42:00+02:00',
+            'title' => 'Yep',
+        ));
         $this->Scheduler->setId($id);
         $this->assertTrue($this->Scheduler->destroy());
     }

--- a/tests/unit/models/TagsTest.php
+++ b/tests/unit/models/TagsTest.php
@@ -46,8 +46,6 @@ class TagsTest extends \PHPUnit\Framework\TestCase
         $Teams->patch(Action::Update, array('user_create_tag' => 0));
         $this->expectException(ImproperActionException::class);
         $Tags->postAction(Action::Create, array('tag' => 'tag2i222'));
-        // bring back config
-        $Teams->patch(Action::Update, array('user_create_tag' => 1));
     }
 
     public function testReadAll(): void

--- a/tests/unit/services/FilterTest.php
+++ b/tests/unit/services/FilterTest.php
@@ -36,8 +36,7 @@ class FilterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('my body', Filter::body('my body'));
         $this->assertEquals('my body', Filter::body('my body<script></script>'));
         $this->expectException(ImproperActionException::class);
-        $body = str_repeat('a', 4120001);
-        Filter::body($body);
+        Filter::body(str_repeat('a', 4120001));
     }
 
     public function testForFilesystem(): void


### PR DESCRIPTION
While working on #4991 I noticed that some unit test are still expecting two exceptions but the second one will never be executed.
To address this issue the corresponding parts are changed.