### PR TITLE
Improvements for links

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -588,8 +588,16 @@ components:
           type: string
         category_title:
           type: string
+        status_color:
+          type: string
+        status_title:
+          type: string
         custom_id:
           type: integer
+        page:
+          type: string
+        type:
+          type: string
     notification:
       type: object
       properties:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1102,6 +1102,27 @@ paths:
             enum: [1, 2, 3]
           description: |
             Set the scope for the results. 1: self, 2: team, 3: everything. It defaults to the user value stored in preferences.
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: ["cat", "comment", "customid", "date", "id", "lastchange", "rating", "status", "title", "user"]
+          description: |
+            Change the ordering of the results.
+          examples:
+            first:
+              summary: Order by category
+              value: cat
+            second:
+              summary: Order by custom ID
+              value: customid
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: ["asc", "desc"]
+          description: |
+            Change the sorting of results: ascending or descending.
       responses:
         '200':
           description: A list of experiments
@@ -1379,6 +1400,27 @@ paths:
             enum: [1, 2, 3]
           description: |
             Set the scope for the results. 1: self, 2: team, 3: everything. It defaults to the user value stored in preferences.
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: ["cat", "comment", "customid", "date", "id", "lastchange", "rating", "status", "title", "user"]
+          description: |
+            Change the ordering of the results.
+          examples:
+            first:
+              summary: Order by category
+              value: cat
+            second:
+              summary: Order by custom ID
+              value: customid
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: ["asc", "desc"]
+          description: |
+            Change the sorting of results: ascending or descending.
       # end duplicate from GET /experiments
       responses:
         '200':

--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -99,25 +99,18 @@ class MakeEln extends MakeStreamZip
             // LINKS (mentions)
             // this array will be added to the "mentions" attribute of the main dataset
             $mentions = array();
-            foreach ($e['items_links'] as $link) {
-                $id = Config::fromEnv('SITE_URL') . '/database.php?mode=view&id=' . $link['itemid'];
-                $mentions[] = array('@id' => $id);
-                $dataEntities[] = array(
-                    '@id' => $id,
-                    '@type' => 'Dataset',
-                    'name' => ($link['category'] ?? '') . ' - ' . $link['title'],
-                    'identifier' => $link['elabid'],
-                );
-            }
-            foreach ($e['experiments_links'] as $link) {
-                $id = Config::fromEnv('SITE_URL') . '/experiments.php?mode=view&id=' . $link['itemid'];
-                $mentions[] = array('@id' => $id);
-                $dataEntities[] = array(
-                    '@id' => $id,
-                    '@type' => 'Dataset',
-                    'name' => ($link['category'] ?? '') . ' - ' . $link['title'],
-                    'identifier' => $link['elabid'],
-                );
+            $linkTypes = array('experiments', 'items');
+            foreach($linkTypes as $type) {
+                foreach ($e[$type . '_links'] as $link) {
+                    $id = Config::fromEnv('SITE_URL') . '/' . $link['page'] . '.php?mode=view&id=' . $link['entityid'];
+                    $mentions[] = array('@id' => $id);
+                    $dataEntities[] = array(
+                        '@id' => $id,
+                        '@type' => 'Dataset',
+                        'name' => ($link['category'] ?? '') . ' - ' . $link['title'],
+                        'identifier' => $link['elabid'],
+                    );
+                }
             }
 
             // JSON

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 148;
+    public const int REQUIRED_SCHEMA = 149;
 
     private Db $Db;
 

--- a/src/models/AbstractLinks.php
+++ b/src/models/AbstractLinks.php
@@ -56,17 +56,22 @@ abstract class AbstractLinks implements RestInterface
     public function readAll(): array
     {
         // main category table
-        $sql = 'SELECT entity.id AS itemid,
+        $sql = 'SELECT entity.id AS entityid,
             entity.title,
             entity.custom_id,
             entity.elabid,
+            "' . $this->getTargetPage() . '" AS page,
+            "' . $this->getTargetType() . '" AS type,
             categoryt.title AS category_title,
             categoryt.color AS category_color,
+            statust.title AS status_title,
+            statust.color AS status_color,
             ' . ($this instanceof ItemsLinks ? 'entity.is_bookable,' : '') . '
             entity.state AS link_state
             FROM ' . $this->getTable() . '
             LEFT JOIN ' . $this->getTargetType() . ' AS entity ON (' . $this->getTable() . '.link_id = entity.id)
             LEFT JOIN ' . $this->getCatTable() . ' AS categoryt ON (entity.category = categoryt.id)
+            LEFT JOIN ' . $this->getStatusTable() . ' AS statust ON (entity.status = statust.id)
             WHERE ' . $this->getTable() . '.item_id = :id AND (entity.state = :state OR entity.state = :statearchived)
             ORDER by categoryt.title ASC, entity.date ASC, entity.title ASC';
 
@@ -89,7 +94,11 @@ abstract class AbstractLinks implements RestInterface
      */
     public function readRelated(): array
     {
-        $sql = 'SELECT entity.id AS entityid, entity.title, entity.custom_id, categoryt.title AS category_title, categoryt.color AS category_color, entity.state AS link_state';
+        $sql = 'SELECT entity.id AS entityid, entity.title, entity.custom_id,
+            "' . $this->getTargetPage() . '" AS page,
+            "' . $this->getTargetType() . '" AS type,
+            categoryt.title AS category_title, categoryt.color AS category_color,
+            statust.title AS status_title, statust.color AS status_color, entity.state AS link_state';
 
         if ($this instanceof ItemsLinks) {
             $sql .= ', entity.is_bookable';
@@ -97,7 +106,8 @@ abstract class AbstractLinks implements RestInterface
 
         $sql .= ' FROM ' . $this->getRelatedTable() . ' as entity_links
             LEFT JOIN ' . $this->getTargetType() . ' AS entity ON (entity_links.item_id = entity.id)
-            LEFT JOIN ' . $this->getCatTable() . ' AS categoryt ON (entity.category = categoryt.id)';
+            LEFT JOIN ' . $this->getCatTable() . ' AS categoryt ON (entity.category = categoryt.id)
+            LEFT JOIN ' . $this->getStatusTable() . ' AS statust ON (entity.status = statust.id)';
 
         $sql .= sprintf('WHERE entity_links.link_id = :id AND (entity.state = %d OR entity.state = %d) ORDER by', State::Normal->value, State::Archived->value);
 
@@ -179,7 +189,11 @@ abstract class AbstractLinks implements RestInterface
 
     abstract protected function getTargetType(): string;
 
+    abstract protected function getTargetPage(): string;
+
     abstract protected function getCatTable(): string;
+
+    abstract protected function getStatusTable(): string;
 
     abstract protected function getTable(): string;
 

--- a/src/models/ExperimentsLinks.php
+++ b/src/models/ExperimentsLinks.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
-use Elabftw\Exceptions\ImproperActionException;
-
 /**
  * All about Experiments Links
  */
@@ -24,9 +22,19 @@ class ExperimentsLinks extends AbstractLinks
         return 'experiments';
     }
 
+    protected function getTargetPage(): string
+    {
+        return 'experiments';
+    }
+
     protected function getCatTable(): string
     {
         return 'experiments_categories';
+    }
+
+    protected function getStatusTable(): string
+    {
+        return 'experiments_status';
     }
 
     protected function getTable(): string
@@ -35,7 +43,7 @@ class ExperimentsLinks extends AbstractLinks
             return 'experiments2experiments';
         }
         if ($this->Entity instanceof Templates) {
-            throw new ImproperActionException('Templates cannot be linked to experiments.');
+            return 'experiments_templates2experiments';
         }
         return 'items2experiments';
     }

--- a/src/models/ItemsLinks.php
+++ b/src/models/ItemsLinks.php
@@ -22,9 +22,19 @@ class ItemsLinks extends AbstractLinks
         return 'items';
     }
 
+    protected function getTargetPage(): string
+    {
+        return 'database';
+    }
+
     protected function getCatTable(): string
     {
         return 'items_types';
+    }
+
+    protected function getStatusTable(): string
+    {
+        return 'items_status';
     }
 
     protected function getTable(): string

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -154,6 +154,7 @@ class Templates extends AbstractTemplateEntity
         $this->canOrExplode('read');
         // add steps and links in there too
         $this->entityData['steps'] = $this->Steps->readAll();
+        $this->entityData['experiments_links'] = $this->ExperimentsLinks->readAll();
         $this->entityData['items_links'] = $this->ItemsLinks->readAll();
         $this->entityData['sharelink'] = sprintf('%s/ucp.php?tab=3&mode=view&templateid=%d', Config::fromEnv('SITE_URL'), $this->id);
         if (!empty($this->entityData['metadata'])) {

--- a/src/sql/schema149-down.sql
+++ b/src/sql/schema149-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 149
+DROP TABLE experiments_templates2experiments;
+UPDATE config SET conf_value = 148 WHERE conf_name = 'schema';

--- a/src/sql/schema149.sql
+++ b/src/sql/schema149.sql
@@ -1,0 +1,20 @@
+-- schema 149
+-- Table structure for table `experiments_templates2experiments`
+CREATE TABLE `experiments_templates2experiments` (
+  `item_id` int UNSIGNED NOT NULL,
+  `link_id` int UNSIGNED NOT NULL,
+  PRIMARY KEY (`item_id`,`link_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+-- Indexes for table `experiments_templates2experiments`
+ALTER TABLE `experiments_templates2experiments`
+  ADD KEY `fk_experiments_templates2experiments_item_id` (`item_id`),
+  ADD KEY `fk_experiments_templates2experiments_link_id` (`link_id`);
+-- Constraints for table `experiments_templates2experiments`
+ALTER TABLE `experiments_templates2experiments`
+  ADD CONSTRAINT `fk_experiments_templates2experiments_item_id`
+    FOREIGN KEY (`item_id`) REFERENCES `experiments` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_experiments_templates2experiments_link_id`
+    FOREIGN KEY (`link_id`) REFERENCES `experiments` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;
+UPDATE config SET conf_value = 149 WHERE conf_name = 'schema';

--- a/src/sql/schema149.sql
+++ b/src/sql/schema149.sql
@@ -12,7 +12,7 @@ ALTER TABLE `experiments_templates2experiments`
 -- Constraints for table `experiments_templates2experiments`
 ALTER TABLE `experiments_templates2experiments`
   ADD CONSTRAINT `fk_experiments_templates2experiments_item_id`
-    FOREIGN KEY (`item_id`) REFERENCES `experiments` (`id`)
+    FOREIGN KEY (`item_id`) REFERENCES `experiments_templates` (`id`)
     ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_experiments_templates2experiments_link_id`
     FOREIGN KEY (`link_id`) REFERENCES `experiments` (`id`)

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1052,6 +1052,24 @@ CREATE TABLE `experiments2experiments` (
 --       `experiments` -> `id`
 --
 
+--
+-- Table structure for table `experiments_templates2experiments`
+--
+
+CREATE TABLE `experiments_templates2experiments` (
+  `item_id` int UNSIGNED NOT NULL,
+  `link_id` int UNSIGNED NOT NULL,
+  PRIMARY KEY (`item_id`, `link_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
+-- RELATIONSHIPS FOR TABLE `experiments_templates2experiments`:
+--   `item_id`
+--       `experiments_templates` -> `id`
+--   `link_id`
+--       `experiments` -> `id`
+--
+
 -- --------------------------------------------------------
 
 --
@@ -1231,6 +1249,13 @@ ALTER TABLE `todolist`
 ALTER TABLE `experiments2experiments`
   ADD KEY `fk_experiments2experiments_item_id` (`item_id`),
   ADD KEY `fk_experiments2experiments_link_id` (`link_id`);
+
+--
+-- Indexes for table `experiments_templates2experiments`
+--
+ALTER TABLE `experiments_templates2experiments`
+  ADD KEY `fk_experiments_templates2experiments_item_id` (`item_id`),
+  ADD KEY `fk_experiments_templates2experiments_link_id` (`link_id`);
 
 --
 -- Indexes for table `items2experiments`
@@ -1486,6 +1511,17 @@ ALTER TABLE `experiments2experiments`
     FOREIGN KEY (`item_id`) REFERENCES `experiments` (`id`)
     ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_experiments2experiments_link_id`
+    FOREIGN KEY (`link_id`) REFERENCES `experiments` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `experiments_templates2experiments`
+--
+ALTER TABLE `experiments_templates2experiments`
+  ADD CONSTRAINT `fk_experiments_templates2experiments_item_id`
+    FOREIGN KEY (`item_id`) REFERENCES `experiments_templates` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_experiments_templates2experiments_link_id`
     FOREIGN KEY (`link_id`) REFERENCES `experiments` (`id`)
     ON DELETE CASCADE ON UPDATE CASCADE;
 

--- a/src/templates/link-view-one.html
+++ b/src/templates/link-view-one.html
@@ -1,0 +1,38 @@
+{# required vars:
+  link: the link to display
+  mode: edit edit-template view etc... #}
+<div class='ml-3 mt-3 col-md-12'>
+  {% set randomId = random() %}
+  <div class='d-flex mb-1 align-items-center' id='parent_{{ randomId }}'>
+    <i class='fas fa-link fa-fw mr-2'></i>
+    {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
+    {% if link.category_title %}
+      <span class='catstat-btn category-btn mr-1' style='--bg: #{{ link.category_color }}'>{{ link.category_title }}</span>
+    {% endif %}
+    {% if link.status_title %}
+      <span class='catstat-btn status-btn mr-1' style='--bg: #{{ link.status_color }}'>{{ link.status_title }}</span>
+    {% endif %}
+    {% if link.custom_id %}
+      <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
+    {% endif %}
+    <a href='{{ link.page }}.php?mode=view&amp;id={{ link.entityid }}' class='text-dark mr-auto hl-hover-gray p-1 rounded'>{{ link.title }}</a>
+    {# toggle body #}
+    <button type='button' data-type='{{ link.type }}' data-action='toggle-body' data-id='{{ link.entityid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
+      <i class='fas fa-fw fa-square-plus'></i>
+    </button>
+    {% if mode == 'edit' %}
+      <button type='button' data-action='import-links' data-target='{{ link.entityid }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+        <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
+      <button type='button' data-action='import-link-body' data-endpoint='{{ link.type }}' data-target='{{ link.entityid }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+        <i class='fas fa-fw fa-lg fa-file-import'></i></button>
+    {% endif %}
+    <button type='button' data-action='destroy-{{ isRelated|default(false) ? 'related-' }}link' data-endpoint='{{ link.type }}_links' data-target='{{ link.entityid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+      <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
+  </div>
+  {# container to hold the body of the entity if it is toggled with the +/- icon #}
+  {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
+  <div hidden id='{{ randomId }}'>
+    {# this div will hold the content #}
+    <div></div>
+  </div>
+</div>

--- a/src/templates/link-view-one.html
+++ b/src/templates/link-view-one.html
@@ -1,7 +1,7 @@
 {# required vars:
   link: the link to display
   mode: edit edit-template view etc... #}
-<div class='ml-3 mt-3 col-md-12'>
+<div class='ml-3 mt-3 col-md-12 countable'>
   {% set randomId = random() %}
   <div class='d-flex mb-1 align-items-center' id='parent_{{ randomId }}'>
     <i class='fas fa-link fa-fw mr-2'></i>

--- a/src/templates/related-snippet.html
+++ b/src/templates/related-snippet.html
@@ -3,8 +3,9 @@
 
   {# RELATED EXPERIMENTS #}
   {% if Entity.entityData.related_experiments_links %}
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedExperimentsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related experiments'|trans }} ({{ Entity.entityData.related_experiments_links|length }})</h3>
-    <div class='row mt-2' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedExperimentsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related experiments'|trans }} (<span id='relatedExperimentsDivCount'>{{ Entity.entityData.related_experiments_links|length }}</span>)</h3>
+    <div class='row mt-2' id='relatedExperimentsDiv' data-count-for='relatedExperimentsDivCount' data-save-hidden='relatedExperimentsDiv'>
+    <!--div class='row mt-2' id='relatedExperimentsDiv' data-count-class='link-view-one' data-counter='relatedExperimentsDivCounter' data-save-hidden='relatedExperimentsDiv'-->
       {% for link in Entity.entityData.related_experiments_links %}
         {% include 'link-view-one.html' with {'isRelated': true} %}
       {% endfor %}
@@ -19,15 +20,15 @@
 
   {# RELATED ITEMS #}
   {% if Entity.entityData.related_items_links %}
-  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedItemsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related items'|trans }} ({{ Entity.entityData.related_items_links|length }})</h3>
-    <div class='row mt-2' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedItemsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related resources'|trans }} (<span id='relatedItemsDivCount'>{{ Entity.entityData.related_items_links|length }}</span>)</h3>
+    <div class='row mt-2' id='relatedItemsDiv' data-count-for='relatedItemsDivCount' data-save-hidden='relatedItemsDiv'>
       {% for link in Entity.entityData.related_items_links %}
         {% include 'link-view-one.html' with {'isRelated': true} %}
       {% endfor %}
 
       <div class='ml-3 mt-3 col-md-12'>
         <i class='fas fa-list mr-1 fa-fw'></i>
-        <a href='database.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}' class='p-1 rounded hl-hover-gray'>{{ 'Show related items'|trans }}</a>
+        <a href='database.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}' class='p-1 rounded hl-hover-gray'>{{ 'Show related resources'|trans }}</a>
       </div>
     </div>
     <hr>

--- a/src/templates/related-snippet.html
+++ b/src/templates/related-snippet.html
@@ -3,75 +3,32 @@
 
   {# RELATED EXPERIMENTS #}
   {% if Entity.entityData.related_experiments_links %}
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedExperimentsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related experiments'|trans }}</h3>
+    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedExperimentsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related experiments'|trans }} ({{ Entity.entityData.related_experiments_links|length }})</h3>
     <div class='row mt-2' id='relatedExperimentsDiv' data-save-hidden='relatedExperimentsDiv'>
       {% for link in Entity.entityData.related_experiments_links %}
-        <div class='ml-3 mt-3 col-md-12'>
-          {% set randomId = random() %}
-          <div class='d-flex mb-4 align-items-center' id='parent_{{ randomId }}'>
-              <i class='fas fa-link fa-fw mr-2'></i>
-              {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
-              {% if link.category_title %}
-                <span class='catstat-btn category-btn mr-1' style='--bg: #{{ link.category_color }}'>{{ link.category_title }}</span>
-              {% endif %}
-              {% if link.custom_id %}
-                <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
-              {% endif %}
-              <a href='experiments.php?mode=view&amp;id={{ link.entityid }}' class='text-dark mr-auto'>{{ link.title }}</a>
-            {# delete link #}
-            <button data-action='destroy-related-link' type='button' data-endpoint='experiments_links' data-target='{{ link.entityid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-              <i class='fas fa-fw fa-trash-alt'></i>
-            </button>
-            {# toggle body #}
-            <button type='button' data-type='experiments' data-action='toggle-body' data-id='{{ link.entityid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
-              <i class='fas fa-fw fa-square-plus'></i>
-            </button>
-          </div>
-          <div hidden id='{{ randomId }}'>
-            <div></div>
-          </div>
-        </div>
+        {% include 'link-view-one.html' with {'isRelated': true} %}
       {% endfor %}
-    </div>
 
-    <div class='ml-3 mt-3'>
-      <i class='fas fa-list mr-1 fa-fw'></i>
-      <a href='experiments.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}'>{{ 'Show related experiments'|trans }}</a>
+      <div class='ml-3 mt-3 col-md-12'>
+        <i class='fas fa-list mr-1 fa-fw'></i>
+        <a href='experiments.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}' class='p-1 rounded hl-hover-gray'>{{ 'Show related experiments'|trans }}</a>
+      </div>
     </div>
     <hr>
   {% endif %}
 
   {# RELATED ITEMS #}
   {% if Entity.entityData.related_items_links %}
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedItemsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related items'|trans }}</h3>
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='relatedItemsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Related items'|trans }} ({{ Entity.entityData.related_items_links|length }})</h3>
     <div class='row mt-2' id='relatedItemsDiv' data-save-hidden='relatedItemsDiv'>
       {% for link in Entity.entityData.related_items_links %}
-        <div class='ml-3 mt-3 col-md-12'>
-          {% set randomId = random() %}
-          <div class='d-flex mb-4 align-items-center' id='parent_{{ randomId }}'>
-            <i class='fas fa-link fa-fw mr-2'></i>
-            {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
-            <span class='catstat-btn category-btn mr-1' style='--bg:#{{ link.category_color }}'>{{ link.category_title }}</span>
-            <a href='database.php?mode=view&amp;id={{ link.entityid }}' class='text-dark mr-auto'>{{ link.title }}</a>
-            {# delete link #}
-            <button data-action='destroy-related-link' type='button' data-endpoint='items_links' data-target='{{ link.entityid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 ny-n2'>
-              <i class='fas fa-trash-alt'></i>
-            </button>
-            {# toggle body #}
-            <button type='button' data-type='items' data-action='toggle-body' data-id='{{ link.entityid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 ny-n2'>
-              <i class='fas fa-square-plus'></i>
-            </button>
-          </div>
-          <div hidden id='{{ randomId }}'>
-            <div></div>
-          </div>
-        </div>
+        {% include 'link-view-one.html' with {'isRelated': true} %}
       {% endfor %}
-    </div>
 
-    <div class='ml-3 mt-3'>
-      <i class='fas fa-list mr-1 fa-fw'></i>
-      <a href='database.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}'>{{ 'Show related items'|trans }}</a>
+      <div class='ml-3 mt-3 col-md-12'>
+        <i class='fas fa-list mr-1 fa-fw'></i>
+        <a href='database.php?mode=show&amp;related={{ Entity.id }}&amp;related_origin={{ Entity.type }}' class='p-1 rounded hl-hover-gray'>{{ 'Show related items'|trans }}</a>
+      </div>
     </div>
     <hr>
   {% endif %}

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,12 +1,12 @@
 <div class='row mt-4'>
   {# STEPS #}
   <div class='col-md-12'>
-    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv' id='stepsDivTitle'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }} ({{ Entity.entityData.steps|length }})</h4>
+    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }} (<span id='stepsCount'>{{ Entity.entityData.steps|length }}</span>)</h4>
     {# ADD STEP #}
-    <div id='stepsDiv' class='mt-2' data-save-hidden='stepsDiv'>
+    <div id='stepsDiv' class='mt-2' data-count-for='stepsCount' data-save-hidden='stepsDiv'>
       <div class='sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types' }}_steps'>
         {% for step in Entity.entityData.steps %}
-          <div class='input-group mb-2' id='step_{{ step.id }}'>
+          <div class='input-group mb-2 countable' id='step_{{ step.id }}'>
             <div class='input-group-prepend'>
               <button type='button' class='btn draggable sortableHandle input-group-text' title='{{ 'Drag to reorder'|trans }}' aria-label='{{ 'Drag to reorder'|trans }}'>
                 <i class='fas fa-sort'></i>
@@ -99,13 +99,13 @@
     Linked experiment
     {% plural 2 %}
     Linked experiments
-    {% endtrans %} ({{ Entity.entityData.experiments_links|length }})</h4>
+    {% endtrans %} (<span id='experimentsLinksCount'>{{ Entity.entityData.experiments_links|length }}</span>)</h4>
     {# display experiments links #}
-    <div class='row mt-2' data-save-hidden='linksExpDiv' id='linksExpDiv'>
+    <div class='row mt-2' data-count-for='experimentsLinksCount' data-save-hidden='linksExpDiv' id='linksExpDiv'>
       {% if Entity.entityData.experiments_links %}
-          {% for link in Entity.entityData.experiments_links %}
-            {% include 'link-view-one.html' %}
-          {% endfor %}
+        {% for link in Entity.entityData.experiments_links %}
+          {% include 'link-view-one.html' %}
+        {% endfor %}
       {% endif %}
     </div>
     {# ADD LINK #}
@@ -131,15 +131,13 @@
 
   {# ITEMS LINKS #}
   <div class='col-md-12'>
-    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Linked resources'|trans }} ({{ Entity.entityData.items_links|length }})</h4>
+    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Linked resources'|trans }} (<span id='itemsLinksCount'>{{ Entity.entityData.items_links|length }}</span>)</h4>
     {# DISPLAY ITEMS LINKS #}
-    <div class='mt-2' data-save-hidden='linksDiv' id='linksDiv'>
+    <div class='row mt-2' data-count-for='itemsLinksCount' data-save-hidden='linksDiv' id='linksDiv'>
       {% if Entity.entityData.items_links %}
-        <div class='row mt-2' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
-          {% for link in Entity.entityData.items_links %}
-            {% include 'link-view-one.html' %}
-          {% endfor %}
-        </div>
+        {% for link in Entity.entityData.items_links %}
+          {% include 'link-view-one.html' %}
+        {% endfor %}
       {% endif %}
     </div>
     {# ADD LINK #}

--- a/src/templates/steps-links-edit.html
+++ b/src/templates/steps-links-edit.html
@@ -1,7 +1,7 @@
 <div class='row mt-4'>
   {# STEPS #}
   <div class='col-md-12'>
-    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }}</h4>
+    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv' id='stepsDivTitle'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }} ({{ Entity.entityData.steps|length }})</h4>
     {# ADD STEP #}
     <div id='stepsDiv' class='mt-2' data-save-hidden='stepsDiv'>
       <div class='sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.type ? Entity.type : 'items_types' }}_steps'>
@@ -93,106 +93,53 @@
 
 
   {# LINKS #}
-  {% if Entity.type == 'items' or Entity.type == 'experiments' %}
-    {# EXPERIMENTS LINKS #}
-    <div class='col-md-12'>
-      <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksExpDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{% trans %}
-      Linked experiment
-      {% plural 2 %}
-      Linked experiments
-      {% endtrans %}</h4>
-      {# display experiments links #}
-      <div class='mt-2' data-save-hidden='linksExpDiv' id='linksExpDiv'>
-        {% if Entity.entityData.experiments_links %}
-          <ul class='list-group'>
-            {% for link in Entity.entityData.experiments_links %}
-              {% set randomId = random() %}
-              <li class='list-group-item' id='parent_{{ randomId }}'>
-                <div class='d-flex align-items-center'>
-                  <i class='fas fa-link mr-1'></i>
-                  <span class='catstat-btn category-btn mr-1' style='--bg:#{{ link.category_color }}'>{{ link.category_title }}</span> <a href='experiments.php?mode=view&amp;id={{ link.itemid }}' class='mr-auto'>
-                  {% if link.custom_id %}
-                    <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
-                  {% endif %}
-                  {{ link.title }}</a>
-                  {# toggle body #}
-                  <button type='button' data-type='experiments' data-id='{{ link.itemid }}' data-randid={{ randomId }} data-action='toggle-body' title='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                    <i class='fas fa-fw fa-plus-square'></i></button>
-                  {% if mode != 'edit-template' %}
-                    <button type='button' data-action='import-links' data-target='{{ link.itemid }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                      <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
-                    <button type='button' data-action='import-link-body' data-endpoint='experiments' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                      <i class='fas fa-fw fa-lg fa-file-import'></i></button>
-                  {% endif %}
-                  <button type='button' data-action='destroy-link' data-endpoint='experiments_links' data-target='{{ link.itemid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                    <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
-                </div>
-                {# container to hold the body of the entity if it is toggled with the +/- icon #}
-                {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
-                <div hidden id='{{ randomId }}' style='overflow:auto;margin: 10px 0 0 20px'><div></div></div>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-      {# ADD LINK #}
-      <div class='input-group mt-2'>
-        <div class='input-group-prepend'>
-          <span class='input-group-text'><i class='fas fa-magnifying-glass'></i></span>
-        </div>
-        <div class='input-group-prepend' style='max-width:33%;'>
-          <select id='addLinkOwnerFilter' class='brl-none brr-none form-control' aria-label='Limit author'>
-            <option selected value=''>{{ 'Any author'|trans }}</option>
-            {% for user in usersArr %}
-              <option value='{{ user.userid }}'>{{ user.fullname }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <input aria-label='{{ 'Add a link'|trans }}' type='text' data-endpoint='experiments_links' id='addLinkExpInput' class='form-control linkinput' data-id='{{ Entity.id }}' placeholder='{{ 'Search in experiments'|trans }}' />
-        <div class='input-group-append'>
-          <button class='btn btn-primary' type='button'>{{ 'Add'|trans }}</button>
-        </div>
-      </div>
-      <hr>
+  {# EXPERIMENTS LINKS #}
+  <div class='col-md-12'>
+    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksExpDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{% trans %}
+    Linked experiment
+    {% plural 2 %}
+    Linked experiments
+    {% endtrans %} ({{ Entity.entityData.experiments_links|length }})</h4>
+    {# display experiments links #}
+    <div class='row mt-2' data-save-hidden='linksExpDiv' id='linksExpDiv'>
+      {% if Entity.entityData.experiments_links %}
+          {% for link in Entity.entityData.experiments_links %}
+            {% include 'link-view-one.html' %}
+          {% endfor %}
+      {% endif %}
     </div>
-
-  {% endif %}
+    {# ADD LINK #}
+    <div class='input-group mt-2'>
+      <div class='input-group-prepend'>
+        <span class='input-group-text'><i class='fas fa-magnifying-glass'></i></span>
+      </div>
+      <div class='input-group-prepend' style='max-width:33%;'>
+        <select id='addLinkOwnerFilter' class='brl-none brr-none form-control' aria-label='Limit author'>
+          <option selected value=''>{{ 'Any author'|trans }}</option>
+          {% for user in usersArr %}
+            <option value='{{ user.userid }}'>{{ user.fullname }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <input aria-label='{{ 'Add a link'|trans }}' type='text' data-endpoint='experiments_links' id='addLinkExpInput' class='form-control linkinput' data-id='{{ Entity.id }}' placeholder='{{ 'Search in experiments'|trans }}' />
+      <div class='input-group-append'>
+        <button class='btn btn-primary' type='button'>{{ 'Add'|trans }}</button>
+      </div>
+    </div>
+    <hr>
+  </div>
 
   {# ITEMS LINKS #}
   <div class='col-md-12'>
-    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Linked resources'|trans }}</h4>
+    <h4 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Linked resources'|trans }} ({{ Entity.entityData.items_links|length }})</h4>
     {# DISPLAY ITEMS LINKS #}
     <div class='mt-2' data-save-hidden='linksDiv' id='linksDiv'>
       {% if Entity.entityData.items_links %}
-        <ul class='list-group'>
+        <div class='row mt-2' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
           {% for link in Entity.entityData.items_links %}
-            {% set randomId = random() %}
-            <li class='list-group-item' id='parent_{{ randomId }}'>
-              <div class='d-flex align-items-center'>
-                <i class='fas fa-link mr-1'></i>
-                <span class='catstat-btn category-btn mr-1' style='--bg:#{{ link.category_color }}'>{{ link.category_title }}</span> <a href='database.php?mode=view&amp;id={{ link.itemid }}' class='mr-auto'>
-                {% if link.custom_id %}
-                  <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
-                {% endif %}
-                {{ link.title }}</a>
-                {# toggle body #}
-                <button type='button' data-type='items' data-id='{{ link.itemid }}' data-randid={{ randomId }} data-action='toggle-body' title='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                  <i class='fas fa-fw fa-plus-square'></i></button>
-                {% if mode != 'edit-template' %}
-                  <button type='button' data-action='import-links' data-target='{{ link.itemid }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                    <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
-                  <button type='button' data-action='import-link-body' data-endpoint='items' data-target='{{ link.itemid }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                    <i class='fas fa-fw fa-lg fa-file-import'></i></button>
-                {% endif %}
-                <button type='button' data-action='destroy-link' data-endpoint='items_links' data-target='{{ link.itemid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-                  <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
-              </div>
-              {# container to hold the body of the entity if it is toggled with the +/- icon #}
-              {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
-              <div hidden id='{{ randomId }}' style='overflow:auto;margin: 10px 0 0 20px'><div></div></div>
-            </li>
+            {% include 'link-view-one.html' %}
           {% endfor %}
-        </ul>
+        </div>
       {% endif %}
     </div>
     {# ADD LINK #}

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -5,7 +5,7 @@
   <div class='row mt-2' id='stepsDivContent' data-save-hidden='stepsDivContent'>
     <div class='ml-3 mt-3 col-md-12'>
       {% for step in Entity.entityData.steps %}
-        <div id='step_view_{{ step.id }}' class='mb-2 rounded p-1 {{ step.finished ? 'finished' }} {{ App.Request.query.get('highlightstep') == step.id ? 'highlighted' }}'>
+        <div id='step_view_{{ step.id }}' class='countable mb-2 rounded p-1 {{ step.finished ? 'finished' }} {{ App.Request.query.get('highlightstep') == step.id ? 'highlighted' }}'>
           <input aria-label='{{ 'Toggle completion'|trans }}' type='checkbox' {{ step.finished ? 'checked' }} {{ Entity.type == 'experiments_templates' ? 'disabled' }} data-id='{{ Entity.id }}' autocomplete='off' data-stepid='{{ step.id }}' class='stepbox mr-2' id='stepCheckbox_{{ step.id }}' />{{ step.body }}
         {% if step.finished %}
         <span class='mr-2 text-muted'>

--- a/src/templates/steps-links-view.html
+++ b/src/templates/steps-links-view.html
@@ -1,7 +1,7 @@
 {# STEPS #}
 <div id='stepsDiv'>
 {% if Entity.entityData.steps %}
-  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDivContent'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Steps'|trans }}</h3>
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDivContent'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Steps'|trans }} ({{ Entity.entityData.steps|length }})</h3>
   <div class='row mt-2' id='stepsDivContent' data-save-hidden='stepsDivContent'>
     <div class='ml-3 mt-3 col-md-12'>
       {% for step in Entity.entityData.steps %}
@@ -27,35 +27,14 @@
 
 {# EXPERIMENTS LINKS #}
 {% if Entity.entityData.experiments_links %}
-  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linkedExperimentsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{% trans %}
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linkExpDiv' id='linksExpDivTitle'><i class='fas fa-caret-down mr-2 fa-fw'></i>{% trans %}
     Linked experiment
     {% plural 2 %}
     Linked experiments
-    {% endtrans %}</h3>
-  <div class='row mt-2' id='linkedExperimentsDiv' data-save-hidden='linkedExperimentsDiv'>
+    {% endtrans %} ({{ Entity.entityData.experiments_links|length }})</h3>
+  <div class='row mt-2' id='linksExpDiv' data-save-hidden='linksExpDiv'>
     {% for link in Entity.entityData.experiments_links %}
-      <div class='ml-3 mt-3 col-md-12'>
-        {% set randomId = random() %}
-        <div class='d-flex mb-4 align-items-center' id='parent_{{ randomId }}'>
-          <i class='fas fa-link fa-fw mr-2'></i>
-          {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
-          <span class='catstat-btn category-btn mr-1' style='--bg:#{{ link.category_color }}'>{{ link.category_title }}</span>
-          {% if link.custom_id %}
-            <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
-          {% endif %}
-          <a href='experiments.php?mode=view&amp;id={{ link.itemid }}' class='text-dark mr-auto'>{{ link.title }}</a>
-          {# toggle body #}
-          <button type='button' data-type='experiments' data-action='toggle-body' data-id='{{ link.itemid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
-            <i class='fas fa-fw fa-square-plus'></i>
-          </button>
-        </div>
-        {# container to hold the body of the entity if it is toggled with the +/- icon #}
-        {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
-        <div hidden id='{{ randomId }}'>
-          {# this div will hold the content #}
-          <div></div>
-        </div>
-      </div>
+      {% include 'link-view-one.html' %}
     {% endfor %}
   </div>
   <hr>
@@ -63,28 +42,10 @@
 
 {# ITEMS LINKS #}
 {% if Entity.entityData.items_links %}
-  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linkedItemsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Linked resources'|trans }}</h3>
-  <div class='row mt-2' id='linkedItemsDiv' data-save-hidden='linkedItemsDiv'>
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv' id='linksDivTitle'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Linked resources'|trans }} ({{ Entity.entityData.items_links|length }})</h3>
+  <div class='row mt-2' id='linksDiv' data-save-hidden='linksDiv'>
     {% for link in Entity.entityData.items_links %}
-      <div class='ml-3 mt-3 col-md-12'>
-        {% set randomId = random() %}
-        <div class='d-flex mb-4 align-items-center' id='parent_{{ randomId }}'>
-          <i class='fas fa-link fa-fw mr-2'></i>
-          {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
-          <span class='catstat-btn category-btn mr-1' style='--bg:#{{ link.category_color }}'>{{ link.category_title }}</span>
-          <a href='database.php?mode=view&amp;id={{ link.itemid }}' class='text-dark mr-auto'>{{ link.title }}</a>
-          {# toggle body #}
-          <button type='button' data-type='items' data-action='toggle-body' data-id='{{ link.itemid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
-            <i class='fas fa-fw fa-square-plus'></i>
-          </button>
-        </div>
-        {# container to hold the body of the entity if it is toggled with the +/- icon #}
-        {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
-        <div hidden id='{{ randomId }}'>
-          {# this div will hold the content #}
-          <div></div>
-        </div>
-      </div>
+      {% include 'link-view-one.html' %}
     {% endfor %}
   </div>
   <hr>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -24,11 +24,11 @@
   {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button' id='uploadsDivTitle'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files
-        {% endtrans %}
+        {% endtrans %} ({{ Entity.entityData.uploads|length }})
       </h3>
     </div>
 

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -24,11 +24,11 @@
   {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button' id='uploadsDivTitle'>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files
-        {% endtrans %} ({{ Entity.entityData.uploads|length }})
+        {% endtrans %} (<span id='uploadsCount'>{{ Entity.entityData.uploads|length }}</span>)
       </h3>
     </div>
 
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class='row mt-2 mx-0' id='uploadsDiv' data-save-hidden='uploadsDiv'>
+  <div class='row mt-2 mx-0' id='uploadsDiv' data-count-for='uploadsCount' data-save-hidden='uploadsDiv'>
     {# ADD NEW FILE #}
     {% if mode == 'edit' %}
       <div class='col-md-4 col-sm-6'>
@@ -69,7 +69,7 @@
         </thead>
         <tbody>
           {% for upload in Entity.entityData.uploads %}
-            <tr id='uploadDiv_{{ upload.id }}'>
+            <tr class='countable' id='uploadDiv_{{ upload.id }}'>
               <td>
                 <button type='button' class='btn lh-normal hl-hover-gray p-1 mr-1' data-action='toggle-next' data-toggle-target='moreinfoDiv_{{ upload.id }}' aria-expanded='false' title='{{ 'More information'|trans }}' aria-label='{{ 'More information'|trans }}'>
                   <i class='fas fa-caret-right fa-fw'></i>
@@ -129,7 +129,7 @@
     {% else %}
       {% for upload in Entity.entityData.uploads %}
         {% set ext = upload.real_name|getExt %}
-        <div class='col-md-4 col-sm-6' id='uploadDiv_{{ upload.id }}'>
+        <div class='col-md-4 col-sm-6 countable' id='uploadDiv_{{ upload.id }}'>
           {% if loop.first %}
             <div id='last-uploaded-link' data-url='app/download.php?f={{ upload.long_name }}' hidden></div>
           {% endif %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -141,10 +141,9 @@
 
 {% include 'uploads.html' %}
 
-<div id='commentsDiv'>
-  {% if App.Session.get('is_auth') and not App.Session.has('is_anon') %}
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='commentsInnerDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Comments'|trans }} (<span id='commentsCount'>{{ Entity.entityData.comments|length }}</span>)</h3>
-  <div class='mt-2' id='commentsInnerDiv' data-count-for='commentsCount' data-save-hidden='commentsInnerDiv'>
+{% if App.Session.get('is_auth') and not App.Session.has('is_anon') %}
+  <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='commentsDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Comments'|trans }} (<span id='commentsCount'>{{ Entity.entityData.comments|length }}</span>)</h3>
+  <div class='mt-2' id='commentsDiv' data-count-for='commentsCount' data-save-hidden='commentsDiv'>
       {% for comment in Entity.entityData.comments %}
         <div class='box countable'>
           <div class='comment-header text-muted p-2'>
@@ -172,8 +171,7 @@
         </div>
       </div>
     </div>
-  {% endif %}
-</div>
+{% endif %}
 
 <div id='info'
     data-page='view'

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -143,34 +143,32 @@
 
 <div id='commentsDiv'>
   {% if App.Session.get('is_auth') and not App.Session.has('is_anon') %}
-    <div id='comment'>
-    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='commentsInnerDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Comments'|trans }}</h3>
-    <div class='mt-2' id='commentsInnerDiv' data-save-hidden='commentsInnerDiv'>
-        {% for comment in Entity.entityData.comments %}
-          <div class='box'>
-            <div class='comment-header text-muted p-2'>
-              {{ comment.fullname }} {{ 'commented'|trans }}
-              <span title='{{ comment.created_at }}' class='relative-moment'></span>
-              {% if comment.created_at != comment.modified_at %}
-                ({{ 'edited'|trans }} <span title='{{ comment.modified_at }}' class='relative-moment'></span>)
-              {% endif %}
-              {% if comment.userid == Entity.Users.userData.userid and comment.immutable == 0 %}
-                <button type='button' class='btn float-right lh-normal border-0 m-0 p-2 my-n2 hl-hover-gray' data-action='destroy-comment' data-id='{{ comment.id }}' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}'>
-                  <i class='fas fa-fw fa-trash-alt fa-lg'></i>
-                </button>
-              {% endif %}
-            </div>
-            {# the comment itself is only editable by the owner #}
-            <p class='comment m-2 p-2 {{ comment.userid == Entity.Users.userData.userid and comment.immutable == 0 ? "editable hl-hover" }}' data-id='{{ comment.id }}'>{{ comment.comment|nl2br }}</p>
+    <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='commentsInnerDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Comments'|trans }} (<span id='commentsCount'>{{ Entity.entityData.comments|length }}</span>)</h3>
+  <div class='mt-2' id='commentsInnerDiv' data-count-for='commentsCount' data-save-hidden='commentsInnerDiv'>
+      {% for comment in Entity.entityData.comments %}
+        <div class='box countable'>
+          <div class='comment-header text-muted p-2'>
+            {{ comment.fullname }} {{ 'commented'|trans }}
+            <span title='{{ comment.created_at }}' class='relative-moment'></span>
+            {% if comment.created_at != comment.modified_at %}
+              ({{ 'edited'|trans }} <span title='{{ comment.modified_at }}' class='relative-moment'></span>)
+            {% endif %}
+            {% if comment.userid == Entity.Users.userData.userid and comment.immutable == 0 %}
+              <button type='button' class='btn float-right lh-normal border-0 m-0 p-2 my-n2 hl-hover-gray' data-action='destroy-comment' data-id='{{ comment.id }}' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}'>
+                <i class='fas fa-fw fa-trash-alt fa-lg'></i>
+              </button>
+            {% endif %}
           </div>
-        {% endfor %}
+          {# the comment itself is only editable by the owner #}
+          <p class='comment m-2 p-2 {{ comment.userid == Entity.Users.userData.userid and comment.immutable == 0 ? "editable hl-hover" }}' data-id='{{ comment.id }}'>{{ comment.comment|nl2br }}</p>
+        </div>
+      {% endfor %}
 
-        {# CREATE COMMENT INPUT #}
-        <div class='input-group my-1 rounded'>
-          <textarea id='commentsCreateArea' class='form-control p-2 brr-none' autocomplete='off' placeholder='{{ 'Add a comment'|trans }}' aria-label='Comment area'></textarea>
-          <div class='input-group-append'>
-            <button class='btn btn-primary' aria-label='{{ 'Add a comment'|trans }}' type='button' data-action='create-comment'><i class='fas fa-paper-plane text-white'></i></button>
-          </div>
+      {# CREATE COMMENT INPUT #}
+      <div class='input-group my-1 rounded'>
+        <textarea id='commentsCreateArea' class='form-control p-2 brr-none' autocomplete='off' placeholder='{{ 'Add a comment'|trans }}' aria-label='Comment area'></textarea>
+        <div class='input-group-append'>
+          <button class='btn btn-primary' aria-label='{{ 'Add a comment'|trans }}' type='button' data-action='create-comment'><i class='fas fa-paper-plane text-white'></i></button>
         </div>
       </div>
     </div>

--- a/src/ts/Counter.class.ts
+++ b/src/ts/Counter.class.ts
@@ -1,0 +1,38 @@
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+/**
+ * This class is responsible for creating a mutation observer that will count all .countable items of the element that has a data-count-for attribute
+ * The count is updated in the element whose id is the value of data-count-for
+ * This is used for steps and links for instance
+ */
+export class Counter {
+  private countEl: HTMLElement;
+  private container: HTMLElement;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+    this.countEl = document.getElementById(this.container.dataset.countFor as string) as HTMLElement;
+    if (!this.countEl) {
+      console.debug(`count element ${container.dataset.countFor} not found!`);
+      return;
+    }
+    this.update(); // Initial update
+    this.observe();
+  }
+
+  private update() {
+    const count = this.container.getElementsByClassName('countable').length;
+    this.countEl.textContent = `${count}`;
+  }
+
+  private observe() {
+    const observer = new MutationObserver(() => this.update());
+    observer.observe(this.container, { childList: true });
+  }
+}

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -48,6 +48,7 @@ import 'bootstrap-markdown-fa5/locale/bootstrap-markdown.zh.js';
 import TableSorting from './TableSorting.class';
 import { KeyboardShortcuts } from './KeyboardShortcuts.class';
 import JsonEditorHelper from './JsonEditorHelper.class';
+import { Counter } from './Counter.class';
 
 document.addEventListener('DOMContentLoaded', () => {
   // HEARTBEAT
@@ -89,6 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
     );
     kbd.init();
   }
+
+  // ACTIVATE REACTIVE COUNT OF .COUNTABLE ITEMS
+  document.querySelectorAll('[data-count-for]').forEach((container: HTMLElement) => new Counter(container));
 
   // BACK TO TOP BUTTON
   const btn = document.createElement('button');

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -318,8 +318,15 @@ export async function reloadElements(elementIds: string[]): Promise<void> {
 export function adjustHiddenState(): void {
   document.querySelectorAll('[data-save-hidden]').forEach(el => {
     const targetElement = (el as HTMLElement).dataset.saveHidden;
+    // failsafe
+    if (!targetElement) {
+      return;
+    }
     const localStorageKey = targetElement + '-isHidden';
     const button = document.querySelector(`[data-toggle-target="${targetElement}"]`) || el.previousElementSibling;
+    if (!button) {
+      return;
+    }
     const caretIcon =  button.querySelector('i');
     if (localStorage.getItem(localStorageKey) === '1') {
       el.setAttribute('hidden', 'hidden');

--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -14,7 +14,6 @@ import { relativeMoment, makeSortableGreatAgain, reloadElement, reloadElements, 
 import { Action, Target } from './interfaces';
 import { Api } from './Apiv2.class';
 
-
 document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('info')) {
     return;
@@ -53,11 +52,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // DESTROY LINK
     } else if (el.matches('[data-action="destroy-link"]')) {
       if (confirm(i18next.t('link-delete-warning'))) {
-        ApiC.delete(`${entity.type}/${entity.id}/${el.dataset.endpoint}/${el.dataset.target}`).then(() => reloadElements(['linksDiv', 'linksExpDiv', 'linksExpDivTitle', 'linksDivTitle']));
+        ApiC.delete(`${entity.type}/${entity.id}/${el.dataset.endpoint}/${el.dataset.target}`)
+          .then(() => el.parentElement.parentElement.remove());
       }
     } else if (el.matches('[data-action="destroy-related-link"]')) {
       if (confirm(i18next.t('link-delete-warning'))) {
-        ApiC.delete(`${el.dataset.endpoint.split('_')[0]}/${el.dataset.target}/${entity.type}_links/${entity.id}`).then(() => reloadElements(['relatedItemsDiv', 'relatedExperimentsDiv']));
+        ApiC.delete(`${el.dataset.endpoint.split('_')[0]}/${el.dataset.target}/${entity.type}_links/${entity.id}`)
+          .then(() => el.parentElement.parentElement.remove());
       }
     }
   });
@@ -76,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const content = input.value;
     if (content.length > 0) {
       StepC.create(content).then(() => {
-        reloadElements(['stepsDiv', 'stepsDivTitle']).then(() => {
+        reloadElement('stepsDiv').then(() => {
           // clear input field
           input.value = '';
           input.focus();
@@ -145,7 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (confirm(i18next.t('step-delete-warning'))) {
       const stepId = e.currentTarget.dataset.stepid;
       StepC.destroy(stepId).then(() => {
-        reloadElements(['stepsDiv', 'stepsDivTitle']).then(() => {
+        reloadElement('stepsDiv').then(() => {
           // keep to do list in sync
           $('#todo_step_' + stepId).parent().hide();
         });

--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // DESTROY LINK
     } else if (el.matches('[data-action="destroy-link"]')) {
       if (confirm(i18next.t('link-delete-warning'))) {
-        ApiC.delete(`${entity.type}/${entity.id}/${el.dataset.endpoint}/${el.dataset.target}`).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
+        ApiC.delete(`${entity.type}/${entity.id}/${el.dataset.endpoint}/${el.dataset.target}`).then(() => reloadElements(['linksDiv', 'linksExpDiv', 'linksExpDivTitle', 'linksDivTitle']));
       }
     } else if (el.matches('[data-action="destroy-related-link"]')) {
       if (confirm(i18next.t('link-delete-warning'))) {
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const content = input.value;
     if (content.length > 0) {
       StepC.create(content).then(() => {
-        reloadElement('stepsDiv').then(() => {
+        reloadElements(['stepsDiv', 'stepsDivTitle']).then(() => {
           // clear input field
           input.value = '';
           input.focus();
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (confirm(i18next.t('step-delete-warning'))) {
       const stepId = e.currentTarget.dataset.stepid;
       StepC.destroy(stepId).then(() => {
-        reloadElement('stepsDiv').then(() => {
+        reloadElements(['stepsDiv', 'stepsDivTitle']).then(() => {
           // keep to do list in sync
           $('#todo_step_' + stepId).parent().hide();
         });

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import Dropzone from '@deltablot/dropzone';
-import { reloadElement } from './misc';
+import { reloadElements } from './misc';
 import i18next from 'i18next';
 
 export class Uploader
@@ -27,7 +27,7 @@ export class Uploader
         // once upload is finished
         this.on('complete', function() {
           if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-            reloadElement('uploadsDiv').then(() => {
+            reloadElements(['uploadsDiv', 'uploadsDivTitle']).then(() => {
               // Now grab the url of the image to give it to tinymce if needed
               // first make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
               if (typeof that.tinyImageSuccess !== 'undefined' && that.tinyImageSuccess !== null) {

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import Dropzone from '@deltablot/dropzone';
-import { reloadElements } from './misc';
+import { reloadElement } from './misc';
 import i18next from 'i18next';
 
 export class Uploader
@@ -27,7 +27,7 @@ export class Uploader
         // once upload is finished
         this.on('complete', function() {
           if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-            reloadElements(['uploadsDiv', 'uploadsDivTitle']).then(() => {
+            reloadElement('uploadsDiv').then(() => {
               // Now grab the url of the image to give it to tinymce if needed
               // first make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
               if (typeof that.tinyImageSuccess !== 'undefined' && that.tinyImageSuccess !== null) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -194,10 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       if (confirm(i18next.t('generic-delete-warning'))) {
         ApiC.delete(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`)
-          .then(() => {
-            document.getElementById(`uploadDiv_${uploadid}`).remove();
-            reloadElement('uploadsDivTitle');
-          });
+          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove());
       }
     }
   });
@@ -212,7 +209,7 @@ document.addEventListener('DOMContentLoaded', () => {
       $3Dmol.autoload();
       displayPlasmidViewer(about);
       malleableFilecomment.listen();
-      if ('edit' === about.page) {
+      if (['edit', 'template-edit'].includes(about.page)) {
         (new Uploader()).init();
       }
       relativeMoment();

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -194,7 +194,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       if (confirm(i18next.t('generic-delete-warning'))) {
         ApiC.delete(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`)
-          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove());
+          .then(() => {
+            document.getElementById(`uploadDiv_${uploadid}`).remove();
+            reloadElement('uploadsDivTitle');
+          });
       }
     }
   });

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -36,12 +36,17 @@ document.addEventListener('DOMContentLoaded', () => {
     // CREATE COMMENT
     if (el.matches('[data-action="create-comment"]')) {
       const content = (document.getElementById('commentsCreateArea') as HTMLTextAreaElement).value;
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Comment}`, {'comment': content}).then(() => reloadElement('commentsDiv'));
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Comment}`, {'comment': content}).then(() => {
+        reloadElement('commentsDiv').then(() => {
+          malleableComments.listen();
+          relativeMoment();
+        });
+      });
 
     // DESTROY COMMENT
     } else if (el.matches('[data-action="destroy-comment"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
-        ApiC.delete(`${entity.type}/${entity.id}/${Model.Comment}/${el.dataset.id}`).then(() => reloadElement('commentsDiv'));
+        ApiC.delete(`${entity.type}/${entity.id}/${Model.Comment}/${el.dataset.id}`).then(() => el.parentElement.parentElement.remove());
       }
     }
   });

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -45,9 +45,9 @@ describe('Experiments', () => {
     cy.get('[title="View mode"]').click();
     cy.get('#commentsCreateArea').type('This is a very nice experiment');
     cy.get('[data-action="create-comment"]').click();
-    cy.get('#comment').contains('Toto Le sysadmin commented').should('be.visible');
+    cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('be.visible');
     cy.get('[data-action="destroy-comment"]').click();
-    cy.get('#comment').contains('Toto Le sysadmin commented').should('not.exist');
+    cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('not.exist');
     cy.htmlvalidate();
     // go back in edit mode for destroy action
     cy.get('[title="Edit"]').click();

--- a/tests/unit/models/LinksTest.php
+++ b/tests/unit/models/LinksTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
-use Elabftw\Exceptions\ImproperActionException;
 
 class LinksTest extends \PHPUnit\Framework\TestCase
 {
@@ -101,7 +100,9 @@ class LinksTest extends \PHPUnit\Framework\TestCase
     public function testReadExperimentsLinksFromTemplate(): void
     {
         $Templates = new Templates(new Users(1, 1), 1);
-        $this->expectException(ImproperActionException::class);
-        $Templates->ExperimentsLinks->readAll();
+        $this->assertEmpty($Templates->ExperimentsLinks->readAll());
+        $Templates->ExperimentsLinks->setId(1);
+        $Templates->ExperimentsLinks->postAction(Action::Create, array());
+        $this->assertEquals(1, count($Templates->ExperimentsLinks->readAll()));
     }
 }


### PR DESCRIPTION
 improvements for links

* add status_color and status_title to links so we can display the
      status next to the category
* add page and type too
* greatly factorize all the link view and edit code by creating
      link-view-one.html template
* allow links to experiments on templates because why not: add a table
      experiments_templates2experiments
* add count for steps, uploads and links in parenthesis next to the
      title + a nice way to keep it synchronized with the content without reloading the element! new Counter() ts class.
* allow adjustHiddenState() to fail gracefully if elements are not found
