### PR TITLE
add a sysconfig setting to prevent users from changing their identity

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 161;
+    public const int REQUIRED_SCHEMA = 162;
 
     private Db $Db;
 

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -191,7 +191,8 @@ final class Config implements RestInterface
             ('onboarding_email_body', NULL),
             ('onboarding_email_different_for_admins', '0'),
             ('onboarding_email_admins_subject', NULL),
-            ('onboarding_email_admins_body', NULL)";
+            ('onboarding_email_admins_body', NULL),
+            ('allow_users_change_identity', '1')";
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':schema', $schema);

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -593,6 +593,14 @@ class Users implements RestInterface
             }
             Filter::email($params->getContent());
         }
+        $Config = Config::getConfig();
+        // prevent modification of identity fields if we are not sysadmin
+        if (in_array($params->getTarget(), array('email', 'firstname', 'lastname'), true)
+            && $Config->configArr['allow_users_change_identity'] === '0'
+            && $this->requester->userData['is_sysadmin'] === 0
+        ) {
+            throw new ImproperActionException('Identity information can only be modified by Sysadmin.');
+        }
         // special case for is_sysadmin: only a sysadmin can affect this column
         if ($params->getTarget() === 'is_sysadmin') {
             if ($this->requester->userData['is_sysadmin'] === 0) {

--- a/src/sql/schema162-down.sql
+++ b/src/sql/schema162-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 162
+DELETE FROM config WHERE conf_name = 'allow_users_change_identity';
+UPDATE config SET conf_value = 161 WHERE conf_name = 'schema';

--- a/src/sql/schema162.sql
+++ b/src/sql/schema162.sql
@@ -1,0 +1,3 @@
+-- schema 162
+INSERT INTO config (conf_name, conf_value) VALUES ('allow_users_change_identity', '1');
+UPDATE config SET conf_value = 162 WHERE conf_name = 'schema';

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -136,10 +136,10 @@
                   </div>
                 </td>
                 <td data-label='{{ 'Firstname'|trans }}'>
-                  <span class='hl-hover-gray p-1 rounded malleableColumn' data-endpoint='users' data-id='{{ user.userid }}' data-target='firstname'>{{ user.firstname }}</span>
+                  <span class='p-1 rounded {{ App.Users.userData.is_sysadmin == '1' or App.Config.configArr.allow_users_change_identity == '1' ? 'malleableColumn hl-hover-gray' }}' data-endpoint='users' data-id='{{ user.userid }}' data-target='firstname'>{{ user.firstname }}</span>
                 </td>
                 <td data-label='{{ 'Lastname'|trans }}'>
-                  <span class='hl-hover-gray p-1 rounded malleableColumn' data-endpoint='users' data-id='{{ user.userid }}' data-target='lastname'>{{ user.lastname }}</span>
+                  <span class='p-1 rounded {{ App.Users.userData.is_sysadmin == '1' or App.Config.configArr.allow_users_change_identity == '1' ? 'malleableColumn hl-hover-gray' }}' data-endpoint='users' data-id='{{ user.userid }}' data-target='lastname'>{{ user.lastname }}</span>
                 </td>
                 <td data-label='{{ 'Email'|trans }}'>
                   <span class='p-1 rounded {{ App.Users.userData.is_sysadmin == '1' ? 'hl-hover-gray malleableColumn' }}' data-ma-type='email' data-endpoint='users' data-id='{{ user.userid }}' data-target='email'>{{ user.email }}</span>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -124,6 +124,8 @@
     </div>
     <hr>
 
+    {% include 'binary-setting.html' with {'label': 'Allow users to change their first name, last name, or email address'|trans, 'slug': 'allow_users_change_identity', 'help': 'When disabled, only a Sysadmin will be allowed to modify these parameters.'} %}
+
   </div>
 
   <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Registration and authentication configuration'|trans }}</h3>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -327,7 +327,7 @@
 
       <div class='d-flex justify-content-between'>
         <label for='email' class='col-form-label'>{{ 'Email'|trans }}</label>
-        <input class='form-control col-md-3' name='email' id='email' type='email' value='{{ App.Users.userData.email|e('html_attr') }}' />
+        <input class='form-control col-md-3' {{ App.Config.configArr.allow_users_change_identity == '0' ? 'disabled' }} name='email' id='email' type='email' value='{{ App.Users.userData.email|e('html_attr') }}' />
       </div>
       <hr>
 
@@ -366,13 +366,13 @@
   <div class='pl-3 mt-2 mb-5' id='ucp-account-form'>
     <div class='d-flex justify-content-between'>
       <label for='firstname' class='col-form-label'>{{ 'Firstname'|trans }}</label>
-      <input class='form-control col-md-3' type='text' id='firstname' name='firstname' value='{{ App.Users.userData.firstname|e('html_attr') }}' />
+      <input class='form-control col-md-3' {{ App.Config.configArr.allow_users_change_identity == '0' ? 'disabled' }} type='text' id='firstname' name='firstname' value='{{ App.Users.userData.firstname|e('html_attr') }}' />
     </div>
     <hr>
 
     <div class='d-flex justify-content-between'>
       <label for='lastname' class='col-form-label'>{{ 'Lastname'|trans }}</label>
-      <input class='form-control col-md-3' type='text' id='lastname' name='lastname' value='{{ App.Users.userData.lastname|e('html_attr') }}' />
+      <input class='form-control col-md-3' {{ App.Config.configArr.allow_users_change_identity == '0' ? 'disabled' }} type='text' id='lastname' name='lastname' value='{{ App.Users.userData.lastname|e('html_attr') }}' />
     </div>
     <hr>
 


### PR DESCRIPTION
* new setting "allow_users_change_identity" defaults to 1
* if disabled, only a Sysadmin can modify first name, last name or email of a user
* Admins do not have special rights either, they are considered normal users
* prevent changes in web ui on profile and editusers, and in Users->update() 
* fix #4987

