### PR TITLE
bug/minor: templates: always pin templates on create or duplicate actions

### DIFF
--- a/src/models/Pins.php
+++ b/src/models/Pins.php
@@ -101,13 +101,13 @@ class Pins
     }
 
     /**
-     * Remove current entity from pinned of current user
+     * Add current entity to pinned of current user
      */
-    private function rmFromPinned(): bool
+    public function addToPinned(): bool
     {
         $this->Entity->canOrExplode('read');
 
-        $sql = 'DELETE FROM pin_' . $this->Entity->entityType->value . '2users WHERE entity_id = :entity_id AND users_id = :users_id';
+        $sql = 'INSERT IGNORE INTO pin_' . $this->Entity->entityType->value . '2users(users_id, entity_id) VALUES (:users_id, :entity_id)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);
@@ -116,13 +116,13 @@ class Pins
     }
 
     /**
-     * Add current entity to pinned of current user
+     * Remove current entity from pinned of current user
      */
-    private function addToPinned(): bool
+    private function rmFromPinned(): bool
     {
         $this->Entity->canOrExplode('read');
 
-        $sql = 'INSERT IGNORE INTO pin_' . $this->Entity->entityType->value . '2users(users_id, entity_id) VALUES (:users_id, :entity_id)';
+        $sql = 'DELETE FROM pin_' . $this->Entity->entityType->value . '2users WHERE entity_id = :entity_id AND users_id = :users_id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':users_id', $this->Entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -95,7 +95,7 @@ class Templates extends AbstractTemplateEntity
         // now pin the newly created template so it directly appears in Create menu
         $fresh = new self($this->Users, $id);
         $Pins = new Pins($fresh);
-        $Pins->togglePin();
+        $Pins->addToPinned();
         return $id;
     }
 
@@ -138,6 +138,10 @@ class Templates extends AbstractTemplateEntity
         if ($copyFiles) {
             $this->Uploads->duplicate($fresh);
         }
+
+        // pin the newly created template so it directly appears in Create menu
+        $Pins = new Pins($fresh);
+        $Pins->addToPinned();
 
         return $newId;
     }

--- a/tests/unit/models/PinsTest.php
+++ b/tests/unit/models/PinsTest.php
@@ -19,12 +19,14 @@ class PinsTest extends \PHPUnit\Framework\TestCase
 
     private Templates $Templates;
 
+    private Users $Users;
+
     protected function setUp(): void
     {
-        $Users = new Users(1, 1);
-        $this->Experiments = new Experiments($Users, 1);
-        $this->Items = new Items($Users, 1);
-        $this->Templates = new Templates($Users, 1);
+        $this->Users = new Users(1, 1);
+        $this->Experiments = new Experiments($this->Users, 1);
+        $this->Items = new Items($this->Users, 1);
+        $this->Templates = new Templates($this->Users, 1);
     }
 
     public function testTogglePin(): void
@@ -48,5 +50,52 @@ class PinsTest extends \PHPUnit\Framework\TestCase
         $this->Templates->Pins->togglePin();
         $this->assertTrue($this->Templates->Pins->isPinned());
         $this->assertTrue(count($this->Templates->Pins->readAll()) > 0);
+    }
+
+    /**
+     * ensure that duplicated entry is not pinned
+     * @return void
+     */
+    public function testDuplicateIsNotPinned(): void
+    {
+        // duplicate existing experiment
+        $source = $this->Experiments;
+        $duplicate = $source->duplicate();
+        $freshSource = new Experiments($this->Users, $duplicate);
+        $this->assertNotEquals($source->entityData['id'], $freshSource->entityData['id']);
+
+        // ensure the duplicate experiment is not pinned
+        $this->assertCount(0, $freshSource->Pins->readAll());
+        $this->assertCount(0, $freshSource->Pins->readAllSimple());
+
+        // duplicate existing item
+        $sourceItem = $this->Items;
+        $duplicateItem = $sourceItem->duplicate();
+        $freshItem = new Items($this->Users, $duplicateItem);
+        $this->assertNotEquals($sourceItem->entityData['id'], $freshItem->entityData['id']);
+
+        // ensure the duplicate item is not pinned
+        $this->assertCount(0, $freshItem->Pins->readAll());
+        $this->assertCount(0, $freshItem->Pins->readAllSimple());
+    }
+
+    /**
+     * ensure that duplicating a pinned/non-pinned template results in a new pinned template in both cases
+     * @return void
+     */
+    public function testTemplateIsAlwaysPinnedWhenCreated(): void
+    {
+        // create a new template and ensure it is pinned
+        $source = new Templates($this->Users, 1);
+        $this->assertTrue($source->Pins->isPinned());
+        $this->assertTrue(count($source->Pins->readAll()) > 0);
+
+        // duplicate the template
+        $duplicate = $source->duplicate();
+        $fresh = new Templates($this->Users, $duplicate);
+        $this->assertNotEquals($source->entityData['id'], $fresh->entityData['id']);
+
+        // ensure the duplicate is pinned on creation
+        $this->assertTrue($fresh->Pins->isPinned());
     }
 }

--- a/tests/unit/models/PinsTest.php
+++ b/tests/unit/models/PinsTest.php
@@ -11,9 +11,6 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
-use Elabftw\Enums\EntityType;
-use Elabftw\Exceptions\ImproperActionException;
-
 class PinsTest extends \PHPUnit\Framework\TestCase
 {
     private Experiments $Experiments;
@@ -82,21 +79,11 @@ class PinsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $fresh->Pins->readAllSimple());
     }
 
-    private function duplicateEntity(Experiments | Items | Templates $entity): Experiments | Items | Templates
+    private function duplicateEntity(AbstractEntity $entity): AbstractEntity
     {
-        $duplicated = $entity->duplicate();
-
-        $fresh = match ($entity->entityType) {
-            EntityType::Experiments => new Experiments($this->Users, $duplicated),
-            EntityType::Items => new Items($this->Users, $duplicated),
-            EntityType::Templates => new Templates($this->Users, $duplicated),
-            default => null
-        };
-
-        if ($fresh === null) {
-            $message = sprintf('Invalid entity type: %s', $entity->entityType->value);
-            throw new ImproperActionException($message);
-        }
+        $newId = $entity->duplicate();
+        $fresh = clone $entity;
+        $fresh->setId($newId);
 
         return $fresh;
     }

--- a/tests/unit/models/PinsTest.php
+++ b/tests/unit/models/PinsTest.php
@@ -60,23 +60,14 @@ class PinsTest extends \PHPUnit\Framework\TestCase
 
     public function testTemplateIsAlwaysPinnedWhenCreated(): void
     {
-        // Confirm the created template is pinned
-        $this->assertTrue($this->Templates->Pins->isPinned());
-        $this->assertTrue(count($this->Templates->Pins->readAll()) > 0);
-
-        // Duplicate the template and ensure it is pinned on creation
         $fresh = $this->duplicateEntity($this->Templates);
-        $this->assertNotEquals($this->Templates->id, $fresh->id);
         $this->assertTrue($fresh->Pins->isPinned());
-        $this->assertTrue(count($fresh->Pins->readAll()) > 0);
     }
 
     private function checkDuplicateIsNotPinned(Experiments | Items $entity): void
     {
         $fresh = $this->duplicateEntity($entity);
-        $this->assertNotEquals($entity->id, $fresh->id);
-        $this->assertCount(0, $fresh->Pins->readAll());
-        $this->assertCount(0, $fresh->Pins->readAllSimple());
+        $this->assertFalse($fresh->Pins->isPinned());
     }
 
     private function duplicateEntity(AbstractEntity $entity): AbstractEntity

--- a/tests/unit/models/PinsTest.php
+++ b/tests/unit/models/PinsTest.php
@@ -85,17 +85,13 @@ class PinsTest extends \PHPUnit\Framework\TestCase
     private function duplicateEntity(Experiments | Items | Templates $entity): Experiments | Items | Templates
     {
         $duplicated = $entity->duplicate();
-        $fresh = null;
 
-        if ($entity->entityType === EntityType::Experiments) {
-            $fresh = new Experiments($this->Users, $duplicated);
-        }
-        if ($entity->entityType === EntityType::Items) {
-            $fresh = new Items($this->Users, $duplicated);
-        }
-        if ($entity->entityType === EntityType::Templates) {
-            $fresh = new Templates($this->Users, $duplicated);
-        }
+        $fresh = match ($entity->entityType) {
+            EntityType::Experiments => new Experiments($this->Users, $duplicated),
+            EntityType::Items => new Items($this->Users, $duplicated),
+            EntityType::Templates => new Templates($this->Users, $duplicated),
+            default => null
+        };
 
         if ($fresh === null) {
             $message = sprintf('Invalid entity type: %s', $entity->entityType->value);


### PR DESCRIPTION
Fix for #5288

- Ensure both created and duplicated templates are pinned.
- Add tests to cover use cases

ps : it appears as if i have modified the Pins.php methods but i only made the addToPinned public and exchanged position with rmFromPrinned, to have methods in correct order (public then private). If disturbing, i can always leave it where it was and change its range.