### PR TITLE
Draft: Support adding media files via upload dropdown menu

### DIFF
--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -15,14 +15,14 @@
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for videos #}
-    {% if ext matches '/(mpeg|mpg|mpe|mp4|ogg|ogv|webm|avi)$/i' %}
+    {% if ext matches '/(mpeg|mpg|mpe|mp4|ogv|webm|avi)$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
         <i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
       </button>
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for audio #}
-    {% if ext matches '/(mp3|mp4|ogg|opus|wav|flac)$/i' %}
+    {% if ext matches '/(mp3|ogg|opus|wav|flac)$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
         <i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
       </button>

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -14,6 +14,20 @@
       </button>
     {% endif %}
 
+    {# INSERT IN TEXT in edit mode for videos #}
+    {% if ext matches '/(mpeg|mpg|mpe|mp4|ogg|ogv|webm|avi)$/i' %}
+      <button type='button' class='dropdown-item' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
+        <i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
+      </button>
+    {% endif %}
+
+    {# INSERT IN TEXT in edit mode for audio #}
+    {% if ext matches '/(mp3|mp4|ogg|opus|wav|flac)$/i' %}
+      <button type='button' class='dropdown-item' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
+        <i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
+      </button>
+    {% endif %}
+
     {# INSERT IN TEXT in edit mode for plain text #}
     {% if ext matches '/txt$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'>

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -15,14 +15,14 @@
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for videos #}
-    {% if ext matches '/(mpeg|mpg|mpe|mp4|ogv|webm|avi)$/i' %}
+    {% if ext matches '/(mkv|mp4|ogv|webm)$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
         <i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
       </button>
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for audio #}
-    {% if ext matches '/(mp3|ogg|opus|wav|flac)$/i' %}
+    {% if ext matches '/(acc|flac|mp3|ogg|opus|wav)$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
         <i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
       </button>

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -6,6 +6,7 @@
  * @package elabftw
  */
 import {
+  escapeHTML,
   escapeRegExp,
   getEntity,
   getNewIdFromPostRequest,
@@ -252,7 +253,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // INSERT VIDEO AT CURSOR POSITION IN TEXT
     } else if (el.matches('[data-action="insert-video-in-body"]')) {
       // link to the video
-      const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+      const url = `app/download.php?name=${encodeURIComponent(el.dataset.name)}&f=${encodeURIComponent(el.dataset.link)}&storage=${encodeURIComponent(el.dataset.storage)}`;
       // no syntax for video in markdown; use plain html in both cases
       const video = document.createElement('video');
       const source = document.createElement('source');
@@ -264,7 +265,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // INSERT AUDIO AT CURSOR POSITION IN TEXT
     } else if (el.matches('[data-action="insert-audio-in-body"]')) {
       // link to the video
-      const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+      const url = `app/download.php?name=${encodeURIComponent(el.dataset.name)}&f=${encodeURIComponent(el.dataset.link)}&storage=${encodeURIComponent(el.dataset.storage)}`;
       // no syntax for audio in markdown; use plain html in both cases
       const audio = document.createElement('audio');
       audio.setAttribute('src', url);

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -249,6 +249,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       editor.setContent(content);
 
+    // INSERT VIDEO AT CURSOR POSITION IN TEXT
+    } else if (el.matches('[data-action="insert-video-in-body"]')) {
+      // link to the video
+      const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+      // no syntax for video in markdown; use plain html in both cases
+      let content = '<video controls>\n<source src="' + url + '" /></video>';
+      editor.setContent(content);
+
+    // INSERT AUDIO AT CURSOR POSITION IN TEXT
+    } else if (el.matches('[data-action="insert-audio-in-body"]')) {
+      // link to the video
+      const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+      // no syntax for video in markdown; use plain html in both cases
+      let content = '<audio src="' + url + '" controls></audio>';
+      editor.setContent(content);
+
     // ADD CONTENT OF PLAIN TEXT FILES AT CURSOR POSITION IN TEXT
     } else if (el.matches('[data-action="insert-plain-text"]')) {
       fetch(`app/download.php?storage=${el.dataset.storage}&f=${el.dataset.path}`).then(response => {

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -257,7 +257,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       const video = document.createElement('video');
       const source = document.createElement('source');
       source.src = url;
-      video.setAttribute('controls', 'controls');
+      video.setAttribute('width', '640');
+      video.setAttribute('controls', '');
       video.appendChild(source);
       editor.setContent(video.outerHTML);
 
@@ -268,7 +269,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // no syntax for audio in markdown; use plain html in both cases
       const audio = document.createElement('audio');
       audio.setAttribute('src', url);
-      audio.setAttribute('controls', 'controls');
+      audio.setAttribute('controls', '');
       editor.setContent(audio.outerHTML);
 
     // ADD CONTENT OF PLAIN TEXT FILES AT CURSOR POSITION IN TEXT

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -254,10 +254,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       // link to the video
       const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
       // no syntax for video in markdown; use plain html in both cases
-      let video = document.createElement('video');
-      let source = document.createElement('source');
+      const video = document.createElement('video');
+      const source = document.createElement('source');
       source.src = url;
-      video.setAttribute("controls", "controls");
+      video.setAttribute('controls', 'controls');
       video.appendChild(source);
       editor.setContent(video.outerHTML);
 
@@ -266,9 +266,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       // link to the video
       const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
       // no syntax for audio in markdown; use plain html in both cases
-      let audio = document.createElement('audio');
-      audio.setAttribute("src", url);
-      audio.setAttribute("controls", "controls");
+      const audio = document.createElement('audio');
+      audio.setAttribute('src', url);
+      audio.setAttribute('controls', 'controls');
       editor.setContent(audio.outerHTML);
 
     // ADD CONTENT OF PLAIN TEXT FILES AT CURSOR POSITION IN TEXT

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -254,16 +254,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       // link to the video
       const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
       // no syntax for video in markdown; use plain html in both cases
-      let content = '<video controls>\n<source src="' + url + '" /></video>';
-      editor.setContent(content);
+      let video = document.createElement('video');
+      let source = document.createElement('source');
+      source.src = url;
+      video.setAttribute("controls", "controls");
+      video.appendChild(source);
+      editor.setContent(video.outerHTML);
 
     // INSERT AUDIO AT CURSOR POSITION IN TEXT
     } else if (el.matches('[data-action="insert-audio-in-body"]')) {
       // link to the video
       const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
       // no syntax for audio in markdown; use plain html in both cases
-      let content = '<audio src="' + url + '" controls></audio>';
-      editor.setContent(content);
+      let audio = document.createElement('audio');
+      audio.setAttribute("src", url);
+      audio.setAttribute("controls", "controls");
+      editor.setContent(audio.outerHTML);
 
     // ADD CONTENT OF PLAIN TEXT FILES AT CURSOR POSITION IN TEXT
     } else if (el.matches('[data-action="insert-plain-text"]')) {

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -6,7 +6,6 @@
  * @package elabftw
  */
 import {
-  escapeHTML,
   escapeRegExp,
   getEntity,
   getNewIdFromPostRequest,

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -261,7 +261,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     } else if (el.matches('[data-action="insert-audio-in-body"]')) {
       // link to the video
       const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
-      // no syntax for video in markdown; use plain html in both cases
+      // no syntax for audio in markdown; use plain html in both cases
       let content = '<audio src="' + url + '" controls></audio>';
       editor.setContent(content);
 

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -106,12 +106,12 @@ function doneTyping(): void {
 // options for tinymce to pass to tinymce.init()
 export function getTinymceBaseConfig(page: string): object {
   let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image media link pagebreak codesample template mention visualblocks visualchars emoticons';
-  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link media | sort-table | save';
+  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link | sort-table | save';
   let removedMenuItems = 'newdocument, image, anchor';
   if (page === 'edit') {
     plugins += ' autosave';
     // add Image button in toolbar
-    toolbar1 = toolbar1.replace('media |', 'media image |');
+    toolbar1 = toolbar1.replace('link |', 'link image |');
     // let Image in menu
     removedMenuItems = 'newdocument, anchor';
   }

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -106,12 +106,12 @@ function doneTyping(): void {
 // options for tinymce to pass to tinymce.init()
 export function getTinymceBaseConfig(page: string): object {
   let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image media link pagebreak codesample template mention visualblocks visualchars emoticons';
-  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link | sort-table | save';
+  let toolbar1 = 'undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link media | sort-table | save';
   let removedMenuItems = 'newdocument, image, anchor';
   if (page === 'edit') {
     plugins += ' autosave';
     // add Image button in toolbar
-    toolbar1 = toolbar1.replace('link |', 'link image |');
+    toolbar1 = toolbar1.replace('media |', 'media image |');
     // let Image in menu
     removedMenuItems = 'newdocument, anchor';
   }


### PR DESCRIPTION
This merge request adds support for embedding uploaded media files via the upload dropdown menu. I furthermore added an icon to access the media dialog alongside the image icon in the editor toolbar (overlooked to restore that in #5188 ).

There is one issue worth discussing before finalizing the implementation:

**1. Ambiguities regarding file extensions:** e.g. mp4 might be an audio or video file. Same is true for ogg. This may be resolved by checking the mime type instead of just matching the file extension. The current implementation will match both audio and video. Hence the user will get both options (adding as audio or video; first screenshot). Worst case the replay will not work if an audio file is embedded as video or vice versa. Last option is to decide that e.g. mp4 is **usually** a video file and exclude it from the audio extensions. Same is possible for ogg which probably will **mostly** be used for audio files.

![Adding a file with ambiguous extension (here: mp4)](https://github.com/user-attachments/assets/3a17b5ad-487e-4af9-bd39-aa35ca5f1695)

![Adding a file that is unambiguously a video file](https://github.com/user-attachments/assets/3a6e6a67-0942-49c8-8b94-d0c03d123832)