### PR TITLE
 bug/minor: template duplicate is not pinned

### DIFF
--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -139,10 +139,6 @@ class Templates extends AbstractTemplateEntity
             $this->Uploads->duplicate($fresh);
         }
 
-        // now pin the newly created template so it directly appears in Create menu
-        $Pins = new Pins($fresh);
-        $Pins->togglePin();
-
         return $newId;
     }
 


### PR DESCRIPTION
No issue related

When duplicating an experiment template, the newly created template is not pinned. After investigating, it turns out the method was toggling an already pinned new template, so all duplicates were unpinned when created.

- remove pin sequence on duplicate method, for experiment templates

Status when duplicated : 
![image](https://github.com/user-attachments/assets/8138c1db-c8df-44fd-a894-2436df416593)
