### PR TITLE
Replace bootstrap-select with tom-select

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -33,8 +33,6 @@ export default defineConfig({
         {
           exclude: [
             '#sketcher_search_dialog', // chemdoodle 2d-sketcher
-            '#bs-select-1', // bootstrap select does not use native select element
-            '#bs-select-2', // bootstrap select does not use native select element
             '#scheduler', // scheduler on the team page has several violations
             'h3[data-action="toggle-next"]', // these get the attribute role='button' ...
             'h4[data-action="toggle-next"]', // ... hence, trigger prefer-native-element

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@yarnpkg/libzip": "^3.0.0",
     "bootstrap": "^4.6.2",
     "bootstrap-markdown-fa5": "^2.10.2",
-    "bootstrap-select": "^1.13.18",
     "css-loader": "^6.9.1",
     "css-minimizer-webpack-plugin": "^5.0.1",
     "diff-match-patch": "^1.0.5",

--- a/src/scss/_tom-select.scss
+++ b/src/scss/_tom-select.scss
@@ -9,8 +9,64 @@
 
  @import 'tom-select/dist/scss/tom-select.bootstrap4';
 
-.focus .ts-control {
+.focus .ts-control,
+.plugin-dropdown_input.focus .ts-dropdown .dropdown-input { /* stylelint-disable-line selector-class-pattern -- next-line does not work here */
     border-color: $elabblue;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(41, 174, 185, 0.6);
     outline: 0;
+}
+
+.ts-dropdown {
+    min-width: 200px;
+
+    .dropdown-input-wrap .dropdown-input {
+        border-radius: .25rem .25rem 0 0;
+        border-width: 1px;
+    }
+}
+
+.ts-wrapper {
+    max-width: clamp(var(--breakpoint-sm), 50vw, 90vw);
+
+    .ts-control .item {
+        background: #efefef;
+        border: 0 solid #dee2e6;
+        border-radius: calc(.25rem - 1px);
+        color: #343a40;
+        cursor: pointer;
+        padding: 1px 5px;
+    }
+
+    // don't block down button
+    .ts-control:not(.rtl) {
+        padding-right: 2rem !important;
+    }
+
+    // keep size of select for tag filter
+    // prevent tags select from collapsing
+    /* stylelint-disable-next-line selector-class-pattern */
+    &.plugin-dropdown_input.dropdown-active:not(.has-items) .items-placeholder {
+        display: inline-block !important;
+    }
+
+    // need some extra space for x so it does not overlay selected options
+    /* stylelint-disable-next-line selector-class-pattern */
+    &.plugin-clear_button .ts-control {
+        padding-right: 30px !important;
+    }
+
+    // don't add padding if not multi
+    &:not(.multi) .ts-control .item {
+        padding: 0 5px;
+    }
+
+    // avoid inheritance form .text-center for team selection on register page
+    #team-ts-dropdown {
+        text-align: left;
+    }
+}
+
+// let the metavalue inuput stretch to same height as metakey select
+#metavalue {
+    height: auto;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -389,7 +389,7 @@ button:disabled {
 }
 
 /* fix for big images uploaded in the text */
-.item .txt {
+.entity .txt {
     overflow: auto;
 }
 
@@ -570,8 +570,8 @@ tr:nth-child(odd) {
     }
 }
 
-/* ITEMS */
-.item {
+/* ENTITIES */
+.entity {
     background-color: $white;
     border: 1px solid $firstlevel;
     border-left: 6px solid var(--left-color);
@@ -1053,7 +1053,7 @@ the form-control fails to do that so we do the border ourselves */
         text-decoration: none !important;
     }
 
-    .item {
+    .entity {
         background-color: #fff;
         font-size: 14px;
         line-height: normal;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -21,7 +21,6 @@ $theme-colors: (
 $navbar-dark-color: $secondlevel;
 $text-muted: $medium;
 @import 'bootstrap/scss/bootstrap';
-@import 'bootstrap-select/sass/bootstrap-select';
 @import 'prismjs/themes/prism';
 @import '@deltablot/dropzone/src/dropzone';
 @import '@fancyapps/fancybox/dist/jquery.fancybox';

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -46,7 +46,7 @@
       {{ App.Session.get('csrf')|csrf }}
       <div class='form-group mx-auto col-md-4'>
         <label for='init_team_select'>{{ 'Select a team'|trans }}</label>
-        <select required name='team_id' class='form-control selectpicker' id='init_team_select' data-show-subtext='true' data-live-search='true'>
+        <select required name='team_id' class='form-control' id='init_team_select' autocomplete='off'>
           {% for team in teamsArr|filter(v => v.visible == 1) %}
             <option value='{{ team.id }}'>{{ team.name }}</option>
           {% endfor %}

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -47,6 +47,7 @@
       <div class='form-group mx-auto col-md-4'>
         <label for='init_team_select'>{{ 'Select a team'|trans }}</label>
         <select required name='team_id' class='form-control' id='init_team_select' autocomplete='off'>
+          <option selected disabled value=''>{{ 'Select a team'|trans }}</option>
           {% for team in teamsArr|filter(v => v.visible == 1) %}
             <option value='{{ team.id }}'>{{ team.name }}</option>
           {% endfor %}

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -38,7 +38,7 @@
         {# TEAM #}
         <div class='row'>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block input-missing-label prefer-native-element: suppress error from tom-select] -->
+            <!-- [html-validate-disable-block input-missing-label, prefer-native-element: suppress errors from tom-select] -->
           {%- endif %}
           <label for='team'>{{ 'Team'|trans }}</label>
           <select name='team' class='form-control' id='team' required autocomplete='off' placeholder='{{ 'Select a team'|trans }}' aria-label='{{ 'Team'|trans }}'>

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -37,11 +37,11 @@
       <div class='form-group mx-auto col-md-4'>
         {# TEAM #}
         <div class='row'>
-          <label for='team'>{{ 'Team'|trans }}</label>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+            <!-- [html-validate-disable-block input-missing-label prefer-native-element: suppress error from tom-select] -->
           {%- endif %}
-          <select name='team' class='form-control selectpicker' id='team' required data-show-subtext='true' data-live-search='true'>
+          <label for='team'>{{ 'Team'|trans }}</label>
+          <select name='team' class='form-control' id='team' required autocomplete='off' placeholder='{{ 'Select a team'|trans }}' aria-label='{{ 'Team'|trans }}'>
             <option value='' selected disabled>{{ 'Select a team'|trans }}</option>
             {# on this page, only show the visible teams #}
             {% for team in teamsArr|filter(v => v.visible == 1) %}

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -154,20 +154,25 @@
 <div class='row mb-2'>
   {# AUTHOR/OWNER HELPER #}
   <div class='col-md-5'>
-    <label for='searchonly'>{{ 'And author is'|trans }}/{{ 'belongs to group:'|trans }}</label>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+      <!-- [html-validate-disable-block input-missing-label element-permitted-content: suppress errors from tom-select] -->
     {%- endif %}
-    <select id='searchonly' name='owner' data-filter='(?:author|group)' class='form-control selectpicker filterHelper' data-show-subtext='true' data-live-search='true'>
-      <option data-action='clear'>{{ 'Select author'|trans }}/{{ 'group'|trans }}</option>
+    <label for='searchonly'>{{ 'And author is'|trans }}/{{ 'belongs to group:'|trans }}</label>
+    <select
+      class='form-control filterHelper'
+      data-filter='(?:author|group)'
+      id='searchonly'
+      name='searchonly'
+    >
+      <option value=''>{{ 'Select author'|trans }}/{{ 'group'|trans }}</option>
       <optgroup label='{{ 'Users'|trans }}'>
         {% for user in usersArr %}
-          <option value='author:{{ user.fullname|e('html_attr') }}' {{- Request.query.get('owner') == 'author:' ~ user.fullname ? ' selected' }}>[{{ 'author'|trans }}] {{ user.fullname }}</option>
+          <option value='author:{{ user.fullname|e('html_attr') }}' {{- Request.query.get('searchonly') == 'author:' ~ user.fullname ? ' selected' }}>[{{ 'author'|trans }}] {{ user.fullname }}</option>
         {% endfor %}
       </optgroup>
       <optgroup label='{{ 'Groups'|trans }}'>
         {% for group in teamGroups %}
-          <option value='group:{{ group }}' {{- Request.query.get('owner') == 'group:' ~ group ? ' selected' }}>[{{ 'group'|trans }}] {{ group }}</option>
+          <option value='group:{{ group }}' {{- Request.query.get('searchonly') == 'group:' ~ group ? ' selected' }}>[{{ 'group'|trans }}] {{ group }}</option>
         {% endfor %}
       </optgroup>
     </select>
@@ -207,19 +212,16 @@
     <span class='d-inline-block mb-2'>{{ 'And extra field is'|trans }}</span>
     <div class='input-group flex-nowrap'>
       {% if App.Config.configArr.debug -%}
-        <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+        <!-- [html-validate-disable-block input-missing-label prefer-native-element: suppress errors from tom-select] -->
       {%- endif %}
       <select
         aria-label='{{ 'Name of field'|trans }}'
-        class='form-control filterHelper selectpicker'
+        class='form-control filterHelper'
         data-filter='extrafield'
-        data-live-search='true'
-        data-style=''
-        data-style-base='form-control filterHelper'
         id='metakey'
         name='metakey'
-        title='{{ 'Name of field'|trans }}'
       >
+        <option value='' disabled>{{ 'Name of field'|trans }}</option>
         <option value='**' {{- '**' == App.Request.query.get('metakey') ? ' selected' }}>{{ 'All fields'|trans }}</option>
         {% for metakey in metakeyArrForSelect %}
           <option value='{{ metakey }}' {{- metakey == App.Request.query.get('metakey') ? ' selected' }}>{{ metakey|raw }}</option>

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -155,7 +155,7 @@
   {# AUTHOR/OWNER HELPER #}
   <div class='col-md-5'>
     {% if App.Config.configArr.debug -%}
-      <!-- [html-validate-disable-block input-missing-label element-permitted-content: suppress errors from tom-select] -->
+      <!-- [html-validate-disable-block input-missing-label, prefer-native-element: suppress errors from tom-select] -->
     {%- endif %}
     <label for='searchonly'>{{ 'And author is'|trans }}/{{ 'belongs to group:'|trans }}</label>
     <select
@@ -212,7 +212,7 @@
     <span class='d-inline-block mb-2'>{{ 'And extra field is'|trans }}</span>
     <div class='input-group flex-nowrap'>
       {% if App.Config.configArr.debug -%}
-        <!-- [html-validate-disable-block input-missing-label prefer-native-element: suppress errors from tom-select] -->
+        <!-- [html-validate-disable input-missing-label, prefer-native-element: suppress errors from tom-select] -->
       {%- endif %}
       <select
         aria-label='{{ 'Name of field'|trans }}'
@@ -227,6 +227,9 @@
           <option value='{{ metakey }}' {{- metakey == App.Request.query.get('metakey') ? ' selected' }}>{{ metakey|raw }}</option>
         {% endfor %}
       </select>
+      {% if App.Config.configArr.debug -%}
+        <!-- [html-validate-enable input-missing-label, prefer-native-element: suppress errors from tom-select] -->
+      {%- endif %}
       <div class='input-group-text px-1 brl-none brr-none' style='margin-left:-1px;margin-right:-1px;'>:</div>
       <input
         aria-label='{{ 'Value'|trans }}'

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -76,10 +76,10 @@
   {# EXPERIMENTS CATEGORIES #}
   <div class='col-md-4' id='experimentsCategoriesDiv' {{ App.Request.query.get('type') == 'items' ? 'hidden' }}>
     <label for='experimentsCategoriesSelect'>{{ 'And category is'|trans }}</label>
-    <select id='experimentsCategoriesSelect' class='form-control filterHelper' data-filter='category'>
+    <select id='experimentsCategoriesSelect' class='form-control filterHelper' data-filter='category' name='expCatHelper'>
       <option value='' data-action='clear'>{{ 'Select category'|trans }}</option>
       {% for category in experimentsCategoriesArr %}
-        <option value='{{ category.title|e('html_attr') }}'>
+        <option value='{{ category.title|e('html_attr') }}' {{- Request.query.get('expCatHelper') == category.title ? ' selected' }}>
           {{ category.title }}
         </option>
       {% endfor %}
@@ -88,10 +88,10 @@
   {# RESOURCES CATEGORIES (items types) #}
   <div class='col-md-4' id='resourcesCategoriesDiv' {{ App.Request.query.get('type') != 'items' ? 'hidden' }}>
     <label for='resourcesCategoriesSelect'>{{ 'And category is'|trans }}</label>
-    <select id='resourcesCategoriesSelect' class='form-control filterHelper' data-filter='category'>
+    <select id='resourcesCategoriesSelect' class='form-control filterHelper' data-filter='category' name='resCatHelper'>
       <option value='' data-action='clear'>{{ 'Select category'|trans }}</option>
       {% for category in itemsTypesArr %}
-        <option value='{{ category.title|e('html_attr') }}'>
+        <option value='{{ category.title|e('html_attr') }}' {{- Request.query.get('resCatHelper') == category.title ? ' selected' }}>
           {{ category.title }}
         </option>
       {% endfor %}
@@ -100,10 +100,10 @@
   {# EXPERIMENTS STATUS #}
   <div class='col-md-4' id='experimentsStatusDiv' {{ App.Request.query.get('type') == 'items' ? 'hidden' }}>
     <label for='experimentsStatusSelect'>{{ 'And status is'|trans }}</label>
-    <select id='experimentsStatusSelect' class='form-control filterHelper' data-filter='status'>
+    <select id='experimentsStatusSelect' class='form-control filterHelper' data-filter='status' name='expStatusHelper'>
       <option value='' data-action='clear'>{{ 'Select status'|trans }}</option>
       {% for category in experimentsStatusArr %}
-        <option value='{{ category.title|e('html_attr') }}'>
+        <option value='{{ category.title|e('html_attr') }}' {{- Request.query.get('expStatusHelper') == category.title ? ' selected' }}>
           {{ category.title }}
         </option>
       {% endfor %}
@@ -112,10 +112,10 @@
   {# RESOURCES STATUS #}
   <div class='col-md-4' id='resourcesStatusDiv' {{ App.Request.query.get('type') != 'items' ? 'hidden' }}>
     <label for='resourcesStatusSelect'>{{ 'And status is'|trans }}</label>
-    <select id='resourcesStatusSelect' class='form-control filterHelper' data-filter='status'>
+    <select id='resourcesStatusSelect' class='form-control filterHelper' data-filter='status' name='resStatusHelper'>
       <option value='' data-action='clear'>{{ 'Select status'|trans }}</option>
       {% for category in itemsStatusArr %}
-        <option value='{{ category.title|e('html_attr') }}'>
+        <option value='{{ category.title|e('html_attr') }}' {{- Request.query.get('resStatusHelper') == category.title ? ' selected' }}>
           {{ category.title }}
         </option>
       {% endfor %}

--- a/src/templates/show-item-table.html
+++ b/src/templates/show-item-table.html
@@ -1,5 +1,5 @@
 {% set randomId = random() %}
-<tr class='item' id='parent_{{ randomId }}' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
+<tr class='entity' id='parent_{{ randomId }}' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
 
   {# DATE #}
   <td class='item-date'>

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -1,7 +1,7 @@
 {# dim the experiment a bit if it's not yours #}
 {% set randomId = random() %}
 
-<section class='item pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
+<section class='entity pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
 
   {# left part, full height: checkbox #}
   <div class='d-flex align-items-center'>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -139,11 +139,18 @@
 
       {# SEARCH WITH TAG #}
       {% if App.Config.configArr.debug -%}
-        <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+        <!-- [html-validate-disable-block prefer-native-element: suppress error from tom-select] -->
       {%- endif %}
-      <select multiple name='tags[]' class='form-control mr-1 mb-2 selectpicker' data-show-subtext='true' data-none-selected-text='{{ 'Tags'|trans }}' data-live-search='true' data-style='' data-style-base='form-control' data-showtick='true' data-actions-box='true'>
+      <select
+        id='tagFilter'
+        multiple
+        name='tags[]'
+        class='form-control mr-1 mb-2 '
+        placeholder='{{ 'Tags'|trans }}'
+      >
+        <option value='' disabled >{{ 'Tags'|trans }}</option>
         {% for tag in tagsArrForSelect %}
-          <option value='{{ tag.tag|e('html_attr') }}'{{ tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag }}</option>
+          <option value='{{ tag.tag|e('html_attr') }}' {{- tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag }}</option>
         {% endfor %}
       </select>
       {# ARCHIVED filter #}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -89,7 +89,9 @@
       <select name='cat' class='autosubmit mr-1 mb-2 form-control' aria-label='{{ 'Filter category'|trans }}'>
         <option value=''>{{ 'Filter category'|trans }}</option>
         {% for category in categoryArr %}
-          <option value='{{ category.id }}'{{ App.Request.query.get('cat') == category.id ? ' selected' }}>
+          <option value='{{ category.id }}'
+            {{- App.Request.query.get('cat') == category.id or (searchPage and (App.Request.query.get('expCatHelper') == category.title or App.Request.query.get('resCatHelper') == category.title)) ? ' selected' -}}
+          >
           {{ category.title }}</option>
         {% endfor %}
       </select>
@@ -98,7 +100,9 @@
       <select name='status' class='autosubmit mr-1 mb-2 form-control' aria-label='{{ 'Filter status'|trans }}'>
         <option value=''>{{ 'Filter status'|trans }}</option>
         {% for status in statusArr %}
-          <option value='{{ status.id }}'{{ App.Request.query.get('status') == status.id ? ' selected' }}>
+          <option value='{{ status.id }}'
+            {{- App.Request.query.get('status') == status.id or (searchPage and (App.Request.query.get('expStatusHelper') == status.title or App.Request.query.get('resStatusHelper') == status.title)) ? ' selected' -}}
+          >
           {{ status.title }}</option>
         {% endfor %}
       </select>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -139,7 +139,7 @@
 
       {# SEARCH WITH TAG #}
       {% if App.Config.configArr.debug -%}
-        <!-- [html-validate-disable-block prefer-native-element: suppress error from tom-select] -->
+        <!-- [html-validate-disable prefer-native-element: suppress error from tom-select] -->
       {%- endif %}
       <select
         id='tagFilter'
@@ -153,6 +153,10 @@
           <option value='{{ tag.tag|e('html_attr') }}' {{- tag.tag in App.Request.query.all('tags') ? ' selected' }}>{{ tag.tag }}</option>
         {% endfor %}
       </select>
+      {% if App.Config.configArr.debug -%}
+        <!-- [html-validate-enable prefer-native-element: end suppress error from tom-select] -->
+      {%- endif %}
+
       {# ARCHIVED filter #}
       <div class='input-group mr-1 mb-2'>
         <div class='input-group-text'>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -118,13 +118,19 @@
         {%- endif %}
         <form aria-label='{{ 'Filter by category'|trans }}'>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+            <!-- [html-validate-disable-block prefer-native-element input-missing-label: suppress errors from tom-select] -->
           {%- endif %}
-          <select name='cat' class='autosubmit mr-1 form-control selectpicker' data-show-subtext='true' data-live-search='true' aria-label='Filter category'>
+          <select
+            aria-label='Filter category'
+            class='autosubmit mr-1 form-control'
+            id='schedulerSelectCat'
+            name='cat'
+          >
             <option value=''>{{ 'Filter by type'|trans }}</option>
             {% for category in bookableItemsTypes %}
               <option value='{{ category.id }}'{{ App.Request.query.get('cat') == category.id ? ' selected' }}>
-            {{ category.title }}</option>
+                {{ category.title }}
+              </option>
             {% endfor %}
           </select>
         </form>
@@ -137,14 +143,20 @@
         {%- endif %}
         <form aria-label='{{ 'Select a resource'|trans }}'>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block element-permitted-content: suppress error from select picker: div child of button] -->
+            <!-- [html-validate-disable-block prefer-native-element input-missing-label: suppress errors from tom-select] -->
           {%- endif %}
-          <select id='itemSelect' name='item' class='autosubmit mr-1 form-control selectpicker' data-show-subtext='true' data-live-search='true' aria-label='Filter item'>
+          <select
+            aria-label='Filter item'
+            class='autosubmit mr-1 form-control'
+            id='itemSelect'
+            name='item'
+          >
             <option value=''>{{ 'Select an equipment'|trans }}</option>
             {% for item in itemsArr %}
               {# data-color is used to set the background during initial drag #}
               <option data-color='{{ item.category_color }}' value='{{ item.id }}'{{ App.Request.query.get('item') == item.id ? ' selected' }}>
-              {{ item.category_title }} - {{ item.title }}</option>
+                {{ item.category_title }} - {{ item.title }}
+              </option>
             {% endfor %}
           </select>
         </form>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -113,12 +113,9 @@
     <div class='row mb-3'>
       <div class='col-md-3'>
         {# CATEGORY #}
-        {% if App.Config.configArr.debug -%}
-          <!-- [html-validate-disable-next wcag/h32: no submit button] -->
-        {%- endif %}
         <form aria-label='{{ 'Filter by category'|trans }}'>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block prefer-native-element input-missing-label: suppress errors from tom-select] -->
+            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
           {%- endif %}
           <select
             aria-label='Filter category'
@@ -138,12 +135,9 @@
 
       <div class='col-md-3'>
         {# ITEM LIST #}
-        {% if App.Config.configArr.debug -%}
-          <!-- [html-validate-disable-next wcag/h32: no submit button] -->
-        {%- endif %}
         <form aria-label='{{ 'Select a resource'|trans }}'>
           {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block prefer-native-element input-missing-label: suppress errors from tom-select] -->
+            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
           {%- endif %}
           <select
             aria-label='Filter item'

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { notif, notifError, reloadElement, updateCatStat } from './misc';
+import { notif, notifError, reloadElement, TomSelect, updateCatStat } from './misc';
 import $ from 'jquery';
 import { Malle } from '@deltablot/malle';
 import i18next from 'i18next';
@@ -15,18 +15,11 @@ import { EntityType, Model, Action } from './interfaces';
 import tinymce from 'tinymce/tinymce';
 import { getTinymceBaseConfig } from './tinymce';
 import Tab from './Tab.class';
-import TomSelect from 'tom-select/dist/js/tom-select.base';
-import TomSelectRemoveButton from 'tom-select/dist/js/plugins/remove_button';
-import TomSelectNoActiveItems from 'tom-select/dist/js/plugins/no_active_items';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (window.location.pathname !== '/admin.php') {
     return;
   }
-
-  // bind plugins to TomSelect
-  TomSelect.define('remove_button', TomSelectRemoveButton);
-  TomSelect.define('no_active_items', TomSelectNoActiveItems);
 
   const ApiC = new Api();
 
@@ -221,7 +214,7 @@ document.addEventListener('DOMContentLoaded', () => {
       reloadElement('sendOnboardingEmailModal')
         .then(() => $('#sendOnboardingEmailModal').modal('toggle'))
         .then(() => new TomSelect('#sendOnboardingEmailToUsers', {
-          plugins: ['remove_button', 'no_active_items'],
+          plugins: ['dropdown_input', 'no_active_items', 'remove_button'],
         }));
     } else if (el.matches('[data-action="send-onboarding-emails"]')) {
       ApiC.notifOnSaved = false;

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -23,6 +23,7 @@ import {
   reloadElement,
   replaceWithTitle,
   togglePlusIcon,
+  TomSelect,
 } from './misc';
 import i18next from 'i18next';
 import EntityClass from './Entity.class';
@@ -167,6 +168,17 @@ document.addEventListener('DOMContentLoaded', () => {
     tooltip: i18next.t('click-to-edit'),
   }).listen();
 
+  // tom-select for team selection on login and register page
+  ['init_team_select', 'team'].forEach(id =>{
+    if (document.getElementById(id)) {
+      new TomSelect(`#${id}`, {
+        plugins: [
+          'dropdown_input',
+          'no_active_items',
+        ],
+      });
+    }
+  });
 
   // validate the form upon change. fix #451
   // add to the input itself, not the form for more flexibility

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -8,7 +8,6 @@
 import $ from 'jquery';
 import { Api } from './Apiv2.class';
 import { Malle } from '@deltablot/malle';
-import 'bootstrap-select';
 import 'bootstrap/js/src/modal.js';
 import {
   adjustHiddenState,

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -15,6 +15,12 @@ import $ from 'jquery';
 import i18next from 'i18next';
 import { Api } from './Apiv2.class';
 import { ChemDoodle } from '@deltablot/chemdoodle-web-mini/dist/chemdoodle.min.js';
+import TomSelect from 'tom-select/dist/esm/tom-select';
+import TomSelectCheckboxOptions from 'tom-select/dist/esm/plugins/checkbox_options/plugin';
+import TomSelectClearButton from 'tom-select/dist/esm/plugins/clear_button/plugin';
+import TomSelectDropdownInput from 'tom-select/dist/esm/plugins/dropdown_input/plugin';
+import TomSelectNoActiveItems from 'tom-select/dist/esm/plugins/no_active_items/plugin';
+import TomSelectRemoveButton from 'tom-select/dist/esm/plugins/remove_button/plugin';
 
 // get html of current page reloaded via get
 function fetchCurrentPage(tag = ''): Promise<Document>{
@@ -552,3 +558,11 @@ export function replaceWithTitle(): void {
     });
   });
 }
+
+// bind used plugins to TomSelect
+TomSelect.define('checkbox_options', TomSelectCheckboxOptions);
+TomSelect.define('clear_button', TomSelectClearButton);
+TomSelect.define('dropdown_input', TomSelectDropdownInput);
+TomSelect.define('no_active_items', TomSelectNoActiveItems);
+TomSelect.define('remove_button', TomSelectRemoveButton);
+export { TomSelect };

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -256,7 +256,7 @@ export function makeSortableGreatAgain(): void {
 
 export function getCheckedBoxes(): Array<CheckableItem> {
   const checkedBoxes = [];
-  $('.item input[type=checkbox]:checked').each(function() {
+  $('.entity input[type=checkbox]:checked').each(function() {
     checkedBoxes.push({
       id: parseInt($(this).data('id')),
       // the randomid is used to get the parent container and hide it when delete

--- a/src/ts/search.ts
+++ b/src/ts/search.ts
@@ -7,6 +7,7 @@
  */
 declare let key: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 import { SearchSyntaxHighlighting } from './SearchSyntaxHighlighting.class';
+import { TomSelect } from './misc';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (window.location.pathname !== '/search.php') {
@@ -191,6 +192,15 @@ document.addEventListener('DOMContentLoaded', () => {
         extendedArea.value = extendedArea.value + addSpace + filter;
       }
       SearchSyntaxHighlighting.update(extendedArea.value);
+    });
+  });
+
+  ['metakey', 'searchonly'].forEach(id => {
+    new TomSelect(`#${id}`, {
+      plugins: [
+        'dropdown_input',
+        'remove_button',
+      ],
     });
   });
 });

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -5,7 +5,15 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getCheckedBoxes, notif, reloadEntitiesShow, getEntity, reloadElement, permissionsToJson } from './misc';
+import {
+  getCheckedBoxes,
+  getEntity,
+  notif,
+  permissionsToJson,
+  reloadElement,
+  reloadEntitiesShow,
+  TomSelect,
+} from './misc';
 import { Action, Model } from './interfaces';
 import 'bootstrap/js/src/modal.js';
 import i18next from 'i18next';
@@ -405,4 +413,17 @@ document.addEventListener('DOMContentLoaded', () => {
   if (localStorage.getItem('isfavtagsOpen') === '1') {
     FavTagC.toggle();
   }
+
+  new TomSelect('#tagFilter', {
+    plugins: {
+      checkbox_options: {
+        checkedClassNames: ['ts-checked'],
+        uncheckedClassNames: ['ts-unchecked'],
+      },
+      clear_button: {},
+      dropdown_input: {},
+      no_active_items: {},
+      remove_button: {},
+    },
+  });
 });

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // we want to know if the newly applied limit actually brought new items
       // because if not, we disable the button
       // so simply count them
-      const previousNumber = document.querySelectorAll('.item').length;
+      const previousNumber = document.querySelectorAll('.entity').length;
       // this will be 0 if the button has not been clicked yet
       const queryLimit = getParamNum('limit');
       const usualLimit = parseInt(about.limit, 10);
@@ -204,7 +204,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // expand and select what was expanded and selected
         setExpandedAndSelectedEntities();
         // remove Load more button if no new entries appeared
-        const newNumber = document.querySelectorAll('.item').length;
+        const newNumber = document.querySelectorAll('.entity').length;
         if (previousNumber === newNumber) {
           document.getElementById('loadMoreBtn').remove();
         }
@@ -250,7 +250,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // TOGGLE PIN
     } else if (el.matches('[data-action="toggle-pin"]')) {
-      ApiC.patch(`${entity.type}/${parseInt(el.dataset.id, 10)}`, {'action': Action.Pin}).then(() => el.closest('.item').remove());
+      ApiC.patch(`${entity.type}/${parseInt(el.dataset.id, 10)}`, {'action': Action.Pin}).then(() => el.closest('.entity').remove());
 
     // remove a favtag
     } else if (el.matches('[data-action="destroy-favtags"]')) {
@@ -280,9 +280,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
       if ((el as HTMLInputElement).checked) {
-        (el.closest('.item') as HTMLElement).style.backgroundColor = bgColor;
+        (el.closest('.entity') as HTMLElement).style.backgroundColor = bgColor;
       } else {
-        (el.closest('.item') as HTMLElement).style.backgroundColor = '';
+        (el.closest('.entity') as HTMLElement).style.backgroundColor = '';
       }
 
     // EXPAND ALL
@@ -310,9 +310,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="select-all-entities"]')) {
       event.preventDefault();
       // check all boxes and set background color
-      document.querySelectorAll('.item input[type=checkbox]').forEach(box => {
+      document.querySelectorAll('.entity input[type=checkbox]').forEach(box => {
         (box as HTMLInputElement).checked = true;
-        (box.closest('.item') as HTMLElement).style.backgroundColor = bgColor;
+        (box.closest('.entity') as HTMLElement).style.backgroundColor = bgColor;
       });
       // show advanced options and withSelected menu
       ['advancedSelectOptions', 'withSelected'].forEach(id => {
@@ -322,9 +322,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // UNSELECT ALL CHECKBOXES
     } else if (el.matches('[data-action="unselect-all-entities"]')) {
       event.preventDefault();
-      document.querySelectorAll('.item input[type=checkbox]').forEach(box => {
+      document.querySelectorAll('.entity input[type=checkbox]').forEach(box => {
         (box as HTMLInputElement).checked = false;
-        (box.closest('.item') as HTMLElement).style.backgroundColor = '';
+        (box.closest('.entity') as HTMLElement).style.backgroundColor = '';
       });
       // hide menu
       ['advancedSelectOptions', 'withSelected'].forEach(id => {
@@ -334,13 +334,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // INVERT SELECTION
     } else if (el.matches('[data-action="invert-entities-selection"]')) {
       event.preventDefault();
-      document.querySelectorAll('.item input[type=checkbox]').forEach(box => {
+      document.querySelectorAll('.entity input[type=checkbox]').forEach(box => {
         (box as HTMLInputElement).checked = !(box as HTMLInputElement).checked;
         let newBgColor = '';
         if ((box as HTMLInputElement).checked) {
           newBgColor = bgColor;
         }
-        (box.closest('.item') as HTMLElement).style.backgroundColor = newBgColor;
+        (box.closest('.entity') as HTMLElement).style.backgroundColor = newBgColor;
       });
 
 

--- a/src/ts/team.ts
+++ b/src/ts/team.ts
@@ -38,7 +38,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import EntityClass from './Entity.class';
 import { Action, EntityType } from './interfaces';
 import { Api } from './Apiv2.class';
-import { notif } from './misc';
+import { notif, TomSelect } from './misc';
 import Tab from './Tab.class';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -331,5 +331,14 @@ document.addEventListener('DOMContentLoaded', () => {
           .catch((e) => notif({'res': false, 'msg': e.message}));
       }
     }
+  });
+
+  ['schedulerSelectCat', 'itemSelect'].forEach(id => {
+    new TomSelect(`#${id}`, {
+      plugins: [
+        'dropdown_input',
+        'remove_button',
+      ],
+    });
   });
 });

--- a/tests/cypress/integration/register.cy.ts
+++ b/tests/cypress/integration/register.cy.ts
@@ -6,7 +6,7 @@ describe('Register new user', () => {
   it('fills form and submits', () => {
     cy.visit('/register.php');
     cy.htmlvalidate();
-    cy.get('div.dropdown.bootstrap-select.form-control').click().get('div.dropdown-menu.show').contains('Alpha').click();
+    cy.get('#team-ts-control').click().get('#team-ts-dropdown').contains('Alpha').click();
     cy.get('#email').type('newCypressUser@yopmail.com').blur();
     cy.get('#password').type('cypress1cypress').blur();
     cy.get('#firstname').type('newCypress').blur();
@@ -19,7 +19,7 @@ describe('Register new user', () => {
   it('detects attempt of a bot to register', () => {
     cy.visit('/register.php');
     cy.get('input[name="bot"]').type('I am a bot', {force: true});
-    cy.get('div.dropdown.bootstrap-select.form-control').click().get('div.dropdown-menu.show').contains('Alpha').click();
+    cy.get('#team-ts-control').click().get('#team-ts-dropdown').contains('Alpha').click();
     cy.get('#email').type('newCypressUser@yopmail.com').blur();
     cy.get('#password').type('cypress1cypress').blur();
     cy.get('#firstname').type('newCypress').blur();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,16 +2188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-select@npm:^1.13.18":
-  version: 1.13.18
-  resolution: "bootstrap-select@npm:1.13.18"
-  peerDependencies:
-    bootstrap: ">=3.0.0"
-    jquery: 1.9.1 - 3
-  checksum: 84a569bc6a66dbffb80003f66b9525a84f20207cc00dc6f8a6f791a46ee8ae055011a5168d0f203f3f19b7c08e42ca7d60dd302b28b9a3ba4896dcce6a9821d8
-  languageName: node
-  linkType: hard
-
 "bootstrap@npm:^4.6.2":
   version: 4.6.2
   resolution: "bootstrap@npm:4.6.2"
@@ -3471,7 +3461,6 @@ __metadata:
     "@yarnpkg/libzip": "npm:^3.0.0"
     bootstrap: "npm:^4.6.2"
     bootstrap-markdown-fa5: "npm:^2.10.2"
-    bootstrap-select: "npm:^1.13.18"
     css-loader: "npm:^6.9.1"
     css-minimizer-webpack-plugin: "npm:^5.0.1"
     cypress: "npm:^13.6.3"


### PR DESCRIPTION
After the addition of [Tom Select](https://github.com/orchidjs/tom-select) in #5029 this PR will remove bootstrap-select completely from eLabFTW and replace it with Tom Select.

There are only a few places where it is used:
- tag filter in show mode
- team selection for saml/ldap login when `$initTeamRequired == true` → `App.Session.has('initial_team_selection_required')`
- team selection on register page
- user and metakey filter helpers on search page
- category and item selection for scheduler
- from last PR: user selection for onboarding emails

Some have slightly different requirements, hence, Tom Select is configured with different plugins for each use case. However, all plugins are bound to Tom Select in `src/ts/misc.ts`.

I tried to bend the default Tom Select CSS to match the eLabFTW style. There were also some quirks that needed some attention so there is more scss than I would like there to be.

The `.item` class in `main.scss` was renamed to `.entity` and the change is reflected in html and ts. The use of `.item` results in conflicts with Tom Select and it seemed easier to rename it rather than to find more specific selectors in `main.scss`.

There were also some side effects (or intentionally behavior?) on the search page between the search helpers and the filters in the result section which I tried to address.

@NicolasCARPi can you please check whether the team selection for the saml/ldap works and looks as expected. I don't have any experience with saml/ldap yet.