### PR TITLE
Allow user without a team to select a team upon login

### DIFF
--- a/src/Auth/External.php
+++ b/src/Auth/External.php
@@ -18,6 +18,7 @@ use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\AuthInterface;
 use Elabftw\Models\ExistingUser;
 use Elabftw\Models\ValidatedUser;
+use Elabftw\Services\UsersHelper;
 use Monolog\Logger;
 
 /**
@@ -69,7 +70,8 @@ class External implements AuthInterface
         }
         $this->AuthResponse->userid = (int) $Users->userData['userid'];
         $this->AuthResponse->isValidated = true;
-        $this->AuthResponse->setTeams();
+        $UsersHelper = new UsersHelper($this->AuthResponse->userid);
+        $this->AuthResponse->setTeams($UsersHelper);
 
         return $this->AuthResponse;
     }

--- a/src/Auth/Ldap.php
+++ b/src/Auth/Ldap.php
@@ -19,6 +19,7 @@ use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\AuthInterface;
 use Elabftw\Models\ExistingUser;
 use Elabftw\Models\ValidatedUser;
+use Elabftw\Services\UsersHelper;
 use LdapRecord\Connection;
 use LdapRecord\Container;
 use LdapRecord\Models\Entry;
@@ -113,7 +114,8 @@ class Ldap implements AuthInterface
         $this->AuthResponse->userid = (int) $Users->userData['userid'];
         $this->AuthResponse->mfaSecret = $Users->userData['mfa_secret'];
         $this->AuthResponse->isValidated = (bool) $Users->userData['validated'];
-        $this->AuthResponse->setTeams();
+        $UsersHelper = new UsersHelper($this->AuthResponse->userid);
+        $this->AuthResponse->setTeams($UsersHelper);
 
         return $this->AuthResponse;
     }

--- a/src/Auth/Local.php
+++ b/src/Auth/Local.php
@@ -24,7 +24,7 @@ use Elabftw\Models\Config;
 use Elabftw\Models\ExistingUser;
 use Elabftw\Models\Users;
 use Elabftw\Services\Filter;
-
+use Elabftw\Services\UsersHelper;
 use PDO;
 use SensitiveParameter;
 
@@ -90,7 +90,8 @@ class Local implements AuthInterface
         $this->AuthResponse->userid = $this->userid;
         $this->AuthResponse->mfaSecret = $res['mfa_secret'];
         $this->AuthResponse->isValidated = (bool) $res['validated'];
-        $this->AuthResponse->setTeams();
+        $UsersHelper = new UsersHelper($this->AuthResponse->userid);
+        $this->AuthResponse->setTeams($UsersHelper);
         return $this->AuthResponse;
     }
 

--- a/src/Auth/Mfa.php
+++ b/src/Auth/Mfa.php
@@ -17,6 +17,7 @@ use Elabftw\Exceptions\InvalidMfaCodeException;
 use Elabftw\Interfaces\AuthInterface;
 use Elabftw\Models\Users;
 use Elabftw\Services\MfaHelper;
+use Elabftw\Services\UsersHelper;
 
 /**
  * Multi Factor Auth service
@@ -42,7 +43,8 @@ class Mfa implements AuthInterface
         $this->AuthResponse->mfaSecret = $Users->userData['mfa_secret'];
         $this->AuthResponse->isValidated = (bool) $Users->userData['validated'];
         $this->AuthResponse->userid = $this->MfaHelper->userid;
-        $this->AuthResponse->setTeams();
+        $UsersHelper = new UsersHelper($this->AuthResponse->userid);
+        $this->AuthResponse->setTeams($UsersHelper);
 
         return $this->AuthResponse;
     }

--- a/src/Auth/Saml.php
+++ b/src/Auth/Saml.php
@@ -26,6 +26,7 @@ use Elabftw\Models\ExistingUser;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users;
 use Elabftw\Models\ValidatedUser;
+use Elabftw\Services\UsersHelper;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
@@ -174,7 +175,8 @@ class Saml implements AuthInterface
         }
 
         // load the teams from db
-        $this->AuthResponse->setTeams();
+        $UsersHelper = new UsersHelper($this->AuthResponse->userid);
+        $this->AuthResponse->setTeams($UsersHelper);
 
         return $this->AuthResponse;
     }

--- a/src/classes/AuthResponse.php
+++ b/src/classes/AuthResponse.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
-use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Users;
 use Elabftw\Services\UsersHelper;
 
 /**
@@ -31,6 +31,8 @@ class AuthResponse
 
     // when user needs to request access to a team
     public bool $initTeamRequired = false;
+
+    public bool $teamSelectionRequired = false;
 
     public bool $isValidated = false;
 
@@ -55,7 +57,11 @@ class AuthResponse
         if ($teamCount === 1) {
             $this->selectedTeam = (int) $this->selectableTeams[0]['id'];
         } elseif ($teamCount === 0) {
-            throw new ImproperActionException('Could not find a team!');
+            $Users = new Users($this->userid);
+            $this->teamSelectionRequired = true;
+            $this->initTeamUserInfo = array(
+                'userid' => $Users->userData['userid'],
+            );
         } else {
             $this->isInSeveralTeams = true;
         }

--- a/src/classes/AuthResponse.php
+++ b/src/classes/AuthResponse.php
@@ -47,10 +47,9 @@ class AuthResponse
 
     public bool $mustRenewPassword = false;
 
-    public function setTeams(): void
+    public function setTeams(UsersHelper $usersHelper): void
     {
-        $UsersHelper = new UsersHelper($this->userid);
-        $this->selectableTeams = $UsersHelper->getTeamsFromUserid();
+        $this->selectableTeams = $usersHelper->getTeamsFromUserid();
 
         // if the user only has access to one team, use this one directly
         $teamCount = count($this->selectableTeams);

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -33,6 +33,7 @@ use Elabftw\Models\Config;
 use Elabftw\Models\ExistingUser;
 use Elabftw\Models\Idps;
 use Elabftw\Models\Users;
+use Elabftw\Models\Users2Teams;
 use Elabftw\Services\DeviceToken;
 use Elabftw\Services\DeviceTokenValidator;
 use Elabftw\Services\LoginHelper;
@@ -90,9 +91,6 @@ class LoginController implements ControllerInterface
             'samesite' => 'Lax',
         );
         setcookie('icanhazcookies', $icanhazcookies, $cookieOptions);
-
-        // INITIAL TEAM SELECTION
-        $this->initTeamSelection($authType);
 
         // TRY TO AUTHENTICATE
         $AuthResponse = $this->getAuthService($authType)->tryAuth();
@@ -168,12 +166,19 @@ class LoginController implements ControllerInterface
             return new RedirectResponse('/login.php');
         }
 
-        // no team was found so user must select one
+        // user does not exist and no team was found so user must select one
         if ($AuthResponse->initTeamRequired) {
             $this->App->Session->set('initial_team_selection_required', true);
             $this->App->Session->set('teaminit_email', $AuthResponse->initTeamUserInfo['email']);
             $this->App->Session->set('teaminit_firstname', $AuthResponse->initTeamUserInfo['firstname']);
             $this->App->Session->set('teaminit_lastname', $AuthResponse->initTeamUserInfo['lastname']);
+            return new RedirectResponse('/login.php');
+        }
+
+        // user exists but no team was found so user must select one
+        if ($AuthResponse->teamSelectionRequired) {
+            $this->App->Session->set('team_selection_required', true);
+            $this->App->Session->set('teaminit_userid', $AuthResponse->initTeamUserInfo['userid']);
             return new RedirectResponse('/login.php');
         }
 
@@ -303,32 +308,47 @@ class LoginController implements ControllerInterface
                     ),
                     $this->App->Request->request->getAlnum('mfa_code'),
                 );
+            case 'teaminit':
+                $this->initTeamSelection();
+                exit;
+            case 'teamselection':
+                $this->teamSelection($this->App->Session->get('teaminit_userid'), $this->App->Request->request->getInt('team_id'));
+                exit;
 
             default:
                 throw new ImproperActionException('Could not determine which authentication service to use.');
         }
     }
 
-    private function initTeamSelection(string $authType): void
+    /**
+     * For when a user already exists but has no associated team
+     */
+    private function teamSelection(int $userid, int $teamId): void
     {
-        if ($authType === 'teaminit'
-            && $this->App->Session->get('initial_team_selection_required')
-        ) {
-            // create a user in the requested team
-            $newUser = ExistingUser::fromScratch(
-                $this->App->Session->get('teaminit_email'),
-                array($this->App->Request->request->getInt('team_id')),
-                $this->App->Request->request->getString('teaminit_firstname'),
-                $this->App->Request->request->getString('teaminit_lastname'),
-            );
-            $this->App->Session->set('teaminit_done', true);
-            // will display the appropriate message to user
-            $this->App->Session->set('teaminit_done_need_validation', (string) $newUser->needValidation);
-            $this->App->Session->remove('initial_team_selection_required');
-            $location = '/login.php';
-            echo "<html><head><meta http-equiv='refresh' content='1;url=$location' /><title>You are being redirected...</title></head><body>You are being redirected...</body></html>";
-            exit;
-        }
+        $this->App->Session->remove('team_selection_required');
+        $Users2Teams = new Users2Teams(new Users($userid));
+        $Users2Teams->create($userid, $teamId);
+        // TODO avoid re-login
+        $this->App->Session->getFlashBag()->add('ok', _('Your account has been associated successfully to a team. Please authenticate again.'));
+        $location = '/login.php';
+        echo "<html><head><meta http-equiv='refresh' content='1;url=$location' /><title>You are being redirected...</title></head><body>You are being redirected...</body></html>";
+    }
+
+    private function initTeamSelection(): void
+    {
+        // create a user in the requested team
+        $newUser = ExistingUser::fromScratch(
+            $this->App->Session->get('teaminit_email'),
+            array($this->App->Request->request->getInt('team_id')),
+            $this->App->Request->request->getString('teaminit_firstname'),
+            $this->App->Request->request->getString('teaminit_lastname'),
+        );
+        $this->App->Session->set('teaminit_done', true);
+        // will display the appropriate message to user
+        $this->App->Session->set('teaminit_done_need_validation', (string) $newUser->needValidation);
+        $this->App->Session->remove('initial_team_selection_required');
+        $location = '/login.php';
+        echo "<html><head><meta http-equiv='refresh' content='1;url=$location' /><title>You are being redirected...</title></head><body>You are being redirected...</body></html>";
     }
 
     private function enableMFA(): string

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -36,7 +36,7 @@
 <section class='text-center'>
   <img src='/assets/images/logo.png' alt='logo elabftw' class='col-md-3' />
 
-  {# Allow user to request access to a team #}
+  {# Allow non existing user to request access to a team #}
   {% if App.Session.has('initial_team_selection_required') %}
     <div class='separator col-md-4 mx-auto'></div>
     <h2>{{ 'Request access to a team'|trans }}</h2>
@@ -57,6 +57,25 @@
 
         <label for='teaminit_lastname_input'>{{ 'Lastname'|trans }}</label>
         <input required class='form-control' name='teaminit_lastname' value='{{ App.Session.get('teaminit_lastname') }}' />
+        <button class='btn btn-primary mt-2' type='submit' name='submit'>{{ 'Request access'|trans }}</button>
+      </div>
+    </form>
+  {# Allow existing user to request access to a team #}
+  {% elseif App.Session.has('team_selection_required') %}
+    <div class='separator col-md-4 mx-auto'></div>
+    <h2>{{ 'Request access to a team'|trans }}</h2>
+    <br>
+    <form method='post' class='form-group' id='team-select' action='app/controllers/LoginController.php' autocomplete='off'>
+      <input type='hidden' name='auth_type' value='teamselection'>
+      {{ App.Session.get('csrf')|csrf }}
+      <div class='form-group mx-auto col-md-4'>
+        <label for='existing_user_team_select'>{{ 'Select a team'|trans }}</label>
+        <select required name='team_id' class='form-control selectpicker' id='existing_user_team_select' data-show-subtext='true' data-live-search='true'>
+          <option selected disabled value=''>{{ 'Select a team'|trans }}</option>
+          {% for team in teamsArr|filter(v => v.visible == 1) %}
+            <option value='{{ team.id }}'>{{ team.name }}</option>
+          {% endfor %}
+        </select>
         <button class='btn btn-primary mt-2' type='submit' name='submit'>{{ 'Request access'|trans }}</button>
       </div>
     </form>

--- a/tests/unit/Auth/AuthResponseTest.php
+++ b/tests/unit/Auth/AuthResponseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Auth;
+
+use Elabftw\Elabftw\AuthResponse;
+use Elabftw\Services\UsersHelper;
+
+class AuthResponseTest extends \PHPUnit\Framework\TestCase
+{
+    public function testTryButUserHasNoTeam(): void
+    {
+        $AuthResponse = new AuthResponse();
+        $AuthResponse->userid = 1;
+        // no team
+        $UsersHelperStub = $this->createStub(UsersHelper::class);
+        $UsersHelperStub->method('getTeamsFromUserid')->willReturn(array());
+        $AuthResponse->setTeams($UsersHelperStub);
+        $this->assertTrue($AuthResponse->teamSelectionRequired);
+        // one team
+        $UsersHelperStub = $this->createStub(UsersHelper::class);
+        $UsersHelperStub->method('getTeamsFromUserid')->willReturn(array(array('id' => 1)));
+        $AuthResponse->setTeams($UsersHelperStub);
+        $this->assertEquals(1, $AuthResponse->selectedTeam);
+        // more than 1 team
+        $UsersHelperStub = $this->createStub(UsersHelper::class);
+        $UsersHelperStub->method('getTeamsFromUserid')->willReturn(array(array('id' => 3), array('id' => 1)));
+        $AuthResponse->setTeams($UsersHelperStub);
+        $this->assertTrue($AuthResponse->isInSeveralTeams);
+    }
+}


### PR DESCRIPTION
this could happen for instance after a successful SAML login, but then the user quits the app before selecting a team, so the user is left created but with no team, and this breaks things. So now the user can come back later and finish setup their account because they'll be asked for a team.
![2024-04-25-023513_498x361_scrot](https://github.com/elabftw/elabftw/assets/3043706/d2f623f8-7062-4128-9261-be71765ac688)
