### PR TITLE
add sysconfig setting to select mass email behavior

### DIFF
--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 162;
+    public const int REQUIRED_SCHEMA = 163;
 
     private Db $Db;
 

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -140,6 +140,7 @@ final class Config implements RestInterface
             ('saml_lowercaseurlencoding', '0'),
             ('saml_fallback_orgid', '0'),
             ('email_domain', NULL),
+            ('email_send_grouped', '1'),
             ('saml_sync_teams', '0'),
             ('saml_sync_email_idp', '0'),
             ('support_url', 'https://github.com/elabftw/elabftw/issues'),

--- a/src/sql/schema163-down.sql
+++ b/src/sql/schema163-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 163
+DELETE FROM config WHERE conf_name = 'email_send_grouped';
+UPDATE config SET conf_value = 162 WHERE conf_name = 'schema';

--- a/src/sql/schema163.sql
+++ b/src/sql/schema163.sql
@@ -1,0 +1,3 @@
+-- schema 163
+INSERT INTO config (conf_name, conf_value) VALUES ('email_send_grouped', '1');
+UPDATE config SET conf_value = 163 WHERE conf_name = 'schema';

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -376,6 +376,9 @@
     <hr>
 
     {% include 'binary-setting.html' with {'label': 'Verify TLS certificate'|trans, 'slug': 'smtp_verify_cert'} %}
+
+    {% include 'binary-setting.html' with {'label': 'Send mass emails grouped'|trans, 'slug': 'email_send_grouped', 'help': 'When enabled, mass emails are sent as a single email with all recipients in Bcc. Disable this setting if you encounter issues with your SMTP server refusing to deliver emails if a recipient has an invalid account or if there are too many recipients.'} %}
+
   </div>
 
   {# TEST EMAIL #}

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -60,18 +60,22 @@ class EmailTest extends \PHPUnit\Framework\TestCase
     {
         $replyTo = new Address('sender@example.com', 'Sergent Garcia');
         // Note that non-validated users are not active users
-        $this->assertEquals(19, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo));
-        $this->assertEquals(10, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo));
-        $this->assertEquals(0, $this->Email->massEmail(EmailTarget::TeamGroup, 1, 'Important message', 'yep', $replyTo));
-        $this->assertEquals(6, $this->Email->massEmail(EmailTarget::Admins, null, 'Important message to admins', 'yep', $replyTo));
-        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::Sysadmins, null, 'Important message to sysadmins', 'yep', $replyTo));
-        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::BookableItem, 1, 'Oops', 'My cells died', $replyTo));
-        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::AdminsOfTeam, 1, 'Important message to admins of a team', 'yep', $replyTo));
+        $this->assertEquals(19, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo, true));
+        // not grouped
+        $this->assertEquals(19, $this->Email->massEmail(EmailTarget::ActiveUsers, null, '', 'yep', $replyTo, false));
+        $this->assertEquals(10, $this->Email->massEmail(EmailTarget::Team, 1, 'Important message', 'yep', $replyTo, true));
+        $this->assertEquals(0, $this->Email->massEmail(EmailTarget::TeamGroup, 1, 'Important message', 'yep', $replyTo, true));
+        $this->assertEquals(6, $this->Email->massEmail(EmailTarget::Admins, null, 'Important message to admins', 'yep', $replyTo, true));
+        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::Sysadmins, null, 'Important message to sysadmins', 'yep', $replyTo, true));
+        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::BookableItem, 1, 'Oops', 'My cells died', $replyTo, true));
+        $this->assertEquals(1, $this->Email->massEmail(EmailTarget::AdminsOfTeam, 1, 'Important message to admins of a team', 'yep', $replyTo, true));
     }
 
     public function testSendEmail(): void
     {
         $this->assertTrue($this->Email->sendEmail(new Address('a@a.fr', 'blah'), 's', 'b'));
+        // with cc
+        $this->assertTrue($this->Email->sendEmail(new Address('a@a.fr', 'blah'), 's', 'b', array(new Address('cc@example.com', 'cc'))));
     }
 
     public function testNotifySysadminsTsBalance(): void

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -63,7 +63,8 @@ try {
             null,
             $App->Request->request->getString('subject'),
             $App->Request->request->getString('body'),
-            $replyTo
+            $replyTo,
+            (bool) $App->Config->configArr['email_send_grouped'],
         );
     }
 

--- a/web/app/controllers/TeamController.php
+++ b/web/app/controllers/TeamController.php
@@ -60,6 +60,7 @@ try {
             $App->Request->request->getString('subject'),
             $App->Request->request->getString('body'),
             $replyTo,
+            (bool) $App->Config->configArr['email_send_grouped'],
         );
         $App->Session->getFlashBag()->add('ok', sprintf(_('Email sent to %d users'), $sent));
     }


### PR DESCRIPTION
Add new setting: email_send_grouped to toggle massEmail() behavior to send emails as a single email with all in Bcc, or to send emails one by one.

Also add a test for sending email with someone in copy, and allow sendEmail() to have a replyTo field.

Fix #4781
