### PR TITLE
Add custom banner for new users editable by Admins

### DIFF
--- a/src/classes/TeamParam.php
+++ b/src/classes/TeamParam.php
@@ -14,6 +14,7 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Services\Check;
+use Elabftw\Services\Filter;
 
 final class TeamParam extends ContentParams
 {
@@ -21,7 +22,7 @@ final class TeamParam extends ContentParams
     {
         return match ($this->target) {
             'name', 'orgid', 'link_name' => parent::getContent(),
-            'announcement',
+            'announcement', 'newcomer_banner',
             'onboarding_email_subject',
             'onboarding_email_body' => $this->getNullableContent(),
             'common_template', 'common_template_md' => $this->getBody(),
@@ -30,7 +31,9 @@ final class TeamParam extends ContentParams
             'do_force_canread',
             'do_force_canwrite',
             'visible',
+            'newcomer_banner_active',
             'onboarding_email_active' => parent::getBinary(),
+            'newcomer_threshold' => parent::getInt(),
             'link_href' => $this->getUrl(),
             'force_canread', 'force_canwrite' => Check::visibility($this->content),
             default => throw new ImproperActionException('Incorrect parameter for team.' . $this->target),
@@ -42,6 +45,6 @@ final class TeamParam extends ContentParams
         if (empty($this->content)) {
             return null;
         }
-        return parent::getContent();
+        return Filter::body(parent::getContent());
     }
 }

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 155;
+    public const int REQUIRED_SCHEMA = 156;
 
     private Db $Db;
 

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -62,7 +62,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity implements CreateFr
     {
         return match ($action) {
             Action::Create => $this->create((int) ($reqBody['category_id'] ?? -1), $reqBody['tags'] ?? array()),
-            Action::Duplicate => $this->duplicate((bool) $reqBody['copyFiles']),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? '')),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/Changelog.php
+++ b/src/models/Changelog.php
@@ -55,8 +55,8 @@ class Changelog
 
     public function readAll(): array
     {
-        $sql = "SELECT created_at, target, content, CONCAT(users.firstname, ' ', users.lastname) AS fullname
-            FROM " . $this->entity->entityType->value . '_changelog LEFT JOIN users ON (users.userid = ' . $this->entity->entityType->value . '_changelog.users_id)
+        $sql = "SELECT ch.created_at, ch.target, ch.content, CONCAT(users.firstname, ' ', users.lastname) AS fullname
+            FROM " . $this->entity->entityType->value . '_changelog AS ch LEFT JOIN users ON (users.userid = ch.users_id)
             WHERE entity_id = :entity_id ORDER BY created_at DESC';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':entity_id', $this->entity->id, PDO::PARAM_INT);

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -21,6 +21,7 @@ use Elabftw\Elabftw\Update;
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\RestInterface;
+use Elabftw\Services\Filter;
 use PDO;
 
 use function array_map;
@@ -271,6 +272,10 @@ final class Config implements RestInterface
         // loop the array and update config
         foreach ($params as $name => $value) {
             if ($this->configArr[$name] !== $value) {
+                // prevent incorrect html in these two things
+                if ($name === 'login_announcement' || $name === 'announcement') {
+                    $value = Filter::body($value);
+                }
                 $req->bindParam(':value', $value);
                 $req->bindParam(':name', $name);
                 $this->Db->execute($req);

--- a/src/models/ProcurementRequests.php
+++ b/src/models/ProcurementRequests.php
@@ -77,8 +77,8 @@ class ProcurementRequests implements RestInterface
 
     public function readForEntity(int $entityId): array
     {
-        $sql = "SELECT CONCAT(users.firstname, ' ', users.lastname) AS requester_fullname, id, created_at, team, requester_userid, entity_id, qty_ordered, body, quote, email_sent, state
-            FROM procurement_requests LEFT JOIN users ON (requester_userid = users.userid) WHERE entity_id = :entity_id";
+        $sql = "SELECT CONCAT(users.firstname, ' ', users.lastname) AS requester_fullname, pr.id, pr.created_at, pr.team, pr.requester_userid, pr.entity_id, pr.qty_ordered, pr.body, pr.quote, pr.email_sent, pr.state
+            FROM procurement_requests AS pr LEFT JOIN users ON (requester_userid = users.userid) WHERE entity_id = :entity_id";
         $req = $this->Db->prepare($sql);
         $req->bindParam(':entity_id', $entityId, PDO::PARAM_INT);
         $this->Db->execute($req);

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -44,7 +44,6 @@ use Elabftw\Services\UsersHelper;
 use PDO;
 use Symfony\Component\HttpFoundation\Request;
 
-use function time;
 use function trim;
 
 /**
@@ -104,9 +103,6 @@ class Users implements RestInterface
         $firstname = trim($firstname);
         $lastname = trim($lastname);
 
-        // Registration date is stored in epoch
-        $registerDate = time();
-
         // get the user group for the new users
         $usergroup ??= $TeamsHelper->getGroup();
 
@@ -123,7 +119,6 @@ class Users implements RestInterface
             `password_hash`,
             `firstname`,
             `lastname`,
-            `register_date`,
             `validated`,
             `lang`,
             `valid_until`,
@@ -137,7 +132,6 @@ class Users implements RestInterface
             :password_hash,
             :firstname,
             :lastname,
-            :register_date,
             :validated,
             :lang,
             :valid_until,
@@ -152,7 +146,6 @@ class Users implements RestInterface
         $req->bindParam(':password_hash', $passwordHash);
         $req->bindParam(':firstname', $firstname);
         $req->bindParam(':lastname', $lastname);
-        $req->bindParam(':register_date', $registerDate);
         $req->bindValue(':validated', $isValidated, PDO::PARAM_INT);
         $req->bindValue(':lang', $Config->configArr['lang']);
         $req->bindValue(':valid_until', $validUntil);
@@ -238,7 +231,7 @@ class Users implements RestInterface
         // NOTE: $tmpTable avoids the use of DISTINCT, so we are able to use ORDER BY with teams_id.
         // Side effect: User is shown in team with lowest id
         $sql = "SELECT users.userid,
-            users.firstname, users.lastname, users.orgid, users.email, users.mfa_secret IS NOT NULL AS has_mfa_enabled,
+            users.firstname, users.lastname, users.created_at, users.orgid, users.email, users.mfa_secret IS NOT NULL AS has_mfa_enabled,
             users.validated, users.archived, users.last_login, users.valid_until, users.is_sysadmin,
             CONCAT(users.firstname, ' ', users.lastname) AS fullname,
             users.orcid, users.auth_service, sig_keys.pubkey AS sig_pubkey

--- a/src/sql/schema156-down.sql
+++ b/src/sql/schema156-down.sql
@@ -1,0 +1,8 @@
+-- revert schema 156
+ALTER TABLE `teams` DROP COLUMN `newcomer_threshold`;
+ALTER TABLE `teams` DROP COLUMN `newcomer_banner`;
+ALTER TABLE `teams` DROP COLUMN `newcomer_banner_active`;
+ALTER TABLE `users` ADD COLUMN `register_date` bigint(20) UNSIGNED NOT NULL;
+UPDATE `users` SET `register_date` = UNIX_TIMESTAMP(`created_at`);
+ALTER TABLE `users` DROP COLUMN `created_at`;
+UPDATE config SET conf_value = 155 WHERE conf_name = 'schema';

--- a/src/sql/schema156.sql
+++ b/src/sql/schema156.sql
@@ -1,0 +1,8 @@
+-- schema 156
+ALTER TABLE `teams` ADD `newcomer_threshold` INT UNSIGNED NOT NULL DEFAULT 15;
+ALTER TABLE `teams` ADD `newcomer_banner` TEXT NULL DEFAULT NULL;
+ALTER TABLE `teams` ADD `newcomer_banner_active` TINYINT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE `users` ADD COLUMN `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+UPDATE `users` SET `created_at` = FROM_UNIXTIME(`register_date`);
+ALTER TABLE `users` DROP COLUMN `register_date`;
+UPDATE config SET conf_value = 156 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1033,6 +1033,9 @@ CREATE TABLE `teams` (
   `onboarding_email_active` TINYINT UNSIGNED NOT NULL DEFAULT 0,
   `onboarding_email_subject` VARCHAR(255) NULL,
   `onboarding_email_body` TEXT NULL,
+  `newcomer_threshold` INT UNSIGNED NOT NULL DEFAULT 15,
+  `newcomer_banner` TEXT NULL DEFAULT NULL,
+  `newcomer_banner_active` TINYINT UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
@@ -1154,7 +1157,7 @@ CREATE TABLE `users` (
   `is_sysadmin` TINYINT UNSIGNED NOT NULL DEFAULT 0,
   `orcid` varchar(19) NULL DEFAULT NULL,
   `orgid` varchar(255) NULL DEFAULT NULL,
-  `register_date` bigint(20) UNSIGNED NOT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `token` varchar(255) DEFAULT NULL,
   `token_created_at` TIMESTAMP NULL DEFAULT NULL,
   `limit_nb` tinyint UNSIGNED NOT NULL DEFAULT 15,

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -141,9 +141,7 @@
       {% if App.Config.configArr.debug -%}
         <!-- [html-validate-disable-block text-content, no-unused-disable: suppress errors from tinymce] -->
       {%- endif %}
-      <textarea style='height:400px' class='markdown-textarea form-control mt-2' name='common_template_md' id='common_template_md'>
-        {{ App.teamArr.common_template_md|raw }}
-      </textarea>
+      <textarea style='height:400px' class='markdown-textarea form-control mt-2' name='common_template_md' id='common_template_md'>{{ App.teamArr.common_template_md|raw }}</textarea>
     </div>
     <p class='smallgray'>{{ 'This is the default text when someone creates an experiment.'|trans }}</p>
     <div class='mt-2 text-center'>

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -155,6 +155,36 @@
 
   {# ONBOARDING EMAIL #}
   {% include 'onboarding-email.html' %}
+
+  {# FRESH USER INFO #}
+  <h3 class='p-2 pl-3 section-title'>{{ 'Newcomer banner'|trans }}</h3>
+  <div class='pl-3 mt-2'>
+    {% include 'binary-setting.html' with {'model': model, 'src': src,
+      'slug': 'newcomer_banner_active',
+      'label': 'Activate newcomer banner'|trans,
+      'help': 'Display a message to users that recently joined the team.'|trans} %}
+
+    <div class='d-flex justify-content-between'>
+      <label for='newcomer_threshold' class='col-form-label'>{{ 'Number of days after registration where a user is considered a newcomer'|trans }}</label>
+      <input class='form-control col-md-4' data-trigger='blur' data-model='teams/current' data-target='newcomer_threshold' type='number' value='{{ App.teamArr.newcomer_threshold|e('html_attr') }}' name='newcomer_threshold' id='newcomer_threshold' />
+    </div>
+    <hr>
+
+    <label for='newcomer_banner' class='col-form-label'>{{ 'Message to display'|trans }}</label>
+    <div>
+      {% if App.Config.configArr.debug -%}
+      {# set no-unused-disable and text-content because removing or leaving text-content brings up error #}
+        <!-- [html-validate-disable-block unique-landmark, element-permitted-content, no-deprecated-attr, prefer-native-element, no-unused-disable, element-permitted-content: suppress errors from tinymce] -->
+      {%- endif %}
+      <textarea style='height:400px' class='mceditable' name='newcomer_banner' id='newcomer_banner'>
+        {{ src.onboarding_email_admins_body|raw }}
+      </textarea>
+    </div>
+    <div class='mt-2 text-center'>
+      <button type='button' data-action='patch-newcomer_banner' class='btn btn-primary'>{{ 'Save'|trans }}</button>
+    </div>
+
+  </div>
 </div>
 
 {# TAB 2 TEAM GROUPS #}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -28,6 +28,17 @@
   {%- if App.teamArr.announcement -%}
     {{ App.teamArr.announcement|msg('warning', false) }}
   {%- endif -%}
+  {# newcomer banner #}
+  {%- if App.teamArr.newcomer_banner_active and App.teamArr.newcomer_banner -%}
+    {% set current_date = date() %}
+    {% set threshold_date = current_date|date_modify('-' ~ App.teamArr.newcomer_threshold ~ ' days') %}
+    {% if App.Users.userData.created_at|date('Y-m-d H:i:s') > threshold_date|date('Y-m-d H:i:s') %}
+    <h3 data-action='toggle-next' data-toggle-target='newcomer_banner' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='newcomer_banner'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Newcomer banner'|trans }}</h3><abbr title='{{ 'You are seeing this because your account is less than %d days old.'|trans|format(App.teamArr.newcomer_threshold) }}'><i class='fas fa-question-circle ml-2'></i></abbr>
+      <div class='my-2' id='newcomer_banner' data-save-hidden='newcomer_banner'>
+        {{ App.teamArr.newcomer_banner|raw }}
+      </div>
+    {% endif %}
+  {%- endif -%}
   <div id='output'></div>
 {%- endif -%}
 

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -14,8 +14,16 @@
 {% embed 'view-edit.html' %}
   {% block createnew %}
     <div class='d-flex'>
-      {# TODO replace 'entry' with experiment|item #}
-      <div class='align-self-center'><h3>{{ Entity.entityType.toPage[:-4]|capitalize|trans }} > {{ 'Editing an entry'|trans }}</h3></div>
+      <div class='align-self-center flex-grow-1 mr-2'>
+        {# CUSTOM ID #}
+        {# TITLE #}
+        <h1 class='text-dark' >
+          {% if Entity.entityData.custom_id %}
+            <span title='{{ 'Custom ID'|trans }}' class='custom-id-badge'>{{ Entity.entityData.custom_id }}</span>
+          {% endif %}
+          <span id='documentTitle' class='breakable malleableColumn hl-hover-gray rounded py-1' data-target='title' data-endpoint='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}'>{{ Entity.entityData.title }}</span>
+        </h1>
+      </div>
       <div class='ml-auto'>
         {% include 'create-new.html' %}
       </div>
@@ -82,13 +90,6 @@
       </div>
       <input id='custom_id_input' class='form-control' data-trigger='change' data-model='{{ Entity.entityType.value }}/{{ Entity.entityData.id }}' data-target='custom_id' type='number' min='0' value='{{ Entity.entityData.custom_id }}' />
     </div>
-  </div>
-
-  {# TITLE #}
-  <div class='d-flex mb-2 justify-content-between align-items-center'>
-    <label for='title_input' class='col-form-label mr-3 edit-mode-label'>{{ 'Title'|trans }}</label>
-    {# no data-trigger here because custom code in edit.ts #}
-    <input id='title_input' class='form-control' maxlength='255' type='text' value='{{ Entity.entityData.title|e('html_attr') }}' required />
   </div>
 
   {# CATEGORY / STATUS #}

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -21,7 +21,7 @@
   <link rel='icon' href='/assets/images/favicon.svg' type='image/svg+xml'>
   <link rel='apple-touch-icon' href='/assets/images/apple-touch-icon.png'>{# 180×180 #}
 
-  <title>{{ App.pageTitle }} - eLabFTW</title>
+  <title>{{ Entity.entityData.title|default(App.pageTitle) }} - eLabFTW</title>
   {# see builder.js to see what gets inside these files #}
   {# CSS #}
   <link rel='stylesheet' media='all' href='/assets/vendor.min.css?v={{ v }}' />

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -200,7 +200,7 @@
   <h3 class='mb-3 p-2 pl-3 section-title' id='teamsSectionTitle'>{{ 'Teams list'|trans }}</h3>
   <div id='teamsDiv' class='pl-3'>
     <div class='mb-3 d-flex justify-content-between'>
-      <p class='col-form-label'>{{ 'This page allows you to edit the teams present on this instance.'|trans }} (<a href='https://doc.elabftw.net/sysadmin-guide.html#configure-teams-optional' target='_blank' rel='noopener' class='external-link'>{{ 'Documentation'|trans|lower }})</a></p>
+      <p class='col-form-label'>{{ 'This page allows you to edit the teams present on this instance.'|trans }} (<a href='https://doc.elabftw.net/sysadmin-guide.html#configure-teams-optional' target='_blank' rel='noopener' class='external-link'>{{ 'Documentation'|trans|lower }}</a>)</p>
       {# CREATE NEW BUTTON the div around the button is necessary or the button itself gets resized on small viewports #}
       <div>
         <button type='button' class='btn btn-primary' data-action='toggle-modal' data-target='createTeamModal'>{{ 'Create a team'|trans }}</button>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -5,8 +5,16 @@
 {% embed 'view-edit.html' %}
   {% block createnew %}
     <div class='d-flex'>
-      {# TODO replace 'entry' with experiment|item #}
-      <div class='align-self-center'><h3>{{ Entity.entityType.toPage[:-4]|capitalize|trans }} > {{ 'Viewing an entry'|trans }}</h3></div>
+      <div class='align-self-center flex-grow-1 mr-2'>
+        {# CUSTOM ID #}
+        {# TITLE #}
+        <h1 class='text-dark' >
+          {% if Entity.entityData.custom_id %}
+            <span title='{{ 'Custom ID'|trans }}' class='custom-id-badge'>{{ Entity.entityData.custom_id }}</span>
+          {% endif %}
+          <span id='documentTitle' class='breakable malleableColumn hl-hover-gray rounded py-1' data-target='title' data-endpoint='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}'>{{ Entity.entityData.title }}</span>
+        </h1>
+      </div>
       <div class='ml-auto'>
         {% include 'create-new.html' %}
       </div>
@@ -53,15 +61,6 @@
       {% endif %}
     </div>
   </div>
-
-  {# CUSTOM ID #}
-  {# TITLE #}
-  <h1 class='mb-4 text-dark' >
-  {% if Entity.entityData.custom_id %}
-    <span title='{{ 'Custom ID'|trans }}' class='custom-id-badge'>{{ Entity.entityData.custom_id }}</span>
-  {% endif %}
-  <span id='documentTitle' class='breakable malleableColumn hl-hover-gray rounded py-1' data-target='title' data-endpoint='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}'>{{ Entity.entityData.title }}</span>
-  </h1>
 
   {% include('catstat-view.html') %}
 

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -282,6 +282,10 @@ document.addEventListener('DOMContentLoaded', () => {
       params['common_template'] = tinymce.get('common_template').getContent();
       params['common_template_md'] = (document.getElementById('common_template_md') as HTMLTextAreaElement).value;
       ApiC.patch(`${Model.Team}/current`, params);
+    } else if (el.matches('[data-action="patch-newcomer_banner"]')) {
+      const params = {};
+      params['newcomer_banner'] = tinymce.get('newcomer_banner').getContent();
+      ApiC.patch(`${Model.Team}/current`, params);
     } else if (el.matches('[data-action="patch-team-common-template-md"]')) {
       const params = {};
       params['common_template_md'] = (document.getElementById('common_template_md') as HTMLTextAreaElement).value;

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -279,29 +279,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateCatStat($(this).data('target'), entity, String($(this).val()));
   });
 
-  // TITLE STUFF
-  const titleInput = document.getElementById('title_input') as HTMLInputElement;
-  // add the title in the page name (see #324)
-  document.title = titleInput.value + ' - eLabFTW';
-
-  // If the title is 'Untitled', clear it on focus
-  titleInput.addEventListener('focus', event => {
-    const el = event.target as HTMLInputElement;
-    if (el.value === i18next.t('entity-default-title')) {
-      el.value = '';
-    }
-  });
-
-  titleInput.addEventListener('blur', () => {
-    if (titleInput.value !== titleInput.defaultValue) {
-      const content = titleInput.value;
-      titleInput.defaultValue = content;
-      EntityC.update(entity.id, Target.Title, content);
-      // update the page's title
-      document.title = content + ' - eLabFTW';
-    }
-  });
-
   // no tinymce stuff when md editor is selected
   if (editor.type === 'tiny') {
     // Object to hold control data for selected image

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // TOGGLE EXCLUSIVE EDIT MODE
     } else if (el.matches('[data-action="toggle-exclusive-edit-mode"]')
-      || el.parentElement.matches('[data-action="toggle-exclusive-edit-mode"]')
+      || el.parentElement?.matches('[data-action="toggle-exclusive-edit-mode"]')
     ) {
       EntityC.patchAction(entity.id, Action.ExclusiveEditMode)
         .then(() => reloadElements(['exclusiveEditModeBtn', 'exclusiveEditModeInfo', 'requestActionsDiv']))

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -10,10 +10,6 @@ describe('Experiments', () => {
     cy.get('#date_input').type('2021-05-01').blur();
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
 
-    // update title
-    cy.get('#title_input').type('Updated from cypress').blur();
-    cy.get('#overlay').should('be.visible').should('contain', 'Saved');
-
     // create Tag
     cy.get('#createTagInput').type('some tag').blur();
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -57,7 +57,7 @@ describe('Experiments', () => {
       cy.get('[title="View mode"]').click();
       cy.get('[data-target="duplicateModal"]').click();
       cy.get('[data-action="duplicate-entity"]').click();
-      cy.contains('Title').should('be.visible');
+      cy.get('#documentTitle').should('be.visible');
       // destroy the duplicated entity now
       entityDestroy();
       // go back to the original entity

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -13,6 +13,15 @@ describe('Exclusive edit mode', () => {
     cy.url().should('include', 'mode=edit');
     cy.wait('@get');
     cy.intercept('PATCH', '/api/v2/experiments/**').as('api');
+    cy.get('#documentTitle').click();
+    cy.get('input[value="Untitled"]').type(title).then(input => {
+      cy.wrap(input)
+        .closest('form')
+        .find('button:contains("Save")')
+        .click();
+    });
+    cy.wait('@api');
+    cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');
     cy.get('#exclusiveEditModeBtn').click();
     cy.wait('@api');

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -12,10 +12,6 @@ describe('Exclusive edit mode', () => {
     cy.get('#createModal_experiments').should('be.visible').should('contain', 'Default template').contains('Default template').click();
     cy.url().should('include', 'mode=edit');
     cy.wait('@get');
-    cy.intercept('PATCH', '/api/v2/experiments/**').as('api');
-    cy.get('#title_input').type(title).blur();
-    cy.wait('@api');
-    cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');
     cy.get('#exclusiveEditModeBtn').click();
     cy.wait('@api');

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -12,6 +12,7 @@ describe('Exclusive edit mode', () => {
     cy.get('#createModal_experiments').should('be.visible').should('contain', 'Default template').contains('Default template').click();
     cy.url().should('include', 'mode=edit');
     cy.wait('@get');
+    cy.intercept('PATCH', '/api/v2/experiments/**').as('api');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');
     cy.get('#exclusiveEditModeBtn').click();
     cy.wait('@api');

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -14,12 +14,8 @@ describe('Exclusive edit mode', () => {
     cy.wait('@get');
     cy.intercept('PATCH', '/api/v2/experiments/**').as('api');
     cy.get('#documentTitle').click();
-    cy.get('input[value="Untitled"]').type(title).then(input => {
-      cy.wrap(input)
-        .closest('form')
-        .find('button:contains("Save")')
-        .click();
-    });
+    cy.get('h1.text-dark').find('input').clear().type(title);
+    cy.get('h1.text-dark').find('button').contains('Save').click();
     cy.wait('@api');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');


### PR DESCRIPTION
* Admin can enable a banner visible on top of all pages with custom text
* Banner is visible for new users where the creation date is less than
  15 days (customizable)
* fix issue with incorrect html in announcements fix https://github.com/elabftw/elabftw/issues/4982
* fix warning with unset copyFiles in request
* BREAKING CHANGE: change register_date (unix timestamp stored as bigint) into created_at
  (timestamp) for users table. Breaking if you rely on register_date in
scripts. Now look at created_at and expect a datetime value instead of
unix timestamp.
* remove the breadcrumb on View and Edit pages and replace it with the
  title
* remove title input from edit mode: title is now in text, editable
  after a click
* fix incorrect parenthesis on sysconfig page, teams tab doc link
![2024-07-15-224031_1754x618_scrot](https://github.com/user-attachments/assets/3cbb6f77-264f-4be2-826f-62410c4d3591)
![2024-07-15-224044_430x314_scrot](https://github.com/user-attachments/assets/97511082-b084-44eb-8ef9-4fe1f3050d58)



