### PR TITLE
do not create teams during saml auth with several teams

### DIFF
--- a/src/classes/AuthResponse.php
+++ b/src/classes/AuthResponse.php
@@ -22,8 +22,7 @@ class AuthResponse
 {
     public int $userid;
 
-    /** @var array<int, array<int, string>> don't use an array of Team but just the ids and name */
-    public $selectableTeams = array();
+    public array $selectableTeams = array();
 
     public int $selectedTeam;
 

--- a/src/models/ExistingUser.php
+++ b/src/models/ExistingUser.php
@@ -38,9 +38,10 @@ class ExistingUser extends Users
         bool $automaticValidationEnabled = false,
         bool $alertAdmin = true,
         ?string $orgid = null,
+        bool $allowTeamCreation = false,
     ): Users {
         $Users = new self();
-        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid);
+        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid, allowTeamCreation: $allowTeamCreation);
         $fresh = new self($userid);
         // we need to report the needValidation flag into the new object
         $fresh->needValidation = $Users->needValidation;

--- a/src/models/Teams.php
+++ b/src/models/Teams.php
@@ -59,12 +59,8 @@ class Teams implements RestInterface
      * Input can come from external auth and reference an uncreated team
      * so with this the team will be created on the fly (if it's allowed)
      */
-    public function getTeamsFromIdOrNameOrOrgidArray(array|string $teams, bool $allowTeamCreation = false): array
+    public function getTeamsFromIdOrNameOrOrgidArray(array $teams, bool $allowTeamCreation = false): array
     {
-        if (is_string($teams)) {
-            // maybe it's a string containing several teams separated by commas
-            $teams = explode(',', $teams);
-        }
         $res = array();
         $sql = 'SELECT id, name FROM teams WHERE id = :query OR name = :query OR orgid = :query';
         $req = $this->Db->prepare($sql);

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -88,13 +88,14 @@ class Users implements RestInterface
         bool $alertAdmin = true,
         ?string $validUntil = null,
         ?string $orgid = null,
+        bool $allowTeamCreation = false,
     ): int {
         $Config = Config::getConfig();
         $Teams = new Teams($this);
 
         // make sure that all the teams in which the user will be are created/exist
         // this might throw an exception if the team doesn't exist and we can't create it on the fly
-        $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teams);
+        $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teams, $allowTeamCreation);
         $TeamsHelper = new TeamsHelper($teams[0]['id']);
 
         $EmailValidator = new EmailValidator($email, $Config->configArr['email_domain']);

--- a/src/models/ValidatedUser.php
+++ b/src/models/ValidatedUser.php
@@ -29,9 +29,9 @@ class ValidatedUser extends ExistingUser
         return self::search('orgid', $orgid, true);
     }
 
-    public static function fromExternal(string $email, array $teams, string $firstname, string $lastname, ?string $orgid = null): Users
+    public static function fromExternal(string $email, array $teams, string $firstname, string $lastname, ?string $orgid = null, bool $allowTeamCreation = false): Users
     {
-        return parent::fromScratch($email, $teams, $firstname, $lastname, automaticValidationEnabled: true, orgid: $orgid);
+        return parent::fromScratch($email, $teams, $firstname, $lastname, automaticValidationEnabled: true, orgid: $orgid, allowTeamCreation: $allowTeamCreation);
     }
 
     public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, Usergroup $usergroup): Users

--- a/src/services/Populate.php
+++ b/src/services/Populate.php
@@ -206,7 +206,7 @@ class Populate
             validUntil: null,
             orgid: $orgid
         );
-        $team = $Teams->getTeamsFromIdOrNameOrOrgidArray(array($user['team']));
+        $team = $Teams->getTeamsFromIdOrNameOrOrgidArray(array($user['team']), true);
         $Requester = new Users(1, 1);
         $Users = new Users($userid, $team[0]['id'], $Requester);
 

--- a/src/services/TeamsHelper.php
+++ b/src/services/TeamsHelper.php
@@ -94,6 +94,16 @@ class TeamsHelper
         return !empty($this->getUserInTeam($userid));
     }
 
+    // just get the id and name array
+    public function getSimple(): array
+    {
+        $sql = 'SELECT id, name FROM teams WHERE id = :team';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':team', $this->team, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $req->fetch();
+    }
+
     /**
      * Get all the userid of active admins of the team
      */

--- a/src/services/UsersHelper.php
+++ b/src/services/UsersHelper.php
@@ -76,6 +76,7 @@ class UsersHelper
 
     /**
      * Get the team id where the user belong
+     * @return array{array{id: int, name: string, is_owner: int, usergroup: int}} | array
      */
     public function getTeamsFromUserid(): array
     {

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -286,9 +286,6 @@
             </div>
           </div>
           {# SAVE AND RESET BUTTONS #}
-          {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable wcag/h32] -->
-          {%- endif %}
           <button data-action='save-multi-changes' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Save'|trans }}</button>
           <button data-action='clear-form' data-target='multiChangesForm' type='reset' class='btn btn-ghost mb-2'>{{ 'Reset'|trans }}</button>
         </form>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -286,8 +286,11 @@
             </div>
           </div>
           {# SAVE AND RESET BUTTONS #}
+          {% if App.Config.configArr.debug -%}
+            <!-- [html-validate-disable wcag/h32] -->
+          {%- endif %}
           <button data-action='save-multi-changes' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Save'|trans }}</button>
-          <button data-action='clear-form' data-target='multiChangesForm' type='button' class='btn btn-ghost mb-2'>{{ 'Reset'|trans }}</button>
+          <button data-action='clear-form' data-target='multiChangesForm' type='reset' class='btn btn-ghost mb-2'>{{ 'Reset'|trans }}</button>
         </form>
       </div>
 

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -286,7 +286,7 @@
             </div>
           </div>
           {# SAVE AND RESET BUTTONS #}
-          <button data-action='save-multi-changes' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Save'|trans }}</button>
+          <button data-action='save-multi-changes' type='submit' class='btn btn-primary mr-1 mb-2'>{{ 'Save'|trans }}</button>
           <button data-action='clear-form' data-target='multiChangesForm' type='reset' class='btn btn-ghost mb-2'>{{ 'Reset'|trans }}</button>
         </form>
       </div>

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -173,6 +173,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // SAVE MULTI CHANGES
     } else if (el.matches('[data-action="save-multi-changes"]')) {
 
+      // prevent form submission
+      event.preventDefault();
+
       // get the item id of all checked boxes
       const checked = getCheckedBoxes();
       if (checked.length === 0) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Tips
+
+To debug a var during unit tests, use this:
+
+~~~php
+fwrite(STDERR, print_r($var, true));
+~~~

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -81,7 +81,8 @@ if ($ci); then
 fi
 # when trying to use a bash variable to hold the skip api options, I ran into issues that this option doesn't exist, so the command is entirely duplicated instead
 if [ "${1:-}" = "unit" ]; then
-    docker exec -it elabtmp php vendor/bin/codecept run --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+    # verbose flag allows to see fwrite debug statements
+    docker exec -it elabtmp php vendor/bin/codecept run --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
 elif [ "${1:-}" = "api" ]; then
     docker exec -it elabtmp php vendor/bin/codecept run --skip unit --skip cypress --coverage --coverage-html --coverage-xml
 # acceptance with cypress

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -80,7 +80,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
         $this->samlUserdata['User.email'] = 'toto@yopmail.com';
         $this->samlUserdata['User.firstname'] = 'Toto';
         $this->samlUserdata['User.lastname'] = 'FTW';
-        $this->samlUserdata['User.team'] = 'Alpha';
+        $this->samlUserdata['User.team'] = array('Alpha');
         $this->SamlAuthLib->method('getAttributes')->willReturn($this->samlUserdata);
 
         $this->IdpsHelper = new IdpsHelper(Config::getConfig(), $Idps);
@@ -386,7 +386,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
     {
         $samlUserdata = $this->samlUserdata;
         $samlUserdata['User.email'] = 'a_new_never_seen_before_user_for_real@example.com';
-        $samlUserdata['User.team'] = 'Bravo';
+        $samlUserdata['User.team'] = array('Bravo');
 
         // create the user on the fly
         $config = $this->configArr;
@@ -400,7 +400,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
     {
         $samlUserdata = $this->samlUserdata;
         $samlUserdata['User.email'] = 'a_new_never_seen_before_user_for_real_yes@example.com';
-        $samlUserdata['User.team'] = 'Bravo';
+        $samlUserdata['User.team'] = array('Bravo');
         $settings = $this->settings;
         // set an empty idp team attribute
         $settings['idp']['teamAttr'] = '';

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -222,7 +222,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     public function testReadAllActiveFromTeam(): void
     {
-        $this->assertCount(8, $this->Users->readAllActiveFromTeam());
+        $this->assertCount(9, $this->Users->readAllActiveFromTeam());
     }
 
     public function testAddUserToTeam(): void

--- a/tests/unit/services/EmailNotificationsTest.php
+++ b/tests/unit/services/EmailNotificationsTest.php
@@ -55,7 +55,7 @@ class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
             'target' => 'team',
             'targetid' => 1,
         ));
-        $this->assertEquals(9, $targetCount);
+        $this->assertEquals(10, $targetCount);
         $this->assertIsArray($Notifications->readOne());
         $this->assertIsArray($Notifications->patch(Action::Update, array()));
         $this->assertIsString($Notifications->getApiPath());

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -60,8 +60,8 @@ class EmailTest extends \PHPUnit\Framework\TestCase
     {
         $replyTo = new Address('sender@example.com', 'Sergent Garcia');
         // Note that non-validated users are not active users
-        $this->assertEquals(18, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
-        $this->assertEquals(9, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
+        $this->assertEquals(19, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
+        $this->assertEquals(10, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(0, $this->Email->massEmail(EmailTarget::TeamGroup, 1, 'Important message', 'yep', $replyTo));
         $this->assertEquals(6, $this->Email->massEmail(EmailTarget::Admins, null, 'Important message to admins', 'yep', $replyTo));
         $this->assertEquals(1, $this->Email->massEmail(EmailTarget::Sysadmins, null, 'Important message to sysadmins', 'yep', $replyTo));


### PR DESCRIPTION
This change will allow having the IDP reply with several teams but the user will get created or synchronized only with the existing teams if saml_team_create is 0.
superseeds #5149

