### PR TITLE
Users->create(): use bool instead of int

### DIFF
--- a/src/models/ExistingUser.php
+++ b/src/models/ExistingUser.php
@@ -26,20 +26,17 @@ class ExistingUser extends Users
         return self::search('orgid', $orgid);
     }
 
-    /**
-     * @param bool $forceValidation true: user is automatically validated
-     */
     public static function fromScratch(
         string $email,
         array $teams,
         string $firstname,
         string $lastname,
         ?Usergroup $usergroup = null,
-        bool $forceValidation = false,
+        bool $automaticValidationEnabled = false,
         bool $alertAdmin = true,
     ): Users {
         $Users = new self();
-        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $forceValidation, $alertAdmin);
+        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin);
         $fresh = new self($userid);
         // we need to report the needValidation flag into the new object
         $fresh->needValidation = $Users->needValidation;

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -148,7 +148,7 @@ class Users implements RestInterface
         $req->bindParam(':firstname', $firstname);
         $req->bindParam(':lastname', $lastname);
         $req->bindParam(':register_date', $registerDate);
-        $req->bindParam(':validated', $isValidated, PDO::PARAM_INT);
+        $req->bindValue(':validated', $isValidated, PDO::PARAM_INT);
         $req->bindValue(':lang', $Config->configArr['lang']);
         $req->bindValue(':valid_until', $validUntil);
         $req->bindValue(':orgid', $orgid);


### PR DESCRIPTION
I was a bit confused about all the 0 and 1 in the `Users->create()` method.
They actually represent boolean values and therefore it is refactored.

Additionally, the variable name `$forceValidation` is somewhat ambiguous: it can be either "we enforce the validation of the user now and here" or it could be "we enforce the validation to be done by an admin".
It is renamed to `$automaticValidationEnabled`. Yes, much longer but more explicit too.