### PR TITLE
feat/medium: batch actions transfer ownership

### DIFF
--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -40,7 +40,7 @@ enum Action: string
     case SetCanread = 'setcanread';
     case SetCanwrite = 'setcanwrite';
     case Timestamp = 'timestamp';
-    case TransferOwnership = 'transferOwnership';
+    case TransferOwnership = 'transferownership';
     case Update = 'update';
     case UpdatePassword = 'updatepassword';
     case UpdateTag = 'updatetag';

--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -40,7 +40,6 @@ enum Action: string
     case SetCanread = 'setcanread';
     case SetCanwrite = 'setcanwrite';
     case Timestamp = 'timestamp';
-    case TransferOwnership = 'transferownership';
     case Update = 'update';
     case UpdatePassword = 'updatepassword';
     case UpdateTag = 'updatetag';

--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -42,7 +42,6 @@ enum Action: string
     case SetCanwrite = 'setcanwrite';
     case Timestamp = 'timestamp';
     case Update = 'update';
-    case UpdateOwner = 'updateowner';
     case UpdatePassword = 'updatepassword';
     case UpdateTag = 'updatetag';
     case UpdateMetadataField = 'updatemetadatafield';

--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -40,6 +40,7 @@ enum Action: string
     case SetCanread = 'setcanread';
     case SetCanwrite = 'setcanwrite';
     case Timestamp = 'timestamp';
+    case TransferOwnership = 'transferOwnership';
     case Update = 'update';
     case UpdatePassword = 'updatepassword';
     case UpdateTag = 'updatetag';

--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -42,6 +42,7 @@ enum Action: string
     case SetCanwrite = 'setcanwrite';
     case Timestamp = 'timestamp';
     case Update = 'update';
+    case UpdateOwner = 'updateowner';
     case UpdatePassword = 'updatepassword';
     case UpdateTag = 'updatetag';
     case UpdateMetadataField = 'updatemetadatafield';

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -386,7 +386,7 @@ abstract class AbstractEntity implements RestInterface
             )(),
             Action::Update => (
                 function () use ($params) {
-                    if ($params['target_owner'] && $params['users']) {
+                    if (isset($params['target_owner']) && isset($params['users'])) {
                         $this->patch(Action::Update, array('userid' => $params['target_owner']));
                     } else {
                         foreach ($params as $key => $value) {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -391,11 +391,7 @@ abstract class AbstractEntity implements RestInterface
                     }
                 }
             )(),
-            Action::UpdateOwner => (
-                function () use ($params) {
-                    $this->patch(Action::Update, array('userid' => $params['target_owner']));
-                }
-            )(),
+            Action::UpdateOwner => $this->patch(Action::Update, array('userid' => $params['target_owner'])),
             Action::ExclusiveEditMode => $this->ExclusiveEditMode->toggle(),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -391,7 +391,6 @@ abstract class AbstractEntity implements RestInterface
                     }
                 }
             )(),
-            Action::UpdateOwner => $this->patch(Action::Update, array('userid' => $params['target_owner'])),
             Action::ExclusiveEditMode => $this->ExclusiveEditMode->toggle(),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -386,13 +386,14 @@ abstract class AbstractEntity implements RestInterface
             )(),
             Action::Update => (
                 function () use ($params) {
-                    if (isset($params['target_owner']) && isset($params['users'])) {
-                        $this->patch(Action::Update, array('userid' => $params['target_owner']));
-                    } else {
-                        foreach ($params as $key => $value) {
-                            $this->update(new EntityParams($key, (string) $value));
-                        }
+                    foreach ($params as $key => $value) {
+                        $this->update(new EntityParams($key, (string) $value));
                     }
+                }
+            )(),
+            Action::UpdateOwner => (
+                function () use ($params) {
+                    $this->patch(Action::Update, array('userid' => $params['target_owner']));
                 }
             )(),
             Action::ExclusiveEditMode => $this->ExclusiveEditMode->toggle(),

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -671,14 +671,14 @@ abstract class AbstractEntity implements RestInterface
     private function transferOwnership(array $params): void
     {
         $previousOwners = $params['users'];
-        $newOwner = $params['new_owner'];
+        $target = $params['target_owner'];
         // Transfer ownership to the new target owner
         foreach ($previousOwners as $owner) {
             $experiments = $this->getIdFromUser($owner);
             foreach ($experiments as $experiment) {
-                $sql = 'UPDATE `experiments` SET userid = :new_owner WHERE id = :id';
+                $sql = 'UPDATE `experiments` SET userid = :target_owner WHERE id = :id';
                 $req = $this->Db->prepare($sql);
-                $req->bindParam(':new_owner', $newOwner, PDO::PARAM_INT);
+                $req->bindParam(':target_owner', $target, PDO::PARAM_INT);
                 $req->bindParam(':id', $experiment, PDO::PARAM_INT);
                 $this->Db->execute($req);
             }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -670,17 +670,15 @@ abstract class AbstractEntity implements RestInterface
 
     private function transferOwnership(array $params): void
     {
-        $newOwner = $params['newOwner'];
-        // Get owners array from parameters
-        $owners = $params['owners'];
-
-        // Transfer ownership of each owner to the requester
-        foreach ($owners as $owner) {
+        $previousOwners = $params['users'];
+        $newOwner = $params['new_owner'];
+        // Transfer ownership to the new target owner
+        foreach ($previousOwners as $owner) {
             $experiments = $this->getIdFromUser($owner);
             foreach ($experiments as $experiment) {
-                $sql = 'UPDATE `experiments` SET userid = :newOwner WHERE id = :id';
+                $sql = 'UPDATE `experiments` SET userid = :new_owner WHERE id = :id';
                 $req = $this->Db->prepare($sql);
-                $req->bindParam(':newOwner', $newOwner, PDO::PARAM_INT);
+                $req->bindParam(':new_owner', $newOwner, PDO::PARAM_INT);
                 $req->bindParam(':id', $experiment, PDO::PARAM_INT);
                 $this->Db->execute($req);
             }

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -52,15 +52,9 @@ class Batch implements RestInterface
             $model = new Experiments($this->requester);
             $Tags2Entity = new Tags2Entity($model->entityType);
             $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['tags']);
-            foreach ($targetIds as $id) {
-                try {
-                    $model->setId($id);
-                    $model->patch($action, $reqBody);
-                    $this->processed++;
-                } catch (IllegalActionException) {
-                    continue;
-                }
-            }
+            // Format tags as associative array to be processed same way as other entries
+            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
+            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
         }
         if ($reqBody['users']) {
             // only process experiments
@@ -97,26 +91,33 @@ class Batch implements RestInterface
 
     private function processEntities(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column, Action $action, array $params): void
     {
+        $entries = $this->getEntriesByIds($idArr, $model, $column);
+        $this->loopOverEntries($entries, $model, $action, $params);
+    }
+
+    private function getEntriesByIds(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column): array
+    {
+        $allEntries = array();
+        foreach ($idArr as $id) {
+            $displayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
+            $displayParams->limit = 100000;
+            $displayParams->appendFilterSql($column, $id);
+            $entries = $model->readShow($displayParams, false);
+            $allEntries = array_merge($allEntries, $entries);
+        }
+        return $allEntries;
+    }
+
+    private function loopOverEntries(array $entries, AbstractConcreteEntity $model, Action $action, array $params): void
+    {
         // On transfer of ownership, only the target owner is required in params
         if ($params['action'] === Action::UpdateOwner->value) {
             $params = array('userid' => $params['target_owner'] ?? throw new ImproperActionException('Target owner is missing!'));
             $action = Action::Update;
         }
-
-        foreach ($idArr as $id) {
-            $DisplayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
-            $DisplayParams->limit = 100000;
-            $DisplayParams->appendFilterSql($column, $id);
-            $entries = $model->readShow($DisplayParams, false);
-            $this->loopOverEntries($entries, $model, $action, $params);
-        }
-    }
-
-    private function loopOverEntries(array $entries, AbstractConcreteEntity $model, Action $action, array $params, bool $isTag = false): void
-    {
         foreach ($entries as $entry) {
             try {
-                $isTag ? $model->setId($entry) : $model->setId($entry['id']);
+                $model->setId($entry['id']);
                 $model->patch($action, $params);
                 $this->processed++;
             } catch (IllegalActionException) {

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -99,10 +99,10 @@ class Batch implements RestInterface
     {
         $allEntries = array();
         foreach ($idArr as $id) {
-            $displayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
-            $displayParams->limit = 100000;
-            $displayParams->appendFilterSql($column, $id);
-            $entries = $model->readShow($displayParams, false);
+            $DisplayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
+            $DisplayParams->limit = 100000;
+            $DisplayParams->appendFilterSql($column, $id);
+            $entries = $model->readShow($DisplayParams, false);
             $allEntries = array_merge($allEntries, $entries);
         }
         return $allEntries;

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -68,31 +68,9 @@ class Batch implements RestInterface
             $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }
 
-        if ($reqBody['owners']) {
-            $newOwner = (int) $reqBody['newOwner'];
-            // only process experiments to change their owner
+        if ($reqBody['new_owner']) {
             $model = new Experiments($this->requester);
-
-            $previousOwners = $reqBody['owners'];
-
-            foreach ($previousOwners as $id) {
-                $column = FilterableColumn::Owner;
-                $DisplayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
-                $DisplayParams->limit = 100000;
-                $DisplayParams->appendFilterSql($column, $id);
-                $entries = $model->readShow($DisplayParams, false);
-
-                foreach ($entries as $entry) {
-                    try {
-                        $entry['userid'] = $newOwner;
-                        $model->setId($id);
-                        $model->patch($action, $reqBody);
-                        $this->processed++;
-                    } catch (IllegalActionException) {
-                        continue;
-                    }
-                }
-            }
+            $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }
         return $this->processed;
     }

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -97,6 +97,11 @@ class Batch implements RestInterface
 
     private function processEntities(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column, Action $action, array $params): void
     {
+        // in case we update ownership, the param sent will contain only the target owner
+        if ($action === Action::Update) {
+            $params = array('userid' => $params['target_owner'] ?? throw new ImproperActionException('Target owner is missing!'));
+        }
+
         foreach ($idArr as $id) {
             $DisplayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
             $DisplayParams->limit = 100000;

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -68,7 +68,7 @@ class Batch implements RestInterface
             $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }
 
-        if ($reqBody['new_owner']) {
+        if ($reqBody['target_owner']) {
             $model = new Experiments($this->requester);
             $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -97,9 +97,10 @@ class Batch implements RestInterface
 
     private function processEntities(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column, Action $action, array $params): void
     {
-        // in case we update ownership, the param sent will contain only the target owner
-        if ($action === Action::Update) {
+        // On transfer of ownership, only the target owner is required in params
+        if ($params['action'] === Action::UpdateOwner->value) {
             $params = array('userid' => $params['target_owner'] ?? throw new ImproperActionException('Target owner is missing!'));
+            $action = Action::Update;
         }
 
         foreach ($idArr as $id) {

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -68,10 +68,6 @@ class Batch implements RestInterface
             $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }
 
-        if ($reqBody['target_owner']) {
-            $model = new Experiments($this->requester);
-            $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
-        }
         return $this->processed;
     }
 

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -52,10 +52,15 @@ class Batch implements RestInterface
             $model = new Experiments($this->requester);
             $Tags2Entity = new Tags2Entity($model->entityType);
             $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['tags']);
-            // On transfer of ownership, only the target owner is required in params
-            // Use local action & reqBody and keep the original for other cases
-            [$tagAction, $tagReqBody] = $this->prepareParamsForOwnershipUpdate($action, $reqBody);
-            $this->loopOverEntries($targetIds, $model, $tagAction, $tagReqBody, isTag: true);
+            foreach ($targetIds as $id) {
+                try {
+                    $model->setId($id);
+                    $model->patch($action, $reqBody);
+                    $this->processed++;
+                } catch (IllegalActionException) {
+                    continue;
+                }
+            }
         }
         if ($reqBody['users']) {
             // only process experiments
@@ -93,7 +98,11 @@ class Batch implements RestInterface
     private function processEntities(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column, Action $action, array $params): void
     {
         // On transfer of ownership, only the target owner is required in params
-        [$action, $params] = $this->prepareParamsForOwnershipUpdate($action, $params);
+        if ($params['action'] === Action::UpdateOwner->value) {
+            $params = array('userid' => $params['target_owner'] ?? throw new ImproperActionException('Target owner is missing!'));
+            $action = Action::Update;
+        }
+
         foreach ($idArr as $id) {
             $DisplayParams = new DisplayParams($this->requester, Request::createFromGlobals(), $model->entityType);
             $DisplayParams->limit = 100000;
@@ -114,16 +123,5 @@ class Batch implements RestInterface
                 continue;
             }
         }
-    }
-
-    private function prepareParamsForOwnershipUpdate(Action $action, array $params): array
-    {
-        if ($action === Action::UpdateOwner) {
-            $params = array(
-                'userid' => $params['target_owner'] ?? throw new ImproperActionException('Target owner is missing!'),
-            );
-            $action = Action::Update;
-        }
-        return array($action, $params);
     }
 }

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -67,7 +67,6 @@ class Batch implements RestInterface
             $model = new Experiments($this->requester);
             $this->processEntities($reqBody['users'], $model, FilterableColumn::Owner, $action, $reqBody);
         }
-
         return $this->processed;
     }
 

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -37,6 +37,7 @@
 {% include 'create-statuslike-modal.html' with {'target': 'experiments_categories', 'title': 'Create new experiments category'|trans} %}
 {% include 'create-statuslike-modal.html' with {'target': 'experiments_status', 'title': 'Create new experiments status'|trans} %}
 {% include 'create-statuslike-modal.html' with {'target': 'items_status', 'title': 'Create new resources status'|trans} %}
+{% include('ownership-transfer-modal.html') %}
 {% include 'onboarding-email-modal.html' %}
 
 {# set variables for binary-settings template and other inputs with a data-model #}
@@ -778,28 +779,9 @@
     {# Action buttons #}
     <button data-action='run-action-selected' data-what='forceLock' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Lock'|trans }}</button>
     <button data-action='run-action-selected' data-what='forceUnlock' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Unlock'|trans }}</button>
+    <button data-action='toggle-modal' type='button' class='btn btn-primary mr-1 mb-2' data-target='ownerModal'>{{ 'Transfer ownership'|trans }}</button>
     <button data-action='run-action-selected' data-what='archive' type='button' class='btn btn-secondary mr-1 mb-2'>{{ 'Archive'|trans }}</button>
     <button data-action='run-action-selected' data-what='destroy' type='button' class='btn btn-danger mr-1 mb-2'>{{ 'Delete'|trans }}</button>
-  </div>
-
-   {# Transfer ownership #}
-  <div class='row'>
-    <div class='col-md-6 mb-3'>
-      <div>
-        {# SELECT USER #}
-        <label for='newOwner'>{{ 'New owner'|trans }}</label>
-        <select id='newOwner' class='form-control'>
-          {% for user in Entity.Users.readAllFromTeam %}
-          <option value='{{ user.userid }}'
-            {{ Entity.entityData.userid == user.userid ? ' selected' }}
-            >{{ user.fullname }}
-          </option>
-          {% endfor %}
-        </select>
-        <button data-action='run-action-selected' data-what='transferOwnership' type='button' class='btn btn-primary mt-3 mx-0'>{{ 'Transfer ownership'|trans }}</button>
-
-      </div>
-    </div>
   </div>
 
   <h4>{{ 'Set permissions'|trans }}</h4>

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -782,6 +782,26 @@
     <button data-action='run-action-selected' data-what='destroy' type='button' class='btn btn-danger mr-1 mb-2'>{{ 'Delete'|trans }}</button>
   </div>
 
+   {# Transfer ownership #}
+  <div class='row'>
+    <div class='col-md-6 mb-3'>
+      <div>
+        {# SELECT USER #}
+        <label for='newOwner'>{{ 'New owner'|trans }}</label>
+        <select id='newOwner' class='form-control'>
+          {% for user in Entity.Users.readAllFromTeam %}
+          <option value='{{ user.userid }}'
+            {{ Entity.entityData.userid == user.userid ? ' selected' }}
+            >{{ user.fullname }}
+          </option>
+          {% endfor %}
+        </select>
+        <button data-action='run-action-selected' data-what='transferOwnership' type='button' class='btn btn-primary mt-3 mx-0'>{{ 'Transfer ownership'|trans }}</button>
+
+      </div>
+    </div>
+  </div>
+
   <h4>{{ 'Set permissions'|trans }}</h4>
   <div class='row'>
     <div class='col-md-6 mb-3'>

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -22,7 +22,7 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
-          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='transferownership'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='update'>{{ 'Transfer ownership'|trans }}</button>
         {% else %}
           <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
         {% endif %}

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -22,7 +22,7 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
-          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='update'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='updateowner'>{{ 'Transfer ownership'|trans }}</button>
         {% else %}
           <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
         {% endif %}

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -22,9 +22,9 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
-          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='update'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='updateowner'>{{ 'Transfer ownership'|trans }}</button>
         {% else %}
-          <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Transfer ownership'|trans }}</button>
         {% endif %}
       </div>
     </div>

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -21,7 +21,11 @@
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
-        <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
+        {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='transferownership'>{{ 'Transfer ownership'|trans }}</button>
+        {% else %}
+          <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -22,9 +22,9 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
-          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='updateowner'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='updateowner' data-dismiss='modal'>{{ 'Transfer ownership'|trans }}</button>
         {% else %}
-          <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='transfer-ownership' data-dismiss='modal'>{{ 'Transfer ownership'|trans }}</button>
         {% endif %}
       </div>
     </div>

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -22,7 +22,7 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if App.Request.getScriptName|split('/')|last == 'admin.php' %}
-          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='updateowner'>{{ 'Transfer ownership'|trans }}</button>
+          <button type='button' class='btn btn-primary' data-action='run-action-selected' data-what='update'>{{ 'Transfer ownership'|trans }}</button>
         {% else %}
           <button type='button' class='btn btn-primary' data-action='transfer-ownership'>{{ 'Save'|trans }}</button>
         {% endif %}

--- a/src/templates/ownership-transfer-modal.html
+++ b/src/templates/ownership-transfer-modal.html
@@ -10,8 +10,8 @@
       </div>
       <div class='modal-body'>
         {# SELECT USER #}
-        <label for='new_owner'>{{ 'New owner'|trans }}</label>
-        <select id='new_owner' class='form-control'>
+        <label for='target_owner'>{{ 'New owner'|trans }}</label>
+        <select id='target_owner' class='form-control'>
           {% for user in Entity.Users.readAllFromTeam %}
             <option value='{{ user.userid }}'
             {{ Entity.entityData.userid == user.userid ? ' selected' }}

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -54,8 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function collectNewOwner(): number {
-    const collected = document.getElementById('newOwner') as HTMLInputElement;
-    // Convert it to an int
+    const collected = document.getElementById('new_owner') as HTMLInputElement;
+    // Convert element to an int
     return collected ? parseInt(collected.value, 10) || 0 : 0;
   }
 
@@ -81,8 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
       experiments_categories: collectSelectable('experiments_categories'),
       tags: collectSelectable('tags'),
       users: collectSelectable('users'),
-      owners: collectSelectable('users'),
-      newOwner: collectNewOwner(),
+      new_owner: collectNewOwner(),
       can: collectCan(),
     };
   }

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -53,6 +53,12 @@ document.addEventListener('DOMContentLoaded', () => {
     return collected;
   }
 
+  function collectNewOwner(): number {
+    const collected = document.getElementById('newOwner') as HTMLInputElement;
+    // Convert it to an int
+    return collected ? parseInt(collected.value, 10) || 0 : 0;
+  }
+
   function collectCan(): string {
     // Warning: copy pasta from common.ts save-permissions action
     // collect existing users listed in ul->li, and store them in a string[] with user:<userid>
@@ -75,6 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
       experiments_categories: collectSelectable('experiments_categories'),
       tags: collectSelectable('tags'),
       users: collectSelectable('users'),
+      owners: collectSelectable('users'),
+      newOwner: collectNewOwner(),
       can: collectCan(),
     };
   }

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -53,8 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
     return collected;
   }
 
-  function collectNewOwner(): number {
-    const collected = document.getElementById('new_owner') as HTMLInputElement;
+  function collectTargetOwner(): number {
+    const collected = document.getElementById('target_owner') as HTMLInputElement;
     // Convert element to an int
     return collected ? parseInt(collected.value, 10) || 0 : 0;
   }
@@ -81,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
       experiments_categories: collectSelectable('experiments_categories'),
       tags: collectSelectable('tags'),
       users: collectSelectable('users'),
-      new_owner: collectNewOwner(),
+      target_owner: collectTargetOwner(),
       can: collectCan(),
     };
   }

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -353,7 +353,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // TRANSFER OWNERSHIP
     } else if (el.matches('[data-action="transfer-ownership"]')) {
-      const value = (document.getElementById('new_owner') as HTMLInputElement).value;
+      const value = (document.getElementById('target_owner') as HTMLInputElement).value;
       const entity = getEntity();
       const params = {};
       params[Target.UserId] = value;

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -49,6 +49,8 @@ interface Selected {
   items_types: number[];
   tags: number[];
   users: number[];
+  owners: number[];
+  newOwner: number;
   can: string;
 }
 

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -49,7 +49,7 @@ interface Selected {
   items_types: number[];
   tags: number[];
   users: number[];
-  new_owner: number;
+  target_owner: number;
   can: string;
 }
 

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -49,8 +49,7 @@ interface Selected {
   items_types: number[];
   tags: number[];
   users: number[];
-  owners: number[];
-  newOwner: number;
+  new_owner: number;
   can: string;
 }
 

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -38,7 +38,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt($this->Batch->postAction(Action::Create, $reqBody));
     }
 
-    public function testCanUpdateOwner(): void
+    public function testInvalidPostAction(): void
     {
         $reqBody = array(
             'action' => Action::Update->value,
@@ -49,6 +49,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
             'tags' => array(),
             'users' => array(1, 2),
         );
+        // on batch, cannot update action without 'target_owner' in the body
         $this->expectException(ImproperActionException::class);
         $this->Batch->postAction(Action::Update, $reqBody);
     }

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -41,16 +41,16 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     public function testCanUpdateOwner(): void
     {
         $reqBody = array(
-            'action' => Action::UpdateOwner->value,
+            'action' => Action::Update->value,
             'items_types' => array(),
             'items_status' => array(),
             'experiments_categories' => array(),
             'experiments_status' => array(),
             'tags' => array(),
             'users' => array(1, 2),
-            'target_owner' => 1,
         );
-        $this->assertIsInt($this->Batch->postAction(Action::Create, $reqBody));
+        $this->expectException(ImproperActionException::class);
+        $this->Batch->postAction(Action::Update, $reqBody);
     }
 
     public function testGetApiPath(): void

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -38,6 +38,21 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt($this->Batch->postAction(Action::Create, $reqBody));
     }
 
+    public function testCanUpdateOwner(): void
+    {
+        $reqBody = array(
+            'action' => Action::UpdateOwner->value,
+            'items_types' => array(),
+            'items_status' => array(),
+            'experiments_categories' => array(),
+            'experiments_status' => array(),
+            'tags' => array(),
+            'users' => array(1, 2),
+            'target_owner' => 1,
+        );
+        $this->assertIsInt($this->Batch->postAction(Action::Create, $reqBody));
+    }
+
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/', $this->Batch->getApiPath());

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -41,7 +41,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     public function testInvalidPostAction(): void
     {
         $reqBody = array(
-            'action' => Action::Update->value,
+            'action' => Action::UpdateOwner->value,
             'items_types' => array(),
             'items_status' => array(),
             'experiments_categories' => array(),
@@ -49,7 +49,7 @@ class BatchTest extends \PHPUnit\Framework\TestCase
             'tags' => array(),
             'users' => array(1, 2),
         );
-        // on batch, cannot update action without 'target_owner' in the body
+        // On batch, cannot update owner action without 'target_owner'
         $this->expectException(ImproperActionException::class);
         $this->Batch->postAction(Action::Update, $reqBody);
     }

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -14,7 +14,6 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
-use ReflectionClass;
 
 class BatchTest extends \PHPUnit\Framework\TestCase
 {
@@ -70,22 +69,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         // On batch, cannot update owner action without 'target_owner'
         $this->expectException(ImproperActionException::class);
         $this->Batch->postAction(Action::Update, $reqBody);
-    }
-
-    public function testPrepareParamsForOwnershipUpdate(): void
-    {
-        $reqBody = array(
-            'action' => Action::UpdateOwner->value,
-            'target_owner' => 2,
-        );
-        // Create a reflection so we can access private methods
-        $reflection = new ReflectionClass($this->Batch);
-        $method = $reflection->getMethod('prepareParamsForOwnershipUpdate');
-        $method->setAccessible(true);
-
-        [$action, $params] = $method->invoke($this->Batch, Action::UpdateOwner, $reqBody);
-        $this->assertEquals(Action::Update, $action);
-        $this->assertEquals(array('userid' => 2), $params);
     }
 
     public function testGetApiPath(): void

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -56,7 +56,6 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $reqBody = $this->baseReqBody;
         $reqBody['action'] = Action::UpdateOwner->value;
         $reqBody['target_owner'] = 2;
-
         $this->assertIsInt($this->Batch->postAction(Action::UpdateOwner, $reqBody));
     }
 
@@ -65,10 +64,9 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         $reqBody = $this->baseReqBody;
         $reqBody['action'] = Action::UpdateOwner->value;
         $reqBody['users'] = array(1, 2);
-
         // On batch, cannot update owner action without 'target_owner'
         $this->expectException(ImproperActionException::class);
-        $this->Batch->postAction(Action::Update, $reqBody);
+        $this->Batch->postAction(Action::UpdateOwner, $reqBody);
     }
 
     public function testGetApiPath(): void


### PR DESCRIPTION
Feature Req #5245 

- Integrate the option to "transfer ownership" as an admin, on Batch Actions panel.
- Create 'UpdateOwner' Action enum.
- Refactoring on Batch actions
- Change "new_owner" to "target_owner" on templates
- Change "Save" to "Transfer ownership" on modal
- Update on tests

![image](https://github.com/user-attachments/assets/7ab0201e-1cbb-4c55-9395-c40d2ddf9b22)

![image](https://github.com/user-attachments/assets/c5f57fd8-10e9-4d4f-aaba-f41733310807)
