### PR TITLE
use Usergroup enum more extensively

### DIFF
--- a/src/models/ExistingUser.php
+++ b/src/models/ExistingUser.php
@@ -9,6 +9,8 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Enums\Usergroup;
+
 /**
  * A user that exists in the db, so we have a userid but not necessarily a team, and they might not be validated
  */
@@ -24,12 +26,15 @@ class ExistingUser extends Users
         return self::search('orgid', $orgid);
     }
 
+    /**
+     * @param bool $forceValidation true: user is automatically validated
+     */
     public static function fromScratch(
         string $email,
         array $teams,
         string $firstname,
         string $lastname,
-        ?int $usergroup = null,
+        ?Usergroup $usergroup = null,
         bool $forceValidation = false,
         bool $alertAdmin = true,
     ): Users {

--- a/src/models/ValidatedUser.php
+++ b/src/models/ValidatedUser.php
@@ -9,6 +9,8 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Enums\Usergroup;
+
 /**
  * A user that exists in the db, so we have a userid but not necessarily a team
  */
@@ -29,7 +31,7 @@ class ValidatedUser extends ExistingUser
         return parent::fromScratch($email, $teams, $firstname, $lastname, null, true);
     }
 
-    public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, int $usergroup): Users
+    public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, Usergroup $usergroup): Users
     {
         return parent::fromScratch($email, $teams, $firstname, $lastname, $usergroup, true, false);
     }

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Services;
 
 use Elabftw\Elabftw\Db;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use PDO;
 
@@ -28,16 +29,16 @@ class TeamsHelper
      * 2 = admin for first user in a team
      * 4 = normal user
      */
-    public function getGroup(): int
+    public function getGroup(): Usergroup
     {
         if ($this->isFirstUser()) {
-            return 1;
+            return Usergroup::Sysadmin;
         }
 
         if ($this->isFirstUserInTeam()) {
-            return 2;
+            return Usergroup::Admin;
         }
-        return 4;
+        return Usergroup::User;
     }
 
     public function getPermissions(int $userid): array
@@ -68,7 +69,7 @@ class TeamsHelper
 
     public function isAdminInTeam(int $userid): bool
     {
-        return $this->getUserInTeam($userid)['groups_id'] <= 2;
+        return $this->getUserInTeam($userid)['groups_id'] <= Usergroup::Admin->value;
     }
 
     /**

--- a/src/services/UserCreator.php
+++ b/src/services/UserCreator.php
@@ -54,7 +54,7 @@ class UserCreator
             (new UserParams('lastname', $this->reqBody['lastname']))->getContent(),
             // password is never set by admin/sysadmin
             '',
-            Check::usergroup($this->requester, Usergroup::from((int) ($this->reqBody['usergroup'] ?? 4)))->value,
+            Check::usergroup($this->requester, Usergroup::from((int) ($this->reqBody['usergroup'] ?? 4))),
             // automatically validate user
             true,
             // don't alert admin

--- a/src/services/UserCreator.php
+++ b/src/services/UserCreator.php
@@ -54,7 +54,7 @@ class UserCreator
             (new UserParams('lastname', $this->reqBody['lastname']))->getContent(),
             // password is never set by admin/sysadmin
             '',
-            Check::usergroup($this->requester, Usergroup::from((int) ($this->reqBody['usergroup'] ?? 4))),
+            Check::usergroup($this->requester, Usergroup::from((int) ($this->reqBody['usergroup'] ?? Usergroup::User->value))),
             // automatically validate user
             true,
             // don't alert admin

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Auth;
 
 use Elabftw\Elabftw\AuthResponse;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\ImproperActionException;
 use Monolog\Logger;
 
@@ -55,7 +56,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $authResponse->userid);
         $this->assertFalse($authResponse->isAnonymous);
         $this->assertEquals(1, $authResponse->selectedTeam);
-        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => 2, 'is_owner' => 0));
+        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => Usergroup::Admin->value, 'is_owner' => 0));
         $this->assertEquals($teams, $authResponse->selectableTeams);
     }
 

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -9,6 +9,7 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 
@@ -35,7 +36,7 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
             'userid' => 2,
             'team' => 1,
             'target' => 'group',
-            'content' => 4,
+            'content' => Usergroup::User->value,
         );
         $this->assertEquals(4, $this->Users2Teams->patchUser2Team($params));
     }

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -12,6 +12,7 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\Scope;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
@@ -200,9 +201,9 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         // force admin validation so we can run all code paths
         $Config = Config::getConfig();
         $Config->patch(Action::Update, array('admin_validate' => 1));
-        $this->assertIsInt($this->Users->createOne('blahblah@yop.fr', array('Bravo'), 'blah', 'yop', 'somePassword!', 2, false, false));
+        $this->assertIsInt($this->Users->createOne('blahblah@yop.fr', array('Bravo'), 'blah', 'yop', 'somePassword!', Usergroup::Admin, false, false));
         $Config->patch(Action::Update, array('admin_validate' => 0));
-        $this->assertIsInt($this->Users->createOne('blahblah2@yop.fr', array('Bravo'), 'blah2', 'yop', 'somePassword!', 2, true, false));
+        $this->assertIsInt($this->Users->createOne('blahblah2@yop.fr', array('Bravo'), 'blah2', 'yop', 'somePassword!', Usergroup::Admin, true, false));
     }
 
     public function testUnArchiveButAnotherUserExists(): void
@@ -211,7 +212,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Admin = new Users(5, 2);
         $Users = new Users(6, 2, $Admin);
         // create another active user with the same email
-        ExistingUser::fromScratch($Users->userData['email'], array('Alpha'), 'f', 'l', 4, false, false);
+        ExistingUser::fromScratch($Users->userData['email'], array('Alpha'), 'f', 'l', Usergroup::User, false, false);
         // try to unarchive
         $this->expectException(ImproperActionException::class);
         $Users->patch(Action::Lock, array());
@@ -236,7 +237,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     public function testDestroy(): void
     {
         $Admin = new Users(5, 2);
-        $id = $Admin->createOne('testdestroy@a.fr', array('Bravo'), 'Life', 'isShort', 'yololololol', 4, false, false);
+        $id = $Admin->createOne('testdestroy@a.fr', array('Bravo'), 'Life', 'isShort', 'yololololol', Usergroup::User, false, false);
         $Target = new Users($id, 2, $Admin);
         $this->assertTrue($Target->destroy());
     }

--- a/tests/unit/models/ValidatedUserTest.php
+++ b/tests/unit/models/ValidatedUserTest.php
@@ -9,6 +9,8 @@
 
 namespace Elabftw\Models;
 
+use Elabftw\Enums\Usergroup;
+
 class ValidatedUserTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateFromAdmin(): void
@@ -18,7 +20,7 @@ class ValidatedUserTest extends \PHPUnit\Framework\TestCase
             array('Alpha'),
             'valid',
             'user',
-            4,
+            Usergroup::User,
         );
         $this->assertInstanceOf(ExistingUser::class, $User);
     }

--- a/tests/unit/services/ExpirationNotifierTest.php
+++ b/tests/unit/services/ExpirationNotifierTest.php
@@ -19,7 +19,7 @@ class ExpirationNotifierTest extends \PHPUnit\Framework\TestCase
     public function testSendEmails(): void
     {
         // first make a user close to expiration
-        $user = ValidatedUser::fromAdmin('expire@soon.example', array(1), 'expire', 'soon', Usergroup::User->value);
+        $user = ValidatedUser::fromAdmin('expire@soon.example', array(1), 'expire', 'soon', Usergroup::User);
         $date = new DateTimeImmutable('tomorrow');
         $user->patch(Action::Update, array('valid_until' => $date->format('Y-m-d')));
         // now alert user and admin

--- a/tests/unit/services/TeamsHelperTest.php
+++ b/tests/unit/services/TeamsHelperTest.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Services;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users;
 
@@ -24,11 +25,11 @@ class TeamsHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetGroup(): void
     {
-        $this->assertEquals(4, $this->TeamsHelper->getGroup());
+        $this->assertEquals(Usergroup::User, $this->TeamsHelper->getGroup());
         // now create a new team and try to get group
         $Teams = new Teams(new Users(1));
         $team = $Teams->postAction(Action::Create, array('name' => 'New team'));
         $TeamsHelper = new TeamsHelper($team);
-        $this->assertEquals(2, $TeamsHelper->getGroup());
+        $this->assertEquals(Usergroup::Admin, $TeamsHelper->getGroup());
     }
 }

--- a/tests/unit/services/UserCreatorTest.php
+++ b/tests/unit/services/UserCreatorTest.php
@@ -10,6 +10,7 @@
 namespace Elabftw\Services;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Config;
@@ -26,7 +27,7 @@ class UserCreatorTest extends \PHPUnit\Framework\TestCase
             'email' => 'livelongandprosper@vulcan.gov.vn',
             'firstname' => 'Leonard',
             'lastname' => 'Nimoy',
-            'usergroup' => 4,
+            'usergroup' => Usergroup::User->value,
         ));
     }
 
@@ -48,7 +49,7 @@ class UserCreatorTest extends \PHPUnit\Framework\TestCase
             'email' => 'praisetheprophets@staff.ds9.bjr',
             'firstname' => 'Kira',
             'lastname' => 'Nerys',
-            'usergroup' => 4,
+            'usergroup' => Usergroup::User->value,
         ));
         $this->assertIsInt($UserCreator->create());
     }
@@ -60,7 +61,7 @@ class UserCreatorTest extends \PHPUnit\Framework\TestCase
             'email' => 'vic@holodeck.ds9.bjr',
             'firstname' => 'Vic',
             'lastname' => 'Fontaine',
-            'usergroup' => 1,
+            'usergroup' => Usergroup::Sysadmin->value,
         ));
         $this->expectException(ImproperActionException::class);
         $UserCreator->create();
@@ -75,7 +76,7 @@ class UserCreatorTest extends \PHPUnit\Framework\TestCase
             'email' => 'vic@holodeck.ds9.bjr',
             'firstname' => 'Vic',
             'lastname' => 'Fontaine',
-            'usergroup' => 1,
+            'usergroup' => Usergroup::Sysadmin->value,
         ));
         $this->expectException(IllegalActionException::class);
         $UserCreator->create();

--- a/tests/unit/services/UsersHelperTest.php
+++ b/tests/unit/services/UsersHelperTest.php
@@ -9,6 +9,8 @@
 
 namespace Elabftw\Services;
 
+use Elabftw\Enums\Usergroup;
+
 class UsersHelperTest extends \PHPUnit\Framework\TestCase
 {
     private UsersHelper $UsersHelper;
@@ -35,7 +37,7 @@ class UsersHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTeamsFromUserid(): void
     {
-        $expected = array(array('id' => 1, 'name' => 'Alpha', 'usergroup' => 2, 'is_owner' => 0));
+        $expected = array(array('id' => 1, 'name' => 'Alpha', 'usergroup' => Usergroup::Admin->value, 'is_owner' => 0));
         $this->assertEquals($expected, $this->UsersHelper->getTeamsFromUserid());
     }
 


### PR DESCRIPTION
While I was looking into the different login/register procedures and the associated creation of users I noticed that the Usergroup enum was not used everywhere.