### PR TITLE
apidoc: replace "status" by "categories" in experiments_categories section

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2267,7 +2267,7 @@ paths:
       operationId: post-team-one-expcat
       summary: Create a new experiments categories.
       requestBody:
-        description: Parameters for creating a status.
+        description: Parameters for creating a category.
         content:
           application/json:
             schema:
@@ -2275,20 +2275,20 @@ paths:
               properties:
                 name:
                   type: string
-                  description: Status name
+                  description: Category name
                 color:
                   type: string
                   description: |
                     Hex color without leading \#.
                 default:
                   type: integer
-                  description: Is it the default status for the team?
+                  description: Is it the default category for the team?
       responses:
         '201':
-          description: Create a status.
+          description: Create a category.
           headers:
             location:
-              description: An URL to the status that was created.
+              description: An URL to the category that was created.
               schema:
                 type: string
   # ONE EXPERIMENTS CATEGORY
@@ -2309,7 +2309,7 @@ paths:
     get:
       tags: ['Experiments categories']
       operationId: read-team-one-expcat
-      summary: Read a status.
+      summary: Read a category.
       responses:
         '200':
           description: Read a category.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2265,7 +2265,7 @@ paths:
     post:
       tags: ['Experiments categories']
       operationId: post-team-one-expcat
-      summary: Create a new experiments status.
+      summary: Create a new experiments categories.
       requestBody:
         description: Parameters for creating a status.
         content:
@@ -2466,7 +2466,7 @@ paths:
     post:
       tags: ['Resources status']
       operationId: post-team-one-resstat
-      summary: Create a new experiments status.
+      summary: Create a new resources status.
       requestBody:
         description: Parameters for creating a resources status.
         content:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2302,7 +2302,7 @@ paths:
           type: integer
       - name: subid
         in: path
-        description: ID of the status
+        description: ID of the category.
         required: true
         schema:
           type: integer

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2265,7 +2265,7 @@ paths:
     post:
       tags: ['Experiments categories']
       operationId: post-team-one-expcat
-      summary: Create a new experiments categories.
+      summary: Create a new category for experiments.
       requestBody:
         description: Parameters for creating a category.
         content:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2466,7 +2466,7 @@ paths:
     post:
       tags: ['Resources status']
       operationId: post-team-one-resstat
-      summary: Create a new resources status.
+      summary: Create a new status for resources.
       requestBody:
         description: Parameters for creating a resources status.
         content:


### PR DESCRIPTION
Fixes #5011 