### PR TITLE
Add emoticons plugin to tinyMCE editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ config.php*
 web/test.php
 web/assets/*.LICENSE.txt
 web/assets/*.svg
+web/assets/tinymce_emojis.js
 src/node/*.LICENSE.txt
 tests/_output/*
 tests/_support/_generated*

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -487,7 +487,7 @@
         {{ 'Note: the text below is a template and must be edited and saved.'|trans|msg('ok', false) }}
       {% endif %}
       {% if configArr.debug -%}
-        <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element: suppress errors from tinymce] -->
+        <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, no-unused-disable: suppress errors from tinymce] -->
       {%- endif %}
       <textarea id='{{ slug }}Input' class='mceditable'>
         {{ configArr[slug]|default('Set your text here.')|raw }}

--- a/src/tools/yarn-plugin-tinymce.js
+++ b/src/tools/yarn-plugin-tinymce.js
@@ -36,17 +36,21 @@ module.exports = {
               }
             }
             const checksum = project.storedChecksums.get(tinymceLocator.locatorHash) ?? null;
-            const path = cache.getLocatorPath(tinymceLocator, checksum);
+            const locatorPath = cache.getLocatorPath(tinymceLocator, checksum);
 
-            const extractFile = (filename) => {
-              const requestedFile = `${path}/node_modules/tinymce/skins/ui/oxide/${filename}`;
+            const extractFile = (nodeModulesPath, sourceName, targetName) => {
+              targetName = typeof targetName === 'string' && targetName !== ''
+                ? targetName
+                : sourceName;
+              const requestedFile = `${locatorPath}/node_modules/${nodeModulesPath}${sourceName}`;
               const fileContent = crossFs.readFileSync(requestedFile);
-              const destinationPath = `web/assets/${filename}`;
+              const destinationPath = `web/assets/${targetName}`;
               crossFs.writeFileSync(destinationPath, fileContent, 'utf8');
             };
 
-            extractFile('skin.min.css');
-            extractFile('content.min.css');
+            extractFile('tinymce/skins/ui/oxide/', 'skin.min.css');
+            extractFile('tinymce/skins/ui/oxide/', 'content.min.css', 'tinymce_content.min.css');
+            extractFile('tinymce/plugins/emoticons/js/', 'emojis.js', 'tinymce_emojis.js');
           },
         },
       },

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -22,6 +22,7 @@ import 'tinymce/plugins/autosave';
 import 'tinymce/plugins/charmap';
 import 'tinymce/plugins/code';
 import 'tinymce/plugins/codesample';
+import 'tinymce/plugins/emoticons';
 import 'tinymce/plugins/fullscreen';
 import 'tinymce/plugins/image';
 import 'tinymce/plugins/insertdatetime';
@@ -122,8 +123,8 @@ function doneTyping(): void {
 
 // options for tinymce to pass to tinymce.init()
 export function getTinymceBaseConfig(page: string): object {
-  let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image link pagebreak codesample template mention visualblocks visualchars';
-  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap adddate | codesample | link | sort-table | save';
+  let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image link pagebreak codesample template mention visualblocks visualchars emoticons';
+  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link | sort-table | save';
   let removedMenuItems = 'newdocument, image, anchor';
   if (page === 'edit') {
     plugins += ' autosave';

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -138,9 +138,10 @@ export function getTinymceBaseConfig(page: string): object {
   return {
     selector: '.mceditable',
     browser_spellcheck: true,
-    // make it load the skin.min.css and content.min.css from there
+    // location of the skin directory
     skin_url: '/assets',
-    content_css: '/assets/content.min.css',
+    content_css: '/assets/tinymce_content.min.css',
+    emoticons_database_url: 'assets/tinymce_emojis.js',
     // remove the "Upgrade" button
     promotion: false,
     autoresize_bottom_margin: 50,


### PR DESCRIPTION
We add the [emoticons plugin](https://www.tiny.cloud/docs/tinymce/6/emoticons/) to tinyMCE to facilitated the addition of emojis to the entity bodies.

This is nice for the web interface.
However, the emojis are not shown in the PDFs because the underlying font(s) do not have the necessary glyphs. A work around could be to enable MPDF's [Font substitution](https://mpdf.github.io/fonts-languages/font-substitution-7-x.html) and/or [Character substitution](https://mpdf.github.io/fonts-languages/character-substitution.html) while providing a font that has glyphs for emojis embedded. But this will increase the amount of resources (CPU and memory) to create a PDF potentially by a lot because in the worst case a long list of glyphs needs to be checked.

[Noto](https://fonts.google.com/noto) could be a good choice as it supports **a lot** of glyphs for many languages and additionally emojis.

closes #4977