### PR TITLE
Avoid unnecessary casting, use PDO::PARAM_X more cautiously

### DIFF
--- a/src/Auth/Cookie.php
+++ b/src/Auth/Cookie.php
@@ -19,7 +19,6 @@ use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Interfaces\AuthInterface;
 use Elabftw\Services\TeamsHelper;
-use PDO;
 
 /**
  * Authenticate with the cookie
@@ -45,7 +44,7 @@ class Cookie implements AuthInterface
             $this->validityMinutes
         );
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':token', $this->Token->getToken(), PDO::PARAM_STR);
+        $req->bindValue(':token', $this->Token->getToken());
         $this->Db->execute($req);
         if ($req->rowCount() !== 1) {
             throw new UnauthorizedException();

--- a/src/Auth/CookieToken.php
+++ b/src/Auth/CookieToken.php
@@ -46,7 +46,7 @@ class CookieToken
     {
         $sql = 'UPDATE users SET token = :token, token_created_at = NOW() WHERE userid = :userid';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':token', $this->token, PDO::PARAM_STR);
+        $req->bindValue(':token', $this->getToken());
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }

--- a/src/Auth/External.php
+++ b/src/Auth/External.php
@@ -68,7 +68,7 @@ class External implements AuthInterface
             $Users = ValidatedUser::fromExternal($email, $teams, $firstname, $lastname);
             $this->log->info('New user (' . $email . ') autocreated from external auth');
         }
-        $this->AuthResponse->userid = (int) $Users->userData['userid'];
+        $this->AuthResponse->userid = $Users->userData['userid'];
         $this->AuthResponse->isValidated = true;
         $UsersHelper = new UsersHelper($this->AuthResponse->userid);
         $this->AuthResponse->setTeams($UsersHelper);

--- a/src/Auth/Ldap.php
+++ b/src/Auth/Ldap.php
@@ -111,7 +111,7 @@ class Ldap implements AuthInterface
             $Users = ValidatedUser::fromExternal($email, $teamFromLdap, $firstname, $lastname);
         }
 
-        $this->AuthResponse->userid = (int) $Users->userData['userid'];
+        $this->AuthResponse->userid = $Users->userData['userid'];
         $this->AuthResponse->mfaSecret = $Users->userData['mfa_secret'];
         $this->AuthResponse->isValidated = (bool) $Users->userData['validated'];
         $UsersHelper = new UsersHelper($this->AuthResponse->userid);

--- a/src/Enums/ApiEndpoint.php
+++ b/src/Enums/ApiEndpoint.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function array_map;
+
 enum ApiEndpoint: string
 {
     case ApiKeys = 'apikeys';
@@ -35,6 +37,6 @@ enum ApiEndpoint: string
 
     public static function getCases(): array
     {
-        return array_map(fn($case) => $case->value, ApiEndpoint::cases());
+        return array_map(fn(self $case) => $case->value, ApiEndpoint::cases());
     }
 }

--- a/src/Enums/ApiEndpoint.php
+++ b/src/Enums/ApiEndpoint.php
@@ -37,6 +37,6 @@ enum ApiEndpoint: string
 
     public static function getCases(): array
     {
-        return array_map(fn(self $case) => $case->value, ApiEndpoint::cases());
+        return array_map(fn(self $case): string => $case->value, ApiEndpoint::cases());
     }
 }

--- a/src/Enums/Language.php
+++ b/src/Enums/Language.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function array_map;
+
 enum Language: string
 {
     case Catalan = 'ca_ES';

--- a/src/Enums/PasswordComplexity.php
+++ b/src/Enums/PasswordComplexity.php
@@ -59,7 +59,7 @@ enum PasswordComplexity: int
     {
         $cases = self::cases();
         $values = array_column($cases, 'value');
-        $descriptions = array_map(function ($case) {
+        $descriptions = array_map(function (self $case) {
             return $case->toHuman();
         }, $cases);
 

--- a/src/Enums/PasswordComplexity.php
+++ b/src/Enums/PasswordComplexity.php
@@ -59,9 +59,10 @@ enum PasswordComplexity: int
     {
         $cases = self::cases();
         $values = array_column($cases, 'value');
-        $descriptions = array_map(function (self $case) {
-            return $case->toHuman();
-        }, $cases);
+        $descriptions = array_map(
+            fn(self $case): string => $case->toHuman(),
+            $cases
+        );
 
         return array_combine($values, $descriptions);
     }

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -73,7 +73,7 @@ abstract class AbstractImport implements ImportInterface
                 return;
             case EntityType::Experiments->value:
                 // check that we can import stuff in experiments of target user
-                if ($this->targetNumber !== (int) $this->Users->userData['userid'] && $this->Users->isAdminOf($this->targetNumber) === false) {
+                if ($this->targetNumber !== $this->Users->userData['userid'] && $this->Users->isAdminOf($this->targetNumber) === false) {
                     throw new IllegalActionException('User tried to import archive in experiments of a user but they are not admin of that user');
                 }
                 // set the Users object to the target user

--- a/src/Import/Csv.php
+++ b/src/Import/Csv.php
@@ -19,6 +19,7 @@ use Elabftw\Models\Experiments;
 use Elabftw\Models\Items;
 use League\Csv\Info as CsvInfo;
 use League\Csv\Reader;
+use PDO;
 
 /**
  * Import entries from a csv file.
@@ -77,10 +78,10 @@ class Csv extends AbstractImport
             if ($this->Entity instanceof Items) {
                 $req->bindParam(':canbook', $this->canread);
             }
-            $req->bindParam(':team', $this->Users->userData['team']);
+            $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
             $req->bindParam(':title', $row['title']);
             $req->bindParam(':body', $body);
-            $req->bindParam(':userid', $this->Users->userData['userid']);
+            $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
             $req->bindParam(':category', $this->targetNumber);
             $req->bindParam(':status', $status);
             $req->bindParam(':custom_id', $customId);

--- a/src/Make/AbstractMakeZip.php
+++ b/src/Make/AbstractMakeZip.php
@@ -95,7 +95,7 @@ abstract class AbstractMakeZip extends AbstractMake implements ZipMakerInterface
             $realNamesSoFar[] = $realName;
             // modify the real_name in place
             $file['real_name'] = $realName;
-            $storageFs = Storage::from((int) $file['storage'])->getStorage()->getFs();
+            $storageFs = Storage::from($file['storage'])->getStorage()->getFs();
 
             // make sure we have a hash
             if (empty($file['hash'])) {

--- a/src/Make/MakeBackupZip.php
+++ b/src/Make/MakeBackupZip.php
@@ -46,9 +46,9 @@ class MakeBackupZip extends AbstractMakeZip
         // loop on every user
         $usersArr = $this->Entity->Users->readFromQuery('');
         foreach ($usersArr as $user) {
-            $idArr = $this->Entity->getIdFromLastchange((int) $user['userid'], $this->period);
+            $idArr = $this->Entity->getIdFromLastchange($user['userid'], $this->period);
             foreach ($idArr as $id) {
-                $this->addToZip((int) $id, $user['fullname']);
+                $this->addToZip($id, $user['fullname']);
             }
         }
         $this->Zip->finish();

--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -36,7 +36,7 @@ class MakeEln extends MakeStreamZip
     // name of the folder containing everything
     private string $root;
 
-    public function __construct(protected ZipStream $Zip, AbstractEntity $entity, protected array $idArr)
+    public function __construct(ZipStream $Zip, AbstractEntity $entity, array $idArr)
     {
         parent::__construct(
             Zip: $Zip,
@@ -94,7 +94,7 @@ class MakeEln extends MakeStreamZip
         foreach ($this->idArr as $id) {
             $hasPart = array();
             try {
-                $this->Entity->setId((int) $id);
+                $this->Entity->setId($id);
             } catch (IllegalActionException $e) {
                 continue;
             }
@@ -121,7 +121,7 @@ class MakeEln extends MakeStreamZip
             }
 
             // JSON
-            $MakeJson = new MakeJson($this->Entity, array((int) $e['id']));
+            $MakeJson = new MakeJson($this->Entity, array($e['id']));
             $json = $MakeJson->getFileContent();
             $this->Zip->addFile($this->folder . '/' . $MakeJson->getFileName(), $json);
             $jsonAtId = './' . $currentDatasetFolder . '/' . $MakeJson->getFileName();

--- a/src/Make/MakePdf.php
+++ b/src/Make/MakePdf.php
@@ -139,7 +139,7 @@ class MakePdf extends AbstractMakePdf
     {
         $entriesCount = count($this->entityIdArr);
         foreach ($this->entityIdArr as $key => $id) {
-            $this->Entity->setId((int) $id);
+            $this->Entity->setId($id);
 
             try {
                 $permissions = $this->Entity->getPermissions();
@@ -209,7 +209,7 @@ class MakePdf extends AbstractMakePdf
 
         if ($locked) {
             // get info about the locker
-            $Locker = new Users((int) $this->Entity->entityData['lockedby']);
+            $Locker = new Users($this->Entity->entityData['lockedby']);
             $lockerName = $Locker->userData['fullname'];
 
             // separate the date and time
@@ -219,7 +219,7 @@ class MakePdf extends AbstractMakePdf
 
         // read the content of the thumbnail here to feed the template
         foreach ($this->Entity->entityData['uploads'] as $key => $upload) {
-            $storageFs = Storage::from((int) $upload['storage'])->getStorage()->getFs();
+            $storageFs = Storage::from($upload['storage'])->getStorage()->getFs();
             $thumbnail = $upload['long_name'] . '_th.jpg';
             // no need to filter on extension, just insert the thumbnail if it exists
             if ($storageFs->fileExists($thumbnail)) {
@@ -333,7 +333,7 @@ class MakePdf extends AbstractMakePdf
         }
 
         foreach ($uploadsArr as $upload) {
-            $storageFs = Storage::from((int) $upload['storage'])->getStorage()->getFs();
+            $storageFs = Storage::from($upload['storage'])->getStorage()->getFs();
             if ($storageFs->fileExists($upload['long_name']) && strtolower(Tools::getExt($upload['real_name'])) === 'pdf') {
                 // the real_name is used in case of error appending it
                 // the content is stored in a temporary file so it can be read with appendPdfs()

--- a/src/Make/MakeQrPdf.php
+++ b/src/Make/MakeQrPdf.php
@@ -69,7 +69,7 @@ class MakeQrPdf extends AbstractMakePdf
         $this->Entity->idFilter = Tools::getIdFilterSql($this->idArr);
         $entityArr = $this->Entity->readShow($DisplayParams, true);
         foreach ($entityArr as &$entity) {
-            $entity['url'] = $this->getUrl((int) $entity['id']);
+            $entity['url'] = $this->getUrl($entity['id']);
         }
         return $entityArr;
     }

--- a/src/Make/MakeReport.php
+++ b/src/Make/MakeReport.php
@@ -76,11 +76,11 @@ class MakeReport extends AbstractMakeCsv
     {
         $allUsers = $this->Teams->Users->readFromQuery('', includeArchived: true);
         foreach ($allUsers as $key => $user) {
-            $UsersHelper = new UsersHelper((int) $user['userid']);
+            $UsersHelper = new UsersHelper($user['userid']);
             // get the teams of user
             $teams = implode(',', $UsersHelper->getTeamsNameFromUserid());
             // get disk usage for all uploaded files
-            $diskUsage = $this->getDiskUsage((int) $user['userid']);
+            $diskUsage = $this->getDiskUsage($user['userid']);
 
             // remove unused columns as they will mess up the csv
             // these columns can be null

--- a/src/Make/MakeStreamZip.php
+++ b/src/Make/MakeStreamZip.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Elabftw\Make;
 
 use DateTimeImmutable;
-
 use Elabftw\Elabftw\App;
-
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Models\AbstractEntity;
 use League\Flysystem\UnableToReadFile;
-
 use ZipStream\ZipStream;
 
+use function array_walk;
 use function count;
 use function json_encode;
 
@@ -39,6 +37,9 @@ class MakeStreamZip extends AbstractMakeZip
             entity: $entity,
             includeChangelog: $includeChangelog
         );
+        array_walk($this->idArr, function (&$id) {
+            $id = (int) $id;
+        });
     }
 
     /**
@@ -47,7 +48,7 @@ class MakeStreamZip extends AbstractMakeZip
     public function getFileName(): string
     {
         if (count($this->idArr) === 1) {
-            $this->Entity->setId((int) $this->idArr[0]);
+            $this->Entity->setId($this->idArr[0]);
             $this->Entity->canOrExplode('read');
             return $this->getBaseFileName() . $this->extension;
         }

--- a/src/classes/AuthResponse.php
+++ b/src/classes/AuthResponse.php
@@ -56,7 +56,7 @@ class AuthResponse
         // if the user only has access to one team, use this one directly
         $teamCount = count($this->selectableTeams);
         if ($teamCount === 1) {
-            $this->selectedTeam = (int) $this->selectableTeams[0]['id'];
+            $this->selectedTeam = $this->selectableTeams[0]['id'];
         } elseif ($teamCount === 0) {
             $Users = new Users($this->userid);
             $this->teamSelectionRequired = true;

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -112,9 +112,10 @@ class DisplayParams
             // the HAVING COUNT is necessary to make an AND search between tags
             // Note: we cannot use a placeholder for the IN of the tags because we need the quotes
             $Db = Db::getConnection();
-            $inPlaceholders = implode(' , ', array_map(function ($key) {
-                return ":tag$key";
-            }, array_keys($tags)));
+            $inPlaceholders = implode(', ', array_map(
+                fn($key): string => ":tag$key",
+                array_keys($tags),
+            ));
             $sql = 'SELECT tags2entity.item_id FROM `tags2entity`
                 INNER JOIN (SELECT id FROM tags WHERE tags.tag IN ( ' . $inPlaceholders . ' )) tg ON tags2entity.tag_id = tg.id
                 WHERE tags2entity.item_type = :type GROUP BY item_id HAVING COUNT(DISTINCT tags2entity.tag_id) = :count';

--- a/src/classes/DisplayParams.php
+++ b/src/classes/DisplayParams.php
@@ -22,6 +22,7 @@ use Elabftw\Services\Check;
 use PDO;
 use Symfony\Component\HttpFoundation\Request;
 
+use function array_map;
 use function implode;
 use function sprintf;
 use function trim;
@@ -98,7 +99,7 @@ class DisplayParams
         // same with an extended search: we show all
         if ($scope === Scope::User->value && empty($this->Request->query->get('owner')) && empty($this->Request->query->get('extended'))) {
             // Note: the cast to int is necessary here (not sure why)
-            $this->appendFilterSql(FilterableColumn::Owner, (int) $this->Users->userData['userid']);
+            $this->appendFilterSql(FilterableColumn::Owner, $this->Users->userData['userid']);
         }
         if ($this->Users->userData['scope_' . $this->entityType->value] === Scope::Team->value) {
             $this->appendFilterSql(FilterableColumn::Team, $this->Users->team);
@@ -120,9 +121,9 @@ class DisplayParams
             $req = $Db->prepare($sql);
             // bind the tags in IN clause
             foreach ($tags as $key => $tag) {
-                $req->bindValue(":tag$key", $tag, PDO::PARAM_STR);
+                $req->bindValue(":tag$key", $tag);
             }
-            $req->bindValue(':type', $this->entityType->value, PDO::PARAM_STR);
+            $req->bindValue(':type', $this->entityType->value);
             $req->bindValue(':count', count($tags), PDO::PARAM_INT);
             $req->execute();
             $this->filterSql = Tools::getIdFilterSql($req->fetchAll(PDO::FETCH_COLUMN));

--- a/src/classes/EntitySqlBuilder.php
+++ b/src/classes/EntitySqlBuilder.php
@@ -368,7 +368,7 @@ class EntitySqlBuilder
      */
     private function canTeams(string $can): string
     {
-        $UsersHelper = new UsersHelper((int) $this->entity->Users->userData['userid']);
+        $UsersHelper = new UsersHelper($this->entity->Users->userData['userid']);
         $teamsOfUser = $UsersHelper->getTeamsIdFromUserid();
         if (!empty($teamsOfUser)) {
             // JSON_OVERLAPS checks for the intersection of two arrays

--- a/src/classes/IdpsHelper.php
+++ b/src/classes/IdpsHelper.php
@@ -76,7 +76,7 @@ class IdpsHelper
             'baseurl' => $this->Config->configArr['saml_baseurl'],
 
             // Save IdP id
-            'idp_id' => (int) $idp['id'],
+            'idp_id' => $idp['id'],
 
             // Service Provider Data that we are deploying
             'sp' => array(

--- a/src/classes/Metadata.php
+++ b/src/classes/Metadata.php
@@ -57,9 +57,10 @@ class Metadata
         }
         // sort the elements based on the position attribute. If not set, will be at the end.
         $extraFields = $this->metadata[MetadataEnum::ExtraFields->value];
-        uasort($extraFields, function (array $a, array $b): int {
-            return ($a['position'] ?? 9999) <=> ($b['position'] ?? 9999);
-        });
+        uasort(
+            $extraFields,
+            fn(array $a, array $b): int => ($a['position'] ?? 9999) <=> ($b['position'] ?? 9999),
+        );
         return $extraFields;
     }
 

--- a/src/classes/OrderingParams.php
+++ b/src/classes/OrderingParams.php
@@ -15,6 +15,8 @@ namespace Elabftw\Elabftw;
 use Elabftw\Enums\Orderable;
 use Elabftw\Exceptions\ImproperActionException;
 
+use function array_map;
+
 /**
  * Parameters passed for ordering stuff
  */
@@ -35,7 +37,7 @@ class OrderingParams
      */
     protected function cleanup(array $ordering): array
     {
-        return array_map(function ($el) {
+        return array_map(function (string $el) {
             return (int) explode('_', $el)[1];
         }, $ordering);
     }

--- a/src/classes/OrderingParams.php
+++ b/src/classes/OrderingParams.php
@@ -37,8 +37,9 @@ class OrderingParams
      */
     protected function cleanup(array $ordering): array
     {
-        return array_map(function (string $el) {
-            return (int) explode('_', $el)[1];
-        }, $ordering);
+        return array_map(
+            fn(string $el): int => (int) explode('_', $el)[1],
+            $ordering,
+        );
     }
 }

--- a/src/classes/Permissions.php
+++ b/src/classes/Permissions.php
@@ -83,21 +83,21 @@ class Permissions
                 return true;
             }
             // check if we have a team in common
-            if ($this->Teams->hasCommonTeamWithCurrent($this->item['userid'], (int) $this->Users->userData['team'])) {
+            if ($this->Teams->hasCommonTeamWithCurrent($this->item['userid'], $this->Users->userData['team'])) {
                 return true;
             }
         }
 
         // if the setting is 'user' (meaning user + admin(s)) check we are admin
         if ($can['base'] === BasePermissions::User->value) {
-            if ($this->Users->isAdmin && $this->Teams->hasCommonTeamWithCurrent($this->item['userid'], (int) $this->Users->userData['team'])) {
+            if ($this->Users->isAdmin && $this->Teams->hasCommonTeamWithCurrent($this->item['userid'], $this->Users->userData['team'])) {
                 return true;
             }
         }
 
         // check for teams
         if (!empty($can['teams'])) {
-            $UsersHelper = new UsersHelper((int) $this->Users->userData['userid']);
+            $UsersHelper = new UsersHelper($this->Users->userData['userid']);
             $teamsOfUser = $UsersHelper->getTeamsIdFromUserid();
             foreach ($can['teams'] as $team) {
                 if (in_array($team, $teamsOfUser, true)) {
@@ -109,19 +109,19 @@ class Permissions
         // check for teamgroups
         if (!empty($can['teamgroups'])) {
             foreach ($can['teamgroups'] as $teamgroup) {
-                if ($this->TeamGroups->isInTeamGroup((int) $this->Users->userData['userid'], (int) $teamgroup)) {
+                if ($this->TeamGroups->isInTeamGroup($this->Users->userData['userid'], (int) $teamgroup)) {
                     return true;
                 }
             }
         }
 
         // check for users
-        if (in_array((int) $this->Users->userData['userid'], $can['users'], true)) {
+        if (in_array($this->Users->userData['userid'], $can['users'], true)) {
             return true;
         }
 
         // if we own the entity, we have access on it for sure
-        if ($this->item['userid'] === (int) $this->Users->userData['userid']) {
+        if ($this->item['userid'] === $this->Users->userData['userid']) {
             return true;
         }
 
@@ -135,7 +135,7 @@ class Permissions
                 }
             } else { // experiment
                 $Owner = new Users($this->item['userid']);
-                if ($this->Teams->hasCommonTeamWithCurrent((int) $Owner->userData['userid'], (int) $this->Users->userData['team'])) {
+                if ($this->Teams->hasCommonTeamWithCurrent($Owner->userData['userid'], $this->Users->userData['team'])) {
                     return true;
                 }
             }
@@ -162,7 +162,7 @@ class Permissions
     {
         // locked entity cannot be written to
         // only the locker can unlock an entity
-        if ($this->item['locked'] && ($this->item['lockedby'] !== (int) $this->Users->userData['userid']) && !$this->Users->isAdmin) {
+        if ($this->item['locked'] && ($this->item['lockedby'] !== $this->Users->userData['userid']) && !$this->Users->isAdmin) {
             return false;
         }
         return $this->getCan($this->canwrite);

--- a/src/classes/Sql.php
+++ b/src/classes/Sql.php
@@ -95,8 +95,9 @@ class Sql
         $content = $this->filesystem->read($filename);
         $linesArr = explode(PHP_EOL, $content);
         // now filter out the uninteresting lines
-        return array_filter($linesArr, function ($v) {
-            return !empty($v) && !preg_match('/^\s*(?:--|#|\/\*(?!!).*\*\/)/', $v);
-        });
+        return array_filter(
+            $linesArr,
+            fn(string $v): bool => !empty($v) && !preg_match('/^\s*(?:--|#|\/\*(?!!).*\*\/)/', $v),
+        );
     }
 }

--- a/src/commands/ExportResources.php
+++ b/src/commands/ExportResources.php
@@ -48,7 +48,7 @@ class ExportResources extends Command
     {
         $categoryId = (int) $input->getArgument('category_id');
         $userid = (int) $input->getArgument('userid');
-        $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
+        $teamid = (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
         $absolutePath = $this->Fs->getPath(sprintf(
             'export-%s-category_id-%d.eln',
             date('Y-m-d_H-i-s'),

--- a/src/commands/ImportResources.php
+++ b/src/commands/ImportResources.php
@@ -52,7 +52,7 @@ class ImportResources extends Command
         $userid = (int) $input->getArgument('userid');
         $filePath = $this->Fs->getPath($input->getArgument('file'));
         $uploadedFile = new UploadedFile($filePath, 'input.eln', null, null, true);
-        $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
+        $teamid = (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
         $Eln = new Eln(new Users($userid, $teamid), sprintf('items:%d', $categoryId), BasePermissions::Team->toJson(), BasePermissions::User->toJson(), $uploadedFile, Storage::CACHE->getStorage()->getFs());
         $Eln->import();
 

--- a/src/commands/ImportUser.php
+++ b/src/commands/ImportUser.php
@@ -50,7 +50,7 @@ class ImportUser extends Command
         $userid = (int) $input->getArgument('userid');
         $filePath = $this->Fs->getPath((string) $input->getArgument('file'));
         $uploadedFile = new UploadedFile($filePath, 'input.eln', null, null, true);
-        $teamid = (int) (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
+        $teamid = (new UsersHelper($userid))->getTeamsFromUserid()[0]['id'];
         $Eln = new Eln(new Users($userid, $teamid), sprintf('experiments:%d', $userid), BasePermissions::User->toJson(), BasePermissions::User->toJson(), $uploadedFile, Storage::CACHE->getStorage()->getFs());
         $Eln->import();
 

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -242,7 +242,7 @@ abstract class AbstractEntityController implements ControllerInterface
         // last modifier name
         $lastModifierFullname = '';
         if ($this->Entity->entityData['lastchangeby'] !== null) {
-            $lastModifier = new Users((int) $this->Entity->entityData['lastchangeby']);
+            $lastModifier = new Users($this->Entity->entityData['lastchangeby']);
             $lastModifierFullname = $lastModifier->userData['fullname'];
         }
 

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -295,7 +295,7 @@ class LoginController implements ControllerInterface
                 // we are already authenticated
             case 'team':
                 return new Team(
-                    (int) $this->App->Session->get('auth_userid'),
+                    $this->App->Session->get('auth_userid'),
                     $this->App->Request->request->getInt('selected_team'),
                 );
 
@@ -303,7 +303,7 @@ class LoginController implements ControllerInterface
             case 'mfa':
                 return new Mfa(
                     new MfaHelper(
-                        (int) $this->App->Session->get('auth_userid'),
+                        $this->App->Session->get('auth_userid'),
                         $this->App->Session->get('mfa_secret'),
                     ),
                     $this->App->Request->request->getAlnum('mfa_code'),
@@ -361,9 +361,7 @@ class LoginController implements ControllerInterface
             return '/login.php';
         }
 
-        $userid = isset($this->App->Users->userData['userid'])
-            ? (int) $this->App->Users->userData['userid']
-            : $this->App->Session->get('auth_userid');
+        $userid = $this->App->Users->userData['userid'] ?? $this->App->Session->get('auth_userid');
         $MfaHelper = new MfaHelper($userid, $this->App->Session->get('mfa_secret'));
 
         // check the input code against the secret stored in session

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -48,6 +48,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use ZipStream\ZipStream;
 
+use function array_map;
 use function count;
 
 /**
@@ -152,7 +153,12 @@ class MakeController implements ControllerInterface
             }
             $this->idArr = $this->Entity->getIdFromUser($targetUserid);
         } elseif ($this->Request->query->has('id')) {
-            $this->idArr = explode(' ', $this->Request->query->getString('id'));
+            $this->idArr = array_map(
+                function (string $id) {
+                    return (int) $id;
+                },
+                explode(' ', $this->Request->query->getString('id')),
+            );
         }
         // generate audit log event if exporting more than $threshold entries
         $count = count($this->idArr);
@@ -185,7 +191,7 @@ class MakeController implements ControllerInterface
     {
         $log = (new Logger('elabftw'))->pushHandler(new ErrorLogHandler());
         if (count($this->idArr) === 1) {
-            $this->Entity->setId((int) $this->idArr[0]);
+            $this->Entity->setId($this->idArr[0]);
             return $this->getFileResponse(new MakePdf($log, $this->getMpdfProvider(), $this->Entity, array($this->Entity->id), $this->shouldIncludeChangelog()));
         }
         return $this->getFileResponse(new MakeMultiPdf($log, $this->getMpdfProvider(), $this->Entity, $this->idArr, $this->shouldIncludeChangelog()));
@@ -202,7 +208,7 @@ class MakeController implements ControllerInterface
         if (count($this->idArr) !== 1) {
             throw new ImproperActionException('QR PNG format is only suitable for one ID.');
         }
-        return $this->getFileResponse(new MakeQrPng(new MpdfQrProvider(), $this->Entity, (int) $this->idArr[0], $this->Request->query->getInt('size')));
+        return $this->getFileResponse(new MakeQrPng(new MpdfQrProvider(), $this->Entity, $this->idArr[0], $this->Request->query->getInt('size')));
     }
 
     private function makeReport(): Response

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -154,9 +154,7 @@ class MakeController implements ControllerInterface
             $this->idArr = $this->Entity->getIdFromUser($targetUserid);
         } elseif ($this->Request->query->has('id')) {
             $this->idArr = array_map(
-                function (string $id) {
-                    return (int) $id;
-                },
+                fn(string $id): int => (int) $id,
                 explode(' ', $this->Request->query->getString('id')),
             );
         }

--- a/src/models/AbstractCategory.php
+++ b/src/models/AbstractCategory.php
@@ -49,8 +49,8 @@ abstract class AbstractCategory implements RestInterface
     {
         $sql = sprintf('SELECT id FROM %s WHERE title = :title AND team = :team', $this->table);
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
-        $req->bindParam(':team', $this->Teams->id, PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
+        $req->bindParam(':team', $this->Teams->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         $res = $req->fetch(PDO::FETCH_COLUMN);
         if (!is_int($res)) {
@@ -67,12 +67,8 @@ abstract class AbstractCategory implements RestInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Teams->id, PDO::PARAM_INT);
         $this->Db->execute($req);
-        $status = $req->fetchColumn();
 
-        // if there is no is_default, null is fine
-        if (!$status) {
-            return null;
-        }
-        return (int) $status;
+        // if there is no default status, null is fine
+        return (int) $req->fetchColumn() ?: null;
     }
 }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -503,7 +503,7 @@ abstract class AbstractEntity implements RestInterface
         $req = $this->Db->prepare($sql);
         $req->bindValue(':statenormal', State::Normal->value, PDO::PARAM_INT);
         $req->bindValue(':statearchived', State::Archived->value, PDO::PARAM_INT);
-        $req->bindParam(':userid', $userid);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $req->execute();
 
         return array_column($req->fetchAll(), 'id');
@@ -717,7 +717,7 @@ abstract class AbstractEntity implements RestInterface
     private function bindExtendedValues(PDOStatement $req): void
     {
         foreach ($this->extendedValues as $bindValue) {
-            $req->bindValue($bindValue['param'], $bindValue['value'], $bindValue['type']);
+            $req->bindValue($bindValue['param'], $bindValue['value'], $bindValue['type'] ?? PDO::PARAM_STR);
         }
     }
 

--- a/src/models/AbstractStatus.php
+++ b/src/models/AbstractStatus.php
@@ -160,8 +160,8 @@ abstract class AbstractStatus extends AbstractCategory
         $sql = sprintf('INSERT INTO %s (title, color, team, is_default)
             VALUES(:title, :color, :team, :is_default)', $this->table);
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
-        $req->bindParam(':color', $color, PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
+        $req->bindParam(':color', $color);
         $req->bindParam(':team', $this->Teams->id, PDO::PARAM_INT);
         $req->bindParam(':is_default', $isDefault, PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -178,7 +178,7 @@ abstract class AbstractStatus extends AbstractCategory
 
         $sql = sprintf('UPDATE %s SET ' . $params->getColumn() . ' = :content WHERE id = :id', $this->table);
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':content', $params->getContent(), PDO::PARAM_STR);
+        $req->bindValue(':content', $params->getContent());
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }

--- a/src/models/AuditLogs.php
+++ b/src/models/AuditLogs.php
@@ -36,7 +36,7 @@ class AuditLogs
         $Db = Db::getConnection();
         $sql = 'INSERT INTO audit_logs(body, category, requester_userid, target_userid) VALUES(:body, :category, :requester, :target)';
         $req = $Db->prepare($sql);
-        $req->bindValue(':body', $event->getBody(), PDO::PARAM_STR);
+        $req->bindValue(':body', $event->getBody());
         $req->bindValue(':category', $event->getCategory()->value, PDO::PARAM_INT);
         $req->bindValue(':requester', $event->getRequesterUserid(), PDO::PARAM_INT);
         $req->bindValue(':target', $event->getTargetUserid(), PDO::PARAM_INT);

--- a/src/models/AuthFail.php
+++ b/src/models/AuthFail.php
@@ -81,7 +81,7 @@ class AuthFail
     {
         $sql = 'INSERT INTO lockout_devices (device_token) VALUES (:device_token)';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':device_token', $this->deviceToken, PDO::PARAM_STR);
+        $req->bindParam(':device_token', $this->deviceToken);
         return $req->execute();
     }
 
@@ -93,7 +93,7 @@ class AuthFail
         $sql = 'INSERT INTO authfail (users_id, device_token) VALUES (:users_id, :device_token)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':users_id', $this->userid, PDO::PARAM_INT);
-        $req->bindParam(':device_token', $this->deviceToken, PDO::PARAM_STR);
+        $req->bindParam(':device_token', $this->deviceToken);
         return $req->execute();
     }
 
@@ -104,7 +104,7 @@ class AuthFail
     {
         $sql = 'SELECT COUNT(id) FROM authfail WHERE device_token = :device_token AND attempt_time > (NOW() - INTERVAL 1 HOUR)';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':device_token', $this->deviceToken, PDO::PARAM_STR);
+        $req->bindParam(':device_token', $this->deviceToken);
         $req->execute();
         return (int) $req->fetchColumn();
     }

--- a/src/models/Changelog.php
+++ b/src/models/Changelog.php
@@ -48,8 +48,8 @@ class Changelog
         $req = $this->Db->prepare($sql);
         $req->bindParam(':entity_id', $this->entity->id, PDO::PARAM_INT);
         $req->bindParam(':users_id', $this->entity->Users->userData['userid'], PDO::PARAM_INT);
-        $req->bindValue(':target', $params->getTarget(), PDO::PARAM_STR);
-        $req->bindParam(':content', $content, PDO::PARAM_STR);
+        $req->bindValue(':target', $params->getTarget());
+        $req->bindParam(':content', $content);
         return $this->Db->execute($req);
     }
 

--- a/src/models/Comments.php
+++ b/src/models/Comments.php
@@ -92,7 +92,7 @@ class Comments implements RestInterface
             comment = :content
             WHERE id = :id AND userid = :userid AND item_id = :item_id';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':content', $params->getContent(), PDO::PARAM_STR);
+        $req->bindValue(':content', $params->getContent());
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
@@ -147,7 +147,7 @@ class Comments implements RestInterface
         }
 
         /** @psalm-suppress PossiblyNullArgument */
-        $Notif = new CommentCreated($this->Entity->page, $this->Entity->id, (int) $this->Entity->Users->userData['userid']);
+        $Notif = new CommentCreated($this->Entity->page, $this->Entity->id, $this->Entity->Users->userData['userid']);
         // target user is the owner of the entry
         $Notif->create($this->Entity->entityData['userid']);
     }

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -242,9 +242,7 @@ final class Config implements RestInterface
             $config['remote_dir_config'][0] = TwigFilters::decrypt($config['remote_dir_config'][0]);
         }
 
-        return array_map(function ($v): mixed {
-            return $v[0];
-        }, $config);
+        return array_map(fn($v): mixed => $v[0], $config);
     }
 
     /**

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -102,14 +102,14 @@ class Experiments extends AbstractConcreteEntity
             VALUES(:team, :title, CURDATE(), :body, :category, :status, :elabid, :canread, :canwrite, :metadata, :custom_id, :userid, :content_type)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
-        $req->bindParam(':body', $body, PDO::PARAM_STR);
-        $req->bindValue(':category', $category, PDO::PARAM_INT);
-        $req->bindValue(':status', $status, PDO::PARAM_INT);
-        $req->bindValue(':elabid', Tools::generateElabid(), PDO::PARAM_STR);
-        $req->bindParam(':canread', $canread, PDO::PARAM_STR);
-        $req->bindParam(':canwrite', $canwrite, PDO::PARAM_STR);
-        $req->bindParam(':metadata', $metadata, PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
+        $req->bindParam(':body', $body);
+        $req->bindValue(':category', $category);
+        $req->bindValue(':status', $status);
+        $req->bindValue(':elabid', Tools::generateElabid());
+        $req->bindParam(':canread', $canread);
+        $req->bindParam(':canwrite', $canwrite);
+        $req->bindParam(':metadata', $metadata);
         $req->bindParam(':custom_id', $customId, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':content_type', $contentType, PDO::PARAM_INT);
@@ -150,20 +150,20 @@ class Experiments extends AbstractConcreteEntity
         // handle the blank_value_on_duplicate attribute on extra fields
         $metadata = (new Metadata($this->entityData['metadata']))->blankExtraFieldsValueOnDuplicate();
         // figure out the custom id
-        $customId = $this->getNextCustomId((int) $this->entityData['category']);
+        $customId = $this->getNextCustomId($this->entityData['category']);
 
         $sql = 'INSERT INTO experiments(team, title, date, body, category, status, elabid, canread, canwrite, userid, metadata, custom_id, content_type)
             VALUES(:team, :title, CURDATE(), :body, :category, :status, :elabid, :canread, :canwrite, :userid, :metadata, :custom_id, :content_type)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
-        $req->bindParam(':body', $this->entityData['body'], PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
+        $req->bindParam(':body', $this->entityData['body']);
         $req->bindValue(':category', $this->entityData['category']);
         $req->bindValue(':status', $Status->getDefault(), PDO::PARAM_INT);
-        $req->bindValue(':elabid', Tools::generateElabid(), PDO::PARAM_STR);
-        $req->bindParam(':canread', $this->entityData['canread'], PDO::PARAM_STR);
-        $req->bindParam(':canwrite', $this->entityData['canwrite'], PDO::PARAM_STR);
-        $req->bindParam(':metadata', $metadata, PDO::PARAM_STR);
+        $req->bindValue(':elabid', Tools::generateElabid());
+        $req->bindParam(':canread', $this->entityData['canread']);
+        $req->bindParam(':canwrite', $this->entityData['canwrite']);
+        $req->bindParam(':metadata', $metadata);
         $req->bindParam(':custom_id', $customId, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':content_type', $this->entityData['content_type'], PDO::PARAM_INT);
@@ -190,18 +190,5 @@ class Experiments extends AbstractConcreteEntity
     {
         // delete from pinned too
         return parent::destroy() && $this->Pins->cleanup();
-    }
-
-    protected function getNextCustomId(int $category): ?int
-    {
-        $sql = 'SELECT custom_id FROM experiments WHERE custom_id IS NOT NULL AND category = :category ORDER BY custom_id DESC LIMIT 1';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':category', $category, PDO::PARAM_INT);
-        $this->Db->execute($req);
-        $res = $req->fetch();
-        if ($res === false || $res['custom_id'] === null) {
-            return null;
-        }
-        return ++$res['custom_id'];
     }
 }

--- a/src/models/ExtraFieldsKeys.php
+++ b/src/models/ExtraFieldsKeys.php
@@ -97,7 +97,7 @@ class ExtraFieldsKeys implements RestInterface
         );
 
         $req = $this->Db->prepare($finalSql);
-        $req->bindValue(':search_term', '%' . $this->searchTerm . '%', PDO::PARAM_STR);
+        $req->bindValue(':search_term', '%' . $this->searchTerm . '%');
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         if ($this->limit > 0) {
             $req->bindParam(':limit', $this->limit, PDO::PARAM_INT);

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -56,14 +56,14 @@ class Items extends AbstractConcreteEntity
             VALUES(:team, :title, CURDATE(), :status, :body, :userid, :category, :elabid, :canread, :canwrite, :canread, :metadata, :custom_id)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindValue(':title', _('Untitled'), PDO::PARAM_STR);
-        $req->bindParam(':status', $itemTemplate['status'], PDO::PARAM_STR);
-        $req->bindParam(':body', $itemTemplate['body'], PDO::PARAM_STR);
+        $req->bindValue(':title', _('Untitled'));
+        $req->bindParam(':status', $itemTemplate['status']);
+        $req->bindParam(':body', $itemTemplate['body']);
         $req->bindParam(':category', $template, PDO::PARAM_INT);
-        $req->bindValue(':elabid', Tools::generateElabid(), PDO::PARAM_STR);
-        $req->bindParam(':canread', $itemTemplate['canread_target'], PDO::PARAM_STR);
-        $req->bindParam(':canwrite', $itemTemplate['canwrite_target'], PDO::PARAM_STR);
-        $req->bindParam(':metadata', $itemTemplate['metadata'], PDO::PARAM_STR);
+        $req->bindValue(':elabid', Tools::generateElabid());
+        $req->bindParam(':canread', $itemTemplate['canread_target']);
+        $req->bindParam(':canwrite', $itemTemplate['canwrite_target']);
+        $req->bindParam(':metadata', $itemTemplate['metadata']);
         $req->bindParam(':custom_id', $customId, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -113,7 +113,7 @@ class Items extends AbstractConcreteEntity
         // handle the blank_value_on_duplicate attribute on extra fields
         $metadata = (new Metadata($this->entityData['metadata']))->blankExtraFieldsValueOnDuplicate();
         // figure out the custom id
-        $customId = $this->getNextCustomId((int) $this->entityData['category']);
+        $customId = $this->getNextCustomId($this->entityData['category']);
 
         $sql = 'INSERT INTO items(team, title, date, body, userid, canread, canwrite, canbook, category, elabid, metadata, custom_id, content_type)
             VALUES(:team, :title, CURDATE(), :body, :userid, :canread, :canwrite, :canbook, :category, :elabid, :metadata, :custom_id, :content_type)';
@@ -152,6 +152,7 @@ class Items extends AbstractConcreteEntity
     {
         parent::destroy();
 
+        // Todo: should this be remove from here as we do soft delete?
         // delete links of this item in experiments with this item linked
         $sql = 'DELETE FROM experiments_links WHERE link_id = :link_id';
         $req = $this->Db->prepare($sql);
@@ -165,19 +166,5 @@ class Items extends AbstractConcreteEntity
 
         // delete from pinned
         return $this->Pins->cleanup();
-    }
-
-    protected function getNextCustomId(int $category): ?int
-    {
-        $sql = 'SELECT custom_id FROM items WHERE custom_id IS NOT NULL AND team = :team AND category = :category ORDER BY custom_id DESC LIMIT 1';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindParam(':category', $category, PDO::PARAM_INT);
-        $this->Db->execute($req);
-        $res = $req->fetch();
-        if ($res === false || $res['custom_id'] === null) {
-            return null;
-        }
-        return ++$res['custom_id'];
     }
 }

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -50,12 +50,12 @@ class ItemsTypes extends AbstractTemplateEntity
         $title = Filter::title($title);
         $sql = 'INSERT INTO items_types(title, team, canread, canwrite, canread_target, canwrite_target) VALUES(:content, :team, :canread, :canwrite, :canread_target, :canwrite_target)';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':content', $title, PDO::PARAM_STR);
+        $req->bindValue(':content', $title);
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
-        $req->bindParam(':canread', $defaultPermissions, PDO::PARAM_STR);
-        $req->bindParam(':canwrite', $defaultPermissions, PDO::PARAM_STR);
-        $req->bindParam(':canread_target', $defaultPermissions, PDO::PARAM_STR);
-        $req->bindParam(':canwrite_target', $defaultPermissions, PDO::PARAM_STR);
+        $req->bindParam(':canread', $defaultPermissions);
+        $req->bindParam(':canwrite', $defaultPermissions);
+        $req->bindParam(':canread_target', $defaultPermissions);
+        $req->bindParam(':canwrite_target', $defaultPermissions);
         $this->Db->execute($req);
 
         return $this->Db->lastInsertId();
@@ -112,7 +112,7 @@ class ItemsTypes extends AbstractTemplateEntity
         $sql = 'SELECT id
             FROM items_types WHERE title = :title AND team = :team';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
         $this->Db->execute($req);
         $res = $req->fetch(PDO::FETCH_COLUMN);

--- a/src/models/Pins.php
+++ b/src/models/Pins.php
@@ -35,7 +35,7 @@ class Pins
     {
         $sql = 'SELECT entity_id FROM pin_' . $this->Entity->type . '2users WHERE entity_id = :entity_id AND users_id = :users_id';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':users_id', $this->Entity->Users->userData['userid']);
+        $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);
 
         $this->Db->execute($req);
@@ -61,7 +61,7 @@ class Pins
             $this->Entity->type
         );
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':users_id', $this->Entity->Users->userData['userid']);
+        $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
 
         $this->Db->execute($req);
 
@@ -77,7 +77,7 @@ class Pins
     {
         $sql = 'SELECT entity_id FROM pin_' . $this->Entity->type . '2users WHERE users_id = :users_id';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':users_id', $this->Entity->Users->userData['userid']);
+        $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
 
         $this->Db->execute($req);
 
@@ -107,7 +107,7 @@ class Pins
 
         $sql = 'DELETE FROM pin_' . $this->Entity->type . '2users WHERE entity_id = :entity_id AND users_id = :users_id';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':users_id', $this->Entity->Users->userData['userid']);
+        $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);
 
         return $this->Db->execute($req);
@@ -122,7 +122,7 @@ class Pins
 
         $sql = 'INSERT IGNORE INTO pin_' . $this->Entity->type . '2users(users_id, entity_id) VALUES (:users_id, :entity_id)';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':users_id', $this->Entity->Users->userData['userid']);
+        $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);
 
         return $this->Db->execute($req);

--- a/src/models/ProcurementRequests.php
+++ b/src/models/ProcurementRequests.php
@@ -95,7 +95,7 @@ class ProcurementRequests implements RestInterface
         $req->bindParam(':requester_userid', $this->Teams->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $reqBody['entity_id'], PDO::PARAM_INT);
         $req->bindParam(':qty_ordered', $reqBody['qty_ordered'], PDO::PARAM_INT);
-        $req->bindParam(':body', $reqBody['body'], PDO::PARAM_STR);
+        $req->bindParam(':body', $reqBody['body']);
         $req->bindParam(':quote', $reqBody['quote'], PDO::PARAM_INT);
         $req->bindValue(':state', ProcurementState::Pending->value, PDO::PARAM_INT);
         $this->Db->execute($req);

--- a/src/models/Scheduler.php
+++ b/src/models/Scheduler.php
@@ -25,6 +25,7 @@ use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\EntityTrait;
 use PDO;
 
+use function array_walk;
 use function preg_replace;
 use function strlen;
 use function substr;
@@ -222,12 +223,12 @@ class Scheduler implements RestInterface
         $TeamsHelper = new TeamsHelper($this->Items->Users->userData['team']);
         $Notif = new EventDeleted($this->readOne(), $this->Items->Users->userData['fullname']);
         $admins = $TeamsHelper->getAllAdminsUserid();
-        array_map(function ($userid) use ($Notif) {
+        array_walk($admins, function ($userid) use ($Notif) {
             if ($userid === $this->Items->Users->userData['userid']) {
                 return;
             }
             $Notif->create($userid);
-        }, $admins);
+        });
         return $this->Db->execute($req);
     }
 
@@ -379,7 +380,7 @@ class Scheduler implements RestInterface
         $sql = 'UPDATE team_events SET title = :title WHERE id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-        $req->bindParam(':title', $title, PDO::PARAM_STR);
+        $req->bindParam(':title', $title);
         return $this->Db->execute($req);
     }
 
@@ -448,8 +449,8 @@ class Scheduler implements RestInterface
             $sql .= ' AND id != :id';
         }
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':start', $start, PDO::PARAM_STR);
-        $req->bindParam(':end', $end, PDO::PARAM_STR);
+        $req->bindParam(':start', $start);
+        $req->bindParam(':end', $end);
         $req->bindParam(':item', $this->Items->id, PDO::PARAM_INT);
         if ($this->id !== null) {
             $req->bindParam(':id', $this->id, PDO::PARAM_INT);

--- a/src/models/SigKeys.php
+++ b/src/models/SigKeys.php
@@ -48,8 +48,8 @@ class SigKeys implements RestInterface
         $this->destroy();
         $sql = 'INSERT INTO sig_keys (pubkey, privkey, userid) VALUES (:pubkey, :privkey, :userid)';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':pubkey', $key->serializePk(), PDO::PARAM_STR);
-        $req->bindValue(':privkey', $key->serializeSk(), PDO::PARAM_STR);
+        $req->bindValue(':pubkey', $key->serializePk());
+        $req->bindValue(':privkey', $key->serializeSk());
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $res = $req->execute();
         $keyId = $this->Db->lastInsertId();

--- a/src/models/Steps.php
+++ b/src/models/Steps.php
@@ -109,7 +109,7 @@ class Steps implements RestInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':item_id', $newId, PDO::PARAM_INT);
         while ($steps = $stepreq->fetch()) {
-            $req->bindParam(':body', $steps['body'], PDO::PARAM_STR);
+            $req->bindParam(':body', $steps['body']);
             $req->bindParam(':ordering', $steps['ordering'], PDO::PARAM_INT);
             $this->Db->execute($req);
         }
@@ -165,7 +165,7 @@ class Steps implements RestInterface
     {
         $sql = 'UPDATE ' . $this->Entity->type . '_steps SET ' . $params->getColumn() . ' = :content WHERE id = :id AND item_id = :item_id';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':content', $params->getContent(), PDO::PARAM_STR);
+        $req->bindValue(':content', $params->getContent());
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
         return $this->Db->execute($req);

--- a/src/models/Tags.php
+++ b/src/models/Tags.php
@@ -125,14 +125,14 @@ class Tags implements RestInterface
         $req->bindValue(':tag', $params->getContent());
         $req->bindParam(':team', $this->Entity->Users->userData['team'], PDO::PARAM_INT);
         $this->Db->execute($req);
-        $tagId = (int) $req->fetchColumn();
+        $tagId = $req->fetchColumn();
 
         // tag doesn't exist already
-        if ($req->rowCount() === 0) {
+        if (!$tagId) {
             // check if we can actually create tags (for non-admins)
-            $Teams = new Teams($this->Entity->Users, (int) $this->Entity->Users->userData['team']);
+            $Teams = new Teams($this->Entity->Users, $this->Entity->Users->userData['team']);
             $teamConfigArr = $Teams->readOne();
-            $TeamsHelper = new TeamsHelper((int) $this->Entity->Users->userData['team']);
+            $TeamsHelper = new TeamsHelper($this->Entity->Users->userData['team']);
             if ($teamConfigArr['user_create_tag'] === 0 && $TeamsHelper->isAdminInTeam($this->Entity->Users->userData['userid']) === false) {
                 throw new ImproperActionException(_('Users cannot create tags.'));
             }

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -84,12 +84,10 @@ class TeamGroups implements RestInterface
                 'name' => $group['name'],
                 'users' => isset($group['userids'])
                     ? array_map(
-                        function (string $userid, ?string $fullname): array {
-                            return array(
-                                'userid' => (int) $userid,
-                                'fullname' => $fullname,
-                            );
-                        },
+                        fn(string $userid, ?string $fullname): array => array(
+                            'userid' => (int) $userid,
+                            'fullname' => $fullname,
+                        ),
                         explode(',', $group['userids']),
                         explode(',', $group['fullnames'])
                     )

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -16,6 +16,7 @@ use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\TeamGroupParams;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
+use Elabftw\Enums\EntityType;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\RestInterface;
@@ -165,19 +166,9 @@ class TeamGroups implements RestInterface
     public function destroy(): bool
     {
         $this->canWriteOrExplode();
-        // TODO add fk to do that
-        $sql = "UPDATE experiments SET canread = 'team', canwrite = 'user' WHERE canread = :id OR canwrite = :id";
-        $req = $this->Db->prepare($sql);
-        // note: setting PDO::PARAM_INT here will throw error because the column type is varchar
-        $req->bindParam(':id', $this->id, PDO::PARAM_STR);
-        $res1 = $this->Db->execute($req);
 
-        // same for items but canwrite is team
-        $sql = "UPDATE items SET canread = 'team', canwrite = 'team' WHERE canread = :id OR canwrite = :id";
-        $req = $this->Db->prepare($sql);
-        // note: setting PDO::PARAM_INT here will throw error because the column type is varchar
-        $req->bindParam(':id', $this->id, PDO::PARAM_STR);
-        $res2 = $this->Db->execute($req);
+        $res1 = $this->updateTeamgroupPermissionsOnDestroy(EntityType::Experiments->value);
+        $res2 = $this->updateTeamgroupPermissionsOnDestroy(EntityType::Items->value);
 
         $sql = 'DELETE FROM team_groups WHERE id = :id';
         $req = $this->Db->prepare($sql);
@@ -280,7 +271,7 @@ class TeamGroups implements RestInterface
     {
         $sql = 'UPDATE team_groups SET name = :name WHERE id = :id AND team = :team';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':name', $params->getContent(), PDO::PARAM_STR);
+        $req->bindValue(':name', $params->getContent());
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
 
@@ -317,5 +308,63 @@ class TeamGroups implements RestInterface
         if (!$this->Users->isAdmin) {
             throw new IllegalActionException(Tools::error(true));
         }
+    }
+
+    private function updateTeamgroupPermissionsOnDestroy(string $type): bool
+    {
+        // the complicated SQL could be avoided if we could use JSON_SEARCH with integers but it only works with strings :(
+        // https://bugs.mysql.com/bug.php?id=90085
+        // we need to do a detour and convert int to string to get the index of the element that we want to remove
+        // and we need to do it for canread and canwrite 🤯
+
+        $sql = 'UPDATE %1$s AS entity
+            -- canwrite join
+            INNER JOIN (
+                SELECT id,
+                    -- find position of value of interest and remove it
+                    JSON_REMOVE(entity.canwrite,
+                        JSON_UNQUOTE(JSON_SEARCH(JSON_OBJECT(
+                        "teamgroups",
+                            JSON_ARRAYAGG(t_write.canwrite_str)
+                        ), "one", :id))
+                    ) AS new
+                FROM %1$s AS entity
+                -- convert int to string
+                JOIN JSON_TABLE(
+                    entity.canwrite->"$.teamgroups",
+                    -- VARCHAR(10) can hold max int value
+                    "$[*]" COLUMNS (canwrite_str VARCHAR(10) PATH "$")
+                ) AS t_write
+                -- collapse json table
+                GROUP BY id
+            ) t_canwrite
+                ON (entity.id = t_canwrite.id)
+            -- canread join
+            INNER JOIN (
+                SELECT id,
+                    -- find position of value of interest and remove it
+                    JSON_REMOVE(entity.canread,
+                        JSON_UNQUOTE(JSON_SEARCH(JSON_OBJECT(
+                        "teamgroups",
+                            JSON_ARRAYAGG(t_read.canread_str)
+                        ), "one", :id))
+                    ) AS new
+                FROM %1$s as entity
+                -- convert int to string
+                JOIN JSON_TABLE(
+                    entity.canread->"$.teamgroups",
+                    -- VARCHAR(10) can hold max int value
+                    "$[*]" COLUMNS (canread_str VARCHAR(10) PATH "$")
+                ) AS t_read
+                -- collapse json table
+                GROUP BY id
+            ) t_canread
+                ON (entity.id = t_canread.id)
+            SET entity.canwrite = COALESCE(t_canwrite.new, entity.canwrite),
+                entity.canread = COALESCE(t_canread.new, entity.canread)';
+
+        $req = $this->Db->prepare(sprintf($sql, $type));
+        $req->bindValue(':id', $this->id);
+        return $this->Db->execute($req);
     }
 }

--- a/src/models/TeamTags.php
+++ b/src/models/TeamTags.php
@@ -57,7 +57,7 @@ class TeamTags implements RestInterface
         $sql = 'SELECT id FROM tags WHERE tag = :tag AND team = :team';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindValue(':tag', $tag, PDO::PARAM_STR);
+        $req->bindValue(':tag', $tag);
         $this->Db->execute($req);
         $res = $req->fetch();
         // insert the tag if it doesn't exist
@@ -65,7 +65,7 @@ class TeamTags implements RestInterface
             $sql = 'INSERT INTO tags (tag, team) VALUES(:tag, :team)';
             $req = $this->Db->prepare($sql);
             $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-            $req->bindValue(':tag', $tag, PDO::PARAM_STR);
+            $req->bindValue(':tag', $tag);
             $this->Db->execute($req);
             return $this->Db->lastInsertId();
         }
@@ -100,7 +100,7 @@ class TeamTags implements RestInterface
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindValue(':query', '%' . $query . '%', PDO::PARAM_STR);
+        $req->bindValue(':query', '%' . $query . '%');
         $this->Db->execute($req);
 
         return $req->fetchAll();
@@ -213,7 +213,7 @@ class TeamTags implements RestInterface
         $sql = 'UPDATE tags SET tag = :tag WHERE id = :id AND team = :team';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-        $req->bindValue(':tag', $params->getContent(), PDO::PARAM_STR);
+        $req->bindValue(':tag', $params->getContent());
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
 
         $this->Db->execute($req);

--- a/src/models/Teams.php
+++ b/src/models/Teams.php
@@ -47,7 +47,7 @@ class Teams implements RestInterface
     {
         $this->Db = Db::getConnection();
         if ($id === null && ($Users->userData['team'] ?? 0) !== 0) {
-            $id = (int) $Users->userData['team'];
+            $id = $Users->userData['team'];
         }
         $this->setId($id);
     }
@@ -257,7 +257,7 @@ class Teams implements RestInterface
         }
         $TeamsHelper = new TeamsHelper($this->id);
 
-        if ($TeamsHelper->isAdminInTeam((int) $this->Users->userData['userid'])) {
+        if ($TeamsHelper->isAdminInTeam($this->Users->userData['userid'])) {
             return;
         }
         throw new IllegalActionException('User tried to update a team setting but they are not admin of that team.');
@@ -326,7 +326,7 @@ class Teams implements RestInterface
         if ($this->Users->userData['is_sysadmin'] === 1) {
             return;
         }
-        if ($this->hasCommonTeamWithCurrent((int) $this->Users->userData['userid'], $this->id)) {
+        if ($this->hasCommonTeamWithCurrent($this->Users->userData['userid'], $this->id)) {
             return;
         }
         throw new IllegalActionException('User tried to read a team setting but they are not part of that team.');

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -113,9 +113,9 @@ class Templates extends AbstractTemplateEntity
 
         // copy links and steps too
         $ItemsLinks = new ItemsLinks($this);
-        $ItemsLinks->duplicate((int) $template['id'], $newId, true);
+        $ItemsLinks->duplicate($template['id'], $newId, true);
         $Steps = new Steps($this);
-        $Steps->duplicate((int) $template['id'], $newId, true);
+        $Steps->duplicate($template['id'], $newId, true);
 
         // now pin the newly created template so it directly appears in Create menu
         $this->setId($newId);
@@ -199,7 +199,7 @@ class Templates extends AbstractTemplateEntity
                     (JSON_EXTRACT(experiments_templates.canread, '$.base') = %d AND experiments_templates.userid = :userid) OR
                     (JSON_EXTRACT(experiments_templates.canread, '$.base') = %d AND experiments_templates.userid = :userid)", BasePermissions::Full->value, BasePermissions::Organization->value, BasePermissions::Team->value, BasePermissions::User->value, BasePermissions::UserOnly->value);
         // look for teams
-        $UsersHelper = new UsersHelper((int) $this->Users->userData['userid']);
+        $UsersHelper = new UsersHelper($this->Users->userData['userid']);
         $teamsOfUser = $UsersHelper->getTeamsIdFromUserid();
         foreach ($teamsOfUser as $team) {
             $sql .= sprintf(' OR (%d MEMBER OF (experiments_templates.canread->>"$.teams"))', $team);

--- a/src/models/UnfinishedSteps.php
+++ b/src/models/UnfinishedSteps.php
@@ -147,7 +147,7 @@ class UnfinishedSteps implements RestInterface
         );
 
         // look for teams
-        $UsersHelper = new UsersHelper((int) $this->Users->userData['userid']);
+        $UsersHelper = new UsersHelper($this->Users->userData['userid']);
         $teamsOfUser = $UsersHelper->getTeamsIdFromUserid();
         foreach ($teamsOfUser as $team) {
             $sql .= sprintf(

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -318,7 +318,7 @@ class Uploads implements RestInterface
     {
         $sql = 'SELECT storage FROM uploads WHERE long_name = :long_name LIMIT 1';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':long_name', $longname, PDO::PARAM_STR);
+        $req->bindParam(':long_name', $longname);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -272,9 +272,10 @@ class Users implements RestInterface
 
     public function readAllActiveFromTeam(): array
     {
-        return array_filter($this->readAllFromTeam(), function ($u) {
-            return $u['archived'] === 0;
-        });
+        return array_filter(
+            $this->readAllFromTeam(),
+            fn($u): bool => $u['archived'] === 0,
+        );
     }
 
     /**

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -70,8 +70,7 @@ class Users implements RestInterface
         if ($team !== null && $userid !== null) {
             $this->team = $team;
             $TeamsHelper = new TeamsHelper($team);
-            $permissions = $TeamsHelper->getPermissions($userid);
-            $this->isAdmin = (bool) $permissions['is_admin'];
+            $this->isAdmin = $TeamsHelper->isAdmin($userid);
         }
         if ($userid !== null) {
             $this->readOneFull();
@@ -100,7 +99,7 @@ class Users implements RestInterface
         // make sure that all the teams in which the user will be are created/exist
         // this might throw an exception if the team doesn't exist and we can't create it on the fly
         $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teams);
-        $TeamsHelper = new TeamsHelper((int) $teams[0]['id']);
+        $TeamsHelper = new TeamsHelper($teams[0]['id']);
 
         $EmailValidator = new EmailValidator($email, $Config->configArr['email_domain']);
         $EmailValidator->validate();
@@ -330,7 +329,7 @@ class Users implements RestInterface
             Usergroup::Admin->value,
         );
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':userid', $this->userData['userid']);
+        $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->rowCount() >= 1;
     }
@@ -355,8 +354,8 @@ class Users implements RestInterface
                     // need to be admin to "import" a user in a team
                     $team = (int) $params['team'];
                     $TeamsHelper = new TeamsHelper($team);
-                    $permissions = $TeamsHelper->getPermissions($this->requester->userData['userid']);
-                    if ($permissions['is_admin'] !== 1 && $this->requester->userData['is_sysadmin'] !== 1) {
+                    $isAdmin = $TeamsHelper->isAdmin($this->requester->userData['userid']);
+                    if ($isAdmin === false && $this->requester->userData['is_sysadmin'] !== 1) {
                         throw new IllegalActionException('Only Admin can add a user to a team (where they are Admin)');
                     }
                     $Users2Teams = new Users2Teams($this->requester);
@@ -499,24 +498,24 @@ class Users implements RestInterface
 
     protected static function search(string $column, string $term, bool $validated = false): self
     {
-        $searchColumn = 'email';
-        if ($column === 'orgid') {
-            $searchColumn = 'orgid';
-        }
-        $validatedFilter = '';
-        if ($validated) {
-            $validatedFilter = ' AND validated = 1 ';
-        }
         $Db = Db::getConnection();
-        $sql = sprintf('SELECT userid FROM users WHERE %s = :term AND archived = 0 %s LIMIT 1', $searchColumn, $validatedFilter);
+        $sql = sprintf(
+            'SELECT userid FROM users WHERE %s = :term AND archived = 0 %s LIMIT 1',
+            $column === 'orgid'
+                ? 'orgid'
+                : 'email',
+            $validated
+                ? 'AND validated = 1'
+                : '',
+        );
         $req = $Db->prepare($sql);
         $req->bindParam(':term', $term);
         $Db->execute($req);
-        $res = $req->fetchColumn();
-        if ($res === false) {
+        $res = (int) $req->fetchColumn();
+        if ($res === 0) {
             throw new ResourceNotFoundException();
         }
-        return new self((int) $res);
+        return new self($res);
     }
 
     private function disable2fa(): array
@@ -678,7 +677,7 @@ class Users implements RestInterface
             $Notifications = new UserNeedValidation($userid, $team);
         }
         foreach ($admins as $admin) {
-            $Notifications->create((int) $admin);
+            $Notifications->create($admin);
         }
     }
 

--- a/src/models/Users2Teams.php
+++ b/src/models/Users2Teams.php
@@ -88,7 +88,7 @@ class Users2Teams
     public function addUserToTeams(int $userid, array $teamIdArr, Usergroup $group = Usergroup::User): void
     {
         foreach ($teamIdArr as $teamId) {
-            $this->create($userid, (int) $teamId, $group);
+            $this->create($userid, $teamId, $group);
         }
     }
 
@@ -100,7 +100,7 @@ class Users2Teams
     public function rmUserFromTeams(int $userid, array $teamIdArr): void
     {
         foreach ($teamIdArr as $teamId) {
-            $this->destroy($userid, (int) $teamId);
+            $this->destroy($userid, $teamId);
         }
     }
 

--- a/src/models/notifications/AbstractNotifications.php
+++ b/src/models/notifications/AbstractNotifications.php
@@ -53,7 +53,7 @@ abstract class AbstractNotifications
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $req->bindValue(':category', $this->category->value, PDO::PARAM_INT);
         $req->bindParam(':send_email', $sendEmail, PDO::PARAM_INT);
-        $req->bindParam(':body', $jsonBody, PDO::PARAM_STR);
+        $req->bindParam(':body', $jsonBody);
         $req->bindParam(':is_ack', $isAck, PDO::PARAM_INT);
         $this->Db->execute($req);
 

--- a/src/models/notifications/UserNotifications.php
+++ b/src/models/notifications/UserNotifications.php
@@ -63,7 +63,7 @@ class UserNotifications implements RestInterface
         foreach ($notifs as $key => &$notif) {
             $notif['body'] = json_decode($notif['body'], true, 512, JSON_THROW_ON_ERROR);
             // remove the step deadline web notif if user doesn't want it shown
-            if ($this->users->userData['notif_step_deadline'] === 0 && ((int) $notif['category']) === Notifications::StepDeadline->value) {
+            if ($this->users->userData['notif_step_deadline'] === 0 && ($notif['category']) === Notifications::StepDeadline->value) {
                 unset($notifs[$key]);
             }
         }

--- a/src/services/AccessKeyHelper.php
+++ b/src/services/AccessKeyHelper.php
@@ -32,7 +32,7 @@ class AccessKeyHelper
     {
         $sql = 'SELECT id FROM ' . $this->entity->type . ' WHERE access_key = :ak';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':ak', $ak, PDO::PARAM_STR);
+        $req->bindParam(':ak', $ak);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }

--- a/src/services/CacheGenerator.php
+++ b/src/services/CacheGenerator.php
@@ -34,9 +34,9 @@ class CacheGenerator
         $TwigEnvironment = $this->getTwig(false);
         $tplFs = FsTools::getFs(dirname(__DIR__, 2) . '/src/templates');
         // iterate over all the templates
-        $templates = $tplFs->listContents('.')->filter(function (StorageAttributes $attributes) {
-            return $attributes->isFile();
-        });
+        $templates = $tplFs
+            ->listContents('.')
+            ->filter(fn(StorageAttributes $attributes): bool => $attributes->isFile());
 
         foreach ($templates as $template) {
             // force compilation of the template into cache php file

--- a/src/services/Check.php
+++ b/src/services/Check.php
@@ -103,7 +103,7 @@ class Check
             throw new ImproperActionException($visibility . ' The visibility parameter is wrong.');
         }
         // Note: if we want to server-side check for useronly disabled, it would be here, by removing 10
-        $allowedBase = array_map(fn(BasePermissions $case) => $case->value, BasePermissions::cases());
+        $allowedBase = array_map(fn(BasePermissions $case): int => $case->value, BasePermissions::cases());
         if (!in_array($decoded['base'], $allowedBase, true)) {
             throw new ImproperActionException('The base visibility parameter is wrong.');
         }

--- a/src/services/Check.php
+++ b/src/services/Check.php
@@ -19,6 +19,7 @@ use Elabftw\Models\Config;
 use Elabftw\Models\Users;
 use JsonException;
 
+use function array_map;
 use function filter_var;
 use function intval;
 use function mb_strlen;
@@ -102,7 +103,7 @@ class Check
             throw new ImproperActionException($visibility . ' The visibility parameter is wrong.');
         }
         // Note: if we want to server-side check for useronly disabled, it would be here, by removing 10
-        $allowedBase = array_map(fn($case) => $case->value, BasePermissions::cases());
+        $allowedBase = array_map(fn(BasePermissions $case) => $case->value, BasePermissions::cases());
         if (!in_array($decoded['base'], $allowedBase, true)) {
             throw new ImproperActionException('The base visibility parameter is wrong.');
         }

--- a/src/services/EmailNotifications.php
+++ b/src/services/EmailNotifications.php
@@ -46,10 +46,10 @@ class EmailNotifications
     {
         $toSend = $this->getNotificationsToSend();
         foreach ($toSend as $notif) {
-            $targetUser = new Users((int) $notif['userid']);
+            $targetUser = new Users($notif['userid']);
             $this->setLang($targetUser->userData['lang']);
             $to = new Address($targetUser->userData['email'], $targetUser->userData['fullname']);
-            $Factory = new NotificationsFactory((int) $notif['category'], $notif['body']);
+            $Factory = new NotificationsFactory($notif['category'], $notif['body']);
             $email = $Factory->getMailable()->getEmail();
             $cc = array_key_exists('cc', $email) ? $email['cc'] : null;
             $htmlBody = array_key_exists('htmlBody', $email) ? (string) $email['htmlBody'] : null;
@@ -61,9 +61,9 @@ class EmailNotifications
                 $htmlBody,
             );
             if ($isEmailSent) {
-                $this->setEmailSent((int) $notif['id']);
+                $this->setEmailSent($notif['id']);
                 if (Notifications::tryFrom($notif['category']) === Notifications::OnboardingEmail) {
-                    AuditLogs::create(new OnboardingEmailSent($email['team'], (int) $notif['userid'], $email['forAdmin']));
+                    AuditLogs::create(new OnboardingEmailSent($email['team'], $notif['userid'], $email['forAdmin']));
                 }
             }
         }

--- a/src/services/Populate.php
+++ b/src/services/Populate.php
@@ -197,7 +197,7 @@ class Populate
         $userid = $Teams->Users->createOne($email, array($user['team']), $firstname, $lastname, $passwordHash, null, true, false, null, $orgid);
         $team = $Teams->getTeamsFromIdOrNameOrOrgidArray(array($user['team']));
         $Requester = new Users(1, 1);
-        $Users = new Users($userid, (int) $team[0]['id'], $Requester);
+        $Users = new Users($userid, $team[0]['id'], $Requester);
 
         if ($user['is_sysadmin'] ?? false) {
             $Users->patch(Action::Update, array('is_sysadmin' => 1));

--- a/src/services/TeamFinder.php
+++ b/src/services/TeamFinder.php
@@ -14,7 +14,6 @@ namespace Elabftw\Services;
 
 use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\ImproperActionException;
-use PDO;
 
 /**
  * Find a team from an access_key
@@ -46,7 +45,7 @@ class TeamFinder
             CROSS JOIN users2teams ON (users2teams.users_id = entity.userid)
             WHERE entity.access_key = :ak';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':ak', $this->ak, PDO::PARAM_STR);
+        $req->bindParam(':ak', $this->ak);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }

--- a/src/services/UploadsChecker.php
+++ b/src/services/UploadsChecker.php
@@ -70,8 +70,8 @@ class UploadsChecker
             }
             $sql = 'UPDATE uploads SET hash = :hash, hash_algorithm = :hash_algorithm WHERE id = :id';
             $req = $this->Db->prepare($sql);
-            $req->bindParam(':hash', $hash, PDO::PARAM_STR);
-            $req->bindValue(':hash_algorithm', Uploads::HASH_ALGORITHM, PDO::PARAM_STR);
+            $req->bindParam(':hash', $hash);
+            $req->bindValue(':hash_algorithm', Uploads::HASH_ALGORITHM);
             $req->bindParam(':id', $upload['id'], PDO::PARAM_INT);
             $this->Db->execute($req);
             $fixedCount += 1;

--- a/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
+++ b/src/services/advancedSearchQuery/visitors/QueryBuilderVisitor.php
@@ -62,14 +62,12 @@ class QueryBuilderVisitor implements Visitor
         $bindValues[] = array(
             'param' => $param,
             'value' => '%' . $simpleValueWrapper->getValue() . '%',
-            'type' => PDO::PARAM_STR,
         );
         // body is stored as html after htmlPurifier worked on it
         // so '<', '>', '&' need to be converted to their htmlentities &lt;, &gt;, &amp;
         $bindValues[] = array(
             'param' => $paramBody,
             'value' => '%' . htmlspecialchars($simpleValueWrapper->getValue(), ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401) . '%',
-            'type' => PDO::PARAM_STR,
         );
         $bindValues[] = array(
             'param' => $paramCustomId,
@@ -106,14 +104,12 @@ class QueryBuilderVisitor implements Visitor
                     : '.' . json_encode($metadataField->getKey(), JSON_HEX_APOS | JSON_THROW_ON_ERROR),
                 MetadataEnum::Value->value,
             ),
-            'type' => PDO::PARAM_STR,
             'additional_columns' => $column,
         );
         // value
         $bindValues[] = array(
             'param' => $valueParam,
             'value' => $metadataField->getAffix() . $metadataField->getValue() . $metadataField->getAffix(),
-            'type' => PDO::PARAM_STR,
             'additional_columns' => $column,
         );
 
@@ -341,7 +337,7 @@ class QueryBuilderVisitor implements Visitor
         return ':' . bin2hex(random_bytes(5));
     }
 
-    private function getWhereCollector(string $sql, string $searchTerm, int $PdoParamConst): WhereCollector
+    private function getWhereCollector(string $sql, string $searchTerm, int $PdoParamConst = PDO::PARAM_STR): WhereCollector
     {
         $param = $this->getUniqueID();
         return new WhereCollector(
@@ -373,7 +369,6 @@ class QueryBuilderVisitor implements Visitor
             array(array(
                 'param' => $param,
                 'value' => $affix . $searchTerm . $affix,
-                'type' => PDO::PARAM_STR,
                 'searchAttachments' => true,
             )),
         );
@@ -384,7 +379,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             "CONCAT(users.firstname, ' ', users.lastname) LIKE ",
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 
@@ -393,7 +387,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             'entity.body LIKE ',
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 
@@ -402,7 +395,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             'categoryt.title LIKE ',
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 
@@ -420,7 +412,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             'entity.elabid LIKE ',
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 
@@ -480,7 +471,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             'statust.title LIKE ',
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 
@@ -498,7 +488,6 @@ class QueryBuilderVisitor implements Visitor
         return $this->getWhereCollector(
             'entity.title LIKE ',
             $affix . $searchTerm . $affix,
-            PDO::PARAM_STR,
         );
     }
 

--- a/src/traits/TwigTrait.php
+++ b/src/traits/TwigTrait.php
@@ -59,9 +59,7 @@ trait TwigTrait
         // |trans filter
         $transFilter = new TwigFilter(
             'trans',
-            function (array $context, string $string): string {
-                return Translation::transGetText($string, $context);
-            },
+            fn(array $context, string $string): string => Translation::transGetText($string, $context),
             array('needs_context' => true)
         );
         $toDatetimeFilter = new TwigFilter('toDatetime', '\Elabftw\Elabftw\TwigFunctions::toDatetime', $filterOptions);

--- a/tests/unit/Auth/CookieTest.php
+++ b/tests/unit/Auth/CookieTest.php
@@ -16,6 +16,7 @@ use Elabftw\Elabftw\AuthResponse;
 use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\UnauthorizedException;
+use PDO;
 
 class CookieTest extends \PHPUnit\Framework\TestCase
 {
@@ -39,7 +40,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         // create a token but 4 minutes in the past
         $req = $this->Db->prepare('UPDATE users SET token = :token, token_created_at = DATE_SUB(NOW(), INTERVAL 4 MINUTE) WHERE userid = :userid');
         $req->bindValue(':token', $this->CookieToken->getToken());
-        $req->bindParam(':userid', $this->userid);
+        $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $req->execute();
         // now try login but our cookie isn't valid anymore
         $this->expectException(UnauthorizedException::class);
@@ -68,7 +69,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         $CookieAuth = new Cookie(220330, 0, $this->CookieToken, 2);
         $req = $this->Db->prepare('UPDATE users SET token = :token WHERE userid = :userid');
         $req->bindValue(':token', $this->CookieToken->getToken());
-        $req->bindParam(':userid', $this->userid);
+        $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $req->execute();
         $this->expectException(UnauthorizedException::class);
         $CookieAuth->tryAuth();
@@ -80,7 +81,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         $req = $this->Db->prepare('UPDATE users SET token = :token, auth_service = :auth_service WHERE userid = :userid');
         $req->bindValue(':token', $this->CookieToken->getToken());
         $req->bindValue(':auth_service', LoginController::AUTH_LOCAL);
-        $req->bindParam(':userid', $this->userid);
+        $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $req->execute();
         $this->expectException(UnauthorizedException::class);
         $CookieAuth->tryAuth();

--- a/tests/unit/Auth/ExternalTest.php
+++ b/tests/unit/Auth/ExternalTest.php
@@ -58,7 +58,7 @@ class ExternalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $authResponse->userid);
         $this->assertFalse($authResponse->isAnonymous);
         $this->assertEquals(1, $authResponse->selectedTeam);
-        $teams = array(array('id' => '1', 'name' => 'Alpha', 'usergroup' => Usergroup::Admin->value, 'is_owner' => 0));
+        $teams = array(array('id' => 1, 'name' => 'Alpha', 'usergroup' => Usergroup::Admin->value, 'is_owner' => 0));
         $this->assertEquals($teams, $authResponse->selectableTeams);
     }
 

--- a/tests/unit/Enums/EnumsTest.php
+++ b/tests/unit/Enums/EnumsTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function array_map;
+
 class EnumsTest extends \PHPUnit\Framework\TestCase
 {
     public function testApiEndpoint(): void
@@ -20,7 +22,7 @@ class EnumsTest extends \PHPUnit\Framework\TestCase
 
     public function testEntrypoint(): void
     {
-        array_map(fn($case) => $this->assertStringEndsWith('.php', $case->toPage()), Entrypoint::cases());
+        array_map(fn(Entrypoint $case) => $this->assertStringEndsWith('.php', $case->toPage()), Entrypoint::cases());
     }
 
     public function testLanguage(): void

--- a/tests/unit/models/TagsTest.php
+++ b/tests/unit/models/TagsTest.php
@@ -44,7 +44,7 @@ class TagsTest extends \PHPUnit\Framework\TestCase
         $id = $Tags->postAction(Action::Create, array('tag' => 'tag2222'));
         $this->assertIsInt($id);
         // now with no rights
-        $Teams = new Teams($this->Users, (int) $this->Users->userData['team']);
+        $Teams = new Teams($this->Users, $this->Users->userData['team']);
         $Teams->patch(Action::Update, array('user_create_tag' => 0));
         $this->expectException(ImproperActionException::class);
         $Tags->postAction(Action::Create, array('tag' => 'tag2i222'));

--- a/web/admin.php
+++ b/web/admin.php
@@ -71,9 +71,10 @@ try {
     $teamsArr = $Teams->readAll();
     $allTeamUsersArr = $App->Users->readAllFromTeam();
     // only the unvalidated ones
-    $unvalidatedUsersArr = array_filter($allTeamUsersArr, function ($u) {
-        return $u['validated'] === 0;
-    });
+    $unvalidatedUsersArr = array_filter(
+        $allTeamUsersArr,
+        fn($u): bool => $u['validated'] === 0,
+    );
     // Users search
     $isSearching = false;
     $usersArr = array();

--- a/web/admin.php
+++ b/web/admin.php
@@ -86,7 +86,7 @@ try {
             $App->Request->query->getBoolean('onlyAdmins'),
         );
         foreach ($usersArr as &$user) {
-            $UsersHelper = new UsersHelper((int) $user['userid']);
+            $UsersHelper = new UsersHelper($user['userid']);
             $user['teams'] = $UsersHelper->getTeamsFromUserid();
         }
     }

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -86,7 +86,7 @@ try {
             $Entity = $model->Steps;
             break;
         case Orderable::Todolist:
-            $Entity = new Todolist((int) $App->Users->userData['userid']);
+            $Entity = new Todolist($App->Users->userData['userid']);
             break;
         case Orderable::ExperimentsTemplates:
             $Entity = new Templates($App->Users);

--- a/web/app/controllers/UcpController.php
+++ b/web/app/controllers/UcpController.php
@@ -49,7 +49,7 @@ try {
 
         // CHANGE PASSWORD (only for local accounts)
         if (!empty($App->Request->request->getString('password'))
-            && (int) $App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL
+            && $App->Users->userData['auth_service'] === LoginController::AUTH_LOCAL
         ) {
             $App->Users->patch(Action::UpdatePassword, $postData);
         }

--- a/web/app/logout.php
+++ b/web/app/logout.php
@@ -13,6 +13,7 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\AuditEvent\UserLogout;
 use Elabftw\Auth\Saml as SamlAuth;
+use Elabftw\Controllers\LoginController;
 use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Models\AuditLogs;
 use Elabftw\Models\AuthenticatedUser;
@@ -60,7 +61,7 @@ $destroySession = function () use ($App): void {
 };
 
 // now if we are logged in through external auth, hit the external auth url
-if ((int) ($App->Users->userData['auth_service'] ?? 0) === \Elabftw\Controllers\LoginController::AUTH_EXTERNAL) {
+if ((int) ($App->Users->userData['auth_service'] ?? 0) === LoginController::AUTH_EXTERNAL) {
     $redirectUrl = $App->Config->configArr['logout_url'];
     if (empty($redirectUrl)) {
         $redirectUrl = '/login.php';

--- a/web/login.php
+++ b/web/login.php
@@ -66,7 +66,7 @@ try {
             if ($App->Session->get('enforce_mfa')) {
                 $App->Users = new Users($App->Session->get('auth_userid'));
             }
-            $MfaHelper = new MfaHelper((int) $App->Users->userData['userid'], $App->Session->get('mfa_secret'));
+            $MfaHelper = new MfaHelper($App->Users->userData['userid'], $App->Session->get('mfa_secret'));
             $renderArr['mfaQRCodeImageDataUri'] = $MfaHelper->getQRCodeImageAsDataUri($App->Users->userData['email']);
             $renderArr['mfaSecret'] = implode(' ', str_split($App->Session->get('mfa_secret'), 4));
         }

--- a/web/search.php
+++ b/web/search.php
@@ -71,10 +71,9 @@ $renderArr = array(
 
 $responseContent = $App->render('search.html', $renderArr);
 
-$getFooterContent = function () use ($App): string {
-    return $App->render('todolist-panel.html', array())
-        . $App->render('footer.html', array());
-};
+$getFooterContent = fn(): string
+    => $App->render('todolist-panel.html', array())
+    . $App->render('footer.html', array());
 
 /**
  * Here the search begins

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -74,9 +74,10 @@ try {
         }
         // further filter if userid is present
         if ($App->Request->query->has('userid')) {
-            $usersArr = array_filter($usersArr, function ($u) use ($App) {
-                return $u['userid'] === $App->Request->query->getInt('userid');
-            });
+            $usersArr = array_filter(
+                $usersArr,
+                fn($u): bool => $u['userid'] === $App->Request->query->getInt('userid'),
+            );
         }
     }
 

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -30,6 +30,8 @@ use GuzzleHttp\Client;
 use PDO;
 use Symfony\Component\HttpFoundation\Response;
 
+use function array_walk;
+
 /**
  * Administrate elabftw install
  *
@@ -67,7 +69,7 @@ try {
             $App->Request->query->getBoolean('onlyAdmins'),
         );
         foreach ($usersArr as &$user) {
-            $UsersHelper = new UsersHelper((int) $user['userid']);
+            $UsersHelper = new UsersHelper($user['userid']);
             $user['teams'] = $UsersHelper->getTeamsFromUserid();
         }
         // further filter if userid is present
@@ -121,7 +123,7 @@ try {
 
     $elabimgVersion = getenv('ELABIMG_VERSION') ?: 'Not in Docker';
     $auditLogsArr = AuditLogs::read($App->Request->query->getInt('limit', AuditLogs::DEFAULT_LIMIT), $App->Request->query->getInt('offset'));
-    array_walk($auditLogsArr, function (&$event) {
+    array_walk($auditLogsArr, function (array &$event) {
         $event['category'] = AuditCategory::from($event['category'])->name;
     });
     $passwordComplexity = PasswordComplexity::from((int) $App->Config->configArr['password_complexity_requirement']);

--- a/web/team.php
+++ b/web/team.php
@@ -66,7 +66,7 @@ try {
         'teamArr' => $Teams->readOne(),
         'teamGroupsArr' => $TeamGroups->readAll(),
         'teamProcurementRequestsArr' => $ProcurementRequests->readAll(),
-        'teamsStats' => $Teams->getStats((int) $App->Users->userData['team']),
+        'teamsStats' => $Teams->getStats($App->Users->userData['team']),
     );
 
     $Response->setContent($App->render($template, $renderArr));

--- a/web/team.php
+++ b/web/team.php
@@ -52,9 +52,10 @@ try {
     $bookableItemsArr = $Items->readBookable();
     $categoriesOfBookableItems = array_column($bookableItemsArr, 'category');
     $allItemsTypes = $ItemsTypes->readAll();
-    $bookableItemsTypes = array_filter($allItemsTypes, function ($a) use ($categoriesOfBookableItems) {
-        return in_array($a['id'], $categoriesOfBookableItems, true);
-    });
+    $bookableItemsTypes = array_filter(
+        $allItemsTypes,
+        fn($a): bool => in_array($a['id'], $categoriesOfBookableItems, true),
+    );
 
     $ProcurementRequests = new ProcurementRequests($Teams);
 


### PR DESCRIPTION
We had some trouble with ids being of type `string` although they should have been of type `int` when loaded from the db.
It turns out that it is due to [`bindParam()`](https://www.php.net/manual/en/pdostatement.bindparam.php) and the wrong data type.

By default the data type is set to `PDO::PARAM_STR` so if we forget to add `PDO::PARAM_INT` while binding `userid` it will be cast to type `string` and propagate throughout the app.

To avoid such problems in the future I suggest we never add `PDO::PARAM_STR` unless we need to explicitly convert an `int` to a `string` and than only use `bindValue()` to avoid propagation of the changed type throughout the app.

On the other hand, we always have to use `PDO::PARAM_INT` when we bind a variable of type `int` to avoid the conversion to type `string`.

In addition...
* some anonymous functions are converted to arrow functions
* a few more types are added
* a few more use statements are added
* `getNextCustomId()` from `Items.php` and `Experiments.php` is combined into `AbstractConcreteEntity.php`
* fix TeamGroups canread and canwrite values upon removal of a teamgroup
* remove and replace deprecated `getGroupInTeam()` method