### PR TITLE
feat/medior: tests: allow running specific tests (one or multiple) via yarn command

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -81,17 +81,22 @@ if ($ci); then
 fi
 # when trying to use a bash variable to hold the skip api options, I ran into issues that this option doesn't exist, so the command is entirely duplicated instead
 if [ "${1:-}" = "unit" ]; then
-    # Run a specified test file
-    TEST_FILE=${2:-}
-    if [ -n "$TEST_FILE" ]; then
-      echo "Running unit tests. Test file: ${TEST_FILE:-none}"
-      # Run one specific test file if path is provided
-      docker exec -it elabtmp php vendor/bin/codecept run "$TEST_FILE" --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+    # Remove "unit" from the list of arguments, we are going to allow multiple arguments (test files) so this one should be excluded from the list.
+    shift
+    # Run one or multiple specific tests if the path is specified.
+    TEST_FILES=("$@")
+    if [ ${#TEST_FILES[@]} -gt 0 ]; then
+        echo "Running unit tests. Test file(s): ${TEST_FILES[*]}"
+        # Loop through each test file and run it individually
+        for TEST_FILE in "${TEST_FILES[@]}"; do
+          echo "Running test: $TEST_FILE"
+          # verbose flag allows to see fwrite debug statements
+          docker exec -it elabtmp php vendor/bin/codecept run "$TEST_FILE" --verbose --skip apiv2 --skip cypress
+        done
     else
-      echo "Running all unit tests."
-      # Run all tests if no file is specified
-      # verbose flag allows to see fwrite debug statements
-      docker exec -it elabtmp php vendor/bin/codecept run --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+        echo "Running all unit tests."
+        # Run all tests if no file is specified
+        docker exec -it elabtmp php vendor/bin/codecept run --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
     fi
 elif [ "${1:-}" = "api" ]; then
     docker exec -it elabtmp php vendor/bin/codecept run --skip unit --skip cypress --coverage --coverage-html --coverage-xml

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -81,8 +81,18 @@ if ($ci); then
 fi
 # when trying to use a bash variable to hold the skip api options, I ran into issues that this option doesn't exist, so the command is entirely duplicated instead
 if [ "${1:-}" = "unit" ]; then
-    # verbose flag allows to see fwrite debug statements
-    docker exec -it elabtmp php vendor/bin/codecept run --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+    # Run a specified test file
+    TEST_FILE=${2:-}
+    if [ -n "$TEST_FILE" ]; then
+      echo "Running unit tests. Test file: ${TEST_FILE:-none}"
+      # Run one specific test file if path is provided
+      docker exec -it elabtmp php vendor/bin/codecept run "$TEST_FILE" --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+    else
+      echo "Running all unit tests."
+      # Run all tests if no file is specified
+      # verbose flag allows to see fwrite debug statements
+      docker exec -it elabtmp php vendor/bin/codecept run --verbose --skip apiv2 --skip cypress --coverage --coverage-html --coverage-xml
+    fi
 elif [ "${1:-}" = "api" ]; then
     docker exec -it elabtmp php vendor/bin/codecept run --skip unit --skip cypress --coverage --coverage-html --coverage-xml
 # acceptance with cypress


### PR DESCRIPTION
I noticed there was no configuration to run a specific unit test, which can be useful when we want to save time.

:koala: :exclamation: This should not prevent from using the `yarn unit` command before commits, to ensure complete test coverage.

- add config to specify test path (use path from content root
`yarn unit tests/unit/path to your unit test`
- allow multiple specific tests
`yarn unit tests/unit/pathToTest1 tests/unit/pathToTest2`
- coverage is not displayed when running specific tests, but is available for the full yarn unit tests.

![Capture d’écran du 2024-10-15 11-09-17](https://github.com/user-attachments/assets/223936b1-bc27-4da9-adcd-f010a8d873a9)
