### PR TITLE
Fix swagger docs examples with urlencoded colon

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -978,7 +978,7 @@ paths:
           examples:
             first:
               summary: Search for all items with a rating of 2.
-              value: "rating%3A2"
+              value: "rating:2"
         - name: related
           in: query
           schema:
@@ -1221,7 +1221,7 @@ paths:
           examples:
             first:
               summary: Search for all items with a rating of 2.
-              value: "rating%3A2"
+              value: "rating:2"
         # This one is not exactly copy paste
         - name: cat
           in: query


### PR DESCRIPTION
Replace `%3A` to `:` in swagger docs. This did not work in chrome at least.

Make sure to read [the contributing documentation](https://doc.elabftw.net/contributing.html).

IMPORTANT: Base your PR off the 'hypernext' branch for a feature, and branch `next` for a bugfix.

IMPORTANT: all new features MUST be have tests added.

Also please note that working on a PR doesn't automatically means that your code will be merged.
