### PR TITLE
Improved configurability of Eln imports

### DIFF
--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -147,6 +147,7 @@ final class Config implements RestInterface
             ('allow_useronly', '1'),
             ('admins_import_users', '0'),
             ('admins_archive_users', '1'),
+            ('trust_imported_archives', '0'),
             ('max_revisions', '10'),
             ('min_delta_revisions', '100'),
             ('min_days_revisions', '23'),

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -490,9 +490,14 @@ class Users implements RestInterface
     // create a user from the information provided in a node of type Person (.eln)
     public function createFromPerson(array $person, int $team): self
     {
-        $TeamsHelper = new TeamsHelper($team);
-        if (!$TeamsHelper->isAdminInTeam($this->requester->userid ?? 0)) {
-            throw new ImproperActionException('Trying to create a user from an Author node but user is not Admin');
+        if ($this->requester->userData['is_sysadmin'] === 0) {
+            $TeamsHelper = new TeamsHelper($team);
+            if (!$TeamsHelper->isAdminInTeam($this->requester->userid ?? 0)) {
+                throw new ImproperActionException('Trying to create a user from an Author node but user is not Admin');
+            }
+            if (Config::getConfig()->configArr['admins_create_users'] !== '1') {
+                throw new IllegalActionException('Admin tried to create user by import but user creation is disabled for admins.');
+            }
         }
         $userid = $this->createOne(
             $person['email'] ?? throw new ImproperActionException('Could not find an email to create the user!'),

--- a/src/sql/schema157-down.sql
+++ b/src/sql/schema157-down.sql
@@ -1,0 +1,5 @@
+-- revert schema 157
+DELETE FROM config WHERE conf_name =  'trust_imported_archives';
+UPDATE config SET conf_value = 156 WHERE conf_name = 'schema';
+
+

--- a/src/sql/schema157.sql
+++ b/src/sql/schema157.sql
@@ -1,4 +1,3 @@
 -- schema 157
-UPDATE `users` SET `created_at` = FROM_UNIXTIME(`register_date`);
 UPDATE config SET conf_value = 0 WHERE conf_name = 'trust_imported_archives';
 UPDATE config SET conf_value = 157 WHERE conf_name = 'schema';

--- a/src/sql/schema157.sql
+++ b/src/sql/schema157.sql
@@ -1,0 +1,4 @@
+-- schema 157
+UPDATE `users` SET `created_at` = FROM_UNIXTIME(`register_date`);
+UPDATE config SET conf_value = 0 WHERE conf_name = 'trust_imported_archives';
+UPDATE config SET conf_value = 157 WHERE conf_name = 'schema';

--- a/src/sql/schema157.sql
+++ b/src/sql/schema157.sql
@@ -1,3 +1,3 @@
 -- schema 157
-UPDATE config SET conf_value = 0 WHERE conf_name = 'trust_imported_archives';
+INSERT INTO config (conf_name, conf_value) values ('trust_imported_archives', '0');
 UPDATE config SET conf_value = 157 WHERE conf_name = 'schema';

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -148,6 +148,7 @@
     {% include 'binary-setting.html' with {'label': 'Admins can create local accounts'|trans, 'slug': 'admins_create_users'} %}
     {% include 'binary-setting.html' with {'label': 'Allow Admins to add existing users to their team'|trans, 'slug': 'admins_import_users'} %}
     {% include 'binary-setting.html' with {'label': 'Allow Admins to archive users'|trans, 'slug': 'admins_archive_users'} %}
+    {% include 'binary-setting.html' with {'label': 'Trust imported files about data ownership and dates'|trans, 'help': 'Allows users eg to import experiments under the identity stated in the file, creating missing users (if allowed).'|trans, 'slug': 'trust_imported_archives'} %}
 
     {% include 'binary-setting.html' with {'label': 'Show local login form'|trans, 'slug': 'local_login', 'help': 'You can still show the local login form by appending ?letmein to the login page URL.'|trans} %}
 

--- a/tests/unit/Import/ElnTest.php
+++ b/tests/unit/Import/ElnTest.php
@@ -98,7 +98,6 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $uploadedFile,
             $this->fs,
         );
-        $Import->importAuthorsAsUsers = false;
         $Import->import();
         $this->assertEquals(1, $Import->getInserted());
     }
@@ -123,7 +122,6 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $uploadedFile,
             $this->fs,
         );
-        $Import->importAuthorsAsUsers = false;
         $Import->import();
         $this->assertEquals(9, $Import->getInserted());
     }
@@ -148,7 +146,6 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $uploadedFile,
             $this->fs,
         );
-        $Import->importAuthorsAsUsers = false;
         $Import->import();
         $this->assertEquals(1, $Import->getInserted());
     }
@@ -173,7 +170,6 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $uploadedFile,
             $this->fs,
         );
-        $Import->importAuthorsAsUsers = false;
         $this->expectException(ImproperActionException::class);
         $Import->import();
     }
@@ -222,7 +218,6 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $uploadedFile,
             $this->fs,
         );
-        $Import->importAuthorsAsUsers = false;
         $Import->import();
         $this->assertEquals(2, $Import->getInserted());
     }


### PR DESCRIPTION
In an alpha version, the functionality of importing experiments with their previous creation dates and creators (instead of some user importing multiple experiments suddenly seeming to have created a lot of them, and at the same time) was introduced. This also allowed for some confusion as to which user did what. See discussion in https://github.com/elabftw/elabftw/commit/ceb768895651ca029ca456ce23718d45d43a0217 

This pull request is a somewhat quick draft of an update that allows sysadmins of instances that want this functionality, either permanently or during a brief window of time, to turn it on.