### PR TITLE
Add missing content.css for tinymce skin

### DIFF
--- a/src/tools/yarn-plugin-tinymce.js
+++ b/src/tools/yarn-plugin-tinymce.js
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 /**
- * This file is a yarn plugin that hooks into the afterAllInstalled hook to execute. Its purpose is to extract two css files from the tinymce folder.
+ * This file is a yarn plugin that hooks into the afterAllInstalled hook to execute. Its purpose is to extract css and js files from the tinymce folder.
  * But because of PnP this is much more difficult to do than previously, when a simple "cp" was enough.
  * doc: https://yarnpkg.com/advanced/pnpapi
  */
@@ -48,7 +48,9 @@ module.exports = {
               crossFs.writeFileSync(destinationPath, fileContent, 'utf8');
             };
 
-            extractFile('tinymce/skins/ui/oxide/', 'skin.min.css');
+            crossFs.mkdirSync('web/assets/tiny_skins', { recursive: true });
+            extractFile('tinymce/skins/ui/oxide/', 'skin.min.css', 'tiny_skins/skin.min.css');
+            extractFile('tinymce/skins/content/default/', 'content.min.css', 'tiny_skins/content.min.css');
             extractFile('tinymce/skins/ui/oxide/', 'content.min.css', 'tinymce_content.min.css');
             extractFile('tinymce/plugins/emoticons/js/', 'emojis.js', 'tinymce_emojis.js');
           },

--- a/src/tools/yarn-plugin-tinymce.js
+++ b/src/tools/yarn-plugin-tinymce.js
@@ -37,6 +37,7 @@ module.exports = {
             }
             const checksum = project.storedChecksums.get(tinymceLocator.locatorHash) ?? null;
             const locatorPath = cache.getLocatorPath(tinymceLocator, checksum);
+            const pathToAssets = 'web/assets/';
 
             const extractFile = (nodeModulesPath, sourceName, targetName) => {
               targetName = typeof targetName === 'string' && targetName !== ''
@@ -44,13 +45,12 @@ module.exports = {
                 : sourceName;
               const requestedFile = `${locatorPath}/node_modules/${nodeModulesPath}${sourceName}`;
               const fileContent = crossFs.readFileSync(requestedFile);
-              const destinationPath = `web/assets/${targetName}`;
-              crossFs.writeFileSync(destinationPath, fileContent, 'utf8');
+              crossFs.writeFileSync(pathToAssets + targetName, fileContent, 'utf8');
             };
 
-            crossFs.mkdirSync('web/assets/tiny_skins', { recursive: true });
-            extractFile('tinymce/skins/ui/oxide/', 'skin.min.css', 'tiny_skins/skin.min.css');
-            extractFile('tinymce/skins/content/default/', 'content.min.css', 'tiny_skins/content.min.css');
+            crossFs.mkdirSync('${pathToAssets}tinymce_skins', { recursive: true });
+            extractFile('tinymce/skins/ui/oxide/', 'skin.min.css', 'tinymce_skins/skin.min.css');
+            extractFile('tinymce/skins/content/default/', 'content.min.css', 'tinymce_skins/content.min.css');
             extractFile('tinymce/skins/ui/oxide/', 'content.min.css', 'tinymce_content.min.css');
             extractFile('tinymce/plugins/emoticons/js/', 'emojis.js', 'tinymce_emojis.js');
           },

--- a/src/tools/yarn-plugin-tinymce.js
+++ b/src/tools/yarn-plugin-tinymce.js
@@ -48,7 +48,7 @@ module.exports = {
               crossFs.writeFileSync(pathToAssets + targetName, fileContent, 'utf8');
             };
 
-            crossFs.mkdirSync('${pathToAssets}tinymce_skins', { recursive: true });
+            crossFs.mkdirSync(`${pathToAssets}tinymce_skins`, { recursive: true });
             extractFile('tinymce/skins/ui/oxide/', 'skin.min.css', 'tinymce_skins/skin.min.css');
             extractFile('tinymce/skins/content/default/', 'content.min.css', 'tinymce_skins/content.min.css');
             extractFile('tinymce/skins/ui/oxide/', 'content.min.css', 'tinymce_content.min.css');

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -12,7 +12,7 @@ import 'tinymce/models/dom';
 import 'tinymce/icons/default';
 import 'tinymce/themes/silver';
 // Note about tinymce css stuff: this page https://www.tiny.cloud/docs/tinymce/6/webpack-es6-npm/ just doesn't work as advertised
-// so it's easier to simply copy/extract the css files to web/assets/tiny_skins instead via the yarn-plugin-tinymce.js
+// so it's easier to simply copy/extract the css files to web/assets/tinymce_skins instead via the yarn-plugin-tinymce.js
 import 'tinymce/plugins/accordion';
 import 'tinymce/plugins/advlist';
 import 'tinymce/plugins/anchor';
@@ -121,7 +121,7 @@ export function getTinymceBaseConfig(page: string): object {
     selector: '.mceditable',
     browser_spellcheck: true,
     // location of the skin directory
-    skin_url: '/assets/tiny_skins',
+    skin_url: '/assets/tinymce_skins',
     content_css: '/assets/tinymce_content.min.css',
     emoticons_database_url: 'assets/tinymce_emojis.js',
     // remove the "Upgrade" button

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -12,7 +12,7 @@ import 'tinymce/models/dom';
 import 'tinymce/icons/default';
 import 'tinymce/themes/silver';
 // Note about tinymce css stuff: this page https://www.tiny.cloud/docs/tinymce/6/webpack-es6-npm/ just doesn't work as advertised
-// so it's easier to simply copy the css files in web/assets/skins instead.
+// so it's easier to simply copy/extract the css files to web/assets/tiny_skins instead via the yarn-plugin-tinymce.js
 import 'tinymce/plugins/accordion';
 import 'tinymce/plugins/advlist';
 import 'tinymce/plugins/anchor';
@@ -121,7 +121,7 @@ export function getTinymceBaseConfig(page: string): object {
     selector: '.mceditable',
     browser_spellcheck: true,
     // location of the skin directory
-    skin_url: '/assets',
+    skin_url: '/assets/tiny_skins',
     content_css: '/assets/tinymce_content.min.css',
     emoticons_database_url: 'assets/tinymce_emojis.js',
     // remove the "Upgrade" button


### PR DESCRIPTION
Rohit Karthikeyan reported via [Element/Gitter](https://app.element.io/#/room/#elabftw_elabftw:gitter.im/$gCooDLMdLw2M_Kieo5EplN_RF6o5tKew93FeU_pW-2U)

> Hi, i just noticed that the content.min.css file isnt part of the new release (5.1.4) and noticed the same in the demo instance too.
> 
> `The resource from “https://demo.elabftw.net/assets/content.min.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff)`
> Would this impact the UI in anyway?

It turns out `content.min.css` was already missing for some time but was not spotted during development because the assets folder does not get cleaned regularly, at least in my dev environment.

Anyway, this PR fixes the issue.