### PR TITLE
combine reloadElement and reloadElements

### DIFF
--- a/src/ts/JsonEditorHelper.class.ts
+++ b/src/ts/JsonEditorHelper.class.ts
@@ -173,7 +173,7 @@ export default class JsonEditorHelper {
     };
     this.api.post(`${this.entity.type}/${this.entity.id}/${Model.Upload}`, params).then(resp => {
       const location = resp.headers.get('location').split('/');
-      reloadElements('uploadsDiv');
+      reloadElements(['uploadsDiv']);
       this.currentUploadId = String(location[location.length - 1]);
     });
   }

--- a/src/ts/JsonEditorHelper.class.ts
+++ b/src/ts/JsonEditorHelper.class.ts
@@ -9,7 +9,7 @@ import { Metadata } from './Metadata.class';
 import JSONEditor from 'jsoneditor';
 import $ from 'jquery';
 import i18next from 'i18next';
-import { notif, notifSaved, reloadElement } from './misc';
+import { notif, notifSaved, reloadElements } from './misc';
 import { Action, Entity, Model } from './interfaces';
 import { Api } from './Apiv2.class';
 import { ValidMetadata } from './metadataInterfaces';
@@ -173,7 +173,7 @@ export default class JsonEditorHelper {
     };
     this.api.post(`${this.entity.type}/${this.entity.id}/${Model.Upload}`, params).then(resp => {
       const location = resp.headers.get('location').split('/');
-      reloadElement('uploadsDiv');
+      reloadElements('uploadsDiv');
       this.currentUploadId = String(location[location.length - 1]);
     });
   }

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { notif, notifError, reloadElement, TomSelect, updateCatStat } from './misc';
+import { notif, notifError, reloadElements, TomSelect, updateCatStat } from './misc';
 import $ from 'jquery';
 import { Malle } from '@deltablot/malle';
 import i18next from 'i18next';
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="create-teamgroup"]')) {
       const input = (document.getElementById('teamGroupCreate') as HTMLInputElement);
       ApiC.post(`${Model.Team}/current/${Model.TeamGroup}`, {'name': input.value}).then(() => {
-        reloadElement('team_groups_div');
+        reloadElements('team_groups_div');
         input.value = '';
       });
     // ADD USER TO TEAM GROUP
@@ -118,7 +118,10 @@ document.addEventListener('DOMContentLoaded', () => {
         notifError(new Error('Use the autocompletion menu to add users.'));
         return;
       }
-      ApiC.patch(`${Model.Team}/current/${Model.TeamGroup}/${el.dataset.groupid}`, {'how': Action.Add, 'userid': user}).then(() => reloadElement('team_groups_div'));
+      ApiC.patch(
+        `${Model.Team}/current/${Model.TeamGroup}/${el.dataset.groupid}`,
+        {'how': Action.Add, 'userid': user},
+      ).then(() => reloadElements('team_groups_div'));
     // RM USER FROM TEAM GROUP
     } else if (el.matches('[data-action="rmuser-teamgroup"]')) {
       ApiC.patch(`${Model.Team}/current/${Model.TeamGroup}/${el.dataset.groupid}`, {'how': Action.Unreference, 'userid': el.dataset.userid})
@@ -147,7 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // assign a new random color
         colorInput.value = getRandomColor();
         // display newly added entry
-        reloadElement(`${el.dataset.target}Div`);
+        reloadElements(`${el.dataset.target}Div`);
       });
     // UPDATE STATUSLIKE
     } else if (el.matches('[data-action="update-status"]')) {
@@ -185,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       ApiC.post(`${Model.TeamTags}`, {'tag': tagInput.value}).then(() => {
         tagInput.value = '';
-        reloadElement('tagMgrDiv');
+        reloadElements('tagMgrDiv');
       });
     } else if (el.matches('[data-action="patch-team-common-template"]')) {
       const params = {};
@@ -208,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     } else if (el.matches('[data-action="open-onboarding-email-modal"]')) {
       // reload the modal in case the users of the team have changed
-      reloadElement('sendOnboardingEmailModal')
+      reloadElements('sendOnboardingEmailModal')
         .then(() => $('#sendOnboardingEmailModal').modal('toggle'))
         .then(() => new TomSelect('#sendOnboardingEmailToUsers', {
           plugins: ['dropdown_input', 'no_active_items', 'remove_button'],

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="create-teamgroup"]')) {
       const input = (document.getElementById('teamGroupCreate') as HTMLInputElement);
       ApiC.post(`${Model.Team}/current/${Model.TeamGroup}`, {'name': input.value}).then(() => {
-        reloadElements('team_groups_div');
+        reloadElements(['team_groups_div']);
         input.value = '';
       });
     // ADD USER TO TEAM GROUP
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ApiC.patch(
         `${Model.Team}/current/${Model.TeamGroup}/${el.dataset.groupid}`,
         {'how': Action.Add, 'userid': user},
-      ).then(() => reloadElements('team_groups_div'));
+      ).then(() => reloadElements(['team_groups_div']));
     // RM USER FROM TEAM GROUP
     } else if (el.matches('[data-action="rmuser-teamgroup"]')) {
       ApiC.patch(`${Model.Team}/current/${Model.TeamGroup}/${el.dataset.groupid}`, {'how': Action.Unreference, 'userid': el.dataset.userid})
@@ -150,7 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // assign a new random color
         colorInput.value = getRandomColor();
         // display newly added entry
-        reloadElements(`${el.dataset.target}Div`);
+        reloadElements([`${el.dataset.target}Div`]);
       });
     // UPDATE STATUSLIKE
     } else if (el.matches('[data-action="update-status"]')) {
@@ -188,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       ApiC.post(`${Model.TeamTags}`, {'tag': tagInput.value}).then(() => {
         tagInput.value = '';
-        reloadElements('tagMgrDiv');
+        reloadElements(['tagMgrDiv']);
       });
     } else if (el.matches('[data-action="patch-team-common-template"]')) {
       const params = {};
@@ -211,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     } else if (el.matches('[data-action="open-onboarding-email-modal"]')) {
       // reload the modal in case the users of the team have changed
-      reloadElements('sendOnboardingEmailModal')
+      reloadElements(['sendOnboardingEmailModal'])
         .then(() => $('#sendOnboardingEmailModal').modal('toggle'))
         .then(() => new TomSelect('#sendOnboardingEmailToUsers', {
           plugins: ['dropdown_input', 'no_active_items', 'remove_button'],

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -293,7 +293,7 @@ document.addEventListener('DOMContentLoaded', () => {
         $('#policiesModal').modal('toggle');
       });
     } else if (el.matches('[data-reload-on-click]')) {
-      reloadElements(el.dataset.reloadOnClick).then(() => relativeMoment());
+      reloadElements([el.dataset.reloadOnClick]).then(() => relativeMoment());
 
     } else if (el.matches('[data-action="add-query-filter"]')) {
       const params = new URLSearchParams(document.location.search.substring(1));
@@ -420,10 +420,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // create a new key and delete the old one
         params[paramKey] = params[el.dataset.rw];
         delete params[el.dataset.rw];
-        ApiC.patch(`${Model.User}/me`, params).then(() => reloadElements(el.dataset.identifier + 'Div'));
+        ApiC.patch(`${Model.User}/me`, params).then(() => reloadElements([el.dataset.identifier + 'Div']));
       } else {
         const entity = getEntity();
-        ApiC.patch(`${entity.type}/${entity.id}`, params).then(() => reloadElements(el.dataset.identifier + 'Div'));
+        ApiC.patch(`${entity.type}/${entity.id}`, params).then(() => reloadElements([el.dataset.identifier + 'Div']));
       }
 
     } else if (el.matches('[data-action="select-lang"]')) {
@@ -509,7 +509,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (el.dataset.href) {
             window.location.href = el.dataset.href;
           } else {
-            reloadElements('navbarNotifDiv');
+            reloadElements(['navbarNotifDiv']);
           }
         });
       } else {
@@ -520,7 +520,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // DESTROY (clear all) NOTIF
     } else if (el.matches('[data-action="destroy-notif"]')) {
-      ApiC.delete(`${Model.User}/me/${Model.Notification}`).then(() => reloadElements('navbarNotifDiv'));
+      ApiC.delete(`${Model.User}/me/${Model.Notification}`).then(() => reloadElements(['navbarNotifDiv']));
 
     } else if (el.matches('[data-action="export-user"]')) {
       let source: string;

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -19,7 +19,7 @@ import {
   notifError,
   permissionsToJson,
   relativeMoment,
-  reloadElement,
+  reloadElements,
   replaceWithTitle,
   togglePlusIcon,
   TomSelect,
@@ -293,7 +293,7 @@ document.addEventListener('DOMContentLoaded', () => {
         $('#policiesModal').modal('toggle');
       });
     } else if (el.matches('[data-reload-on-click]')) {
-      reloadElement(el.dataset.reloadOnClick).then(() => relativeMoment());
+      reloadElements(el.dataset.reloadOnClick).then(() => relativeMoment());
 
     } else if (el.matches('[data-action="add-query-filter"]')) {
       const params = new URLSearchParams(document.location.search.substring(1));
@@ -420,10 +420,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // create a new key and delete the old one
         params[paramKey] = params[el.dataset.rw];
         delete params[el.dataset.rw];
-        ApiC.patch(`${Model.User}/me`, params).then(() => reloadElement(el.dataset.identifier + 'Div'));
+        ApiC.patch(`${Model.User}/me`, params).then(() => reloadElements(el.dataset.identifier + 'Div'));
       } else {
         const entity = getEntity();
-        ApiC.patch(`${entity.type}/${entity.id}`, params).then(() => reloadElement(el.dataset.identifier + 'Div'));
+        ApiC.patch(`${entity.type}/${entity.id}`, params).then(() => reloadElements(el.dataset.identifier + 'Div'));
       }
 
     } else if (el.matches('[data-action="select-lang"]')) {
@@ -509,7 +509,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (el.dataset.href) {
             window.location.href = el.dataset.href;
           } else {
-            reloadElement('navbarNotifDiv');
+            reloadElements('navbarNotifDiv');
           }
         });
       } else {
@@ -520,7 +520,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // DESTROY (clear all) NOTIF
     } else if (el.matches('[data-action="destroy-notif"]')) {
-      ApiC.delete(`${Model.User}/me/${Model.Notification}`).then(() => reloadElement('navbarNotifDiv'));
+      ApiC.delete(`${Model.User}/me/${Model.Notification}`).then(() => reloadElements('navbarNotifDiv'));
 
     } else if (el.matches('[data-action="export-user"]')) {
       let source: string;

--- a/src/ts/doodle.ts
+++ b/src/ts/doodle.ts
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'real_name': realName,
       'content': image,
     };
-    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
+    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadElements(['uploadsDiv']));
   });
 
 

--- a/src/ts/doodle.ts
+++ b/src/ts/doodle.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { reloadElement } from './misc';
+import { reloadElements } from './misc';
 import i18next from 'i18next';
 import { Action, Model } from './interfaces';
 import { Api } from './Apiv2.class';
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'real_name': realName,
       'content': image,
     };
-    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadElement('uploadsDiv'));
+    ApiC.post(`${elDataset.type}/${elDataset.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
   });
 
 

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getEntity, notif, updateCatStat, escapeRegExp, notifError, reloadElement, updateEntityBody } from './misc';
+import { getEntity, notif, updateCatStat, escapeRegExp, notifError, reloadElements, updateEntityBody } from './misc';
 import { getTinymceBaseConfig } from './tinymce';
 import { EntityType, Target, Upload, Model, Action } from './interfaces';
 import './doodle';
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'real_name': realName,
         'content': content,
       };
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElement('uploadsDiv'));
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
 
     // ANNOTATE IMAGE
     } else if (el.matches('[data-action="annotate-image"]')) {
@@ -333,7 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
               resolve(`app/download.php?f=${json.long_name}&storage=${json.storage}`);
               // save here because using the old real_name will not return anything from the db (status is archived now)
               updateEntityBody();
-              reloadElement('uploadsDiv');
+              reloadElements('uploadsDiv');
             });
           });
         } else {
@@ -432,7 +432,7 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         body: formData,
       }).then(resp => {
-        reloadElement('uploadsDiv');
+        reloadElements('uploadsDiv');
         // return early if longName is not found in body
         if ((editorCurrentContent.indexOf(searchPrefixSrc + formElement.dataset.longName) === -1)
           && (editorCurrentContent.indexOf(searchPrefixMd + formElement.dataset.longName) === -1)

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'real_name': realName,
         'content': content,
       };
-      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
+      ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params).then(() => reloadElements(['uploadsDiv']));
 
     // ANNOTATE IMAGE
     } else if (el.matches('[data-action="annotate-image"]')) {
@@ -333,7 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
               resolve(`app/download.php?f=${json.long_name}&storage=${json.storage}`);
               // save here because using the old real_name will not return anything from the db (status is archived now)
               updateEntityBody();
-              reloadElements('uploadsDiv');
+              reloadElements(['uploadsDiv']);
             });
           });
         } else {
@@ -432,7 +432,7 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         body: formData,
       }).then(resp => {
-        reloadElements('uploadsDiv');
+        reloadElements(['uploadsDiv']);
         // return early if longName is not found in body
         if ((editorCurrentContent.indexOf(searchPrefixSrc + formElement.dataset.longName) === -1)
           && (editorCurrentContent.indexOf(searchPrefixMd + formElement.dataset.longName) === -1)

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
         el.closest('div.form-group').querySelectorAll('input').forEach(input => {
           input.value = '';
         });
-        reloadElements('editUsersBox');
+        reloadElements(['editUsersBox']);
       });
 
     // CREATE USER(s) FROM REMOTE DIRECTORY
@@ -54,20 +54,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // UPDATE USER
     } else if (el.matches('[data-action="update-user"]')) {
-      ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElements('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElements(['editUsersBox']));
 
     // REMOVE 2FA
     } else if (el.matches('[data-action="remove-user-2fa"]')) {
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Disable2fa}).then(() => reloadElements('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Disable2fa}).then(() => reloadElements(['editUsersBox']));
 
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
       const group = el.dataset.promote === '1' ? 2 : 4;
-      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElements('editUsersBox'));
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElements(['editUsersBox']));
 
     // ADD TO TEAM
     } else if (el.matches('[data-action="add-user-to-team"]')) {
-      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {'action': Action.Add, 'team': el.dataset.team}).then(() => reloadElements('editUsersBox'));
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {'action': Action.Add, 'team': el.dataset.team}).then(() => reloadElements(['editUsersBox']));
 
     // ARCHIVE USER TOGGLE
     } else if (el.matches('[data-action="toggle-archive-user"]')) {
@@ -75,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (document.getElementById(`lockSwitch_${el.dataset.userid}`)) {
         lockExp = (document.getElementById(`lockSwitch_${el.dataset.userid}`) as HTMLInputElement).checked;
       }
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElements('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElements(['editUsersBox']));
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import i18next from 'i18next';
-import { collectForm, reloadElement } from './misc';
+import { collectForm, reloadElements } from './misc';
 import { InputType, Malle } from '@deltablot/malle';
 import { Api } from './Apiv2.class';
 import { Action, Model } from './interfaces';
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
         el.closest('div.form-group').querySelectorAll('input').forEach(input => {
           input.value = '';
         });
-        reloadElement('editUsersBox');
+        reloadElements('editUsersBox');
       });
 
     // CREATE USER(s) FROM REMOTE DIRECTORY
@@ -54,20 +54,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // UPDATE USER
     } else if (el.matches('[data-action="update-user"]')) {
-      ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, collectForm(el.closest('div.form-group'))).then(() => reloadElements('editUsersBox'));
 
     // REMOVE 2FA
     } else if (el.matches('[data-action="remove-user-2fa"]')) {
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Disable2fa}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Disable2fa}).then(() => reloadElements('editUsersBox'));
 
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
       const group = el.dataset.promote === '1' ? 2 : 4;
-      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: el.dataset.userid}).then(() => reloadElements('editUsersBox'));
 
     // ADD TO TEAM
     } else if (el.matches('[data-action="add-user-to-team"]')) {
-      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {'action': Action.Add, 'team': el.dataset.team}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`${Model.User}/${el.dataset.userid}`, {'action': Action.Add, 'team': el.dataset.team}).then(() => reloadElements('editUsersBox'));
 
     // ARCHIVE USER TOGGLE
     } else if (el.matches('[data-action="toggle-archive-user"]')) {
@@ -75,11 +75,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if (document.getElementById(`lockSwitch_${el.dataset.userid}`)) {
         lockExp = (document.getElementById(`lockSwitch_${el.dataset.userid}`) as HTMLInputElement).checked;
       }
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElements('editUsersBox'));
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Validate}).then(() => reloadElement('unvalidatedUsersBox')).then(() => reloadElement('editUsersBox'));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Validate}).then(() => reloadElements(['unvalidatedUsersBox', 'editUsersBox']));
     // SET PASSWORD (from sysadmin page)
     } else if (el.matches('[data-action="reset-user-password"]')) {
       const password = (document.getElementById(`resetUserPasswordInput_${el.dataset.userid}`) as HTMLInputElement).value;
@@ -89,12 +89,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // DESTROY USER
     } else if (el.matches('[data-action="destroy-user"]')) {
       if (confirm('Are you sure you want to remove permanently this user and all associated data?')) {
-        ApiC.delete(`users/${el.dataset.userid}`).then(() => {
-          reloadElement('editUsersBox');
-          if (document.getElementById('unvalidatedUsersBox')) {
-            reloadElement('unvalidatedUsersBox');
-          }
-        });
+        ApiC.delete(`users/${el.dataset.userid}`)
+          .then(() => reloadElements(['editUsersBox', 'unvalidatedUsersBox']));
       }
     }
   });

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -90,7 +90,7 @@ function triggerHandler(event: Event, el: HTMLInputElement): void {
           if (toreload === 'reloadEntitiesShow') {
             reloadEntitiesShow();
           } else {
-            reloadElement(toreload).then(() => relativeMoment());
+            reloadElements(toreload).then(() => relativeMoment());
           }
         });
       }
@@ -295,20 +295,30 @@ export async function reloadEntitiesShow(tag = ''): Promise<void | Response> {
   listenTrigger();
 }
 
-export async function reloadElement(elementId: string): Promise<void> {
-  if (!document.getElementById(elementId)) {
-    console.error(`Could not find element with id ${elementId} to reload!`);
+export async function reloadElements(elementIds: string[]|string): Promise<void> {
+  const elementExists = (elementId: string): boolean => {
+    if (!document.getElementById(elementId)) {
+      console.error(`Could not find element with id ${elementId} to reload!`);
+      return false;
+    }
+    return true;
+  };
+
+  if (typeof elementIds === 'string') {
+    elementIds = [elementIds];
+  }
+
+  elementIds = elementIds.filter(elementExists);
+  if (elementIds.length === 0) {
     return;
   }
+
   const html = await fetchCurrentPage();
-  document.getElementById(elementId).innerHTML = html.getElementById(elementId).innerHTML;
-
+  elementIds.forEach(elementId => {
+    document.getElementById(elementId).innerHTML = html.getElementById(elementId).innerHTML;
+    listenTrigger(elementId);
+  });
   (new TableSorting()).init();
-  listenTrigger(elementId);
-}
-
-export async function reloadElements(elementIds: string[]): Promise<void> {
-  elementIds.forEach(id => reloadElement(id));
 }
 
 /**
@@ -601,7 +611,7 @@ export async function updateEntityBody(): Promise<void> {
     const lastSavedAt = document.getElementById('lastSavedAt');
     if (lastSavedAt) {
       lastSavedAt.title = json.modified_at;
-      reloadElement('lastSavedAt').then(() => relativeMoment());
+      reloadElements('lastSavedAt').then(() => relativeMoment());
     }
   }).catch(() => {
     // detect if the session timedout (Session expired error is thrown)

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -296,19 +296,16 @@ export async function reloadEntitiesShow(tag = ''): Promise<void | Response> {
 }
 
 export async function reloadElements(elementIds: string[]|string): Promise<void> {
-  const elementExists = (elementId: string): boolean => {
+  elementIds = Array.isArray(elementIds) ? elementIds : [elementIds];
+
+  elementIds = elementIds.filter((elementId: string): boolean => {
     if (!document.getElementById(elementId)) {
       console.error(`Could not find element with id ${elementId} to reload!`);
       return false;
     }
     return true;
-  };
+  });
 
-  if (typeof elementIds === 'string') {
-    elementIds = [elementIds];
-  }
-
-  elementIds = elementIds.filter(elementExists);
   if (elementIds.length === 0) {
     return;
   }

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -90,7 +90,7 @@ function triggerHandler(event: Event, el: HTMLInputElement): void {
           if (toreload === 'reloadEntitiesShow') {
             reloadEntitiesShow();
           } else {
-            reloadElements(toreload).then(() => relativeMoment());
+            reloadElements([toreload]).then(() => relativeMoment());
           }
         });
       }
@@ -295,9 +295,7 @@ export async function reloadEntitiesShow(tag = ''): Promise<void | Response> {
   listenTrigger();
 }
 
-export async function reloadElements(elementIds: string[]|string): Promise<void> {
-  elementIds = Array.isArray(elementIds) ? elementIds : [elementIds];
-
+export async function reloadElements(elementIds: string[]): Promise<void> {
   elementIds = elementIds.filter((elementId: string): boolean => {
     if (!document.getElementById(elementId)) {
       console.error(`Could not find element with id ${elementId} to reload!`);
@@ -608,7 +606,7 @@ export async function updateEntityBody(): Promise<void> {
     const lastSavedAt = document.getElementById('lastSavedAt');
     if (lastSavedAt) {
       lastSavedAt.title = json.modified_at;
-      reloadElements('lastSavedAt').then(() => relativeMoment());
+      reloadElements(['lastSavedAt']).then(() => relativeMoment());
     }
   }).catch(() => {
     // detect if the session timedout (Session expired error is thrown)

--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -16,7 +16,7 @@ declare global {
 import '@teselagen/ove';
 import '@teselagen/ove/style.css';
 import { anyToJson } from '@teselagen/bio-parsers';
-import { notif, reloadElement } from './misc';
+import { notif, reloadElements } from './misc';
 import { Action, Model } from './interfaces';
 import { Api } from './Apiv2.class';
 
@@ -49,7 +49,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
           'real_name': realName + '.png',
           'content': reader.result,
         };
-        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadElement('uploadsDiv'));
+        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
       };
     }
 
@@ -132,7 +132,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
         generatePng: true,
         handleFullscreenClose: function(): void { // event could be used as parameter
           editor[viewerID].close();
-          reloadElement('uploadsDiv');
+          reloadElements('uploadsDiv');
         },
         onCopy: function(event, copiedSequenceData, editorState): void {
           // the copiedSequenceData is the subset of the sequence that has been copied in the teselagen sequence format

--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -49,7 +49,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
           'real_name': realName + '.png',
           'content': reader.result,
         };
-        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadElements('uploadsDiv'));
+        ApiC.post(`${about.type}/${about.id}/${Model.Upload}`, params).then(() => reloadElements(['uploadsDiv']));
       };
     }
 
@@ -132,7 +132,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
         generatePng: true,
         handleFullscreenClose: function(): void { // event could be used as parameter
           editor[viewerID].close();
-          reloadElements('uploadsDiv');
+          reloadElements(['uploadsDiv']);
         },
         onCopy: function(event, copiedSequenceData, editorState): void {
           // the copiedSequenceData is the subset of the sequence that has been copied in the teselagen sequence format

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -253,7 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // remove a favtag
     } else if (el.matches('[data-action="destroy-favtags"]')) {
-      FavTagC.destroy(parseInt(el.dataset.id, 10)).then(() => reloadElements('favtagsTagsDiv'));
+      FavTagC.destroy(parseInt(el.dataset.id, 10)).then(() => reloadElements(['favtagsTagsDiv']));
 
     // SORT COLUMN IN TABULAR MODE
     } else if (el.matches('[data-action="reorder-entities"]')) {

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -10,7 +10,7 @@ import {
   getEntity,
   notif,
   permissionsToJson,
-  reloadElement,
+  reloadElements,
   reloadEntitiesShow,
   TomSelect,
 } from './misc';
@@ -253,7 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // remove a favtag
     } else if (el.matches('[data-action="destroy-favtags"]')) {
-      FavTagC.destroy(parseInt(el.dataset.id, 10)).then(() => reloadElement('favtagsTagsDiv'));
+      FavTagC.destroy(parseInt(el.dataset.id, 10)).then(() => reloadElements('favtagsTagsDiv'));
 
     // SORT COLUMN IN TABULAR MODE
     } else if (el.matches('[data-action="reorder-entities"]')) {

--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -34,18 +34,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="step-update-deadline"]')) {
       const value = (document.getElementById('stepSelectDeadline_' + el.dataset.stepid) as HTMLSelectElement).value;
       StepC.update(parseInt(el.dataset.stepid, 10), value, Target.Deadline).then(() => {
-        reloadElements('stepsDiv');
+        reloadElements(['stepsDiv']);
       });
     // ADD STEP
     } else if (el.matches('[data-action="create-step"]')) {
       createStep(el.parentElement.parentElement.querySelector('input'));
     // TOGGLE DEADLINE NOTIFICATIONS ON STEP
     } else if (el.matches('[data-action="step-toggle-deadline-notif"]')) {
-      StepC.notif(parseInt(el.dataset.stepid, 10)).then(() => reloadElements('stepsDiv'));
+      StepC.notif(parseInt(el.dataset.stepid, 10)).then(() => reloadElements(['stepsDiv']));
     // DESTROY DEADLINE ON STEP
     } else if (el.matches('[data-action="step-destroy-deadline"]')) {
       StepC.update(parseInt(el.dataset.stepid, 10), null, Target.Deadline)
-        .then(() => reloadElements('stepsDiv'));
+        .then(() => reloadElements(['stepsDiv']));
     // IMPORT LINK(S) OF LINK
     } else if (el.matches('[data-action="import-links"]')) {
       Promise.allSettled(['items_links', 'experiments_links'].map(endpoint => ApiC.post(`${entity.type}/${entity.id}/${endpoint}/${el.dataset.target}`, {'action': Action.Duplicate}))).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const content = input.value;
     if (content.length > 0) {
       StepC.create(content).then(() => {
-        reloadElements('stepsDiv').then(() => {
+        reloadElements(['stepsDiv']).then(() => {
           // clear input field
           input.value = '';
           input.focus();
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const stepId = e.currentTarget.dataset.stepid;
     const StepNew = new Step(newentity);
     StepNew.finish(stepId).then(() => {
-      reloadElements('stepsDiv').then(() => {
+      reloadElements(['stepsDiv']).then(() => {
         // keep to do list in sync
         $('#todo_step_' + stepId).prop('checked', $('.stepbox[data-stepid="' + stepId + '"]').prop('checked'));
       });

--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -10,7 +10,7 @@ import 'jquery-ui/ui/widgets/autocomplete';
 import { Malle } from '@deltablot/malle';
 import Step from './Step.class';
 import i18next from 'i18next';
-import { relativeMoment, makeSortableGreatAgain, reloadElement, reloadElements, addAutocompleteToLinkInputs, getCheckedBoxes, notif, getEntity, adjustHiddenState } from './misc';
+import { relativeMoment, makeSortableGreatAgain, reloadElements, addAutocompleteToLinkInputs, getCheckedBoxes, notif, getEntity, adjustHiddenState } from './misc';
 import { Action, Target } from './interfaces';
 import { Api } from './Apiv2.class';
 
@@ -34,18 +34,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="step-update-deadline"]')) {
       const value = (document.getElementById('stepSelectDeadline_' + el.dataset.stepid) as HTMLSelectElement).value;
       StepC.update(parseInt(el.dataset.stepid, 10), value, Target.Deadline).then(() => {
-        reloadElement('stepsDiv');
+        reloadElements('stepsDiv');
       });
     // ADD STEP
     } else if (el.matches('[data-action="create-step"]')) {
       createStep(el.parentElement.parentElement.querySelector('input'));
     // TOGGLE DEADLINE NOTIFICATIONS ON STEP
     } else if (el.matches('[data-action="step-toggle-deadline-notif"]')) {
-      StepC.notif(parseInt(el.dataset.stepid, 10)).then(() => reloadElement('stepsDiv'));
+      StepC.notif(parseInt(el.dataset.stepid, 10)).then(() => reloadElements('stepsDiv'));
     // DESTROY DEADLINE ON STEP
     } else if (el.matches('[data-action="step-destroy-deadline"]')) {
       StepC.update(parseInt(el.dataset.stepid, 10), null, Target.Deadline)
-        .then(() => reloadElement('stepsDiv'));
+        .then(() => reloadElements('stepsDiv'));
     // IMPORT LINK(S) OF LINK
     } else if (el.matches('[data-action="import-links"]')) {
       Promise.allSettled(['items_links', 'experiments_links'].map(endpoint => ApiC.post(`${entity.type}/${entity.id}/${endpoint}/${el.dataset.target}`, {'action': Action.Duplicate}))).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const content = input.value;
     if (content.length > 0) {
       StepC.create(content).then(() => {
-        reloadElement('stepsDiv').then(() => {
+        reloadElements('stepsDiv').then(() => {
           // clear input field
           input.value = '';
           input.focus();
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const stepId = e.currentTarget.dataset.stepid;
     const StepNew = new Step(newentity);
     StepNew.finish(stepId).then(() => {
-      reloadElement('stepsDiv').then(() => {
+      reloadElements('stepsDiv').then(() => {
         // keep to do list in sync
         $('#todo_step_' + stepId).prop('checked', $('.stepbox[data-stepid="' + stepId + '"]').prop('checked'));
       });

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
       AjaxC.postForm('app/controllers/SysconfigAjaxController.php', { [el.dataset.action]: '1' })
         .then(res => res.json().then(json => {
           if (json.res) {
-            reloadElements('bruteforceDiv');
+            reloadElements(['bruteforceDiv']);
           }
           notif(json);
         }));
@@ -140,14 +140,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       const userid = parseInt(el.dataset.userid, 10);
       ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team})
-        .then(() => reloadElements(`manageUsers2teamsModal_${userid}`));
+        .then(() => reloadElements([`manageUsers2teamsModal_${userid}`]));
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         const userid = parseInt(el.dataset.userid, 10);
         const team = parseInt(el.dataset.teamid, 10);
         ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team})
-          .then(() => reloadElements(`manageUsers2teamsModal_${userid}`));
+          .then(() => reloadElements([`manageUsers2teamsModal_${userid}`]));
       }
     // MODIFY USER GROUP IN TEAM
     } else if (el.matches('[data-action="patch-user2team-group"]')) {
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: team, target: 'group', content: group, userid: userid});
     // DESTROY ts_password
     } else if (el.matches('[data-action="destroy-ts-password"]')) {
-      ApiC.patch(Model.Config, {'ts_password': ''}).then(() => reloadElements('ts_loginpass'));
+      ApiC.patch(Model.Config, {'ts_password': ''}).then(() => reloadElements(['ts_loginpass']));
     // PATCH ANNOUNCEMENT - save or clear
     } else if (el.matches('[data-action="patch-announcement"]')) {
       const input = (document.getElementById(el.dataset.inputid) as HTMLInputElement);
@@ -175,7 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = {};
       params[key] = null;
       ApiC.patch(Model.Config, params)
-        .then(() => reloadElements(el.dataset.reload));
+        .then(() => reloadElements([el.dataset.reload]));
     // PATCH POLICY - save or clear
     } else if (el.matches('[data-action="patch-policy"]')) {
       let content = tinymce.get(el.dataset.textarea).getContent();
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = collectForm(document.getElementById('createIdpForm'));
       ApiC.post(Model.Idp, params).then(() => {
         $('#createIdpModal').modal('hide');
-        reloadElements('idpsDiv');
+        reloadElements(['idpsDiv']);
       });
     } else if (el.matches('[data-action="destroy-idp"]')) {
       event.preventDefault();
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
         AjaxC.postForm('app/controllers/SysconfigAjaxController.php', {
           idpsDestroy: '1',
           id: el.dataset.id,
-        }).then(() => reloadElements('idpsDiv'));
+        }).then(() => reloadElements(['idpsDiv']));
       }
       // PATCH ONBOARDING EMAIL USERS
     } else if (el.matches('[data-action="patch-onboarding-email"]')) {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { collectForm, notif, notifError, reloadElement, reloadElements, removeEmpty } from './misc';
+import { collectForm, notif, notifError, reloadElements, removeEmpty } from './misc';
 import { Action, Model } from './interfaces';
 import i18next from 'i18next';
 import tinymce from 'tinymce/tinymce';
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
       AjaxC.postForm('app/controllers/SysconfigAjaxController.php', { [el.dataset.action]: '1' })
         .then(res => res.json().then(json => {
           if (json.res) {
-            reloadElement('bruteforceDiv');
+            reloadElements('bruteforceDiv');
           }
           notif(json);
         }));
@@ -139,13 +139,15 @@ document.addEventListener('DOMContentLoaded', () => {
       const selectEl = (el.previousElementSibling as HTMLSelectElement);
       const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       const userid = parseInt(el.dataset.userid, 10);
-      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team}).then(() => reloadElement(`manageUsers2teamsModal_${userid}`));
+      ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Add, 'team': team})
+        .then(() => reloadElements(`manageUsers2teamsModal_${userid}`));
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         const userid = parseInt(el.dataset.userid, 10);
         const team = parseInt(el.dataset.teamid, 10);
-        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team}).then(() => reloadElement(`manageUsers2teamsModal_${userid}`));
+        ApiC.patch(`${Model.User}/${userid}`, {'action': Action.Unreference, 'team': team})
+          .then(() => reloadElements(`manageUsers2teamsModal_${userid}`));
       }
     // MODIFY USER GROUP IN TEAM
     } else if (el.matches('[data-action="patch-user2team-group"]')) {
@@ -158,7 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: team, target: 'group', content: group, userid: userid});
     // DESTROY ts_password
     } else if (el.matches('[data-action="destroy-ts-password"]')) {
-      ApiC.patch(Model.Config, {'ts_password': ''}).then(() => reloadElement('ts_loginpass'));
+      ApiC.patch(Model.Config, {'ts_password': ''}).then(() => reloadElements('ts_loginpass'));
     // PATCH ANNOUNCEMENT - save or clear
     } else if (el.matches('[data-action="patch-announcement"]')) {
       const input = (document.getElementById(el.dataset.inputid) as HTMLInputElement);
@@ -172,9 +174,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const key = `${el.dataset.target}_password`;
       const params = {};
       params[key] = null;
-      ApiC.patch(Model.Config, params).then(() => {
-        reloadElement(el.dataset.reload);
-      });
+      ApiC.patch(Model.Config, params)
+        .then(() => reloadElements(el.dataset.reload));
     // PATCH POLICY - save or clear
     } else if (el.matches('[data-action="patch-policy"]')) {
       let content = tinymce.get(el.dataset.textarea).getContent();
@@ -209,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = collectForm(document.getElementById('createIdpForm'));
       ApiC.post(Model.Idp, params).then(() => {
         $('#createIdpModal').modal('hide');
-        reloadElement('idpsDiv');
+        reloadElements('idpsDiv');
       });
     } else if (el.matches('[data-action="destroy-idp"]')) {
       event.preventDefault();
@@ -217,7 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
         AjaxC.postForm('app/controllers/SysconfigAjaxController.php', {
           idpsDestroy: '1',
           id: el.dataset.id,
-        }).then(() => reloadElement('idpsDiv'));
+        }).then(() => reloadElements('idpsDiv'));
       }
       // PATCH ONBOARDING EMAIL USERS
     } else if (el.matches('[data-action="patch-onboarding-email"]')) {

--- a/src/ts/tags.ts
+++ b/src/ts/tags.ts
@@ -9,7 +9,7 @@ import 'jquery-ui/ui/widgets/autocomplete';
 import { Malle } from '@deltablot/malle';
 import FavTag from './FavTag.class';
 import i18next from 'i18next';
-import { addAutocompleteToTagInputs, getCheckedBoxes, notif, reloadEntitiesShow, getEntity, reloadElement, reloadElements } from './misc';
+import { addAutocompleteToTagInputs, getCheckedBoxes, notif, reloadEntitiesShow, getEntity, reloadElements } from './misc';
 import { Action, Model } from './interfaces';
 import { Api } from './Apiv2.class';
 
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     (new FavTag()).create(el.value).then(() => {
-      reloadElement('favtagsTagsDiv');
+      reloadElements('favtagsTagsDiv');
       el.value = '';
     });
   };
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = (event.target as HTMLElement);
     // DEDUPLICATE (from admin panel/tag manager)
     if (el.matches('[data-action="deduplicate-tag"]')) {
-      ApiC.patch(`${Model.TeamTags}`, {'action': Action.Deduplicate}).then(() => reloadElement('tagMgrDiv'));
+      ApiC.patch(`${Model.TeamTags}`, {'action': Action.Deduplicate}).then(() => reloadElements('tagMgrDiv'));
     // UNREFERENCE (remove link between tag and entity)
     } else if (el.matches('[data-action="unreference-tag"]')) {
       if (confirm(i18next.t('tag-delete-warning'))) {

--- a/src/ts/tags.ts
+++ b/src/ts/tags.ts
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     (new FavTag()).create(el.value).then(() => {
-      reloadElements('favtagsTagsDiv');
+      reloadElements(['favtagsTagsDiv']);
       el.value = '';
     });
   };
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = (event.target as HTMLElement);
     // DEDUPLICATE (from admin panel/tag manager)
     if (el.matches('[data-action="deduplicate-tag"]')) {
-      ApiC.patch(`${Model.TeamTags}`, {'action': Action.Deduplicate}).then(() => reloadElements('tagMgrDiv'));
+      ApiC.patch(`${Model.TeamTags}`, {'action': Action.Deduplicate}).then(() => reloadElements(['tagMgrDiv']));
     // UNREFERENCE (remove link between tag and entity)
     } else if (el.matches('[data-action="unreference-tag"]')) {
       if (confirm(i18next.t('tag-delete-warning'))) {

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -200,10 +200,10 @@ export function getTinymceBaseConfig(page: string): object {
           return `<span><a href='${entity.page}.php?mode=view&id=${entity.id}'>${category}${selected.title}</a></span>`;
         };
         if (selected.type === 'items') {
-          ApiC.post(`${entity.type}/${entity.id}/items_links/${selected.id}`).then(() => reloadElements('linksDiv'));
+          ApiC.post(`${entity.type}/${entity.id}/items_links/${selected.id}`).then(() => reloadElements(['linksDiv']));
         }
         if (selected.type === 'experiments' && (entity.type === EntityType.Experiment || entity.type === EntityType.Item)) {
-          ApiC.post(`${entity.type}/${entity.id}/experiments_links/${selected.id}`).then(() => reloadElements('linksExpDiv'));
+          ApiC.post(`${entity.type}/${entity.id}/experiments_links/${selected.id}`).then(() => reloadElements(['linksExpDiv']));
         }
         return format(selected);
       },

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -56,7 +56,7 @@ import '../js/tinymce-langs/sl_SI.js';
 import '../js/tinymce-langs/zh_CN.js';
 import '../js/tinymce-plugins/mention/plugin.js';
 import { EntityType } from './interfaces';
-import { getEntity, reloadElement, escapeExtendedQuery, updateEntityBody } from './misc';
+import { getEntity, reloadElements, escapeExtendedQuery, updateEntityBody } from './misc';
 import { Api } from './Apiv2.class';
 import { isSortable } from './TableSorting.class';
 
@@ -200,10 +200,10 @@ export function getTinymceBaseConfig(page: string): object {
           return `<span><a href='${entity.page}.php?mode=view&id=${entity.id}'>${category}${selected.title}</a></span>`;
         };
         if (selected.type === 'items') {
-          ApiC.post(`${entity.type}/${entity.id}/items_links/${selected.id}`).then(() => reloadElement('linksDiv'));
+          ApiC.post(`${entity.type}/${entity.id}/items_links/${selected.id}`).then(() => reloadElements('linksDiv'));
         }
         if (selected.type === 'experiments' && (entity.type === EntityType.Experiment || entity.type === EntityType.Item)) {
-          ApiC.post(`${entity.type}/${entity.id}/experiments_links/${selected.id}`).then(() => reloadElement('linksExpDiv'));
+          ApiC.post(`${entity.type}/${entity.id}/experiments_links/${selected.id}`).then(() => reloadElements('linksExpDiv'));
         }
         return format(selected);
       },

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('container').append(overlay);
       ApiC.patch(`${entity.type}/${entity.id}`, {'action': Action.Bloxberg})
         // reload uploaded files on success
-        .then(() => reloadElements('uploadsDiv'))
+        .then(() => reloadElements(['uploadsDiv']))
         // remove overlay in all cases
         .finally(() => document.getElementById('container').removeChild(document.getElementById('loadingOverlay')));
 
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
         action: Action.Create,
         target_action: actionSelect.value,
         target_userid: userSelect.value,
-      }).then(() => reloadElements('requestActionsDiv'))
+      }).then(() => reloadElements(['requestActionsDiv']))
         .then(() => relativeMoment());
     // SHOW ACTION
     } else if (el.matches('[data-action="show-action"]')) {

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     // LOCK TEMPLATE
     } else if (el.matches('[data-action="toggle-lock"]')) {
-      EntityC.patchAction(parseInt(el.dataset.id), Action.Lock).then(() => reloadElements('lockTemplateButton'));
+      EntityC.patchAction(parseInt(el.dataset.id), Action.Lock).then(() => reloadElements(['lockTemplateButton']));
     // UPDATE TEMPLATE
     } else if (el.matches('[data-action="update-template"]')) {
       EntityC.update(entity.id, Target.Body, editor.getContent());
@@ -92,12 +92,12 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="create-sigkeys"]')) {
       const passphraseInput = (document.getElementById('sigPassphraseInput') as HTMLInputElement);
       ApiC.post(`${Model.Sigkeys}`, {action: Action.Create, passphrase: passphraseInput.value})
-        .then(() => reloadElements('ucp-sigkeys'));
+        .then(() => reloadElements(['ucp-sigkeys']));
     // REGENERATE SIGKEY
     } else if (el.matches('[data-action="regenerate-sigkeys"]')) {
       const passphraseInput = (document.getElementById('regen_sigPassphraseInput') as HTMLInputElement);
       ApiC.patch(`${Model.Sigkeys}`, {action: Action.Update, passphrase: passphraseInput.value})
-        .then(() => reloadElements('ucp-sigkeys'));
+        .then(() => reloadElements(['ucp-sigkeys']));
     // DOWNLOAD SIG KEY (pub or priv)
     } else if (el.matches('[data-action="download-sigkey"]')) {
       ApiC.getJson(`${Model.User}/me`).then(user => {
@@ -118,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const canwrite = parseInt((document.getElementById('apikeyCanwrite') as HTMLInputElement).value, 10);
       ApiC.post(`${Model.Apikey}`, {'name': content, 'canwrite': canwrite}).then(resp => {
         const location = resp.headers.get('location').split('/');
-        reloadElements('apiTable');
+        reloadElements(['apiTable']);
         const warningDiv = document.createElement('div');
         warningDiv.classList.add('alert', 'alert-warning');
         const chevron = document.createElement('i');

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -5,7 +5,7 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { getEntity, notif, reloadElement, collectForm, updateCatStat, saveStringAsFile } from './misc';
+import { getEntity, notif, reloadElements, collectForm, updateCatStat, saveStringAsFile } from './misc';
 import tinymce from 'tinymce/tinymce';
 import { getTinymceBaseConfig } from './tinymce';
 import i18next from 'i18next';
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     // LOCK TEMPLATE
     } else if (el.matches('[data-action="toggle-lock"]')) {
-      EntityC.patchAction(parseInt(el.dataset.id), Action.Lock).then(() => reloadElement('lockTemplateButton'));
+      EntityC.patchAction(parseInt(el.dataset.id), Action.Lock).then(() => reloadElements('lockTemplateButton'));
     // UPDATE TEMPLATE
     } else if (el.matches('[data-action="update-template"]')) {
       EntityC.update(entity.id, Target.Body, editor.getContent());
@@ -91,11 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // GENERATE SIGKEY
     } else if (el.matches('[data-action="create-sigkeys"]')) {
       const passphraseInput = (document.getElementById('sigPassphraseInput') as HTMLInputElement);
-      ApiC.post(`${Model.Sigkeys}`, {action: Action.Create, passphrase: passphraseInput.value}).then(() => reloadElement('ucp-sigkeys'));
+      ApiC.post(`${Model.Sigkeys}`, {action: Action.Create, passphrase: passphraseInput.value})
+        .then(() => reloadElements('ucp-sigkeys'));
     // REGENERATE SIGKEY
     } else if (el.matches('[data-action="regenerate-sigkeys"]')) {
       const passphraseInput = (document.getElementById('regen_sigPassphraseInput') as HTMLInputElement);
-      ApiC.patch(`${Model.Sigkeys}`, {action: Action.Update, passphrase: passphraseInput.value}).then(() => reloadElement('ucp-sigkeys'));
+      ApiC.patch(`${Model.Sigkeys}`, {action: Action.Update, passphrase: passphraseInput.value})
+        .then(() => reloadElements('ucp-sigkeys'));
     // DOWNLOAD SIG KEY (pub or priv)
     } else if (el.matches('[data-action="download-sigkey"]')) {
       ApiC.getJson(`${Model.User}/me`).then(user => {
@@ -116,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const canwrite = parseInt((document.getElementById('apikeyCanwrite') as HTMLInputElement).value, 10);
       ApiC.post(`${Model.Apikey}`, {'name': content, 'canwrite': canwrite}).then(resp => {
         const location = resp.headers.get('location').split('/');
-        reloadElement('apiTable');
+        reloadElements('apiTable');
         const warningDiv = document.createElement('div');
         warningDiv.classList.add('alert', 'alert-warning');
         const chevron = document.createElement('i');

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import Dropzone from '@deltablot/dropzone';
-import { reloadElement } from './misc';
+import { reloadElements } from './misc';
 import i18next from 'i18next';
 
 export class Uploader
@@ -27,7 +27,7 @@ export class Uploader
         // once upload is finished
         this.on('complete', function() {
           if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-            reloadElement('uploadsDiv').then(() => {
+            reloadElements('uploadsDiv').then(() => {
               // Now grab the url of the image to give it to tinymce if needed
               // first make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
               if (typeof that.tinyImageSuccess !== 'undefined' && that.tinyImageSuccess !== null) {

--- a/src/ts/uploader.ts
+++ b/src/ts/uploader.ts
@@ -27,7 +27,7 @@ export class Uploader
         // once upload is finished
         this.on('complete', function() {
           if (this.getUploadingFiles().length === 0 && this.getQueuedFiles().length === 0) {
-            reloadElements('uploadsDiv').then(() => {
+            reloadElements(['uploadsDiv']).then(() => {
               // Now grab the url of the image to give it to tinymce if needed
               // first make sure the success function is set by tinymce and we are dealing with an image drop and not a regular upload
               if (typeof that.tinyImageSuccess !== 'undefined' && that.tinyImageSuccess !== null) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -10,7 +10,7 @@ import { Action as MalleAction, Malle } from '@deltablot/malle';
 import * as $3Dmol from '3dmol';
 import '@fancyapps/fancybox/dist/jquery.fancybox.js';
 import { Action, Model } from './interfaces';
-import { displayMolFiles, getEntity, relativeMoment, reloadElement, reloadElements } from './misc';
+import { displayMolFiles, getEntity, relativeMoment, reloadElements } from './misc';
 import { displayPlasmidViewer } from './ove';
 import i18next from 'i18next';
 import { Api } from './Apiv2.class';
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'content': (document.getElementById(el.dataset.canvasid) as HTMLCanvasElement).toDataURL(),
       };
       ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params)
-        .then(() => reloadElement('uploadsDiv'));
+        .then(() => reloadElements('uploadsDiv'));
 
     // CHANGE 3DMOL FILES VISUALIZATION STYLE
     } else if (el.matches('[data-action="set-3dmol-style"]')) {
@@ -187,7 +187,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="archive-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive})
-        .then(() => reloadElement('uploadsDiv'));
+        .then(() => reloadElements('uploadsDiv'));
 
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'content': (document.getElementById(el.dataset.canvasid) as HTMLCanvasElement).toDataURL(),
       };
       ApiC.post(`${entity.type}/${entity.id}/${Model.Upload}`, params)
-        .then(() => reloadElements('uploadsDiv'));
+        .then(() => reloadElements(['uploadsDiv']));
 
     // CHANGE 3DMOL FILES VISUALIZATION STYLE
     } else if (el.matches('[data-action="set-3dmol-style"]')) {
@@ -187,7 +187,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="archive-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive})
-        .then(() => reloadElements('uploadsDiv'));
+        .then(() => reloadElements(['uploadsDiv']));
 
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="create-comment"]')) {
       const content = (document.getElementById('commentsCreateArea') as HTMLTextAreaElement).value;
       ApiC.post(`${entity.type}/${entity.id}/${Model.Comment}`, {'comment': content}).then(() => {
-        reloadElements('commentsDiv').then(() => {
+        reloadElements(['commentsDiv']).then(() => {
           malleableComments.listen();
           relativeMoment();
         });
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await ApiC.patch(`${entity.type}/${entity.id}/${Model.Comment}/${original.dataset.id}`, {'comment': value});
       const json = await resp.json();
       // we reload all so the edition date is also reloaded
-      reloadElements('commentsDiv').then(() => {
+      reloadElements(['commentsDiv']).then(() => {
         malleableComments.listen();
         relativeMoment();
       });

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -8,7 +8,7 @@
 import i18next from 'i18next';
 import { InputType, Malle, SelectOptions } from '@deltablot/malle';
 import { Api } from './Apiv2.class';
-import { getEntity, updateCatStat, relativeMoment, reloadElement } from './misc';
+import { getEntity, updateCatStat, relativeMoment, reloadElements } from './misc';
 import { EntityType, Model } from './interfaces';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="create-comment"]')) {
       const content = (document.getElementById('commentsCreateArea') as HTMLTextAreaElement).value;
       ApiC.post(`${entity.type}/${entity.id}/${Model.Comment}`, {'comment': content}).then(() => {
-        reloadElement('commentsDiv').then(() => {
+        reloadElements('commentsDiv').then(() => {
           malleableComments.listen();
           relativeMoment();
         });
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const resp = await ApiC.patch(`${entity.type}/${entity.id}/${Model.Comment}/${original.dataset.id}`, {'comment': value});
       const json = await resp.json();
       // we reload all so the edition date is also reloaded
-      reloadElement('commentsDiv').then(() => {
+      reloadElements('commentsDiv').then(() => {
         malleableComments.listen();
         relativeMoment();
       });


### PR DESCRIPTION
There is no need to maintain two javascript functions to reload HTML elements.
By using a modified `reloadElements(elementIds: string[]|string)` function we get away with one HTTP request to reload all necessary HTML elements.
This will also address potential issues like `// using reloadElements here doesn't work for relativeMoment`.
