### PR TITLE
feat/minor: optional link to original resource

### DIFF
--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -80,7 +80,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity
                 defaultTemplateHtml: $teamConfigArr['common_template'] ?? '',
                 defaultTemplateMd: $teamConfigArr['common_template_md'] ?? '',
             ),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToPrevious'] ?? '')),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToOriginal'] ?? '')),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -80,7 +80,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity
                 defaultTemplateHtml: $teamConfigArr['common_template'] ?? '',
                 defaultTemplateMd: $teamConfigArr['common_template_md'] ?? '',
             ),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToOriginal'] ?? '')),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false), (bool) ($reqBody['linkToOriginal'] ?? false)),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -80,7 +80,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity
                 defaultTemplateHtml: $teamConfigArr['common_template'] ?? '',
                 defaultTemplateMd: $teamConfigArr['common_template_md'] ?? '',
             ),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? '')),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToPrevious'] ?? '')),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -144,7 +144,7 @@ abstract class AbstractEntity implements RestInterface
      *
      * @return int the new item id
      */
-    abstract public function duplicate(bool $copyFiles = false): int;
+    abstract public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int;
 
     abstract public function readOne(): array;
 

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -144,7 +144,7 @@ abstract class AbstractEntity implements RestInterface
      *
      * @return int the new item id
      */
-    abstract public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int;
+    abstract public function duplicate(bool $copyFiles = false, bool $linkToOriginal = false): int;
 
     abstract public function readOne(): array;
 

--- a/src/models/AbstractTemplateEntity.php
+++ b/src/models/AbstractTemplateEntity.php
@@ -24,7 +24,7 @@ abstract class AbstractTemplateEntity extends AbstractEntity
     {
         return match ($action) {
             Action::Create => $this->create(title: $reqBody['title'] ?? null),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false)),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false), (bool) ($reqBody['linkToPrevious'] ?? false)),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/AbstractTemplateEntity.php
+++ b/src/models/AbstractTemplateEntity.php
@@ -24,7 +24,7 @@ abstract class AbstractTemplateEntity extends AbstractEntity
     {
         return match ($action) {
             Action::Create => $this->create(title: $reqBody['title'] ?? null),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToOriginal'] ?? '')),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false), (bool) ($reqBody['linkToOriginal'] ?? false)),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/AbstractTemplateEntity.php
+++ b/src/models/AbstractTemplateEntity.php
@@ -24,7 +24,7 @@ abstract class AbstractTemplateEntity extends AbstractEntity
     {
         return match ($action) {
             Action::Create => $this->create(title: $reqBody['title'] ?? null),
-            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false), (bool) ($reqBody['linkToPrevious'] ?? false)),
+            Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? ''), (bool) ($reqBody['linkToOriginal'] ?? '')),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
     }

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -143,7 +143,7 @@ class Experiments extends AbstractConcreteEntity
      *
      * @return int the ID of the new item
      */
-    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToOriginal = false): int
     {
         $this->canOrExplode('read');
 
@@ -176,8 +176,8 @@ class Experiments extends AbstractConcreteEntity
         $this->ItemsLinks->duplicate($this->id, $newId);
         $this->Steps->duplicate($this->id, $newId);
         $this->Tags->copyTags($newId);
-        // also add a link to the previous experiment if requested
-        if ($linkToPrevious) {
+        // also add a link to the original experiment if requested
+        if ($linkToOriginal) {
             $ExperimentsLinks = new Experiments2ExperimentsLinks($fresh);
             $ExperimentsLinks->setId($this->id);
             $ExperimentsLinks->postAction(Action::Create, array());

--- a/src/models/Experiments.php
+++ b/src/models/Experiments.php
@@ -143,7 +143,7 @@ class Experiments extends AbstractConcreteEntity
      *
      * @return int the ID of the new item
      */
-    public function duplicate(bool $copyFiles = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
     {
         $this->canOrExplode('read');
 
@@ -176,10 +176,12 @@ class Experiments extends AbstractConcreteEntity
         $this->ItemsLinks->duplicate($this->id, $newId);
         $this->Steps->duplicate($this->id, $newId);
         $this->Tags->copyTags($newId);
-        // also add a link to the previous experiment
-        $ExperimentsLinks = new Experiments2ExperimentsLinks($fresh);
-        $ExperimentsLinks->setId($this->id);
-        $ExperimentsLinks->postAction(Action::Create, array());
+        // also add a link to the previous experiment if requested
+        if ($linkToPrevious) {
+            $ExperimentsLinks = new Experiments2ExperimentsLinks($fresh);
+            $ExperimentsLinks->setId($this->id);
+            $ExperimentsLinks->postAction(Action::Create, array());
+        }
         if ($copyFiles) {
             $this->Uploads->duplicate($fresh);
         }

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -129,7 +129,7 @@ class Items extends AbstractConcreteEntity
         return $this->Users->isAdmin || (bool) $this->entityData['book_users_can_in_past'];
     }
 
-    public function duplicate(bool $copyFiles = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
     {
         $this->canOrExplode('read');
 
@@ -154,9 +154,11 @@ class Items extends AbstractConcreteEntity
         $this->Steps->duplicate($this->id, $newId);
         $this->Tags->copyTags($newId);
         // also add a link to the previous resource
-        $ItemsLinks = new Items2ItemsLinks($fresh);
-        $ItemsLinks->setId($this->id);
-        $ItemsLinks->postAction(Action::Create, array());
+        if ($linkToPrevious) {
+            $ItemsLinks = new Items2ItemsLinks($fresh);
+            $ItemsLinks->setId($this->id);
+            $ItemsLinks->postAction(Action::Create, array());
+        }
         if ($copyFiles) {
             $this->Uploads->duplicate($fresh);
         }

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -129,7 +129,7 @@ class Items extends AbstractConcreteEntity
         return $this->Users->isAdmin || (bool) $this->entityData['book_users_can_in_past'];
     }
 
-    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToOriginal = false): int
     {
         $this->canOrExplode('read');
 
@@ -153,8 +153,8 @@ class Items extends AbstractConcreteEntity
         $this->ItemsLinks->duplicate($this->id, $newId);
         $this->Steps->duplicate($this->id, $newId);
         $this->Tags->copyTags($newId);
-        // also add a link to the previous resource
-        if ($linkToPrevious) {
+        // also add a link to the original resource
+        if ($linkToOriginal) {
             $ItemsLinks = new Items2ItemsLinks($fresh);
             $ItemsLinks->setId($this->id);
             $ItemsLinks->postAction(Action::Create, array());

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -129,7 +129,7 @@ class ItemsTypes extends AbstractTemplateEntity
         return $this->entityData;
     }
 
-    public function duplicate(bool $copyFiles = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
     {
         // TODO: implement
         throw new ImproperActionException('No duplicate action for resources categories.');

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -129,7 +129,7 @@ class ItemsTypes extends AbstractTemplateEntity
         return $this->entityData;
     }
 
-    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToOriginal = false): int
     {
         // TODO: implement
         throw new ImproperActionException('No duplicate action for resources categories.');

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -102,7 +102,7 @@ class Templates extends AbstractTemplateEntity
     /**
      * Duplicate a template from someone else
      */
-    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToOriginal = false): int
     {
         $this->canOrExplode('read');
         $title = $this->entityData['title'] . ' I';

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -102,7 +102,7 @@ class Templates extends AbstractTemplateEntity
     /**
      * Duplicate a template from someone else
      */
-    public function duplicate(bool $copyFiles = false): int
+    public function duplicate(bool $copyFiles = false, bool $linkToPrevious = false): int
     {
         $this->canOrExplode('read');
         $title = $this->entityData['title'] . ' I';

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -18,7 +18,7 @@
           </label>
         </div>
 
-      {% if Entity.entityType.value == 'items' or Entity.entityType.value == 'experiments' %}
+      {% if Entity.entityType.value == 'experiments' or Entity.entityType.value == 'items' %}
         <div class='d-flex justify-content-between'>
           <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
           <label class='switch ucp-align'>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -18,9 +18,9 @@
           </label>
         </div>
         <div class='d-flex justify-content-between'>
-          <label for='duplicateLinkToPrevious' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
+          <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
           <label class='switch ucp-align'>
-            <input type='checkbox' autocomplete='off' id='duplicateLinkToPrevious' checked>
+            <input type='checkbox' autocomplete='off' id='duplicateLinkToOriginal' checked>
             <span class='slider'></span>
           </label>
         </div>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -17,6 +17,8 @@
             <span class='slider'></span>
           </label>
         </div>
+
+      {% if Entity.entityType.value != 'experiments_templates' %}
         <div class='d-flex justify-content-between'>
           <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
           <label class='switch ucp-align'>
@@ -24,6 +26,8 @@
             <span class='slider'></span>
           </label>
         </div>
+      {% endif %}
+
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -18,7 +18,7 @@
           </label>
         </div>
 
-      {% if Entity.entityType.value != 'experiments_templates' %}
+      {% if Entity.entityType.value == 'items' or Entity.entityType.value == 'experiments' %}
         <div class='d-flex justify-content-between'>
           <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
           <label class='switch ucp-align'>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -17,6 +17,13 @@
             <span class='slider'></span>
           </label>
         </div>
+        <div class='d-flex justify-content-between'>
+          <label for='duplicateLinkToPrevious' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
+          <label class='switch ucp-align'>
+            <input type='checkbox' autocomplete='off' id='duplicateLinkToPrevious' checked>
+            <span class='slider'></span>
+          </label>
+        </div>
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/templates/view-edit-template.html
+++ b/src/templates/view-edit-template.html
@@ -89,13 +89,6 @@
   {# DOWNLOAD / EXPORT MENU #}
   {% include 'export-menu.html' %}
 
-  {# IMPORT #}
-  {% if Entity.entityData.userid != App.Users.userid -%}
-    <button type='button' title='{{ 'Import to your profile'|trans }}' aria-label='{{ 'Import to your profile'|trans }}' data-action='import-template' data-id='{{ Entity.id }}' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
-      <i class='fas fa-file-import fa-fw'></i>
-    </button>
-  {% endif %}
-
   {# RIGHT PART #}
   {# TOGGLE PIN #}
   <button type='button' title='{{ 'Toggle pin (add to create button menu)'|trans }}' aria-label='{{ 'Toggle pin (add to create button menu)'|trans }}' data-action='toggle-pin' data-id='{{ Entity.id }}' class='btn {{ Entity.Pins.isPinned ? 'bgnd-gray' : 'hl-hover-gray' }} p-2 lh-normal border-0 ml-auto mr-2'>

--- a/src/ts/Entity.class.ts
+++ b/src/ts/Entity.class.ts
@@ -50,8 +50,8 @@ export default class Entity {
     return this.api.patch(`${this.model}/${id}`, params);
   }
 
-  duplicate(id: number, copyFiles: boolean, linkToPrevious: boolean): Promise<Response> {
-    return this.api.post(`${this.model}/${id}`, {'action': Action.Duplicate, 'copyFiles': copyFiles, 'linkToPrevious': linkToPrevious});
+  duplicate(id: number, copyFiles: boolean, linkToOriginal: boolean): Promise<Response> {
+    return this.api.post(`${this.model}/${id}`, {'action': Action.Duplicate, 'copyFiles': copyFiles, 'linkToOriginal': linkToOriginal});
   }
 
   destroy(id: number): Promise<Response> {

--- a/src/ts/Entity.class.ts
+++ b/src/ts/Entity.class.ts
@@ -50,8 +50,8 @@ export default class Entity {
     return this.api.patch(`${this.model}/${id}`, params);
   }
 
-  duplicate(id: number, copyFiles: boolean): Promise<Response> {
-    return this.api.post(`${this.model}/${id}`, {'action': Action.Duplicate, 'copyFiles': copyFiles});
+  duplicate(id: number, copyFiles: boolean, linkToPrevious: boolean): Promise<Response> {
+    return this.api.post(`${this.model}/${id}`, {'action': Action.Duplicate, 'copyFiles': copyFiles, 'linkToPrevious': linkToPrevious});
   }
 
   destroy(id: number): Promise<Response> {

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // DUPLICATE
     if (el.matches('[data-action="duplicate-entity"]')) {
       const copyFiles = (document.getElementById('duplicateKeepFilesSelect') as HTMLInputElement);
-      const linkToPreviousExperiment = (document.getElementById('duplicateLinkToPrevious') as HTMLInputElement);
+      const linkToOriginalExperiment = (document.getElementById('duplicateLinkToOriginal') as HTMLInputElement);
       let queryString = '';
       let page = '';
       if (about.page.startsWith('template-')) {
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
         page = '/ucp.php';
       }
 
-      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), Boolean(linkToPreviousExperiment.checked))
+      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), Boolean(linkToOriginalExperiment.checked))
         .then(resp => {
           const newId = getNewIdFromPostRequest(resp);
           window.location.href = `${page}?mode=edit&${queryString}id=${newId}`;

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
         page = '/ucp.php';
       }
 
-      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), Boolean(linkToOriginalExperiment.checked))
+      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), (linkToOriginalExperiment ? Boolean(linkToOriginalExperiment.checked) : false))
         .then(resp => {
           const newId = getNewIdFromPostRequest(resp);
           window.location.href = `${page}?mode=edit&${queryString}id=${newId}`;

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -44,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // DUPLICATE
     if (el.matches('[data-action="duplicate-entity"]')) {
       const copyFiles = (document.getElementById('duplicateKeepFilesSelect') as HTMLInputElement);
+      const linkToPreviousExperiment = (document.getElementById('duplicateLinkToPrevious') as HTMLInputElement);
       let queryString = '';
       let page = '';
       if (about.page.startsWith('template-')) {
@@ -51,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
         page = '/ucp.php';
       }
 
-      EntityC.duplicate(entity.id, Boolean(copyFiles.checked))
+      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), Boolean(linkToPreviousExperiment.checked))
         .then(resp => {
           const newId = getNewIdFromPostRequest(resp);
           window.location.href = `${page}?mode=edit&${queryString}id=${newId}`;

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -52,7 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
         page = '/ucp.php';
       }
 
-      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), (linkToOriginalExperiment ? Boolean(linkToOriginalExperiment.checked) : false))
+      // Ensure the link to original exists because this feature is not available for Template entities
+      EntityC.duplicate(entity.id, Boolean(copyFiles.checked), Boolean(linkToOriginalExperiment?.checked ?? false))
         .then(resp => {
           const newId = getNewIdFromPostRequest(resp);
           window.location.href = `${page}?mode=edit&${queryString}id=${newId}`;

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -105,7 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // IMPORT TPL
     } else if (el.matches('[data-action="import-template"]')) {
-      TemplateC.duplicate(parseInt(el.dataset.id), false);
+      TemplateC.duplicate(parseInt(el.dataset.id), false, false);
 
     // GENERATE SIGKEY
     } else if (el.matches('[data-action="create-sigkeys"]')) {

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -103,10 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       ApiC.patch(`${Model.User}/me`, params);
 
-    // IMPORT TPL
-    } else if (el.matches('[data-action="import-template"]')) {
-      TemplateC.duplicate(parseInt(el.dataset.id), false, false);
-
     // GENERATE SIGKEY
     } else if (el.matches('[data-action="create-sigkeys"]')) {
       const passphraseInput = (document.getElementById('sigPassphraseInput') as HTMLInputElement);

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -17,11 +17,10 @@ import {
 import tinymce from 'tinymce/tinymce';
 import { getTinymceBaseConfig } from './tinymce';
 import i18next from 'i18next';
-import { Action, Model, Target, EntityType } from './interfaces';
+import { Action, Model, Target } from './interfaces';
 import Templates from './Templates.class';
 import { getEditor } from './Editor.class';
 import Tab from './Tab.class';
-import EntityClass from './Entity.class';
 import { Api } from './Apiv2.class';
 import $ from 'jquery';
 import { Uploader } from './uploader';
@@ -58,7 +57,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // MAIN LISTENER
   document.querySelector('.real-container').addEventListener('click', (event) => {
     const el = (event.target as HTMLElement);
-    const TemplateC = new EntityClass(EntityType.Template);
     // CREATE TEMPLATE
     if (el.matches('[data-action="create-template"]')) {
       const title = prompt(i18next.t('template-title'));


### PR DESCRIPTION
Fix #5262
- Add an optional link to original resource when duplicating one (default : true)
- Hide this feature on the template because there are no link from template to template
- Remove importing templates from a different user (duplicate is already implemented)
