### PR TITLE
fix auth cookie not being set for saml login

### DIFF
--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -189,13 +189,7 @@
               {% endif %}
             {% endfor %}
           </select>
-          {# Remember me checkbox #}
-          {% if App.Config.configArr.remember_me_allowed %}
-            <div class='form-check mt-2'>
-              <input type='checkbox' class='form-check-input' {{ App.Config.configArr.remember_me_checked ? 'checked' }} name='rememberme' id='rememberme-2' />
-              <label for='rememberme-2' class='form-check-label'>{{ 'Remember me'|trans }}</label>
-            </div>
-          {% endif %}
+          {# No remember me checkbox for SAML because it's toggled by remember_me_allowed at the instance level #}
           <button class='btn btn-primary mt-2' type='submit' name='submit'>{{ 'Login'|trans }}</button>
         </div>
       </form>


### PR DESCRIPTION
fix #5135
previously the $remember me variable would always be false. Now we directly use the instance level config value to decide if we set cookies or not. The remember me checkbox is removed from saml form too.

