### PR TITLE
Some changes to the new request actions

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 149;
+    public const int REQUIRED_SCHEMA = 150;
 
     private Db $Db;
 

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -129,7 +129,7 @@ abstract class AbstractEntityController implements ControllerInterface
         $itemsCategoryArr = $ItemsTypes->readAll();
 
         $template = 'show.html';
-        $RequestActions = new UserRequestActions($this->App->Users);
+        $UserRequestActions = new UserRequestActions($this->App->Users);
 
         $renderArr = array(
             'DisplayParams' => $DisplayParams,
@@ -142,7 +142,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'maxUploadSizeRaw' => ini_get('post_max_size'),
             'pinnedArr' => $this->Entity->Pins->readAll(),
             'itemsArr' => $itemsArr,
-            'requestActionsArr' => $RequestActions->readAllFull(),
+            'requestActionsArr' => $UserRequestActions->readAllFull(),
             // generate light show page
             'searchPage' => $isSearchPage,
             'tagsArr' => $tagsArr,

--- a/src/models/RequestActions.php
+++ b/src/models/RequestActions.php
@@ -63,7 +63,7 @@ class RequestActions implements RestInterface
 
     public function readAllFull(): array
     {
-        return array_map(function ($action) {
+        return array_map(function (array $action): array {
             $Requester = new Users($action['requester_userid']);
             $action['requester_fullname'] = $Requester->userData['fullname'];
             $Target = new Users($action['target_userid']);
@@ -147,13 +147,15 @@ class RequestActions implements RestInterface
             'UPDATE %s_request_actions
                 SET state = :state
                 WHERE action = :action
-                    AND target_userid = :userid',
+                    AND target_userid = :userid
+                    AND entity_id = :entity_id',
             $this->entity->entityType->value,
         );
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', State::Archived->value, PDO::PARAM_INT);
         $req->bindValue(':action', $action->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->requester->userData['userid'], PDO::PARAM_INT);
+        $req->bindParam(':entity_id', $this->entity->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }
 

--- a/src/models/UserRequestActions.php
+++ b/src/models/UserRequestActions.php
@@ -50,13 +50,13 @@ class UserRequestActions implements RestInterface
         foreach($tables as $table) {
             $sql[] = sprintf(
                 '(SELECT "%1$s" AS entity_page, entity.title AS entity_title, %2$s_request_actions.id,
-                %2$s_request_actions.created_at, requester_userid, target_userid, entity_id, action,
-                %2$s_request_actions.state
-              FROM %2$s_request_actions
-              LEFT JOIN %2$s AS entity
-                ON entity.id = %2$s_request_actions.entity_id
-              WHERE target_userid = :userid
-                AND %2$s_request_actions.state = :state)',
+                        %2$s_request_actions.created_at, requester_userid, target_userid, entity_id, action,
+                        %2$s_request_actions.state
+                    FROM %2$s_request_actions
+                    LEFT JOIN %2$s AS entity
+                        ON entity.id = %2$s_request_actions.entity_id
+                    WHERE target_userid = :userid
+                        AND %2$s_request_actions.state = :state)',
                 $table['page'],
                 $table['entity_type'],
             );

--- a/src/models/UserRequestActions.php
+++ b/src/models/UserRequestActions.php
@@ -71,7 +71,7 @@ class UserRequestActions implements RestInterface
 
     public function readAllFull(): array
     {
-        return array_map(function ($action) {
+        return array_map(function (array $action): array {
             $Requester = new Users($action['requester_userid']);
             $action['requester_firstname'] = $Requester->userData['firstname'];
             $action['action'] = RequestableAction::from($action['action'])->name;

--- a/src/sql/schema150-down.sql
+++ b/src/sql/schema150-down.sql
@@ -1,8 +1,12 @@
 -- revert schema 150
 ALTER TABLE `experiments_request_actions`
   DROP FOREIGN KEY `fk_experiments_request_actions_requester_users_userid`,
-  DROP FOREIGN KEY `fk_experiments_request_actions_target_users_userid`;
+  DROP INDEX `fk_experiments_request_actions_requester_users_userid`,
+  DROP FOREIGN KEY `fk_experiments_request_actions_target_users_userid`,
+  DROP INDEX `fk_experiments_request_actions_target_users_userid`;
 ALTER TABLE `items_request_actions`
   DROP FOREIGN KEY `fk_items_request_actions_requester_users_userid`,
-  DROP FOREIGN KEY `fk_items_request_actions_target_users_userid`;
+  DROP INDEX `fk_items_request_actions_requester_users_userid`,
+  DROP FOREIGN KEY `fk_items_request_actions_target_users_userid`,
+  DROP INDEX `fk_items_request_actions_target_users_userid`;
 UPDATE config SET conf_value = 149 WHERE conf_name = 'schema';

--- a/src/sql/schema150-down.sql
+++ b/src/sql/schema150-down.sql
@@ -1,0 +1,8 @@
+-- revert schema 150
+ALTER TABLE `experiments_request_actions`
+  DROP FOREIGN KEY `fk_experiments_request_actions_requester_users_userid`,
+  DROP FOREIGN KEY `fk_experiments_request_actions_target_users_userid`;
+ALTER TABLE `items_request_actions`
+  DROP FOREIGN KEY `fk_items_request_actions_requester_users_userid`,
+  DROP FOREIGN KEY `fk_items_request_actions_target_users_userid`;
+UPDATE config SET conf_value = 149 WHERE conf_name = 'schema';

--- a/src/sql/schema150.sql
+++ b/src/sql/schema150.sql
@@ -1,0 +1,21 @@
+-- schema 150
+ALTER TABLE `experiments_request_actions`
+  ADD INDEX `fk_experiments_request_actions_requester_users_userid` (`requester_userid`),
+  ADD CONSTRAINT `fk_experiments_request_actions_requester_users_userid`
+    FOREIGN KEY (`requester_userid`) REFERENCES `users` (`userid`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD INDEX `fk_experiments_request_actions_target_users_userid` (`target_userid`),
+  ADD CONSTRAINT `fk_experiments_request_actions_target_users_userid`
+    FOREIGN KEY (`target_userid`) REFERENCES `users` (`userid`)
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `items_request_actions`
+  ADD INDEX `fk_items_request_actions_requester_users_userid` (`requester_userid`),
+  ADD CONSTRAINT `fk_items_request_actions_requester_users_userid`
+    FOREIGN KEY (`requester_userid`) REFERENCES `users` (`userid`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD INDEX `fk_items_request_actions_target_users_userid` (`target_userid`),
+  ADD CONSTRAINT `fk_items_request_actions_target_users_userid`
+    FOREIGN KEY (`target_userid`) REFERENCES `users` (`userid`)
+    ON DELETE CASCADE ON UPDATE CASCADE;
+UPDATE config SET conf_value = 150 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -538,7 +538,7 @@ CREATE TABLE IF NOT EXISTS `items_request_actions` (
 
 --
 -- RELATIONSHIPS FOR TABLE `items_request_actions`:
---   `iteentity_idm_id`
+--   `entity_id`
 --       `items` -> `id`
 --   `requester_userid`
 --       `users` -> `userid`

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -208,7 +208,23 @@ CREATE TABLE IF NOT EXISTS `experiments_request_actions` (
     `state` TINYINT UNSIGNED NOT NULL DEFAULT 1,
     PRIMARY KEY (`id`),
     KEY `fk_experiments_request_actions_experiments_id` (`entity_id`),
-    CONSTRAINT `fk_experiments_request_actions_experiments_id` FOREIGN KEY (`entity_id`) REFERENCES `experiments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);
+    CONSTRAINT `fk_experiments_request_actions_experiments_id`
+      FOREIGN KEY (`entity_id`) REFERENCES `experiments` (`id`)
+      ON DELETE CASCADE ON UPDATE CASCADE,
+    KEY `fk_experiments_request_actions_requester_users_userid` (`requester_userid`),
+    KEY `fk_experiments_request_actions_target_users_userid` (`target_userid`));
+
+--
+-- RELATIONSHIPS FOR TABLE `experiments_request_actions`:
+--   `entity_id`
+--       `experiments` -> `id`
+--   `requester_userid`
+--       `users` -> `userid`
+--   `target_userid`
+--       `users` -> `userid`
+--
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `experiments_revisions`
@@ -514,7 +530,23 @@ CREATE TABLE IF NOT EXISTS `items_request_actions` (
     `state` TINYINT UNSIGNED NOT NULL DEFAULT 1,
     PRIMARY KEY (`id`),
     KEY `fk_items_request_actions_items_id` (`entity_id`),
-    CONSTRAINT `fk_items_request_actions_items_id` FOREIGN KEY (`entity_id`) REFERENCES `items` (`id`) ON DELETE CASCADE ON UPDATE CASCADE);
+    CONSTRAINT `fk_items_request_actions_items_id`
+      FOREIGN KEY (`entity_id`) REFERENCES `items` (`id`)
+      ON DELETE CASCADE ON UPDATE CASCADE,
+    KEY `fk_items_request_actions_requester_users_userid` (`requester_userid`),
+    KEY `fk_items_request_actions_target_users_userid` (`target_userid`));
+
+--
+-- RELATIONSHIPS FOR TABLE `items_request_actions`:
+--   `iteentity_idm_id`
+--       `items` -> `id`
+--   `requester_userid`
+--       `users` -> `userid`
+--   `target_userid`
+--       `users` -> `userid`
+--
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `items_revisions`
@@ -1295,6 +1327,17 @@ ALTER TABLE `experiments_comments`
   ADD CONSTRAINT `fk_experiments_comments_users_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
+-- Constraints for table `experiments_request_actions`
+--
+ALTER TABLE `experiments_request_actions`
+    ADD CONSTRAINT `fk_experiments_request_actions_requester_users_userid`
+      FOREIGN KEY (`requester_userid`) REFERENCES `users` (`userid`)
+      ON DELETE CASCADE ON UPDATE CASCADE,
+    ADD CONSTRAINT `fk_experiments_request_actions_target_users_userid`
+      FOREIGN KEY (`target_userid`) REFERENCES `users` (`userid`)
+      ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
 -- Constraints for table `experiments_links`
 --
 ALTER TABLE `experiments_links`
@@ -1349,6 +1392,17 @@ ALTER TABLE `items`
 ALTER TABLE `items_comments`
   ADD CONSTRAINT `fk_items_comments_items_id` FOREIGN KEY (`item_id`) REFERENCES `items` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   ADD CONSTRAINT `fk_items_comments_users_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `items_request_actions`
+--
+ALTER TABLE `items_request_actions`
+  ADD CONSTRAINT `fk_items_request_actions_requester_users_userid`
+      FOREIGN KEY (`requester_userid`) REFERENCES `users` (`userid`)
+      ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_items_request_actions_target_users_userid`
+      FOREIGN KEY (`target_userid`) REFERENCES `users` (`userid`)
+      ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
 -- Constraints for table `items_revisions`

--- a/src/templates/request-actions-show.html
+++ b/src/templates/request-actions-show.html
@@ -6,7 +6,7 @@
         <div class='d-flex'>
           <i class='fas fa-person-circle-exclamation color-blue mr-2'></i>
           <div>
-            {{ '%s is requesting %s on'|trans|format(action.requester_firstname, action.action) }} <a href='/{{ action.entity_page }}.php?mode=view&id={{ action.entity_id }}'>{{ action.entity_title }}</a><span title='{{ action.created_at }}' class='relative-moment text-nowrap smallgray ml-2'></span></a>
+            {{ '%s is requesting %s on'|trans|format(action.requester_firstname, action.action) }} <a href='/{{ action.entity_page }}.php?mode=view&amp;id={{ action.entity_id }}'>{{ action.entity_title }}</a><span title='{{ action.created_at }}' class='relative-moment text-nowrap smallgray ml-2'></span></a>
           </div>
         </div>
       </li>

--- a/src/templates/view-edit.html
+++ b/src/templates/view-edit.html
@@ -24,7 +24,11 @@
         <div class='d-flex'>
           <i class='fas fa-person-circle-exclamation color-blue mr-2'></i>
           <div>
-            {{ action.action }} has been requested by {{ action.requester_fullname }} for {{ action.target_fullname }}<span title='{{ action.created_at }}' class='relative-moment text-nowrap smallgray ml-2'></span>
+            {{- '%s has been requested by %s for %s'|trans|format(
+              action.action,
+              action.requester_fullname,
+              action.target_fullname
+            ) }}<span title='{{ action.created_at }}' class='relative-moment text-nowrap smallgray ml-2'></span>
               <div class='mt-2'>
             {% if action.target_userid == App.Users.userData.userid %}
                 <button type='button' class='btn btn-primary btn-sm mr-2' data-action='do-requestable-action' data-target='{{ action.action }}'>{{ action.action }}</button>

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
         target_userid: userSelect.value,
       }).then(() => reloadElements(['requestActionsDiv']))
         .then(() => relativeMoment())
-        // the request might be rejected during the timeout period
+        // the request gets rejected if repeated
         .catch(error => console.error(error.message));
     // SHOW ACTION
     } else if (el.matches('[data-action="show-action"]')) {

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -114,7 +114,9 @@ document.addEventListener('DOMContentLoaded', () => {
         target_action: actionSelect.value,
         target_userid: userSelect.value,
       }).then(() => reloadElements(['requestActionsDiv']))
-        .then(() => relativeMoment());
+        .then(() => relativeMoment())
+        // the request might be rejected during the timeout period
+        .catch(error => console.error(error.message));
     // SHOW ACTION
     } else if (el.matches('[data-action="show-action"]')) {
       const btn = document.getElementById(`actionButton-${el.dataset.target}`);

--- a/tests/unit/models/RequestActionsTest.php
+++ b/tests/unit/models/RequestActionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten github@marcelbolten.de
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Enums\RequestableAction;
+use Elabftw\Exceptions\ImproperActionException;
+
+class RequestActionsTest extends \PHPUnit\Framework\TestCase
+{
+    private Experiments $Experiments;
+
+    private RequestActions $RequestActions;
+
+    protected function setUp(): void
+    {
+        $Users = new Users(1, 1);
+        $this->Experiments = new Experiments($Users, 1);
+        $this->RequestActions = new RequestActions($Users, $this->Experiments);
+    }
+
+    public function testPostAction(): void
+    {
+        $reqBody = array(
+            'target_userid' => 2,
+            'target_action' => RequestableAction::Archive->value,
+        );
+        $newRequestActionId = $this->RequestActions->postAction(
+            Action::Create, // this action is irrelevant
+            $reqBody,
+        );
+        $this->assertIsInt($newRequestActionId);
+        // request the same again to trigger timeout
+        $this->expectException(ImproperActionException::class);
+        $this->RequestActions->postAction(
+            Action::Create, // this action is irrelevant
+            $reqBody,
+        );
+    }
+
+    public function testPatch(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->RequestActions->patch(Action::Create, array());
+    }
+
+    public function testReadAllFull(): void
+    {
+        $this->assertIsArray($this->RequestActions->readAllFull());
+    }
+
+    public function testReadOne(): void
+    {
+        $this->RequestActions->setId(1);
+        $this->assertIsArray($this->RequestActions->readOne());
+    }
+
+    public function testGetPage(): void
+    {
+        $this->assertIsString($this->RequestActions->getPage());
+    }
+
+    public function testDestroy(): void
+    {
+        $this->assertTrue($this->RequestActions->destroy());
+    }
+}

--- a/tests/unit/models/RequestActionsTest.php
+++ b/tests/unit/models/RequestActionsTest.php
@@ -40,7 +40,7 @@ class RequestActionsTest extends \PHPUnit\Framework\TestCase
             $reqBody,
         );
         $this->assertIsInt($newRequestActionId);
-        // request the same again to trigger timeout
+        // request the same again to trigger rejection
         $this->expectException(ImproperActionException::class);
         $this->RequestActions->postAction(
             Action::Create, // this action is irrelevant

--- a/tests/unit/models/UserRequestActionsTest.php
+++ b/tests/unit/models/UserRequestActionsTest.php
@@ -20,7 +20,8 @@ class UserRequestActionsTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->ura = new UserRequestActions(new Users(1, 1));
+        // use user 2 as it was used to setup the db entries in testRequestActions
+        $this->ura = new UserRequestActions(new Users(2, 1));
     }
 
     public function testRead(): void


### PR DESCRIPTION
This PR should be reviewed and merged after #5086 and #5087.

* add foreign keys for `requester_userid` and `target_userid` so they can be linked to `userid`
* add missing translation in view-edit.html
* ~add a timeout (15 min) to avoid that the same action can be requested over and over again from the same user for a particular target user. Maybe the actual timeout could be a (sys)admin setting?~
  don't let users request the same action multiple times