### PR TITLE
bug/minor: apidoc: complete endpoints and methods spec

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/setup-python@v4
       - name: Install codespell
         run: |
-            python -m pip install --break-system-packages codespell
+            python -m pip install codespell
       - name: Run codespell
         run: codespell --config src/tools/codespellrc

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -943,7 +943,7 @@ paths:
     post:
       tags: ['Api keys']
       summary: Create an API key
-      description: >-
+      description: |
         Create an API key. The cleartext key is sent back in the location
         header.
       operationId: post-apikeys
@@ -1059,13 +1059,13 @@ paths:
               properties:
                 category_id:
                   type: integer
-                  description: >-
+                  description: |
                     The template id to use, or 0 to use the common team
                     template, or -1 to have an empty body.
                   default: -1
                 tags:
                   type: array
-                  description: >-
+                  description: |
                     An array of tags to assign to the created entry.
                   items:
                     type: string
@@ -1242,17 +1242,18 @@ paths:
               properties:
                 action:
                   type: string
-                  description: >-
+                  description: |
                     The "duplicate" action creates a new entity based from the given entity id.
                   default: 'duplicate'
                 copyFiles:
                   type: boolean
-                  description: >-
-                    If "true", the action will import the files of the original entity.
                   default: false
+                  description: |
+                    If "true", the action will import the files of the original entity.
                 linkToOriginal:
                   type: boolean
-                  description: >-
+                  default: true
+                  description: |
                     If "true", the action will create a link to the original entity.
       responses:
         '201':
@@ -1286,6 +1287,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Include a full JSON export in the ZIP archive. Only applicable if format is zip(a).
           examples:
@@ -1299,6 +1301,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -1323,6 +1326,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Toggles if the changelog should be included in PDF exports (pdf, pdfa, zip, zipa). Changelog is by default included if the export provides PDF/A, otherwise not.
           examples:
@@ -1639,17 +1643,18 @@ paths:
               properties:
                 action:
                   type: string
-                  description: >-
+                  description: |
                     The "duplicate" action creates a new item based from the given item id.
                   default: 'duplicate'
                 copyFiles:
                   type: boolean
-                  description: >-
-                    If "true", the action will import the files of the original item.
                   default: false
+                  description: |
+                    If "true", the action will import the files of the original item.
                 linkToOriginal:
                   type: boolean
-                  description: >-
+                  default: true
+                  description: |
                     If "true", the action will create a link to the original item.
       responses:
         '201':
@@ -1684,6 +1689,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Include a full JSON export in the ZIP archive. Only applicable if format is zip(a).
           examples:
@@ -1697,6 +1703,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -1721,6 +1728,7 @@ paths:
           in: query
           schema:
             type: boolean
+            default: true
           description: |
             Toggles if the changelog should be included in PDF exports (pdf, pdfa, zip, zipa). Changelog is by default included if the export provides PDF/A, otherwise not.
           examples:
@@ -2305,19 +2313,19 @@ paths:
               properties:
                 action:
                   type: string
-                  description: >-
+                  description: |
                     The "duplicate" action creates a new entity based from the given entity id.
                   default: 'duplicate'
                 copyFiles:
                   type: boolean
-                  description: >-
-                    If "true", the action will import the files of the original entity.
                   default: false
+                  description: |
+                    If "true", the action will import the files of the original entity.
                 linkToOriginal:
                   type: boolean
-                  description: >-
-                    This action does not apply to experiment templates, as there is no link between templates.
                   default: false
+                  description: |
+                    This action does not apply to experiment templates, as there is no link between templates.
       responses:
         '201':
           description: The experiment template has been duplicated.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1301,7 +1301,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: false
+            default: true
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -1703,7 +1703,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: false
+            default: true
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -2321,11 +2321,6 @@ paths:
                   default: false
                   description: |
                     If "true", the action will import the files of the original entity.
-                linkToOriginal:
-                  type: boolean
-                  default: false
-                  description: |
-                    This action does not apply to experiment templates, as there is no link between templates.
       responses:
         '201':
           description: The experiment template has been duplicated.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1287,7 +1287,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Include a full JSON export in the ZIP archive. Only applicable if format is zip(a).
           examples:
@@ -1301,7 +1301,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -1326,7 +1326,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Toggles if the changelog should be included in PDF exports (pdf, pdfa, zip, zipa). Changelog is by default included if the export provides PDF/A, otherwise not.
           examples:
@@ -1689,7 +1689,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Include a full JSON export in the ZIP archive. Only applicable if format is zip(a).
           examples:
@@ -1703,7 +1703,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Include the title in the QR code. Only applicable if format is qrpng.
           examples:
@@ -1728,7 +1728,7 @@ paths:
           in: query
           schema:
             type: boolean
-            default: true
+            default: false
           description: |
             Toggles if the changelog should be included in PDF exports (pdf, pdfa, zip, zipa). Changelog is by default included if the export provides PDF/A, otherwise not.
           examples:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2277,7 +2277,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/experiment_template'
   /experiments_templates/{id}:
-    summary: Actions on an experiment template
+    summary: Actions on a specific experiment template
     parameters:
       - name: id
         in: path
@@ -2285,6 +2285,47 @@ paths:
         required: true
         schema:
           type: integer
+    post:
+      tags: ['Experiments templates']
+      summary: Duplicate an experiment template with its ID
+      operationId: post-experiment_template-by-id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the experiment template to duplicate.
+          schema:
+            type: integer
+      requestBody:
+        description: Parameters for duplicating an experiment template
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  description: >-
+                    The "duplicate" action creates a new entity based from the given entity id.
+                  default: 'duplicate'
+                copyFiles:
+                  type: boolean
+                  description: >-
+                    If "true", the action will import the files of the original entity.
+                  default: false
+                linkToOriginal:
+                  type: boolean
+                  description: >-
+                    This action does not apply to experiment templates, as there is no link between templates.
+                  default: false
+      responses:
+        '201':
+          description: The experiment template has been duplicated.
+          headers:
+            location:
+              description: An URL to the experiment template that was duplicated.
+              schema:
+                type: string
     get:
       tags: ['Experiments templates']
       summary: Read an experiment template

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1214,7 +1214,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/experiment'
   /experiments/{id}:
-    summary: Actions on an experiment
+    summary: Actions on a specific experiment
     parameters:
       - name: id
         in: path
@@ -1222,6 +1222,46 @@ paths:
         required: true
         schema:
           type: integer
+    post:
+      tags: ['Experiments']
+      summary: Duplicate an experiment with its ID
+      operationId: post-experiment-by-id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the experiment to duplicate.
+          schema:
+            type: integer
+      requestBody:
+        description: Parameters for duplicating an experiment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  description: >-
+                    The "duplicate" action creates a new entity based from the given entity id.
+                  default: 'duplicate'
+                copyFiles:
+                  type: boolean
+                  description: >-
+                    If "true", the action will import the files of the original entity.
+                  default: false
+                linkToOriginal:
+                  type: boolean
+                  description: >-
+                    If "true", the action will create a link to the original entity.
+      responses:
+        '201':
+          description: The experiment has been duplicated.
+          headers:
+            location:
+              description: An URL to the experiment that was duplicated.
+              schema:
+                type: string
     get:
       tags: ['Experiments']
       summary: Read an experiment
@@ -1571,7 +1611,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/item'
   /items/{id}:
-    summary: Actions on an item
+    summary: Actions on a specific item
     parameters:
       - name: id
         in: path
@@ -1579,6 +1619,46 @@ paths:
         required: true
         schema:
           type: integer
+    post:
+      tags: ['Items']
+      summary: Duplicate an item with its ID
+      operationId: post-item-by-id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the item to duplicate.
+          schema:
+            type: integer
+      requestBody:
+        description: Parameters for duplicating an item
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  description: >-
+                    The "duplicate" action creates a new item based from the given item id.
+                  default: 'duplicate'
+                copyFiles:
+                  type: boolean
+                  description: >-
+                    If "true", the action will import the files of the original item.
+                  default: false
+                linkToOriginal:
+                  type: boolean
+                  description: >-
+                    If "true", the action will create a link to the original item.
+      responses:
+        '201':
+          description: The item has been duplicated.
+          headers:
+            location:
+              description: An URL to the item that was duplicated.
+              schema:
+                type: string
     get:
       tags: ['Items']
       summary: Read an item

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -20,9 +20,7 @@
 
       {% if Entity.entityType.value == 'experiments' or Entity.entityType.value == 'items' %}
         <div class='d-flex justify-content-between'>
-          <label for='duplicateLinkToOriginal' class='col-form-label'>
-            {{ 'Link to original ' ~ (Entity.entityType.value == 'experiments' ? 'experiment' : 'item')|trans }}
-          </label>
+          <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original entry'|trans }}</label>
           <label class='switch ucp-align'>
             <input type='checkbox' autocomplete='off' id='duplicateLinkToOriginal' checked>
             <span class='slider'></span>

--- a/src/templates/duplicate-modal.html
+++ b/src/templates/duplicate-modal.html
@@ -20,7 +20,9 @@
 
       {% if Entity.entityType.value == 'experiments' or Entity.entityType.value == 'items' %}
         <div class='d-flex justify-content-between'>
-          <label for='duplicateLinkToOriginal' class='col-form-label'>{{ 'Link to original experiment'|trans }}</label>
+          <label for='duplicateLinkToOriginal' class='col-form-label'>
+            {{ 'Link to original ' ~ (Entity.entityType.value == 'experiments' ? 'experiment' : 'item')|trans }}
+          </label>
           <label class='switch ucp-align'>
             <input type='checkbox' autocomplete='off' id='duplicateLinkToOriginal' checked>
             <span class='slider'></span>


### PR DESCRIPTION
- Experiments routes : add /experiment/{id} on POST, with duplicate action and parameters
- Items routes : add /items/{id} on POST, with duplicate action and parameters
- Experiments Templates routes : add /experiments_templates/{id} on POST, with duplicate action and parameters

Harmonize : 
- replace `>-` with `|`
- set default values for booleans (initially true). Specifying it to allow readability and schema display.

![Capture d’écran du 2024-10-15 09-22-51](https://github.com/user-attachments/assets/786bb572-4826-4a16-8141-1cee06b1b994)

![image](https://github.com/user-attachments/assets/6a42e501-5f74-4e37-869f-87d004a9001d)
![image](https://github.com/user-attachments/assets/40cf4a20-e5f5-422c-be84-fb246a90ce6e)
![Capture d’écran du 2024-10-04 10-37-14](https://github.com/user-attachments/assets/d82d4aed-2028-42af-a4f8-0aecdfde7b82)

- side note : quick fix on the duplicate modal template, to label as "resource" on item duplicate page.

Before when duplicating a resource : 
![Capture d’écran du 2024-10-04 09-35-05](https://github.com/user-attachments/assets/703708ee-ce5e-4b36-a2ac-b9219fd3837c)

Now : 
![Capture d’écran du 2024-10-04 09-50-06](https://github.com/user-attachments/assets/86eaa82d-2674-450c-b2a6-94765ef6c5aa)
