### PR TITLE
Add scope for teamgroups

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 156;
+    public const int REQUIRED_SCHEMA = 158;
 
     private Db $Db;
 

--- a/src/classes/UserParams.php
+++ b/src/classes/UserParams.php
@@ -53,7 +53,7 @@ final class UserParams extends ContentParams implements ContentParamsInterface
             'display_mode' => (DisplayMode::tryFrom($this->content) ?? DisplayMode::Normal)->value,
             'sort' => (Sort::tryFrom($this->content) ?? Sort::Desc)->value,
             'orderby' => (Orderby::tryFrom($this->content) ?? Orderby::Date)->value,
-            'scope_experiments', 'scope_items', 'scope_experiments_templates' => (string) (Scope::tryFrom((int) $this->content) ?? Scope::Team)->value,
+            'scope_experiments', 'scope_items', 'scope_experiments_templates', 'scope_teamgroups' => (string) (Scope::tryFrom((int) $this->content) ?? Scope::Team)->value,
             'sc_create', 'sc_favorite', 'sc_todo', 'sc_edit', 'sc_search' => Filter::firstLetter($this->content),
             'is_sysadmin', 'uploads_layout', 'cjk_fonts', 'pdf_sig', 'use_markdown', 'use_isodate', 'inc_files_pdf', 'append_pdfs', 'disable_shortcuts', 'validated', 'notif_comment_created', 'notif_comment_created_email', 'notif_step_deadline', 'notif_step_deadline_email', 'notif_user_created', 'notif_user_created_email', 'notif_user_need_validation', 'notif_user_need_validation_email', 'notif_event_deleted', 'notif_event_deleted_email', 'always_show_owned' => (string) Filter::toBinary($this->content),
             'lang' => (Language::tryFrom($this->content) ?? Language::EnglishGB)->value,

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -61,9 +61,7 @@ abstract class AbstractEntityController implements ControllerInterface
 
     protected array $templatesArr = array();
 
-    protected array $teamGroupsFromUser = array();
-
-    protected array $allTeamgroupsArr = array();
+    protected array $scopedTeamgroupsArr = array();
 
     public function __construct(protected App $App, protected AbstractEntity $Entity)
     {
@@ -78,8 +76,8 @@ abstract class AbstractEntityController implements ControllerInterface
             ARRAY_FILTER_USE_KEY,
         );
         $this->currencyArr = Currency::getAssociativeArray();
-        $this->teamGroupsFromUser = $TeamGroups->readGroupsFromUser();
-        $this->allTeamgroupsArr = $TeamGroups->readAllGlobal();
+        $this->scopedTeamgroupsArr = $TeamGroups->readScopedTeamgroups();
+        //$this->allTeamgroupsArr = $TeamGroups->readAllGlobal();
         $Templates = new Templates($this->Entity->Users);
         $this->templatesArr = $Templates->Pins->readAllSimple();
         if ($App->Request->query->has('archived') && $Entity instanceof AbstractConcreteEntity) {
@@ -158,12 +156,12 @@ abstract class AbstractEntityController implements ControllerInterface
             'pinnedArr' => $this->Entity->Pins->readAll(),
             'itemsArr' => $itemsArr,
             'requestActionsArr' => $UserRequestActions->readAllFull(),
+            'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             // generate light show page
             'searchPage' => $isSearchPage,
             'tagsArr' => $tagsArr,
             // get all the tags for the top search bar
             'tagsArrForSelect' => $TeamTags->readFull(),
-            'teamGroupsFromUser' => $this->teamGroupsFromUser,
             'templatesArr' => $this->templatesArr,
             'usersArr' => $this->App->Users->readAllActiveFromTeam(),
             'visibilityArr' => $this->visibilityArr,
@@ -222,7 +220,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'mode' => 'view',
             'hideTitle' => true,
             'teamsArr' => $Teams->readAll(),
-            'allTeamgroupsArr' => $this->allTeamgroupsArr,
+            'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             'templatesArr' => $this->templatesArr,
             ...$this->Entity instanceof AbstractConcreteEntity
                     ? array('timestamperFullname' => $this->Entity->getTimestamperFullname())
@@ -295,7 +293,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'statusArr' => $this->statusArr,
             'teamsArr' => $Teams->readAll(),
             'teamTagsArr' => $TeamTags->readAll(),
-            'allTeamgroupsArr' => $this->allTeamgroupsArr,
+            'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             'meaningArr' => $this->meaningArr,
             'requestableActionArr' => $this->requestableActionArr,
             'templatesArr' => $this->templatesArr,

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -77,7 +77,6 @@ abstract class AbstractEntityController implements ControllerInterface
         );
         $this->currencyArr = Currency::getAssociativeArray();
         $this->scopedTeamgroupsArr = $TeamGroups->readScopedTeamgroups();
-        //$this->allTeamgroupsArr = $TeamGroups->readAllGlobal();
         $Templates = new Templates($this->Entity->Users);
         $this->templatesArr = $Templates->Pins->readAllSimple();
         if ($App->Request->query->has('archived') && $Entity instanceof AbstractConcreteEntity) {

--- a/src/models/TeamGroups.php
+++ b/src/models/TeamGroups.php
@@ -132,7 +132,7 @@ class TeamGroups implements RestInterface
 
     public function readScopedTeamgroups(): array
     {
-        $scope = Scope::from($this->Users->userData['teamgroups_scope']);
+        $scope = Scope::from($this->Users->userData['scope_teamgroups']);
         return match ($scope) {
             Scope::User => $this->readAllUser(),
             Scope::Team => $this->readAllTeam(),

--- a/src/sql/schema158-down.sql
+++ b/src/sql/schema158-down.sql
@@ -1,3 +1,3 @@
 -- revert schema 158
-ALTER TABLE `users` DROP COLUMN `teamgroups_scope`;
+ALTER TABLE `users` DROP COLUMN `scope_teamgroups`;
 UPDATE config SET conf_value = 157 WHERE conf_name = 'schema';

--- a/src/sql/schema158-down.sql
+++ b/src/sql/schema158-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 158
+ALTER TABLE `users` DROP COLUMN `teamgroups_scope`;
+UPDATE config SET conf_value = 157 WHERE conf_name = 'schema';

--- a/src/sql/schema158.sql
+++ b/src/sql/schema158.sql
@@ -1,0 +1,3 @@
+-- schema 158
+ALTER TABLE `users` ADD `teamgroups_scope` TINYINT UNSIGNED NOT NULL DEFAULT 3;
+UPDATE config SET conf_value = 158 WHERE conf_name = 'schema';

--- a/src/sql/schema158.sql
+++ b/src/sql/schema158.sql
@@ -1,3 +1,3 @@
 -- schema 158
-ALTER TABLE `users` ADD `teamgroups_scope` TINYINT UNSIGNED NOT NULL DEFAULT 3;
+ALTER TABLE `users` ADD `scope_teamgroups` TINYINT UNSIGNED NOT NULL DEFAULT 3;
 UPDATE config SET conf_value = 158 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1169,6 +1169,7 @@ CREATE TABLE `users` (
   `scope_experiments` tinyint UNSIGNED NOT NULL DEFAULT 2,
   `scope_items` tinyint UNSIGNED NOT NULL DEFAULT 2,
   `scope_experiments_templates` tinyint UNSIGNED NOT NULL DEFAULT 2,
+  `scope_teamgroups` tinyint UNSIGNED NOT NULL DEFAULT 3,
   `use_isodate` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `uploads_layout` tinyint UNSIGNED NOT NULL DEFAULT 1,
   `validated` tinyint UNSIGNED NOT NULL DEFAULT 0,

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -59,7 +59,7 @@
             <div class='ml-auto'>
               <details closed>
                 <summary class='p-2 rounded hl-hover-gray'>{{ 'Set scope'|trans }}</summary>
-                <select data-trigger='change' data-model='users/me' data-reload='{{ identifier }}_select_teamgroups' data-target='scope_teamgroups' class='form-control'>
+                <select aria-label='{{ 'Set scope'|trans }}' data-trigger='change' data-model='users/me' data-reload='{{ identifier }}_select_teamgroups' data-target='scope_teamgroups' class='form-control'>
                   {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
                   <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>
                   <option value='2' {{ App.Users.userData.scope_teamgroups == 2 ? ' selected' }}>{{ 'Team'|trans }}</option>

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -53,7 +53,21 @@
             {% endfor %}
           </select>
           {# TEAMGROUPS #}
-          <label for='{{ identifier }}_select_teamgroups' class='mt-2'>+ {{ 'Teamgroups'|trans }}</label> <p class='smallgray d-inline'>{{ '(hold %sctrl%s key to select multiple entries)'|trans|format('<kbd>', '</kbd>')|raw }}</p>
+          <label for='{{ identifier }}_select_teamgroups' class='mt-2'>+ {{ 'Teamgroups'|trans }}</label>
+          <div class='d-flex'>
+            <p class='smallgray'>{{ '(hold %sctrl%s key to select multiple entries)'|trans|format('<kbd>', '</kbd>')|raw }}</p>
+            <div class='ml-auto'>
+              <details closed>
+                <summary class='p-2 rounded hl-hover-gray'>{{ 'Set scope'|trans }}</summary>
+                <select data-trigger='change' data-model='users/me' data-reload='{{ identifier }}_select_teamgroups' data-target='scope_teamgroups' class='form-control'>
+                  {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
+                  <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>
+                  <option value='2' {{ App.Users.userData.scope_teamgroups == 2 ? ' selected' }}>{{ 'Team'|trans }}</option>
+                  <option value='3' {{ App.Users.userData.scope_teamgroups == 3 ? ' selected' }}>{{ 'Everything'|trans }}</option>
+                </select>
+              </details>
+            </div>
+          </div>
           <p class='smallgray'>{{ 'Selecting a teamgroup here will give access to all users part of this teamgroup.'|trans }}</p>
           <select {{ scopedTeamgroupsArr|length == 0 ? 'disabled' }} id='{{ identifier }}_select_teamgroups' multiple class='form-control' autocomplete='off'>
             {% for tg in scopedTeamgroupsArr %}

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -55,8 +55,8 @@
           {# TEAMGROUPS #}
           <label for='{{ identifier }}_select_teamgroups' class='mt-2'>+ {{ 'Teamgroups'|trans }}</label> <p class='smallgray d-inline'>{{ '(hold %sctrl%s key to select multiple entries)'|trans|format('<kbd>', '</kbd>')|raw }}</p>
           <p class='smallgray'>{{ 'Selecting a teamgroup here will give access to all users part of this teamgroup.'|trans }}</p>
-          <select {{ allTeamgroupsArr|length == 0 ? 'disabled' }} id='{{ identifier }}_select_teamgroups' multiple class='form-control' autocomplete='off'>
-            {% for tg in allTeamgroupsArr %}
+          <select {{ scopedTeamgroupsArr|length == 0 ? 'disabled' }} id='{{ identifier }}_select_teamgroups' multiple class='form-control' autocomplete='off'>
+            {% for tg in scopedTeamgroupsArr %}
               <option value='teamgroup:{{ tg.id }}'
               {{ permissionsJson|isInJsonArray('teamgroups', tg.id) == ('teamgroup:' ~ tg.id) ? ' selected' }}
                       >{{ 'Teamgroup'|trans }} - {{ tg.name }}</option>

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -1,4 +1,4 @@
-{# required vars: rw visibilityArr teamsArr allTeamgroupsArr usersArr #}
+{# required vars: rw visibilityArr teamsArr scopedTeamgroupsArr usersArr #}
 {% if ucpPage %}{# set this to true on ucp page for default permissions #}
   {% set column = rw == 'canread' ? 'default_read' : 'default_write' %}
   {% set permissionsJson = App.Users.userData[column] %}

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -284,6 +284,17 @@
         <span class='slider'></span>
       </label>
     </div>
+    <hr>
+
+    <div class='d-flex justify-content-between'>
+      <label for='scope_teamgroups' class='col-form-label'>{{ 'Select the scope for teamgroups'|trans }}</label>
+      <select id='scope_teamgroups' data-trigger='change' data-model='users/me' data-target='scope_teamgroups' class='form-control col-md-3'>
+        {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
+        <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>
+        <option value='2' {{ App.Users.userData.scope_teamgroups == 2 ? ' selected' }}>{{ 'Team'|trans }}</option>
+        <option value='3' {{ App.Users.userData.scope_teamgroups == 3 ? ' selected' }}>{{ 'Everything'|trans }}</option>
+      </select>
+    </div>
   </div>
 
 </div>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -287,7 +287,10 @@
     <hr>
 
     <div class='d-flex justify-content-between'>
-      <label for='scope_teamgroups' class='col-form-label'>{{ 'Select the scope for teamgroups'|trans }}</label>
+      <div>
+        <label for='scope_teamgroups' class='col-form-label'>{{ 'Select the scope for teamgroups'|trans }}</label>
+        <p class='smallgray'>{{ 'This setting controls which teamgroups will be listed in the permission settings window.'|trans }}</p>
+      </div>
       <select id='scope_teamgroups' data-trigger='change' data-model='users/me' data-target='scope_teamgroups' class='form-control col-md-3'>
         {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
         <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>

--- a/tests/unit/models/TeamGroupsTest.php
+++ b/tests/unit/models/TeamGroupsTest.php
@@ -60,8 +60,9 @@ class TeamGroupsTest extends \PHPUnit\Framework\TestCase
     public function testRead(): void
     {
         $this->assertIsArray($this->TeamGroups->readAll());
-        $this->assertIsArray($this->TeamGroups->readAllSimple());
-        $this->assertIsArray($this->TeamGroups->readAllGlobal());
+        $this->assertIsArray($this->TeamGroups->readAllUser());
+        $this->assertIsArray($this->TeamGroups->readAllTeam());
+        $this->assertIsArray($this->TeamGroups->readAllEverything());
     }
 
     public function testDestroy(): void

--- a/web/admin.php
+++ b/web/admin.php
@@ -121,7 +121,7 @@ try {
         'isSearching' => $isSearching,
         'itemsCategoryArr' => $itemsCategoryArr,
         'metadataGroups' => $metadataGroups,
-        'allTeamgroupsArr' => $TeamGroups->readAllGlobal(),
+        'allTeamgroupsArr' => $TeamGroups->readAllEverything(),
         'statusArr' => $statusArr,
         'experimentsCategoriesArr' => $experimentsCategoriesArr,
         'itemsStatusArr' => $itemsStatusArr,


### PR DESCRIPTION
fix #5000 

Add dropdown menu in Settings to control which teamgroups are displayed:
![2024-07-19-003827_1179x109_scrot](https://github.com/user-attachments/assets/636a3d99-a033-46c4-9e9a-942b45fcdce0)


Add the same menu in the permission modal window:

![simplescreenrecorder-2024-07-19_00 36 03-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9a3bd681-1761-4400-962f-ae41d8ef2595)