### PR TITLE
Add uploads for experiments templates

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -496,6 +496,10 @@ components:
         tags_id:
           type: string
           nullable: true
+        uploads:
+          type: array
+          items:
+            $ref: '#/components/schemas/upload'
     idp:
       type: object
       properties:

--- a/src/classes/CreateUpload.php
+++ b/src/classes/CreateUpload.php
@@ -24,7 +24,7 @@ class CreateUpload implements CreateUploadParamsInterface
 
     protected State $state = State::Normal;
 
-    public function __construct(private string $realName, private string $filePath, private ?string $comment = null) {}
+    public function __construct(private string $realName, protected string $filePath, private ?string $comment = null) {}
 
     public function getFilename(): string
     {
@@ -34,6 +34,11 @@ class CreateUpload implements CreateUploadParamsInterface
     public function getFilePath(): string
     {
         return $this->filePath;
+    }
+
+    public function getTmpFilePath(): string
+    {
+        return basename($this->filePath);
     }
 
     public function getComment(): ?string

--- a/src/classes/CreateUploadFromS3.php
+++ b/src/classes/CreateUploadFromS3.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Enums\Storage;
+use League\Flysystem\Filesystem;
+use Override;
+
+class CreateUploadFromS3 extends CreateUpload
+{
+    #[Override]
+    public function getSourceFs(): Filesystem
+    {
+        return Storage::from(Storage::S3->value)->getStorage()->getFs();
+    }
+
+    #[Override]
+    public function getSourcePath(): string
+    {
+        return $this->filePath;
+    }
+
+    #[Override]
+    public function getTmpFilePath(): string
+    {
+        return $this->filePath;
+    }
+}

--- a/src/interfaces/CreateUploadParamsInterface.php
+++ b/src/interfaces/CreateUploadParamsInterface.php
@@ -26,6 +26,8 @@ interface CreateUploadParamsInterface
 
     public function getFilePath(): string;
 
+    public function getTmpFilePath(): string;
+
     public function getSourceFs(): Filesystem;
 
     public function getSourcePath(): string;

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -115,6 +115,7 @@ class Experiments extends AbstractConcreteEntity
         $req->bindParam(':content_type', $contentType, PDO::PARAM_INT);
         $this->Db->execute($req);
         $newId = $this->Db->lastInsertId();
+        $this->setId($newId);
 
         // insert the tags, steps and links from the template
         if ($template > 0) {
@@ -122,6 +123,7 @@ class Experiments extends AbstractConcreteEntity
             $Tags->copyTags($newId, true);
             $this->Steps->duplicate($template, $newId, true);
             $this->ItemsLinks->duplicate($template, $newId, true);
+            $Templates->Uploads->duplicate($this);
         }
 
         $this->insertTags($tags, $newId);

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -159,6 +159,7 @@ class Templates extends AbstractTemplateEntity
         if (!empty($this->entityData['metadata'])) {
             $this->entityData['metadata_decoded'] = json_decode($this->entityData['metadata']);
         }
+        $this->entityData['uploads'] = $this->Uploads->readAll();
         return $this->entityData;
     }
 

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -175,10 +175,6 @@ class Uploads implements RestInterface
     {
         $uploads = $this->readAll();
         foreach ($uploads as $upload) {
-            // only consider non deleted uploads
-            if ($upload['state'] !== State::Normal->value) {
-                return;
-            }
             if ($upload['storage'] === Storage::LOCAL->value) {
                 $prefix = '/elabftw/uploads/';
                 $param = new CreateUpload($upload['real_name'], $prefix . $upload['long_name'], $upload['comment']);

--- a/src/templates/view-edit-template.html
+++ b/src/templates/view-edit-template.html
@@ -162,6 +162,7 @@
     </div>
     <hr>
     {% set mode = 'edit-template' %}
+    {% include 'uploads.html' with {'mode': 'edit'} %}
     {% include 'steps-links-edit.html' %}
     {% include 'json-editor.html' %}
   {% endif %}
@@ -169,5 +170,5 @@
 </div>
 {# in view mode templates-view.html gets included which has its own <div id='info'> #}
 {% if mode != 'view' %}
-  <div id='info' data-page='template-edit' data-type='experiments_templates' data-id='{{ Entity.id }}'></div>
+  <div id='info' data-maxsize='{{ maxUploadSize }}' data-page='template-edit' data-type='experiments_templates' data-id='{{ Entity.id }}'></div>
 {% endif %}

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -12,7 +12,7 @@
         {# SELECT ACTION #}
         <label for='requestActionActionSelect'>{{ 'Select action'|trans }}</label>
         <select id='requestActionActionSelect' class='form-control'>
-          {% for value, text in requestableActionArr|sort %}
+          {% for value, text in requestableActionArr|default([])|sort %}
             <option value='{{ value }}'>{{ text }}</option>
           {% endfor %}
         </select>
@@ -99,7 +99,7 @@
         {% else %}
           <label for='sigMeaningSelect'>{{ 'Select a meaning for this signature'|trans }}</label>
           <select id='sigMeaningSelect' class='form-control'>
-            {% for meaning, text in meaningArr|sort %}
+            {% for meaning, text in meaningArr|default([])|sort %}
               <option value='{{ meaning }}'>{{ text }}</option>
             {% endfor %}
           </select>

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -592,8 +592,10 @@ export async function updateEntityBody(): Promise<void> {
       tinymce.activeEditor.setDirty(false);
     }
     const lastSavedAt = document.getElementById('lastSavedAt');
-    lastSavedAt.title = json.modified_at;
-    reloadElement('lastSavedAt').then(() => relativeMoment());
+    if (lastSavedAt) {
+      lastSavedAt.title = json.modified_at;
+      reloadElement('lastSavedAt').then(() => relativeMoment());
+    }
   }).catch(() => {
     // detect if the session timedout (Session expired error is thrown)
     // store the modifications in local storage to prevent any data loss

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -16,6 +16,7 @@ import Tab from './Tab.class';
 import { Ajax } from './Ajax.class';
 import { Api } from './Apiv2.class';
 import $ from 'jquery';
+import { Uploader } from './uploader';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (window.location.pathname !== '/ucp.php') {
@@ -29,6 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const EntityC = new Templates();
   const ApiC = new Api();
+  // initialize the file uploader
+  (new Uploader()).init();
 
   const entity = getEntity();
   const TabMenu = new Tab();

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const pages = ['edit', 'view'];
+  const pages = ['edit', 'view', 'template-edit'];
   if (!pages.includes(about.page)) {
     return;
   }

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -36,6 +36,7 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
         $fixturesFs = Storage::FIXTURES->getStorage();
         $fileName = 'example.png';
         $this->Entity->Uploads->create(new CreateUpload($fileName, $fixturesFs->getPath() . '/' . $fileName));
+        $this->Entity->Uploads->duplicate($this->Entity);
     }
 
     public function testReadFilesizeSum(): void

--- a/web/ucp.php
+++ b/web/ucp.php
@@ -120,6 +120,7 @@ try {
         'entityData' => $entityData,
         'itemsCategoryArr' => $itemsCategoryArr,
         'teamsArr' => $Teams->readAll(),
+        'maxUploadSize' => Tools::getMaxUploadSize(),
         'metadataGroups' => $metadataGroups,
         'allTeamgroupsArr' => $TeamGroups->readGroupsFromUser(),
         'notificationsSettings' => $notificationsSettings,


### PR DESCRIPTION
* add new CreateUploadFromS3 class to handle copying uploads from S3 to
      storage: when creating experiment from Template with uploads in S3
* add a duplicate public function to Uploads
* read templates uploads in output of readOne()
* fix lastSavedAt generating error on template page
* use default([]) for meaningArr and requestableActionArr
