### PR TITLE
Make Resources Categories honor permissions

### DIFF
--- a/src/classes/ItemsTypesSqlBuilder.php
+++ b/src/classes/ItemsTypesSqlBuilder.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Enums\EntityType;
+use Override;
+
+class ItemsTypesSqlBuilder extends EntitySqlBuilder
+{
+    #[Override]
+    protected function entitySelect(bool $fullSelect): void
+    {
+        // get all the columns of entity table
+        $this->selectSql[] = '
+            entity.id,
+            entity.userid,
+            entity.created_at,
+            entity.modified_at,
+            entity.team,
+            entity.color,
+            entity.title,
+            entity.status,
+            entity.body,
+            entity.ordering,
+            entity.canread,
+            entity.canwrite,
+            entity.canread_target,
+            entity.canwrite_target,
+            entity.metadata,
+            entity.state';
+    }
+
+    #[Override]
+    protected function status(): void
+    {
+        $this->selectSql[] = 'statust.title AS status_title,
+            statust.color AS status_color';
+        // use items_status as there are no items_types_status table
+        $this->joinsSql[] = 'LEFT JOIN items_status AS statust
+            ON (statust.id = entity.status)';
+    }
+
+    #[Override]
+    protected function comments(): void
+    {
+        return;
+    }
+
+    #[Override]
+    protected function category(): void
+    {
+        return;
+    }
+
+    #[Override]
+    protected function steps(): void
+    {
+        return;
+    }
+
+    #[Override]
+    protected function links(EntityType $relatedOrigin): void
+    {
+        return;
+    }
+
+    #[Override]
+    protected function uploads(): void
+    {
+        return;
+    }
+}

--- a/src/classes/Permissions.php
+++ b/src/classes/Permissions.php
@@ -140,25 +140,13 @@ class Permissions
     }
 
     /**
-     * For ItemType write permission check for metadata
-     */
-    public function forItemType(): array
-    {
-        if ($this->Users->isAdmin && ($this->item['team'] === $this->Users->userData['team'])) {
-            return array('read' => true, 'write' => true);
-        }
-        // everyone has read access
-        return array('read' => true, 'write' => false);
-    }
-
-    /**
      * Get the write permission for an exp/item
      */
     private function getWrite(): bool
     {
         // locked entity cannot be written to
         // only the locker can unlock an entity
-        if ($this->item['locked'] && ($this->item['lockedby'] !== $this->Users->userData['userid']) && !$this->Users->isAdmin) {
+        if (array_key_exists('locked', $this->item) && $this->item['locked'] && ($this->item['lockedby'] !== $this->Users->userData['userid']) && !$this->Users->isAdmin) {
             return false;
         }
         return $this->getCan($this->canwrite);

--- a/src/classes/Permissions.php
+++ b/src/classes/Permissions.php
@@ -146,7 +146,7 @@ class Permissions
     {
         // locked entity cannot be written to
         // only the locker can unlock an entity
-        if (array_key_exists('locked', $this->item) && $this->item['locked'] && ($this->item['lockedby'] !== $this->Users->userData['userid']) && !$this->Users->isAdmin) {
+        if ($this->item['locked'] && ($this->item['lockedby'] !== $this->Users->userData['userid']) && !$this->Users->isAdmin) {
             return false;
         }
         return $this->getCan($this->canwrite);

--- a/src/classes/TemplatesSqlBuilder.php
+++ b/src/classes/TemplatesSqlBuilder.php
@@ -12,10 +12,9 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
-use Elabftw\Enums\EntityType;
 use Override;
 
-class ItemsTypesSqlBuilder extends EntitySqlBuilder
+class TemplatesSqlBuilder extends EntitySqlBuilder
 {
     #[Override]
     protected function entitySelect(bool $fullSelect): void
@@ -27,7 +26,6 @@ class ItemsTypesSqlBuilder extends EntitySqlBuilder
             entity.created_at,
             entity.modified_at,
             entity.team,
-            entity.color,
             entity.title,
             entity.status,
             entity.body,
@@ -41,7 +39,11 @@ class ItemsTypesSqlBuilder extends EntitySqlBuilder
             entity.lockedby,
             entity.locked_at,
             entity.metadata,
-            entity.state';
+            entity.state,
+            (pin_experiments_templates2users.entity_id IS NOT NULL) AS is_pinned';
+        $this->joinsSql[] = 'LEFT JOIN pin_experiments_templates2users
+                ON (entity.id = pin_experiments_templates2users.entity_id
+                    AND pin_experiments_templates2users.users_id = :userid)';
     }
 
     #[Override]
@@ -49,37 +51,13 @@ class ItemsTypesSqlBuilder extends EntitySqlBuilder
     {
         $this->selectSql[] = 'statust.title AS status_title,
             statust.color AS status_color';
-        // use items_status as there are no items_types_status table
-        $this->joinsSql[] = 'LEFT JOIN items_status AS statust
+        // use experiments_status
+        $this->joinsSql[] = 'LEFT JOIN experiments_status AS statust
             ON (statust.id = entity.status)';
     }
 
     #[Override]
     protected function comments(): void
-    {
-        return;
-    }
-
-    #[Override]
-    protected function category(): void
-    {
-        return;
-    }
-
-    #[Override]
-    protected function steps(): void
-    {
-        return;
-    }
-
-    #[Override]
-    protected function links(EntityType $relatedOrigin): void
-    {
-        return;
-    }
-
-    #[Override]
-    protected function uploads(): void
     {
         return;
     }

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -291,18 +291,12 @@ abstract class AbstractConcreteEntity extends AbstractEntity
             return $category;
         }
         $sql = sprintf(
-            'SELECT custom_id FROM experiments
-                WHERE custom_id IS NOT NULL AND category = :category %s
+            'SELECT custom_id FROM %s WHERE custom_id IS NOT NULL AND category = :category
                 ORDER BY custom_id DESC LIMIT 1',
-            $this instanceof Items
-                ? 'AND team = :team'
-                : '',
+            $this->entityType->value
         );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':category', $category, PDO::PARAM_INT);
-        if ($this instanceof Items) {
-            $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        }
         $this->Db->execute($req);
         $res = $req->fetch();
         if ($res === false || $res['custom_id'] === null) {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -133,6 +133,7 @@ abstract class AbstractEntity implements RestInterface
         ?int $customId = null,
         ?string $metadata = null,
         int $rating = 0,
+        ?int $contentType = null,
         bool $forceExpTpl = false,
         string $defaultTemplateHtml = '',
         string $defaultTemplateMd = '',
@@ -417,6 +418,9 @@ abstract class AbstractEntity implements RestInterface
      */
     public function canOrExplode(string $rw): void
     {
+        if ($this->id === null) {
+            throw new ImproperActionException('Cannot check permissions without an id!');
+        }
         if ($this->bypassWritePermission && $rw === 'write') {
             return;
         }

--- a/src/models/AbstractLinks.php
+++ b/src/models/AbstractLinks.php
@@ -133,7 +133,7 @@ abstract class AbstractLinks implements RestInterface
         if ($fromTpl) {
             $table = $this->getTemplateTable();
         }
-        $sql = 'INSERT INTO ' . $this->getTable() . ' (item_id, link_id)
+        $sql = 'INSERT IGNORE INTO ' . $this->getTable() . ' (item_id, link_id)
             SELECT :new_id, link_id
             FROM ' . $table . '
             WHERE item_id = :old_id';

--- a/src/models/AbstractTemplateEntity.php
+++ b/src/models/AbstractTemplateEntity.php
@@ -24,7 +24,7 @@ abstract class AbstractTemplateEntity extends AbstractEntity
     {
         return match ($action) {
             Action::Create => $this->create(title: $reqBody['title'] ?? null),
-            Action::Duplicate => $this->duplicate(),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false)),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -62,7 +62,7 @@ class Experiments extends AbstractConcreteEntity
             $body = null;
         }
         $metadata = null;
-        $contentType ??= $this->Users->userData['use_markdown'] === AbstractEntity::CONTENT_HTML ? AbstractEntity::CONTENT_HTML : AbstractEntity::CONTENT_MD;
+        $contentType ??= $this->Users->userData['use_markdown'] === 1 ? AbstractEntity::CONTENT_MD : AbstractEntity::CONTENT_HTML;
 
         // do we want template ?
         // $templateId can be a template id, or 0: common template, or -1: null body
@@ -77,7 +77,7 @@ class Experiments extends AbstractConcreteEntity
             $canread = $templateArr['canread_target'];
             $canwrite = $templateArr['canwrite_target'];
             $metadata = $templateArr['metadata'];
-            $contentType = (int) $templateArr['content_type'];
+            $contentType = $templateArr['content_type'];
         }
 
         // we don't use a proper template (use of common tpl or blank)

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -45,6 +45,7 @@ class Experiments extends AbstractConcreteEntity
         ?int $customId = null,
         ?string $metadata = null,
         int $rating = 0,
+        ?int $contentType = null,
         bool $forceExpTpl = false,
         string $defaultTemplateHtml = '',
         string $defaultTemplateMd = '',
@@ -61,10 +62,7 @@ class Experiments extends AbstractConcreteEntity
             $body = null;
         }
         $metadata = null;
-        $contentType = AbstractEntity::CONTENT_HTML;
-        if ($this->Users->userData['use_markdown'] ?? 0) {
-            $contentType = AbstractEntity::CONTENT_MD;
-        }
+        $contentType ??= $this->Users->userData['use_markdown'] === AbstractEntity::CONTENT_HTML ? AbstractEntity::CONTENT_HTML : AbstractEntity::CONTENT_MD;
 
         // do we want template ?
         // $templateId can be a template id, or 0: common template, or -1: null body
@@ -150,35 +148,28 @@ class Experiments extends AbstractConcreteEntity
     {
         $this->canOrExplode('read');
 
+        $Teams = new Teams($this->Users);
+        $Status = new ExperimentsStatus($Teams);
+
         // let's add something at the end of the title to show it's a duplicate
         // capital i looks good enough
         $title = $this->entityData['title'] . ' I';
 
-        $Teams = new Teams($this->Users);
-        $Status = new ExperimentsStatus($Teams);
-
         // handle the blank_value_on_duplicate attribute on extra fields
         $metadata = (new Metadata($this->entityData['metadata']))->blankExtraFieldsValueOnDuplicate();
-        // figure out the custom id
-        $customId = $this->getNextCustomId($this->entityData['category']);
 
-        $sql = 'INSERT INTO experiments(team, title, date, body, category, status, elabid, canread, canwrite, userid, metadata, custom_id, content_type)
-            VALUES(:team, :title, CURDATE(), :body, :category, :status, :elabid, :canread, :canwrite, :userid, :metadata, :custom_id, :content_type)';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
-        $req->bindParam(':title', $title);
-        $req->bindParam(':body', $this->entityData['body']);
-        $req->bindValue(':category', $this->entityData['category']);
-        $req->bindValue(':status', $Status->getDefault(), PDO::PARAM_INT);
-        $req->bindValue(':elabid', Tools::generateElabid());
-        $req->bindParam(':canread', $this->entityData['canread']);
-        $req->bindParam(':canwrite', $this->entityData['canwrite']);
-        $req->bindParam(':metadata', $metadata);
-        $req->bindParam(':custom_id', $customId, PDO::PARAM_INT);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
-        $req->bindParam(':content_type', $this->entityData['content_type'], PDO::PARAM_INT);
-        $this->Db->execute($req);
-        $newId = $this->Db->lastInsertId();
+        $newId = $this->create(
+            title: $title,
+            body: $this->entityData['body'],
+            category: $this->entityData['category'],
+            // use default status instead of copying the current one
+            status: $Status->getDefault(),
+            canread: $this->entityData['canread'],
+            canwrite: $this->entityData['canwrite'],
+            metadata: $metadata,
+            contentType: $this->entityData['content_type'],
+        );
+
         $fresh = new self($this->Users, $newId);
         /** @psalm-suppress PossiblyNullArgument
          * this->id cannot be null here, checked during canOrExplode */

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -45,6 +45,7 @@ class ItemsTypes extends AbstractTemplateEntity
         ?int $customId = null,
         ?string $metadata = null,
         int $rating = 0,
+        ?int $contentType = null,
         bool $forceExpTpl = false,
         string $defaultTemplateHtml = '',
         string $defaultTemplateMd = '',
@@ -97,7 +98,7 @@ class ItemsTypes extends AbstractTemplateEntity
         $sql .= sprintf(' WHERE entity.state = %d', State::Normal->value);
         // add the json permissions
         $sql .= $builder->getCanFilter('canread');
-        $sql .= ' GROUP BY entity.id, entity.userid, entity.created_at, entity.modified_at, entity.team, entity.color, entity.title, entity.status, entity.body, entity.ordering, entity.canread, entity.canwrite, entity.canread_target, entity.canwrite_target, entity.metadata, entity.state, statust.title, statust.color, users.firstname, users.lastname, users.orcid, teams.name';
+        $sql .= ' GROUP BY id';
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->Users->userid, PDO::PARAM_INT);
@@ -130,6 +131,7 @@ class ItemsTypes extends AbstractTemplateEntity
 
     public function duplicate(bool $copyFiles = false): int
     {
+        // TODO: implement
         throw new ImproperActionException('No duplicate action for resources categories.');
     }
 

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -74,7 +74,7 @@ class Templates extends AbstractTemplateEntity
         if (isset($this->Users->userData['default_write'])) {
             $canwrite = $this->Users->userData['default_write'];
         }
-        $contentType ??= $this->Users->userData['use_markdown'] === AbstractEntity::CONTENT_HTML ? AbstractEntity::CONTENT_HTML : AbstractEntity::CONTENT_MD;
+        $contentType ??= $this->Users->userData['use_markdown'] === 1 ? AbstractEntity::CONTENT_MD : AbstractEntity::CONTENT_HTML;
 
         $sql = 'INSERT INTO experiments_templates(team, title, body, userid, canread, canwrite, canread_target, canwrite_target, content_type, rating)
             VALUES(:team, :title, :body, :userid, :canread, :canwrite, :canread_target, :canwrite_target, :content_type, :rating)';

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -13,14 +13,16 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use DateTimeImmutable;
+use Elabftw\Elabftw\TemplatesSqlBuilder;
 use Elabftw\Elabftw\Tools;
+use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Scope;
 use Elabftw\Enums\State;
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Services\Filter;
-use Elabftw\Services\UsersHelper;
 use Elabftw\Traits\SortableTrait;
 use PDO;
 
@@ -57,6 +59,7 @@ class Templates extends AbstractTemplateEntity
         ?int $customId = null,
         ?string $metadata = null,
         int $rating = 0,
+        ?int $contentType = null,
         bool $forceExpTpl = false,
         string $defaultTemplateHtml = '',
         string $defaultTemplateMd = '',
@@ -71,16 +74,14 @@ class Templates extends AbstractTemplateEntity
         if (isset($this->Users->userData['default_write'])) {
             $canwrite = $this->Users->userData['default_write'];
         }
-        $contentType = self::CONTENT_HTML;
-        if ($this->Users->userData['use_markdown'] === 1) {
-            $contentType = self::CONTENT_MD;
-        }
+        $contentType ??= $this->Users->userData['use_markdown'] === AbstractEntity::CONTENT_HTML ? AbstractEntity::CONTENT_HTML : AbstractEntity::CONTENT_MD;
 
-        $sql = 'INSERT INTO experiments_templates(team, title, userid, canread, canwrite, canread_target, canwrite_target, content_type, rating)
-            VALUES(:team, :title, :userid, :canread, :canwrite, :canread_target, :canwrite_target, :content_type, :rating)';
+        $sql = 'INSERT INTO experiments_templates(team, title, body, userid, canread, canwrite, canread_target, canwrite_target, content_type, rating)
+            VALUES(:team, :title, :body, :userid, :canread, :canwrite, :canread_target, :canwrite_target, :content_type, :rating)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
-        $req->bindValue(':title', $title);
+        $req->bindParam(':title', $title);
+        $req->bindParam(':body', $body);
         $req->bindParam(':userid', $this->Users->userid, PDO::PARAM_INT);
         $req->bindParam(':canread', $canread);
         $req->bindParam(':canwrite', $canwrite);
@@ -92,35 +93,35 @@ class Templates extends AbstractTemplateEntity
         $id = $this->Db->lastInsertId();
 
         // now pin the newly created template so it directly appears in Create menu
-        $this->setId($id);
-        $Pins = new Pins($this);
+        $fresh = new self($this->Users, $id);
+        $Pins = new Pins($fresh);
         $Pins->togglePin();
         return $id;
     }
 
     /**
-     * Duplicate a template from someone else in the team
+     * Duplicate a template from someone else
      */
     public function duplicate(bool $copyFiles = false): int
     {
-        $template = $this->readOne();
-
-        $sql = 'INSERT INTO experiments_templates(team, title, category, status, body, userid, canread, canwrite, canread_target, canwrite_target, metadata)
-            VALUES(:team, :title, :category, :status, :body, :userid, :canread, :canwrite, :canread_target, :canwrite_target, :metadata)';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindParam(':title', $template['title']);
-        $req->bindParam(':body', $template['body']);
-        $req->bindParam(':category', $template['category']);
-        $req->bindParam(':status', $template['status']);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
-        $req->bindParam(':canread', $template['canread']);
-        $req->bindParam(':canwrite', $template['canwrite']);
-        $req->bindParam(':canread_target', $template['canread_target']);
-        $req->bindParam(':canwrite_target', $template['canwrite_target']);
-        $req->bindParam(':metadata', $template['metadata']);
-        $req->execute();
-        $newId = $this->Db->lastInsertId();
+        $this->canOrExplode('read');
+        $title = $this->entityData['title'] . ' I';
+        $newId = $this->create(
+            title: $title,
+            body: $this->entityData['body'],
+            category: $this->entityData['category'],
+            status: $this->entityData['status'],
+            canread: $this->entityData['canread'],
+            canwrite: $this->entityData['canwrite'],
+            metadata: $this->entityData['metadata'],
+            contentType: $this->entityData['content_type'],
+        );
+        // add missing can*_target
+        $fresh = new self($this->Users, $newId);
+        $fresh->patch(Action::Update, array(
+            'canread_target' => $this->entityData['canread_target'],
+            'canwrite_target' => $this->entityData['canwrite_target'],
+        ));
 
         // copy tags
         $Tags = new Tags($this);
@@ -128,15 +129,18 @@ class Templates extends AbstractTemplateEntity
 
         // copy links and steps too
         $ItemsLinks = new ExperimentsTemplates2ItemsLinks($this);
-        $ItemsLinks->duplicate($template['id'], $newId, true);
+        /** @psalm-suppress PossiblyNullArgument */
+        $ItemsLinks->duplicate($this->id, $newId, true);
         $ExperimentsLinks = new ExperimentsTemplates2ExperimentsLinks($this);
-        $ExperimentsLinks->duplicate($template['id'], $newId, true);
+        $ExperimentsLinks->duplicate($this->id, $newId, true);
         $Steps = new Steps($this);
-        $Steps->duplicate($template['id'], $newId, true);
+        $Steps->duplicate($this->id, $newId, true);
+        if ($copyFiles) {
+            $this->Uploads->duplicate($fresh);
+        }
 
         // now pin the newly created template so it directly appears in Create menu
-        $this->setId($newId);
-        $Pins = new Pins($this);
+        $Pins = new Pins($fresh);
         $Pins->togglePin();
 
         return $newId;
@@ -144,33 +148,17 @@ class Templates extends AbstractTemplateEntity
 
     public function readOne(): array
     {
-        $sql = "SELECT experiments_templates.id, experiments_templates.title, experiments_templates.body,
-                experiments_templates.created_at, experiments_templates.modified_at, experiments_templates.content_type,
-                experiments_templates.userid, experiments_templates.canread, experiments_templates.canwrite,
-                experiments_templates.canread_target, experiments_templates.canwrite_target,
-                experiments_templates.locked, experiments_templates.lockedby, experiments_templates.locked_at,
-                CONCAT(users.firstname, ' ', users.lastname) AS fullname, experiments_templates.metadata, experiments_templates.state,
-                users.firstname, users.lastname, users.orcid,
-                experiments_templates.category,experiments_templates.status,
-                categoryt.title AS category_title, categoryt.color AS category_color, statust.title AS status_title, statust.color AS status_color,
-                GROUP_CONCAT(tags.tag SEPARATOR '|') AS tags, GROUP_CONCAT(tags.id) AS tags_id
-            FROM experiments_templates
-            LEFT JOIN users
-                ON (experiments_templates.userid = users.userid)
-            LEFT JOIN tags2entity
-                ON (experiments_templates.id = tags2entity.item_id
-                    AND tags2entity.item_type = 'experiments_templates')
-            LEFT JOIN tags
-                ON (tags2entity.tag_id = tags.id)
-            LEFT JOIN experiments_categories AS categoryt
-                ON (experiments_templates.category = categoryt.id)
-            LEFT JOIN experiments_status AS statust
-                ON (experiments_templates.status = statust.id)
-            WHERE experiments_templates.id = :id";
+        if ($this->id === null) {
+            throw new IllegalActionException('No id was set!');
+        }
+        $builder = new TemplatesSqlBuilder($this);
+        $sql = $builder->getReadSqlBeforeWhere(getTags: true, fullSelect: true);
+        $sql .= sprintf(' WHERE entity.id = %d', $this->id);
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $req->bindParam(':userid', $this->Users->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
         $this->entityData = $this->Db->fetch($req);
+        // this is needed because the query will return something with everything null instead of throwing the exception at fetch()
         if ($this->entityData['id'] === null) {
             throw new ResourceNotFoundException();
         }
@@ -205,102 +193,25 @@ class Templates extends AbstractTemplateEntity
      */
     public function readAll(): array
     {
-        $sql = array();
-        $sql[] = "SELECT DISTINCT experiments_templates.id, experiments_templates.title, experiments_templates.body,
-                experiments_templates.userid, experiments_templates.canread, experiments_templates.canwrite, experiments_templates.content_type,
-                experiments_templates.locked, experiments_templates.lockedby, experiments_templates.locked_at,
-                experiments_templates.canread_target, experiments_templates.canwrite_target,
-                CONCAT(users.firstname, ' ', users.lastname) AS fullname, experiments_templates.metadata, experiments_templates.modified_at,
-                users2teams.teams_id, teams.name AS team_name,
-                (pin_experiments_templates2users.entity_id IS NOT NULL) AS is_pinned,
-                experiments_templates.category,experiments_templates.status,
-                categoryt.title AS category_title, categoryt.color AS category_color, statust.title AS status_title, statust.color AS status_color,
-                GROUP_CONCAT(tags.tag SEPARATOR '|') AS tags, GROUP_CONCAT(tags.id) AS tags_id
-            FROM experiments_templates
-            LEFT JOIN users ON (experiments_templates.userid = users.userid)
-            LEFT JOIN users2teams
-                ON (users2teams.users_id = users.userid
-                    AND users2teams.teams_id = :team)
-            LEFT JOIN teams ON (teams.id = experiments_templates.team)
-            LEFT JOIN tags2entity
-                ON (experiments_templates.id = tags2entity.item_id
-                    AND tags2entity.item_type = 'experiments_templates')
-            LEFT JOIN tags
-                ON (tags2entity.tag_id = tags.id)
-            LEFT JOIN experiments_categories AS categoryt
-                ON (experiments_templates.category = categoryt.id)
-            LEFT JOIN experiments_status AS statust
-                ON (experiments_templates.status = statust.id)
-            LEFT JOIN pin_experiments_templates2users
-                ON (experiments_templates.id = pin_experiments_templates2users.entity_id
-                    AND pin_experiments_templates2users.users_id = :userid)
-            WHERE experiments_templates.userid != 0
-                AND experiments_templates.state = :state";
-
-        $canSql = array();
-        $canSql[] = sprintf(
-            "experiments_templates.canread->'$.base' = %d",
-            BasePermissions::Full->value,
-        );
-        $canSql[] = sprintf(
-            "experiments_templates.canread->'$.base' = %d",
-            BasePermissions::Organization->value,
-        );
-        $canSql[] = sprintf(
-            "experiments_templates.canread->'$.base' = %d AND users2teams.users_id = experiments_templates.userid",
-            BasePermissions::Team->value,
-        );
-        $canSql[] = sprintf(
-            "experiments_templates.canread->'$.base' = %d AND experiments_templates.userid = :userid",
-            BasePermissions::User->value,
-        );
-        $canSql[] = sprintf(
-            "experiments_templates.canread->'$.base' = %d AND experiments_templates.userid = :userid",
-            BasePermissions::UserOnly->value,
-        );
-        // look for teams
-        $teamsOfUser = (new UsersHelper($this->Users->userData['userid']))->getTeamsIdFromUserid();
-        if (!empty($teamsOfUser)) {
-            // JSON_OVERLAPS checks for the intersection of two arrays
-            // for instance [4,5,6] vs [2,6] has 6 in common -> 1 (true)
-            $canSql[] = sprintf(
-                "JSON_OVERLAPS(experiments_templates.canread->'$.teams', CAST('[%s]' AS JSON))",
-                implode(', ', $teamsOfUser),
-            );
-        }
-        // look for teamgroups
-        $teamgroupsOfUser = array_column((new TeamGroups($this->Users))->readGroupsFromUser(), 'id');
-        if (!empty($teamgroupsOfUser)) {
-            $canSql[] = sprintf(
-                "JSON_OVERLAPS(experiments_templates.canread->'$.teamgroups', CAST('[%s]' AS JSON))",
-                implode(', ', $teamgroupsOfUser),
-            );
-        }
-        // look for our userid in users part of the json
-        $canSql[] = ':userid MEMBER OF (experiments_templates.canread->>"$.users")';
-
-        $sql[] = sprintf(
-            ' AND (%s)',
-            implode(' OR ', $canSql),
-        );
-
+        $builder = new TemplatesSqlBuilder($this);
+        $sql = $builder->getReadSqlBeforeWhere(getTags: false, fullSelect: false);
+        // first WHERE is the state, possibly including archived
+        // also add a check for no userid 0 which is the common template (this will need to go away!!)
+        $sql .= sprintf(' WHERE entity.state = %d AND entity.userid != 0', State::Normal->value);
+        // add the json permissions
+        $sql .= $builder->getCanFilter('canread');
         if ($this->Users->userData['scope_experiments_templates'] === Scope::User->value) {
-            $sql[] = 'AND experiments_templates.userid = :userid';
+            $sql .= 'AND entity.userid = :userid';
         }
         if ($this->Users->userData['scope_experiments_templates'] === Scope::Team->value) {
-            $sql[] = 'AND experiments_templates.team = :team';
+            $sql .= 'AND entity.team = :team';
         }
 
-        $sql[] = $this->filterSql;
+        $sql .= ' GROUP BY id ORDER BY entity.created_at DESC, fullname DESC, is_pinned DESC, entity.ordering ASC';
 
-        $sql[] = str_replace('entity', 'experiments_templates', $this->idFilter);
-
-        $sql[] = 'GROUP BY id ORDER BY experiments_templates.created_at DESC, fullname DESC, is_pinned DESC, experiments_templates.ordering ASC';
-
-        $req = $this->Db->prepare(implode(' ', $sql));
-        $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
-        $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':userid', $this->Users->userid, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->Users->team, PDO::PARAM_INT);
         $this->Db->execute($req);
 
         return $req->fetchAll();

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -181,6 +181,10 @@ class Uploads implements RestInterface
             $id = $entity->Uploads->create($param);
             $fresh = new self($entity, $id);
             // replace links in body with the new long_name
+            // don't bother if body is null
+            if ($entity->entityData['body'] === null) {
+                return;
+            }
             $newBody = str_replace($upload['long_name'], $fresh->uploadData['long_name'], $entity->entityData['body']);
             $entity->patch(Action::Update, array('body' => $newBody));
         }

--- a/src/services/Populate.php
+++ b/src/services/Populate.php
@@ -33,11 +33,11 @@ use Elabftw\Models\Users;
  */
 class Populate
 {
-    /** @var string DEFAULT_PASSWORD the password to use if none are provided */
-    private const DEFAULT_PASSWORD = 'totototototo';
+    // the password to use if none are provided
+    private const string DEFAULT_PASSWORD = 'totototototo';
 
-    /** @var int TEMPLATES_ITER number of templates to generate */
-    private const TEMPLATES_ITER = 5;
+    // number of templates to generate
+    private const int TEMPLATES_ITER = 5;
 
     private \Faker\Generator $faker;
 
@@ -157,6 +157,8 @@ class Populate
             }
 
             // CATEGORY
+            // blank the custom_id first or we might run into an issue when changing the category because another entry has the same custom_id
+            $Entity->patch(Action::Update, array('custom_id' => ''));
             $category = $this->faker->randomElement($categoryArr);
             $Entity->patch(Action::Update, array('category' => (string) $category['id']));
 

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -308,7 +308,7 @@
   <h3 id='itemsCategoriesAnchor' class='mb-3 p-2 pl-3 section-title'>{{ 'Resources categories'|trans }}</h3>
   <div class='pl-3' id='itemsCategoriesDiv'>
     <div {{ App.Request.query.has('templateid') ? 'hidden' }}>
-      <div class='d-flex justify-content-between'>
+      <div class='d-flex justify-content-between mb-2'>
         <p class='col-form-label'>{{ 'This menu allows you to define categories for your resources. A resource category is similar to an experiment template but for resources entries.'|trans }}</p>
         {# CREATE NEW BUTTON the div around the button is necessary or the button itself gets resized on small viewports #}
         <div>
@@ -321,10 +321,12 @@
     <a href='?tab=4' class='btn hl-hover-gray'>
       <i class='fas fa-chevron-left mr-1 fa-fw'></i>{{ 'Back to listing'|trans }}
     </a>
+
   {% else %}
-    <ul class='list-group form-group sortable' data-axis='y' data-table='items_types'>
+
+    <ul class='list-group form-group sortable mb-2' data-axis='y' data-table='items_types'>
       {% for itemType in itemsCategoryArr %}
-        <li class='box' id='itemstypes_{{ itemType.id }}' style='color: #{{ itemType.color }}'><span class='sortableHandle draggable mr-2'><i class='fas fa-grip-vertical fa-fw'></i></span><a href='?tab=4&amp;templateid={{ itemType.id }}#itemsCategoriesAnchor' aria-label='{{ 'Edit'|trans }} {{ itemType.title|e('html_attr') }}' title='{{ 'Edit'|trans }}' class='p-2 mr-2 rounded hl-hover-gray'><i class='fas fa-pencil-alt'></i></a>{{ itemType.title }}</li>
+      <li class='list-group-item' id='itemstypes_{{ itemType.id }}'><div class='d-flex'><span class='sortableHandle draggable p-2 mr-2'><i class='fas fa-grip-vertical'></i></span><a href='?tab=4&amp;templateid={{ itemType.id }}#itemsCategoriesAnchor' aria-label='{{ 'Edit'|trans }} {{ itemType.title|e('html_attr') }}' title='{{ 'Edit'|trans }}' class='p-2 mx-2 rounded hl-hover-gray'><i class='fas fa-pencil-alt'></i></a><span class='p-2' style='color: #{{ itemType.color }}'>{{ itemType.title }}</span><span class='user-badge ml-auto'>{{ itemType.team_name }}</span></div></li>
       {% endfor %}
     </ul>
     {% if itemsCategoryArr %}
@@ -374,6 +376,11 @@
         {% endif %}
       </div>
 
+      <div class='d-flex my-2 align-items-center'>
+        <div class='edit-mode-label'>
+          <i aria-hidden='true' class='fas fa-fw fa-users mr-1'></i>{{ 'Team'|trans }}<span class='ml-2'>{{ Entity.entityData.team_name }}</span>
+        </div>
+      </div>
       <ul class='list-inline'>
         <li class='list-inline-item'>
           <label for='itemsTypesName'>{{ 'Name'|trans }}</label>

--- a/src/templates/catstat-edit.html
+++ b/src/templates/catstat-edit.html
@@ -1,4 +1,4 @@
-{% if Entity.EntityType.value != 'items_types' %}
+{% if Entity.entityType.value != 'items_types' %}
   {# CATEGORIES : not shown on resources categories edit page on admin panel #}
   <div class='d-flex mb-2 align-items-center'>
     <label for='category_select' class='col-form-label mr-3 edit-mode-label'>{{ 'Category'|trans }}</label>
@@ -17,7 +17,7 @@
 {% endif %}
 
 {# STATUS #}
-{% if Entity.EntityType.value == 'items_types' %}
+{% if Entity.entityType.value == 'items_types' %}
   {% set statusArr = itemsStatusArr %}
 {% endif %}
 <div class='d-flex mb-2 align-items-center'>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -1,0 +1,27 @@
+{# Modal for duplicate #}
+<div class='modal fade' id='duplicateModal' tabindex='-1' role='dialog' aria-labelledby='duplicateModalLabel'>
+  <div class='modal-dialog' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='duplicateModalLabel'>{{ 'Duplicate entry'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
+        <p>{{ 'Duplicating an entry will create a new entry with the same attributes.'|trans }}</p>
+        <div class='d-flex justify-content-between'>
+          <label for='duplicateKeepFilesSelect' class='col-form-label'>{{ 'Copy attached files'|trans }}</label>
+          <label class='switch ucp-align'>
+            <input type='checkbox' autocomplete='off' id='duplicateKeepFilesSelect'>
+            <span class='slider'></span>
+          </label>
+        </div>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
+        <button type='button' data-action='duplicate-entity' data-dismiss='modal' class='btn btn-primary'>{{ 'Duplicate'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/link-view-one.html
+++ b/src/templates/link-view-one.html
@@ -21,12 +21,12 @@
       <i class='fas fa-fw fa-square-plus'></i>
     </button>
     {% if mode == 'edit' %}
-      <button type='button' data-action='import-links' data-target='{{ link.entityid }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+      <button type='button' data-action='import-links' data-target='{{ link.entityid }}' aria-label='{{ 'Import links'|trans }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
         <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
-      <button type='button' data-action='import-link-body' data-endpoint='{{ link.type }}' data-target='{{ link.entityid }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+      <button type='button' data-action='import-link-body' data-endpoint='{{ link.type }}' data-target='{{ link.entityid }}' aria-label='{{ 'Import'|trans }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
         <i class='fas fa-fw fa-lg fa-file-import'></i></button>
     {% endif %}
-    <button type='button' data-action='destroy-{{ isRelated|default(false) ? 'related-' }}link' data-endpoint='{{ link.type }}_links' data-target='{{ link.entityid }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+    <button type='button' data-action='destroy-{{ isRelated|default(false) ? 'related-' }}link' data-endpoint='{{ link.type }}_links' data-target='{{ link.entityid }}' aria-label='{{ 'Delete'|trans }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
       <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
   </div>
   {# container to hold the body of the entity if it is toggled with the +/- icon #}

--- a/src/templates/view-edit-template.html
+++ b/src/templates/view-edit-template.html
@@ -1,5 +1,6 @@
 {% set mode = App.Request.query.get('mode')|default('view') %}
 {% include('ownership-transfer-modal.html') %}
+{% include 'duplicate-modal.html' %}
 
 {# REQUEST ACTIONS #}
 <div id='requestActionsDiv'>
@@ -81,7 +82,7 @@
   </button>
 
   {# DUPLICATE TEMPLATE #}
-  <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' data-action='duplicate-entity' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
+  <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' data-action='toggle-modal' data-target='duplicateModal' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
     <i class='fas fa-copy fa-fw'></i>
   </button>
 

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -33,33 +33,7 @@
     </div>
   </div>
 </div>
-{# Modal for duplicate #}
-<div class='modal fade' id='duplicateModal' tabindex='-1' role='dialog' aria-labelledby='duplicateModalLabel'>
-  <div class='modal-dialog' role='document'>
-    <div class='modal-content'>
-      <div class='modal-header'>
-        <h5 class='modal-title' id='duplicateModalLabel'>{{ 'Duplicate entry'|trans }}</h5>
-        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
-          <span aria-hidden='true'>&times;</span>
-        </button>
-      </div>
-      <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
-        <p>{{ 'Duplicating an entry will create a new entry with the same attributes.'|trans }}</p>
-        <div class='d-flex justify-content-between'>
-          <label for='duplicateKeepFilesSelect' class='col-form-label'>{{ 'Copy attached files'|trans }}</label>
-          <label class='switch ucp-align'>
-            <input type='checkbox' autocomplete='off' id='duplicateKeepFilesSelect'>
-            <span class='slider'></span>
-          </label>
-        </div>
-      </div>
-      <div class='modal-footer'>
-        <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
-        <button type='button' data-action='duplicate-entity' data-dismiss='modal' class='btn btn-primary'>{{ 'Duplicate'|trans }}</button>
-      </div>
-    </div>
-  </div>
-</div>
+{% include 'duplicate-modal.html' %}
 {# Modal for timestamping #}
 <div class='modal fade' id='timestampModal' tabindex='-1' role='dialog' aria-labelledby='timestampModalLabel'>
   <div class='modal-dialog' role='document'>

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -79,6 +79,19 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="switch-editor"]')) {
       EntityC.update(entity.id, Target.ContentType, editor.switch() === 'tiny' ? '1' : '2');
 
+    // INSERT IMAGE AT CURSOR POSITION IN TEXT FIXME TODO duplicated code from edit.ts
+    } else if (el.matches('[data-action="insert-image-in-body"]')) {
+      // link to the image
+      const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+      // switch for markdown or tinymce editor
+      let content: string;
+      if (editor.type === 'md') {
+        content = '\n![image](' + url + ')\n';
+      } else if (editor.type === 'tiny') {
+        content = '<img src="' + url + '" />';
+      }
+      editor.setContent(content);
+
     // DESTROY TEMPLATE
     } else if (el.matches('[data-action="destroy-template"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {

--- a/tests/unit/Make/MakeQrPdfTest.php
+++ b/tests/unit/Make/MakeQrPdfTest.php
@@ -11,8 +11,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Make;
 
-use Elabftw\Elabftw\EntitySlug;
-use Elabftw\Enums\EntityType;
+use Elabftw\Models\Experiments;
 use Elabftw\Models\Users;
 use Elabftw\Services\MpdfProvider;
 
@@ -24,7 +23,7 @@ class MakeQrPdfTest extends \PHPUnit\Framework\TestCase
     {
         $requester = new Users(1, 1);
         $MpdfProvider = new MpdfProvider('Toto');
-        $this->MakePdf = new MakeQrPdf($MpdfProvider, $requester, array(new EntitySlug(EntityType::Experiments, 1), new EntitySlug(EntityType::Experiments, 2)));
+        $this->MakePdf = new MakeQrPdf($MpdfProvider, $requester, array(new Experiments($requester, 1), new Experiments($requester, 2)));
     }
 
     public function testGetFileContent(): void

--- a/web/admin.php
+++ b/web/admin.php
@@ -65,9 +65,9 @@ try {
     $experimentsCategoriesArr = $ExperimentsCategories->readAll();
     if ($App->Request->query->has('templateid')) {
         $ItemsTypes->setId($App->Request->query->getInt('templateid'));
+        $ItemsTypes->canOrExplode('write');
     }
     $statusArr = $Status->readAll();
-    $itemsStatusArr = $ItemsStatus->readAll();
     $teamGroupsArr = $TeamGroups->readAll();
     $teamsArr = $Teams->readAll();
     $allTeamUsersArr = $App->Users->readAllFromTeam();
@@ -125,7 +125,7 @@ try {
         'allTeamgroupsArr' => $TeamGroups->readAllEverything(),
         'statusArr' => $statusArr,
         'experimentsCategoriesArr' => $experimentsCategoriesArr,
-        'itemsStatusArr' => $itemsStatusArr,
+        'itemsStatusArr' => $ItemsStatus->readAll(),
         'passwordInputHelp' => $passwordComplexity->toHuman(),
         'passwordInputPattern' => $passwordComplexity->toPattern(),
         'teamGroupsArr' => $teamGroupsArr,


### PR DESCRIPTION
This change implements proper permissions handling for items_types, aka Resources Categories.

See: #5217. Fix: #5162 

It also makes the Templates use a builder, similar to concrete entities. Overall, more features and less lines of code as a result :100: edit: ok not less lines of code with all commits, but still a lot of "if" removed.

Also includes fixes for duplicating templates with files, and insert image js code from template page.