### PR TITLE
added another save button to edit mode

### DIFF
--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -104,6 +104,11 @@
   <div {{ not displayMainText ? 'hidden' }}>
     <h3 data-action='toggle-next' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Main text'|trans }}</h3><span class='ml-4 smallgray'>{{ 'Last saved:'|trans }}</span><span id='lastSavedAt' class='ml-2 relative-moment smallgray' title='{{ Entity.entityData.modified_at }}'></span>
     <div data-save-hidden='mainTextDiv'>
+      <div class='mt-4 text-center'>
+        <button type='button' {{ not displayMainText ? 'hidden' }} data-action='update-entity-body' class='btn btn-primary'>{{ 'Save'|trans }}</button>
+        <button type='button' data-action='update-entity-body' data-redirect='view' class='btn btn-secondary'>{{ 'Save and go back'|trans }}</button>
+      </div>
+
       <div class='mt-4'>{# << this div is important around the textarea to fix an issue on mobile editor. See #3107 #}
         {% if editor == 'md' %}
           <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='markdown-textarea' data-language='{{ App.getJsLang }}' name='body'>{{ Entity.entityData.body }}</textarea>


### PR DESCRIPTION
I added a second "Save" and "Save and go back" button to the top of the tinyMCE editor to not always have to scroll all the way down.