### PR TITLE
Calendar feeds for team events, todo items, and unfinished steps

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -35,6 +35,58 @@ components:
           type: integer
         team_name:
           type: string
+    calendar:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        token:
+          type: string
+        team:
+          type: integer
+        created_by:
+          type: integer
+        fullname:
+          type: string
+        created_at:
+          type: string
+        state:
+          type: integer
+        all_events:
+          type: integer
+          enum: [0, 1]
+        todo:
+          type: integer
+          enum: [0, 1]
+        unfinished_steps_scope:
+          type: integer
+          enum: [0, 1, 2]
+          description: >-
+            0: do not include unfinished steps, 1: unfinished steps of the calendar creator, 2: unfinished steps of the team
+        items:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              title:
+                type: string
+        categories:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              color:
+                type: string
+              title:
+                type: string
     comment:
       type: object
       properties:
@@ -1004,6 +1056,115 @@ paths:
       responses:
         '204':
           description: The key was deleted
+  /calendars:
+    summary: Actions on calendars
+    post:
+      tags: ['Calendars']
+      summary: Create a calendar
+      operationId: post-calendar
+      requestBody:
+        description: >-
+          Parameters for creating a calendar feed
+          to which you can subscribe via https://eln.example.org/calendar.php?token={token}
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: The title of the calendar.
+                  nullable: true
+                all_events:
+                  type: boolean
+                  description: >-
+                    Whether to include all events of a team in the calendar.
+                    "categories" and "items" can be used for fine control.
+                  default: null
+                  nullable: true
+                categories:
+                  type: array
+                  description: >-
+                    An array of category ids of categories with bookable items
+                    to include in the calendar. Should not be used with all_events.
+                  items:
+                    type: integer
+                  default: null
+                  nullable: true
+                items:
+                  type: array
+                  description: >-
+                    An array of item ids of bookabale items to include in the calendar.
+                    Should not be used with all_events.
+                  items:
+                    type: integer
+                  default: null
+                  nullable: true
+                todo:
+                  type: boolean
+                  description: Whether to include your todo items in the calendar.
+                  default: null
+                  nullable: true
+                unfinished_steps_scope:
+                  type: string
+                  description: >-
+                    Unfinished steps of experiments and resources. Either "user" for your unfinished steps
+                    or "team" for all unfinished steps of the team.
+                  enum: ['user', 'team']
+                  default: null
+                  nullable: true
+      responses:
+        '201':
+          description: The calendar has been created.
+          headers:
+            location:
+              description: An URL to the calendar that was created.
+              schema:
+                type: string
+    get:
+      tags: ['Calendars']
+      summary: Read all calendars
+      operationId: read-calendars
+      responses:
+        '200':
+          description: A list of calendars
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/calendar'
+  /calendars/{id}:
+    summary: Actions on a calendar
+    parameters:
+      - name: id
+        in: path
+        description: ID of the calendar
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: ['Calendars']
+      summary: Read a calendar
+      operationId: read-calendar
+      responses:
+        '200':
+          description: A calendar
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/calendar'
+    delete:
+      tags: ['Calendars']
+      summary: Delete a calendar.
+      description: The calendar gets soft-deleted.
+      requestBody:
+        content:
+          application/json: {}
+      operationId: delete-calendar
+      responses:
+        '204':
+          description: The calendar was deleted
   /config:
     summary: The general instance configuration settings
     get:

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
   "name": "elabftw/elabftw",
   "description": "Laboratory notebook for research labs",
   "homepage": "https://www.elabftw.net",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/MarcelBolten/iCal"
+    }
+  ],
   "require": {
     "php": ">=8.3.0",
     "ext-ctype": "*",
@@ -52,7 +58,8 @@
     "guzzlehttp/psr7": "^2.6",
     "psr/http-message": "^2.0",
     "psr/log": "^3.0",
-    "setasign/fpdi": "^2.6"
+    "setasign/fpdi": "^2.6",
+    "eluceo/ical": "dev-vtodo"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e70d00a0073823150ec567ee0971960",
+    "content-hash": "eadfd6a75db11456479d52ed5b05dc95",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -588,6 +588,74 @@
                 }
             ],
             "time": "2023-10-06T06:47:41+00:00"
+        },
+        {
+            "name": "eluceo/ical",
+            "version": "dev-vtodo",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarcelBolten/iCal.git",
+                "reference": "c56c862891c04f81db20904757c672f4cd112b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarcelBolten/iCal/zipball/c56c862891c04f81db20904757c672f4cd112b8c",
+                "reference": "c56c862891c04f81db20904757c672f4cd112b8c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0"
+            },
+            "conflict": {
+                "php": "7.4.6"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.23.1",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "infection/infection": "^0.23 || ^0.26 || ^0.27",
+                "phpmd/phpmd": "^2.13",
+                "phpunit/phpunit": "^9.5",
+                "vimeo/psalm": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eluceo\\iCal\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Eluceo\\iCal\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Poerschke",
+                    "email": "markus@poerschke.nrw",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The eluceo/iCal package offers an abstraction layer for creating iCalendars. You can easily create iCal files by using PHP objects instead of typing your *.ics file by hand. The output will follow RFC 5545 as best as possible.",
+            "homepage": "https://github.com/markuspoerschke/iCal",
+            "keywords": [
+                "calendar",
+                "ical",
+                "icalendar",
+                "ics",
+                "php calendar"
+            ],
+            "support": {
+                "issues": "https://github.com/markuspoerschke/iCal/issues",
+                "forum": "https://github.com/markuspoerschke/iCal/discussions",
+                "source": "https://github.com/markuspoerschke/iCal",
+                "docs": "https://ical.poerschke.nrw"
+            },
+            "time": "2024-10-14T04:04:21+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -11634,6 +11702,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "eluceo/ical": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/src/Enums/ApiEndpoint.php
+++ b/src/Enums/ApiEndpoint.php
@@ -18,24 +18,25 @@ enum ApiEndpoint: string
 {
     case ApiKeys = 'apikeys';
     case Batch = 'batch';
+    case Calendars = 'calendars';
     case Config = 'config';
+    case Event = 'event';
+    case Events = 'events';
+    case Experiments = 'experiments';
+    case ExperimentsTemplates = 'experiments_templates';
+    case Export = 'exports';
+    case ExtraFieldsKeys = 'extra_fields_keys';
+    case FavTags = 'favtags';
     case Idps = 'idps';
     case IdpsSources = 'idps_sources';
     case Import = 'import';
     case Info = 'info';
-    case Experiments = 'experiments';
-    case Export = 'exports';
     case Items = 'items';
-    case ExperimentsTemplates = 'experiments_templates';
     case ItemsTypes = 'items_types';
-    case Event = 'event';
-    case Events = 'events';
-    case ExtraFieldsKeys = 'extra_fields_keys';
-    case FavTags = 'favtags';
 
     // @deprecated
-    case TeamTags = 'team_tags';
     case Teams = 'teams';
+    case TeamTags = 'team_tags';
     case Todolist = 'todolist';
     case UnfinishedSteps = 'unfinished_steps';
     case Users = 'users';

--- a/src/Enums/CalendarKeys.php
+++ b/src/Enums/CalendarKeys.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Enums;
+
+use Elabftw\Traits\EnumsTrait;
+
+enum CalendarKeys: string
+{
+    use EnumsTrait;
+
+    case AllEvents = 'all_events';
+    case Categories = 'categories';
+    case Items = 'items';
+    case Title = 'title';
+    case Todo = 'todo';
+    case UnfinishedStepsScope = 'unfinished_steps_scope';
+
+    public static function toArray(): array
+    {
+        return array_map(fn(self $case): string => $case->value, self::cases());
+    }
+
+    public static function getDefaultValues(): array
+    {
+        return array(
+            self::AllEvents->value => 0,
+            self::Categories->value => null,
+            self::Items->value => null,
+            self::Title->value => _('Untitled'),
+            self::Todo->value => 0,
+            self::UnfinishedStepsScope->value => 0,
+        );
+    }
+}

--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function strtolower;
+
 enum Scope: int
 {
     case User = 1;
@@ -24,6 +26,19 @@ enum Scope: int
             Scope::User => 'user',
             Scope::Team => 'users',
             Scope::Everything => 'globe',
+        };
+    }
+
+    /**
+     * Get a string representation of a case
+     * "user", "team", or "everything"
+     */
+    public function toString(): string
+    {
+        return match ($this) {
+            Scope::User => strtolower(Scope::User->name),
+            Scope::Team => strtolower(Scope::Team->name),
+            Scope::Everything => strtolower(Scope::Everything->name),
         };
     }
 }

--- a/src/Make/MakeICal.php
+++ b/src/Make/MakeICal.php
@@ -1,0 +1,289 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Make;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use Elabftw\Enums\ApiEndpoint;
+use Elabftw\Enums\ApiSubModels;
+use Elabftw\Enums\EntityType;
+use Elabftw\Enums\Scope;
+use Elabftw\Interfaces\StringMakerInterface;
+use Elabftw\Models\Config;
+use Elabftw\Models\Items;
+use Elabftw\Models\Scheduler;
+use Elabftw\Models\Users;
+use Elabftw\Models\Todolist;
+use Elabftw\Models\UnfinishedSteps;
+use Elabftw\Models\Notifications\StepDeadline;
+use Elabftw\Models\Steps;
+use Eluceo\iCal\Domain\Entity\Calendar;
+use Eluceo\iCal\Domain\Entity\Event;
+use Eluceo\iCal\Domain\Entity\Todo;
+use Eluceo\iCal\Domain\ValueObject\Alarm;
+use Eluceo\iCal\Domain\ValueObject\Alarm\DisplayAction;
+use Eluceo\iCal\Domain\ValueObject\Alarm\RelativeTrigger;
+use Eluceo\iCal\Domain\ValueObject\DateTime;
+use Eluceo\iCal\Domain\ValueObject\TimeSpan;
+use Eluceo\iCal\Domain\ValueObject\UniqueIdentifier;
+use Eluceo\iCal\Presentation\Factory\CalendarFactory;
+
+use function array_merge;
+use function date_default_timezone_get;
+use function json_decode;
+use function sprintf;
+use function strlen;
+
+/**
+ * Make an iCal file
+ */
+class MakeICal extends AbstractMake implements StringMakerInterface
+{
+    protected string $contentType = 'text/calendar; charset=utf-8';
+
+    public function __construct(protected string $calendarToken)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Create an iCal file from events
+     */
+    public function getFileContent(): string
+    {
+        $iCalString = $this->getICalString($this->getEntries($this->getCalendarProperties()));
+        $this->contentSize = strlen($iCalString);
+        return $iCalString;
+    }
+
+    /**
+     * Return a nice name for the file
+     */
+    public function getFileName(): string
+    {
+        return 'eLabFTW-calendar.ics';
+    }
+
+    private function getCalendarProperties(): array
+    {
+        $sql = 'SELECT `team`, `created_by`,
+                        `all_events`,
+                        JSON_ARRAYAGG(`category`) AS `categories`,
+                        JSON_ARRAYAGG(`item`) AS `items`,
+                        `todo`, `unfinished_steps_scope`
+                    FROM `calendars`
+                    LEFT JOIN `calendar2items_types` ON `calendars`.`id` = `calendar2items_types`.`calendar`
+                    LEFT JOIN `calendar2items` ON `calendars`.`id` = `calendar2items`.`calendar`
+                    WHERE `token` LIKE :token
+                    GROUP BY `calendars`.`id`
+                    LIMIT 1';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':token', $this->calendarToken);
+        $this->Db->execute($req);
+        $res = $this->Db->fetch($req);
+        foreach (array('categories', 'items') as $key) {
+            $res[$key] = json_decode($res[$key], true);
+            if ($res[$key][0] === null) {
+                $res[$key] = null;
+            }
+        }
+        return $res;
+    }
+
+    private function getEntries(array $calendarProps): array
+    {
+        $entries = array();
+        // read an individual event
+        // can be used to export a single event
+        // if (isset($calendarProps['event'])) {
+        //     $Item = new Items(new Users(team: $calendarProps['team']), bypassReadPermission: true);
+        //     $Item->Users->userData['team'] = $calendarProps['team'];
+        //     $Scheduler = new Scheduler($Item, $calendarProps['event']);
+        //     $entries = array($Scheduler->readOne());
+        // }
+
+        // read all events of one bookable item
+        if ($calendarProps['items'] !== null) {
+            $Item = new Items(new Users($calendarProps['created_by'], $calendarProps['team']));
+            foreach ($calendarProps['items'] as $item) {
+                $Item->setId($item);
+                foreach ((new Scheduler($Item))->readOne() as $event) {
+                    $event['entry_type'] = 'event';
+                    $entries[] = $event;
+                };
+            }
+        }
+
+        // read all events of one resource category
+        if ($calendarProps['categories'] !== null) {
+            $Item = new Items(new Users($calendarProps['created_by'], $calendarProps['team']));
+            foreach ($calendarProps['categories'] as $category) {
+                foreach ((new Scheduler($Item, category: $category))->readAll() as $event) {
+                    $event['entry_type'] = 'event';
+                    $entries[] = $event;
+                }
+            }
+        }
+
+        // read all events
+        if ($calendarProps['all_events'] === 1) {
+            $Item = new Items(new Users($calendarProps['created_by'], $calendarProps['team']));
+            foreach ((new Scheduler($Item))->readAll() as $event) {
+                $event['entry_type'] = 'event';
+                $entries[] = $event;
+            }
+        }
+
+        // read all todo entries
+        if ($calendarProps['todo'] === 1) {
+            foreach ((new Todolist($calendarProps['created_by']))->readAll() as $todo) {
+                $todo['entry_type'] = 'todo';
+                $entries[] = $todo;
+            }
+        }
+
+        // unfinished steps user/team
+        if ($calendarProps['unfinished_steps_scope'] !== 0) {
+            $entries = array_merge(
+                $entries,
+                $this->prepareSteps($calendarProps, $calendarProps['unfinished_steps_scope'] === Scope::User->value),
+            );
+        }
+
+        return $entries;
+    }
+
+    private function getICalString(array $entries): string
+    {
+        $calendar = new Calendar();
+        foreach ($entries as $entry) {
+            if ($entry['entry_type'] === 'event') {
+                $calendar->addEvent($this->getEvent($entry));
+            } elseif ($entry['entry_type'] === 'todo') {
+                $calendar->addTodo($this->getTodo($entry));
+            } elseif ($entry['entry_type'] === 'steps') {
+                $calendar->addTodo($this->getStep($entry));
+            }
+        }
+        return (string) (new CalendarFactory())->createCalendar($calendar);
+    }
+
+    private function getEvent(array $event): Event
+    {
+        /** @psalm-suppress PossiblyFalseArgument */
+        return (new Event(
+            new UniqueIdentifier(sprintf(
+                '%s/event/%d',
+                Config::fromEnv('SITE_URL'),
+                $event['id'],
+            ))
+        ))
+        ->setSummary($event['title'] ?? _('Untitled'))
+        ->setDescription(trim(sprintf(
+            "%s\n%s\n%s\n%s\n%s",
+            $event['title_only'] ?? _('Untitled'), // event title
+            $event['fullname'] ?? '', // name of the user who booked the event
+            $event['item_title'] ?? '', // title of the bookable resource item
+            $event['experiment_title'] ?? '', // title of a linked experiment
+            $event['item_link_title'] ?? '', // title of a linked resource item
+        )))
+        ->setOccurrence(new TimeSpan(
+            /** @phpstan-ignore argument.type */
+            new DateTime(DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $event['start']), false),
+            /** @phpstan-ignore argument.type */
+            new DateTime(DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $event['end']), false),
+        ));
+    }
+
+    private function getTodo(array $todo): Todo
+    {
+        return (new Todo(
+            new UniqueIdentifier(sprintf(
+                '%s/%s/%d',
+                Config::fromEnv('SITE_URL'),
+                ApiEndpoint::Todolist->value,
+                $todo['id'],
+            ))
+        ))->setSummary($todo['body']);
+    }
+
+    // id, title, entity_type, step_id, step_body, deadline
+    private function getStep(array $step): Todo
+    {
+        $todo = (new Todo(
+            new UniqueIdentifier(sprintf(
+                '%s/%s/%d/%s/%d',
+                Config::fromEnv('SITE_URL'),
+                $step['entity_type'],
+                $step['id'],
+                ApiSubModels::Steps->value,
+                $step['step_id'],
+            ))
+        ))->setSummary(sprintf(
+            '[%s] %s - %s',
+            $step['entity_type'],
+            $step['title'],
+            $step['step_body'],
+        ));
+
+        if ($step['deadline'] !== null) {
+            // todo check if timezone is correct, are the deadlines stored in server time zone or UTC?
+            /** @phpstan-ignore argument.type */ /** @psalm-suppress PossiblyFalseArgument */
+            $todo->setDue(new DateTime(DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $step['deadline'], new DateTimeZone(date_default_timezone_get())), true));
+        }
+
+        if ($step['deadline_notif'] !== null) {
+            $todo->addAlarm(new Alarm(
+                new DisplayAction(_('A step deadline is approaching.')),
+                (new RelativeTrigger(DateInterval::createFromDateString(sprintf('-%d minutes', StepDeadline::NOTIFLEADTIME))))->withRelationToEnd(),
+            ));
+        }
+
+        return $todo;
+    }
+
+    private function prepareSteps(array $calendarProps, bool $teamScope = false): array
+    {
+        $User = new Users($calendarProps['created_by'], $calendarProps['team']);
+        $UnfinishedArr = (new UnfinishedSteps($User, $teamScope))->readAll();
+
+        $entries = array();
+        foreach ($UnfinishedArr as $type => $UnfinishedStepsArr) {
+            foreach ($UnfinishedStepsArr as $UnfinishedStep) {
+                $UnfinishedStep['entity_type'] = $type;
+                // id, title, entity_type, steps:array(array(0=>id, 1=>body),...)
+                foreach ($UnfinishedStep['steps'] as $step) {
+                    $entry = $UnfinishedStep;
+                    unset($entry['steps']);
+                    $entry['step_id'] = (int) $step[0];
+                    $entry['step_body'] = $step[1];
+                    $fullStep = (new Steps(
+                        EntityType::from($entry['entity_type'])
+                            ->toInstance($User, $entry['id']),
+                        $entry['step_id']
+                    ))->readOne();
+                    $entry['deadline'] = $fullStep['deadline'];
+                    $entry['deadline_notif'] = $fullStep['deadline_notif'];
+                    $entry['entry_type'] = 'steps';
+                    // id, title, entity_type, step_id, step_body, deadline, deadline_notif, entry_type
+                    $entries[] = $entry;
+                }
+            }
+        }
+
+        return $entries;
+    }
+}

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -33,7 +33,7 @@ use function sprintf;
 class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 166;
+    public const int REQUIRED_SCHEMA = 167;
 
     private Db $Db;
 

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -18,6 +18,7 @@ use Elabftw\Enums\ApiSubModels;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\ExportFormat;
+use Elabftw\Enums\Scope;
 use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
@@ -30,6 +31,7 @@ use Elabftw\Make\Exports;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\ApiKeys;
 use Elabftw\Models\Batch;
+use Elabftw\Models\Calendar;
 use Elabftw\Models\Comments;
 use Elabftw\Models\Config;
 use Elabftw\Models\ExperimentsCategories;
@@ -259,6 +261,7 @@ class Apiv2Controller extends AbstractApiController
             ApiEndpoint::ApiKeys => new ApiKeys($this->requester, $this->id),
             ApiEndpoint::Batch => new Batch($this->requester),
             ApiEndpoint::Config => Config::getConfig(),
+            ApiEndpoint::Calendars => new Calendar($this->requester, $this->id),
             ApiEndpoint::Idps => new Idps($this->requester, $this->id),
             ApiEndpoint::IdpsSources => new IdpsSources($this->requester, $this->id),
             ApiEndpoint::Import => new ImportHandler($this->requester, $logger),
@@ -290,7 +293,7 @@ class Apiv2Controller extends AbstractApiController
             ApiEndpoint::Todolist => new Todolist($this->requester->userData['userid'], $this->id),
             ApiEndpoint::UnfinishedSteps => new UnfinishedSteps(
                 $this->requester,
-                $this->Request->query->get('scope') === 'team',
+                $this->Request->query->get('scope') === Scope::Team->toString(),
             ),
             ApiEndpoint::Users => new Users($this->id, $this->requester->team, $this->requester),
         };

--- a/src/controllers/CalendarController.php
+++ b/src/controllers/CalendarController.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Interfaces\ControllerInterface;
+use Elabftw\Interfaces\StringMakerInterface;
+use Elabftw\Make\MakeICal;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Create ical/ics
+ */
+class CalendarController implements ControllerInterface
+{
+    public function __construct(protected Request $Request) {}
+
+    public function getResponse(): Response
+    {
+        return $this->getFileResponse(new MakeICal($this->Request->query->getString('token')));
+    }
+
+    private function getFileResponse(StringMakerInterface $Maker): Response
+    {
+        return new Response(
+            $Maker->getFileContent(),
+            Response::HTTP_OK,
+            array(
+                'Content-Type' => $Maker->getContentType(),
+                'Content-Size' => $Maker->getContentSize(),
+                'Content-disposition' => 'inline; filename="' . $Maker->getFileName() . '"',
+                'Cache-Control' => 'no-store',
+                'Last-Modified' => gmdate('D, d M Y H:i:s') . ' GMT',
+            )
+        );
+    }
+}

--- a/src/models/Calendar.php
+++ b/src/models/Calendar.php
@@ -1,0 +1,321 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Enums\Action;
+use Elabftw\Enums\CalendarKeys;
+use Elabftw\Enums\EntityType;
+use Elabftw\Enums\Scope;
+use Elabftw\Enums\State;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Interfaces\RestInterface;
+use Elabftw\Services\Filter;
+use Elabftw\Traits\SetIdTrait;
+use PDO;
+use Symfony\Component\HttpFoundation\Request;
+
+use function array_combine;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function array_walk;
+use function count;
+use function end;
+use function explode;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sprintf;
+use function str_repeat;
+use function strlen;
+use function strtoupper;
+use function random_int;
+
+/**
+ * All about calendars - iCal feeds of team events
+ */
+class Calendar implements RestInterface
+{
+    use SetIdTrait;
+
+    public const int TOKEN_LENGTH = 60;
+
+    private Db $Db;
+
+    public function __construct(private Users $User, ?int $id = null)
+    {
+        $this->Db = Db::getConnection();
+        $this->setId($id);
+    }
+
+    public function create(array $reqBody = array()): int
+    {
+        $sql = 'INSERT INTO calendars (title, token, team, created_by, all_events, todo, unfinished_steps_scope)
+                    VALUES (:title, :token, :team, :created_by, :all_events, :todo, :unfinished_steps_scope)';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':title', $reqBody['title']);
+        $req->bindValue(':token', $this::randomAlphaNumericString(self::TOKEN_LENGTH));
+        $req->bindParam(':team', $this->User->team, PDO::PARAM_INT);
+        $req->bindParam(':all_events', $reqBody['all_events']);
+        $req->bindParam(':todo', $reqBody['todo']);
+        $req->bindParam(':unfinished_steps_scope', $reqBody['unfinished_steps_scope']);
+        $req->bindParam(':created_by', $this->User->userid, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $newId = $this->Db->lastInsertId();
+
+        $this->populateJunctionTables($newId, $reqBody);
+
+        return $newId;
+    }
+
+    public function postAction(Action $action, array $reqBody): int
+    {
+        $normalizedReqBody = CalendarKeys::getDefaultValues();
+
+        foreach (CalendarKeys::toArray() as $key) {
+            if (isset($reqBody[$key])) {
+                $normalizedReqBody[$key] = match ($key) {
+                    CalendarKeys::Title->value => Filter::title((string) $reqBody[$key]),
+                    CalendarKeys::Todo->value,
+                    CalendarKeys::AllEvents->value => Filter::toBinary($reqBody[$key]),
+                    CalendarKeys::UnfinishedStepsScope->value => match ($reqBody[$key]) {
+                        Scope::User->toString() => Scope::User->value,
+                        Scope::Team->toString() => Scope::Team->value,
+                        default => 0,
+                    },
+                    CalendarKeys::Categories->value,
+                    CalendarKeys::Items->value => is_array($reqBody[$key]) ? array_filter($reqBody[$key], 'is_int') : null,
+                    default => null,
+                };
+            }
+        }
+
+        return $this->create($normalizedReqBody);
+    }
+
+    public function patch(Action $action, array $params): array
+    {
+        throw new ImproperActionException('No PATCH action.');
+    }
+
+    public function getApiPath(): string
+    {
+        return 'api/v2/calendar/';
+    }
+
+    public function readAll(): array
+    {
+        $page = explode('/', (Request::createFromGlobals())->getScriptName());
+        $isProfile = end($page) === 'profile.php';
+        $sql = sprintf(
+            '%s %s',
+            $this->getCommonSQL(),
+            !$this->User->isAdmin || $isProfile
+                ? 'AND calendars.created_by = :user'
+                : '',
+        );
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->User->team, PDO::PARAM_INT);
+        if (!$this->User->isAdmin || $isProfile) {
+            $req->bindParam(':user', $this->User->userid, PDO::PARAM_INT);
+        }
+        $this->Db->execute($req);
+        $result = $req->fetchAll();
+        $this->postProcessRead($result);
+        return $result;
+    }
+
+    public function readOne(): array
+    {
+        if ($this->id === null) {
+            throw new IllegalActionException('No id was set!');
+        }
+
+        $sql = sprintf(
+            '%s AND id = :id %s',
+            $this->getCommonSQL(),
+            !$this->User->isAdmin
+                ? 'AND calendars.created_by = :user'
+                : '',
+        );
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->User->team, PDO::PARAM_INT);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        if (!$this->User->isAdmin) {
+            $req->bindParam(':user', $this->User->userid, PDO::PARAM_INT);
+        }
+        $this->Db->execute($req);
+        $result = $req->fetchAll();
+        $this->postProcessRead($result);
+        return $result[0];
+    }
+
+    public function destroy(): bool
+    {
+        $this->canOrExplode();
+        $sql = 'UPDATE calendars
+                  SET state = :state
+                  WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        return $this->Db->execute($req);
+    }
+
+    /**
+     * Generate a random alphanumeric string
+     */
+    public static function randomAlphaNumericString(int $length): string
+    {
+        $usedChars  = 'abcdefghijklmnopqrstuvwxyz';
+        $usedChars .= strtoupper($usedChars);
+        $usedChars .= '0123456789';
+        $randomMax = strlen($usedChars) - 1;
+
+        $token = str_repeat(' ', $length);
+        for ($i = 0; $i < $length; $i++) {
+            $token[$i] = $usedChars[random_int(0, $randomMax)];
+        }
+
+        return $token;
+    }
+
+    private function canOrExplode(): void
+    {
+        if ($this->id === null) {
+            throw new IllegalActionException('No id was set!');
+        }
+
+        $sql = 'SELECT created_by FROM calendars
+                    WHERE state = :state
+                        AND team = :team
+                        AND id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->User->team, PDO::PARAM_INT);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $res = $req->fetch();
+        if (count($res) === 0 || $res['created_by'] !== $this->User->userid && $this->User->isAdminOf($res['created_by']) === false) {
+            throw new IllegalActionException('You are not allowed to do this.');
+        }
+    }
+
+    private function populateJunctionTables(int $calendarId, array $reqBody): void
+    {
+        $tables = array(
+            CalendarKeys::Categories->value => array(
+                'table' => EntityType::ItemsTypes->value,
+                'column' => 'category',
+            ),
+            CalendarKeys::Items->value => array(
+                'table' => EntityType::Items->value,
+                'column' => 'item',
+            ),
+        );
+        foreach ($tables as $key => $value) {
+            if (isset($reqBody[$key])) {
+                $sql = sprintf(
+                    'INSERT INTO calendar2%s (calendar, %s)
+                        VALUES (:calendar_id, :entity_id)',
+                    $value['table'],
+                    $value['column'],
+                );
+                $req = $this->Db->prepare($sql);
+                $req->bindParam(':calendar_id', $calendarId, PDO::PARAM_INT);
+                foreach ($reqBody[$key] as $id) {
+                    $req->bindParam(':entity_id', $id, PDO::PARAM_INT);
+                    $this->Db->execute($req);
+                }
+            }
+        }
+    }
+
+    private function postProcessRead(array &$result): void
+    {
+        array_walk($result, function (&$row) {
+            // hide token from admins if calendar contains a todolist
+            if ($this->User->isAdmin
+                && $this->User->userid !== $row['created_by']
+                && $row['todo'] === 1
+            ) {
+                $row['token'] = str_repeat('·', self::TOKEN_LENGTH);
+            }
+
+            foreach (array('items', 'categories') as $key) {
+                if (is_string($row[$key])) {
+                    $row[$key] = $this->transformJsonAgg($row[$key]);
+                }
+            }
+        });
+    }
+
+    /**
+     * Transforms the MySQL JSON object of aggregate arrays into an array of associative arrays
+     *
+     * example: JSON input string: {"id": [1, 2, 3], "title": ["foo", "bar", "baz"]}
+     *          PHP output array:  [['id' => 1, 'title' => 'foo'], ['id' => 2, 'title' => 'bar'], ['id' => 3, 'title' => 'baz']]
+     */
+    private function transformJsonAgg(string $json): array
+    {
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            return array();
+        }
+        return array_map(
+            fn(...$values) => array_combine(array_keys($decoded), $values),
+            ...array_values($decoded),
+        );
+    }
+
+    private function getCommonSQL(): string
+    {
+        return 'WITH agg_items AS (
+                SELECT calendar2items.calendar,
+                    JSON_OBJECT(
+                        "id", JSON_ARRAYAGG(items.id),
+                        "title", JSON_ARRAYAGG(items.title)
+                    ) as items
+                FROM calendar2items
+                JOIN items ON calendar2items.item = items.id
+                GROUP BY calendar2items.calendar
+            ),
+            agg_items_types AS (
+                SELECT calendar2items_types.calendar,
+                    JSON_OBJECT(
+                        "id", JSON_ARRAYAGG(items_types.id),
+                        "title", JSON_ARRAYAGG(items_types.title),
+                        "color", JSON_ARRAYAGG(items_types.color)
+                    ) as categories
+                FROM calendar2items_types
+                JOIN items_types ON calendar2items_types.category = items_types.id
+                GROUP BY calendar2items_types.calendar
+            )
+            SELECT calendars.*,
+                agg_items.items,
+                agg_items_types.categories,
+                CONCAT(users.firstname, " ", users.lastname) as fullname
+            FROM calendars
+            LEFT JOIN agg_items ON calendars.id = agg_items.calendar
+            LEFT JOIN agg_items_types ON calendars.id = agg_items_types.calendar
+            LEFT JOIN users ON calendars.created_by = users.userid
+            WHERE calendars.state = :state
+                AND calendars.team = :team';
+    }
+}

--- a/src/models/Items.php
+++ b/src/models/Items.php
@@ -102,10 +102,9 @@ class Items extends AbstractConcreteEntity
     /**
      * Get all items with is_bookable that we can read
      */
-    public function readBookable(): array
+    public function readBookable(Request $Request): array
     {
-        $Request = Request::createFromGlobals();
-        $DisplayParams = new DisplayParams($this->Users, $Request, EntityType::Items);
+        $DisplayParams = new DisplayParams($this->Users, $Request, $this->entityType);
         // we only want the bookable type of items
         $DisplayParams->appendFilterSql(FilterableColumn::Bookable, 1);
         // make limit very big because we want to see ALL the bookable items here

--- a/src/models/ItemsTypes.php
+++ b/src/models/ItemsTypes.php
@@ -178,6 +178,19 @@ class ItemsTypes extends AbstractTemplateEntity
         }
     }
 
+    /**
+     * Get the bookable items_types
+     * @param array $bookableItemsArr the items that are bookable as provided by Items->readBookable()
+     */
+    public function readBookable(array $bookableItemsArr): array
+    {
+        return array_filter($this->readAll(), fn(array $category): bool => in_array(
+            $category['id'],
+            array_column($bookableItemsArr, 'category'),
+            true,
+        ));
+    }
+
     private function isAdminOrExplode(): void
     {
         if ($this->bypassWritePermission === false && !$this->Users->isAdmin) {

--- a/src/models/UnfinishedSteps.php
+++ b/src/models/UnfinishedSteps.php
@@ -58,9 +58,10 @@ class UnfinishedSteps implements RestInterface
 
     public function readAll(): array
     {
-        $experimentsSteps = $this->cleanUpResult($this->getSteps(EntityType::Experiments));
-        $itemsSteps = $this->cleanUpResult($this->getSteps(EntityType::Items));
-        return array('experiments' => $experimentsSteps, 'items' => $itemsSteps);
+        return array(
+            EntityType::Experiments->value => $this->cleanUpResult($this->getSteps(EntityType::Experiments)),
+            EntityType::Items->value => $this->cleanUpResult($this->getSteps(EntityType::Items)),
+        );
     }
 
     public function destroy(): bool

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -405,6 +405,8 @@ button:disabled {
   thead {
     position: sticky;
     top: 0;
+    /* hide input group below header */
+    z-index: 3;
 
     /* thead with no filter on top need to have this class to have a top border */
     /* stylelint-disable-next-line selector-no-qualifying-type */
@@ -693,6 +695,12 @@ tr:nth-child(odd) {
 /* make the text of buttons in bold to increase readability because contrast ratio is not great */
 .btn {
   font-weight: bold;
+
+  /* invert icon color on hover for copy-to-clipboard btn */
+  &[data-action=copy-to-clipboard]:hover .fas {
+    color: $firstlevel;
+    transition: color 0.15s ease-in-out;
+  }
 }
 
 .btn-dropdown-item {
@@ -1231,7 +1239,8 @@ the form-control fails to do that so we do the border ourselves */
  */
 .far,
 .fas,
-.fab {
+.fab,
+.fa-stack {
   color: $medium;
   pointer-events: none;
 }

--- a/src/services/Filter.php
+++ b/src/services/Filter.php
@@ -120,7 +120,7 @@ class Filter
     }
 
     /**
-     * Sanitize title with a filter_var and remove the line breaks.
+     * Sanitize title and remove line breaks.
      *
      * @param string $input The title to sanitize
      * @return string Will return Untitled if there is no input.

--- a/src/sql/schema167-down.sql
+++ b/src/sql/schema167-down.sql
@@ -1,0 +1,12 @@
+-- revert schema 167
+DROP TABLE calendar2items_types;
+DROP TABLE calendar2items;
+DROP TABLE calendars;
+ALTER TABLE `team_events`
+  DROP FOREIGN KEY `fk_team_events_items_id`,
+  DROP KEY `fk_team_events_items_id`,
+  DROP FOREIGN KEY `fk_team_events_experiments_id`,
+  DROP KEY `fk_team_events_experiments_id`,
+  DROP FOREIGN KEY `fk_team_events_item_link_id`,
+  DROP KEY `fk_team_events_item_link_id`;
+UPDATE config SET conf_value = 166 WHERE conf_name = 'schema';

--- a/src/sql/schema167.sql
+++ b/src/sql/schema167.sql
@@ -1,0 +1,70 @@
+-- schema 167
+CREATE TABLE `calendars` (
+  `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) NOT NULL,
+  `token` varchar(60) NOT NULL,
+  `team` int UNSIGNED NOT NULL,
+  `created_by` int UNSIGNED NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `state` tinyint UNSIGNED NOT NULL DEFAULT '1',
+  `all_events` tinyint UNSIGNED NOT NULL DEFAULT '0',
+  `todo` tinyint UNSIGNED NOT NULL DEFAULT '0',
+  `unfinished_steps_scope` tinyint UNSIGNED NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE `unique_calendars_token` (`token`) USING HASH,
+  KEY `fk_calendars_team` (`team`),
+  KEY `idx_calendars_todo` (`todo`),
+  KEY `idx_calendars_unfinished_steps_scope` (`unfinished_steps_scope`),
+  KEY `idx_calendars_state` (`state`),
+  KEY `fk_calendars_created_by` (`created_by`),
+  CONSTRAINT `fk_calendars_team`
+    FOREIGN KEY (`team`) REFERENCES `teams` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_calendars_created_by`
+    FOREIGN KEY (`created_by`) REFERENCES `users` (`userid`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `calendar2items` (
+  `calendar` int UNSIGNED NOT NULL,
+  `item` int UNSIGNED NOT NULL,
+  PRIMARY KEY (`calendar`, `item`),
+  KEY `fk_calendar2items_calendar` (`calendar`),
+  KEY `fk_calendar2items_item` (`item`),
+  CONSTRAINT `fk_calendar2items_calendar`
+    FOREIGN KEY (`calendar`) REFERENCES `calendars` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_calendar2items_item`
+    FOREIGN KEY (`item`) REFERENCES `items` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `calendar2items_types` (
+  `calendar` int UNSIGNED NOT NULL,
+  `category` int UNSIGNED NOT NULL,
+  PRIMARY KEY (`calendar`, `category`),
+  KEY `fk_calendar2items_types_calendar` (`calendar`),
+  KEY `fk_calendar2items_types_category` (`category`),
+  CONSTRAINT `fk_calendar2items_types_calendar`
+    FOREIGN KEY (`calendar`) REFERENCES `calendars` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_calendar2items_types_category`
+    FOREIGN KEY (`category`) REFERENCES `items_types` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+ALTER TABLE `team_events`
+  ADD KEY `fk_team_events_items_id` (`item`),
+  ADD CONSTRAINT `fk_team_events_items_id`
+    FOREIGN KEY (`item`) REFERENCES `items` (`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD KEY `fk_team_events_experiments_id` (`experiment`),
+  ADD CONSTRAINT `fk_team_events_experiments_id`
+    FOREIGN KEY (`experiment`) REFERENCES `experiments` (`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD KEY `fk_team_events_item_link_id` (`item_link`),
+  ADD CONSTRAINT `fk_team_events_item_link_id`
+    FOREIGN KEY (`item_link`) REFERENCES `items` (`id`)
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+UPDATE config SET conf_value = 167 WHERE conf_name = 'schema';

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -27,6 +27,7 @@
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='6'>{{ 'Export'|trans }}</button></li>
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='7'>{{ 'Tag manager'|trans }}</button></li>
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='8'>{{ 'Batch actions'|trans }}</button></li>
+  <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='9'>{{ 'Calendar feeds'|trans }}</button></li>
 </ul>
 
 {# loading spinner #}
@@ -833,6 +834,11 @@
       </div>
     </div>
   </div>
+</div>
+
+{# TAB 9 CALENDAR FEEDS #}
+<div data-tabcontent='9' hidden>
+  {% include 'calendar-feeds.html' %}
 </div>
 
 <div id='info' data-page='template-edit' data-type='items_types' data-id='{{ App.Request.query.get('templateid') }}'></div>

--- a/src/templates/calendar-feeds.html
+++ b/src/templates/calendar-feeds.html
@@ -1,0 +1,97 @@
+{% set page = App.Request.getScriptName|split('/')|last %}
+  <h3 class='p-2 pl-3 section-title'>{{ 'calendar feeds'|trans }}</h3>
+  <div class='pl-3 mt-2 d-flex'>
+    <p class='smallgrey'>
+      {% if page == 'admin.php' %}
+        {{ 'This page allows you to view and revoke your teams calendar feeds.'|trans }}
+      {% else %}
+        {{ 'This page allows you to view and revoke your calendar feeds.'|trans }}
+      {% endif %}
+    </p>
+    {% if page == 'profile.php' %}
+        <button type='button' class='btn btn-primary ml-auto mb-2'
+          data-action='toggle-modal' data-target='calendarModal'
+        >
+          <i class='far fa-calendar' style='color:#fff;'></i>
+          {{ 'Generate a new calendar'|trans }}
+        </button>
+    {% endif %}
+  </div>
+  <table class='table' aria-describedby='todo' data-table-sort='true'>
+    <thead>
+      <tr>
+        <th scope='col'>{{ 'Id'|trans }}</th>
+        <th scope='col'>{{ 'Title'|trans }}</th>
+        <th scope='col'>{{ 'URL'|trans }}</th>
+        <th scope='col'>{{ 'Content'|trans }}</th>
+        <th scope='col'>{{ 'Creation date'|trans }}</th>
+        {% if page == 'admin.php' %}
+          <th scope='col'>{{ 'User'|trans }}</th>
+        {% endif %}
+        <th scope='col'>{{ 'Action'|trans }}</th>
+      </tr>
+    </thead>
+    <tbody id='calendarTable'>
+      {% for calendar in calendars %}
+        <tr>
+          <td data-label='{{ 'Id'|trans }}'>{{ calendar.id }}</td>
+          <td data-label='{{ 'Title'|trans }}'>{{ calendar.title }}</td>
+          <td data-label='{{ 'URL'|trans }}'>
+            {% if page == 'admin.php' and calendar.todo == 1 and App.Users.userid != calendar.created_by %}
+              <span class='smallgray'>{{ 'Not shown, as it contains the users todolist.'|trans }}</span>
+            {% else %}
+              <div class='input-group input-group-sm'>
+                <div class='input-group-prepend'>
+                  <button title='{{ 'Copy to clipboard'|trans }}' class='btn btn-outline-secondary' type='button' data-action='copy-to-clipboard' data-target='calendarFeedUrl{{ calendar.id }}'>
+                    <i class='fas fa-clone'></i>
+                  </button>
+                </div>
+                {% set feedUrl = App.Config.fromEnv('SITE_URL') ~ '/calendar.php?token=' ~ calendar.token %}
+                <input type='text' class='form-control' readonly id='calendarFeedUrl{{ calendar.id }}'
+                  value='{{ feedUrl }}' title='{{ feedUrl }}'>
+              </div>
+            {% endif %}
+          </td>
+          <td data-label='{{ 'Calendar Content'|trans }}'>
+            <div class='d-flex flex-wrap align-items-baseline'>
+              {% if calendar.all_events %}
+                <span class='p-1 rounded smallgray border mr-1 mb-1'>{{ 'All events of your team'|trans }}</span>
+              {% endif %}
+              {% if calendar.todo %}
+                <span class='p-1 rounded smallgray border mr-1 mb-1'>{{ 'Todolist'|trans }}</span>
+              {% endif %}
+              {% if calendar.unfinished_steps_scope == 1 %}
+                <span class='p-1 rounded smallgray border mr-1 mb-1'>{{ 'Unfinished steps of your experiments and resources'|trans }}</span>
+              {% elseif calendar.unfinished_steps_scope == 2 %}
+                <span class='p-1 rounded smallgray border mr-1 mb-1'>{{ 'All unfinished steps of your team'|trans }}</span>
+              {% endif %}
+              {% if calendar.items %}
+                <span style='flex-basis:100%;height:0;'></span>
+                <span class='mr-1'>{{ 'Items:'|trans }}</span>
+                {% for item in calendar.items %}
+                  <span class='p-1 rounded smallgray border mr-1 mb-1'><a href='database.php?mode=view&amp;id={{ item.id }}'>{{ item.title }}</a></span>
+                {% endfor %}
+              {% endif %}
+              {% if calendar.categories %}
+                <span style='flex-basis:100%;height:0;'></span>
+                <span class='mr-1'>{{ 'Categories:'|trans }}</span>
+                {% for category in calendar.categories %}
+                  <a href='database.php?mode=show&amp;cat={{ category.id }}' class='btn mr-2 catstat-btn category-btn mb-1' style='--bg: #{{ category.color }}'>{{ category.title }}</a>
+                {% endfor %}
+              {% endif %}
+            </div>
+          </td>
+          <td data-label='{{ 'Creation date'|trans }}'><span class='relative-moment' title='{{ calendar.created_at }}'></span></td>
+          {% if page == 'admin.php' %}
+            <td data-label='{{ 'User'|trans }}'>{{ calendar.fullname }}</td>
+          {% endif %}
+          <td data-label='{{ 'Action'|trans }}'>
+            <button type='button' class='btn hover-danger lh-normal border-0 p-2 m-0 my-n2' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}'
+              data-action='destroy-calendar' data-calendarid='{{ calendar.id }}'>
+              <i class='fas fa-trash-alt fa-fw'></i>
+            </button>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>

--- a/src/templates/calendar-modal.html
+++ b/src/templates/calendar-modal.html
@@ -1,0 +1,109 @@
+{# Modal for calendar feeds #}
+<div class='modal fade' id='calendarModal' tabindex='-1' role='dialog' aria-labelledby='calendarModalLabel'>
+  <div class='modal-dialog modal-lg' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='calendarModalLabel'>{{ 'Create a calendar feed'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body' data-wait='{{ 'Please wait…'|trans }}'>
+        <label for='calendarTitle'>{{ 'Title'|trans }}</label>
+        <input class='form-control' type='text' id='calendarTitle' />
+        <hr>
+        <div class='form-check form-check-inline'>
+          <label class='form-check-label mr-2' for='calendarTeam'>{{ 'Subscribe to all events of the team'|trans }}</label>
+          <input class='form-check-input' type='checkbox' id='calendarTeam'>
+        </div>
+        <br>
+        <strong>{{ 'or'|trans }}</strong>
+        <div class='mt-2 mb-2'>
+          <label for='calendarSelectCat'>{{ 'Select the categories you want to include in the feed:'|trans }}</label>
+          {% if App.Config.configArr.debug -%}
+            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
+          {%- endif %}
+          <select
+            aria-label='{{ 'Select categories'|trans }}'
+            class='form-control'
+            id='calendarSelectCat'
+            multiple
+          >
+            <option value=''>{{ 'Select categories'|trans }}</option>
+            {% for category in bookableItemsTypes %}
+              <option value='{{ category.id }}'{{ App.Request.query.get('cat') == category.id ? ' selected' }}>
+                {{ category.title }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class='mt-2 mb-2'>
+          <label for='calendarSelectItem'>{{ 'Select the resources you want to include in the feed:'|trans }}</label>
+          {% if App.Config.configArr.debug -%}
+            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
+          {%- endif %}
+          <select
+            aria-label='{{ 'Select resources'|trans }}'
+            class='form-control'
+            id='calendarSelectItem'
+            multiple
+          >
+            <option value=''>{{ 'Select resources'|trans }}</option>
+            {% for item in itemsArr %}
+              {# data-color is used to set the background during initial drag #}
+              <option data-color='{{ item.category_color }}' value='{{ item.id }}'{{ App.Request.query.get('item') == item.id ? ' selected' }}>
+                {{ item.category_title }} - {{ item.title }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+
+        {% if App.Request.getScriptName|split('/')|last == 'profile.php' %}
+          <hr>
+          <div class='mt-2 mb-2'>
+            <div class='form-check form-check-inline'>
+              <label class='form-check-label mr-2' for='calendarTodo'>{{ 'Include my todolist'|trans }}</label>
+              <input class='form-check-input' type='checkbox' id='calendarTodo'>
+            </div>
+          </div>
+          <div class='mt-2 mb-2'>
+            <div class='form-check form-check-inline'>
+              <label class='form-check-label mr-2' for='calendarUnfinishedStepsUser'>{{ 'Include unfinished steps for '|trans }}</label>
+              <input class='form-check-input' type='radio' name='calendarUnfinishedSteps' id='calendarUnfinishedStepsUser' value='user'>
+              <label class='form-check-label' for='calendarUnfinishedStepsUser'>{{ 'myself'|trans }}</label>
+            </div>
+            <div class='form-check form-check-inline'>
+              <input class='form-check-input' type='radio' name='calendarUnfinishedSteps' id='calendarUnfinishedStepsTeam' value='team'>
+              <label class='form-check-label' for='calendarUnfinishedStepsTeam'>{{ 'my team'|trans }}</label>
+            </div>
+            <div class='form-check form-check-inline'>
+              <input class='form-check-input' type='radio' name='calendarUnfinishedSteps' id='calendarUnfinishedStepsDisabled' value='none' checked='checked'>
+              <label class='form-check-label' for='calendarUnfinishedStepsDisabled'>{{ 'Do not include'|trans }}</label>
+            </div>
+          </div>
+        {% endif %}
+
+        <hr>
+        <button type='button' class='btn btn-primary' data-action='create-calendar'>
+          {{ 'Get a link for this calendar feed'|trans }}
+        </button>
+        <div hidden id='calendarUrlDisplay' class='mt-2 mb-2'>
+          <label>{{ 'You can access the calendar with the following public link:'|trans }}</label>
+          <div class='input-group mt-1'>
+            <div class='input-group-prepend'>
+              <button title='{{ 'Copy to clipboard'|trans }}' class='btn btn-outline-secondary' type='button'
+                data-action='copy-to-clipboard' data-target='calendarFeedUrl'>
+                <i class='fas fa-clone'></i>
+              </button>
+            </div>
+            <input type='text' class='form-control' id='calendarFeedUrl' readonly='readonly'>
+          </div>
+        </div>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -7,6 +7,7 @@
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='2'>{{ 'Attachments'|trans }}</button></li>
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='3'>{{ 'Import'|trans }}</button></li>
   <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='4'>{{ 'Export'|trans }}</button></li>
+  <li><button type='button' class='btn' data-action='switch-tab' data-tabtarget='5'>{{ 'Calendar feeds'|trans }}</button></li>
 </ul>
 
 {# loading spinner #}
@@ -300,5 +301,11 @@
       {% endfor %}
     </ul>
   </div>
+</div>
+
+{# TAB 5 CALENDAR FEEDS #}
+{% include 'calendar-modal.html' %}
+<div data-tabcontent='5' hidden>
+  {% include 'calendar-feeds.html' %}
 </div>
 {% endblock body %}

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -107,11 +107,23 @@
   </div>
 </div>
 
+{% include 'calendar-modal.html' %}
+
 {# TAB 1 SCHEDULER #}
 <div data-tabcontent='1' hidden>
   <div class='d-flex mb-2'>
     <div id='selectBookableWarningDiv' hidden>{{ 'Select a resource below in order to book it.'|trans }}</div>
     <div class='ml-auto'>
+      <button type='button' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'
+        title='{{ 'Get a calendar feed'|trans }}' aria-label='{{ 'Get a calendar feed'|trans }}'
+        data-action='toggle-modal' data-target='calendarModal'
+      >
+        <span class='fa-stack'>
+          <i class='far fa-calendar fa-stack-2x'></i>
+          <i class='fas fa-right-long fa-stack-1x' style='top:4px'></i>
+        </span>
+      </button>
+
       {% include 'scope-button.html' with {'reload': 'page', 'target': 'scope_items'} %}
     </div>
   </div>
@@ -120,63 +132,63 @@
     {% if itemsArr|length == 0 %}
       {{ 'No bookable items.'|trans|msg('warning', false) }}
     {% else %}
-    <div class='row mb-3'>
-      <div class='col-md-3'>
-        {# CATEGORY #}
-        <form aria-label='{{ 'Filter by category'|trans }}'>
-          {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
-          {%- endif %}
-          <select
-            aria-label='{{ 'Filter by category'|trans }}'
-            class='autosubmit mr-1 form-control'
-            id='schedulerSelectCat'
-            name='cat'
-          >
-            <option value=''>{{ 'Filter by category'|trans }}</option>
-            {% for category in bookableItemsTypes %}
-              <option value='{{ category.id }}'{{ App.Request.query.get('cat') == category.id ? ' selected' }}>
-                {{ category.title }}
-              </option>
-            {% endfor %}
-          </select>
-        </form>
-      </div>
-
-      <div class='col-md-3'>
-        {# ITEM LIST #}
-        <form aria-label='{{ 'Select a resource'|trans }}'>
-          {% if App.Config.configArr.debug -%}
-            <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
-          {%- endif %}
-          <select
-            aria-label='{{ 'Select a resource'|trans }}'
-            class='autosubmit mr-1 form-control'
-            id='itemSelect'
-            name='item'
-          >
-            <option value=''>{{ 'Select a resource'|trans }}</option>
-            {% for item in itemsArr %}
-              {# data-color is used to set the background during initial drag #}
-              <option data-color='{{ item.category_color }}' value='{{ item.id }}'{{ App.Request.query.get('item') == item.id ? ' selected' }}>
-                {{ item.category_title }} - {{ item.title }}
-              </option>
-            {% endfor %}
-          </select>
-        </form>
-      </div>
-
-      {% if bookableItemData %}
-        <div class='col-md-3 ml-auto'>
-          <div class='input-group justify-content-end flex-nowrap'>
-            <div class='input-group-prepend'>
-              <button class='btn btn-secondary' type='button' data-action='remove-param-reload' data-target='item'>X</button>
-            </div>
-            <a href='database.php?mode=view&amp;id={{ bookableItemData.id }}' class='list-group-item hl-hover-gray'><span style='--bg: #{{ bookableItemData.category_color }}' class='catstat-btn category-btn mr-2'>{{ bookableItemData.category_title }}</span>{{ bookableItemData.title }}</a>
-          </div>
+      <div class='row mb-3'>
+        <div class='col-md-3'>
+          {# CATEGORY #}
+          <form aria-label='{{ 'Filter by category'|trans }}'>
+            {% if App.Config.configArr.debug -%}
+              <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
+            {%- endif %}
+            <select
+              aria-label='{{ 'Filter by category'|trans }}'
+              class='autosubmit mr-1 form-control'
+              id='schedulerSelectCat'
+              name='cat'
+            >
+              <option value=''>{{ 'Filter by category'|trans }}</option>
+              {% for category in bookableItemsTypes %}
+                <option value='{{ category.id }}'{{ App.Request.query.get('cat') == category.id ? ' selected' }}>
+                  {{ category.title }}
+                </option>
+              {% endfor %}
+            </select>
+          </form>
         </div>
-      {% endif %}
-    </div>
+
+        <div class='col-md-3'>
+          {# ITEM LIST #}
+          <form aria-label='{{ 'Select a resource'|trans }}'>
+            {% if App.Config.configArr.debug -%}
+              <!-- [html-validate-disable-block input-missing-label, prefer-native-element, no-unused-disable: suppress errors from tom-select] -->
+            {%- endif %}
+            <select
+              aria-label='{{ 'Select a resource'|trans }}'
+              class='autosubmit mr-1 form-control'
+              id='itemSelect'
+              name='item'
+            >
+              <option value=''>{{ 'Select a resource'|trans }}</option>
+              {% for item in itemsArr %}
+                {# data-color is used to set the background during initial drag #}
+                <option data-color='{{ item.category_color }}' value='{{ item.id }}'{{ App.Request.query.get('item') == item.id ? ' selected' }}>
+                  {{ item.category_title }} - {{ item.title }}
+                </option>
+              {% endfor %}
+            </select>
+          </form>
+        </div>
+
+        {% if bookableItemData %}
+            <div class='col-md-3 ml-auto'>
+              <div class='input-group justify-content-end flex-nowrap'>
+                <div class='input-group-prepend'>
+                  <button class='btn btn-secondary' type='button' data-action='remove-param-reload' data-target='item'>X</button>
+                </div>
+                <a href='database.php?mode=view&amp;id={{ bookableItemData.id }}' class='list-group-item hl-hover-gray'><span style='--bg: #{{ bookableItemData.category_color }}' class='catstat-btn category-btn mr-2'>{{ bookableItemData.category_title }}</span>{{ bookableItemData.title }}</a>
+              </div>
+            </div>
+        {% endif %}
+      </div>
     {% endif %}
   </div>
   <div id='scheduler' data-lang='{{ App.getJsLang }}' data-render={{ itemsArr|length > 0 ? 'true' : 'false' }}></div>

--- a/src/ts/Calendar.class.ts
+++ b/src/ts/Calendar.class.ts
@@ -1,0 +1,122 @@
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+import { Api } from './Apiv2.class';
+import { getNewIdFromPostRequest, relativeMoment, reloadElements, TomSelect } from './misc';
+import i18next from 'i18next';
+
+export default class Calendar {
+
+  private page: string;
+  private ApiC: Api;
+
+  constructor() {
+    this.page = window.location.pathname;
+    this.ApiC = new Api();
+
+    this.addResetModalEventListener();
+    this.initializeTomSelect();
+  }
+
+  public async create() {
+    // gather data from inputs
+    const title = (document.getElementById('calendarTitle') as HTMLInputElement).value;
+    const allTeamEvents = (document.getElementById('calendarTeam') as HTMLInputElement).checked;
+    let todo = false;
+    let UnfinishedStepsScope = 'none';
+    if (this.page === '/profile.php') {
+      todo = (document.getElementById('calendarTodo') as HTMLInputElement).checked;
+      UnfinishedStepsScope = (document.querySelector('input[name="calendarUnfinishedSteps"]:checked') as HTMLInputElement).value;
+    }
+    let categories: number[] = [];
+    let items: number[] = [];
+
+    const getSelectedOptions = (id: string): number[] =>
+      Array.from((document.getElementById(id) as HTMLSelectElement).options)
+        .filter(option => option.selected)
+        .map(option => parseInt(option.value, 10));
+    if (!allTeamEvents) {
+      categories = getSelectedOptions('calendarSelectCat');
+      items = getSelectedOptions('calendarSelectItem');
+    }
+
+    // check if there is any content
+    if (!allTeamEvents
+        && categories.length === 0
+        && items.length === 0
+        && (this.page === '/team.php'
+            || (this.page === '/profile.php'
+                && todo
+                && UnfinishedStepsScope === 'none'
+            )
+        )
+    ) {
+      alert(i18next.t('nothing-selected'));
+      return;
+    }
+
+    // prepare post request params
+    const postParams = {
+      title,
+      'all_events': allTeamEvents,
+      categories,
+      items,
+      todo,
+      'unfinished_steps_scope': UnfinishedStepsScope,
+    };
+
+    const postResult = await this.ApiC.post('calendars', postParams);
+    const getResponse = await this.ApiC.get(`calendars/${getNewIdFromPostRequest(postResult)}`);
+    const calendarData = await getResponse.json();
+    (document.getElementById('calendarFeedUrl') as HTMLInputElement).value = `${window.location.origin}/calendar.php?token=${calendarData.token}`;
+    document.getElementById('calendarUrlDisplay').hidden = false;
+    if (this.page === '/profile.php') {
+      await reloadElements(['calendarTable']);
+      relativeMoment();
+    }
+  }
+
+  private addResetModalEventListener(): void {
+    $('#calendarModal').on('hidden.bs.modal', () => {
+      (document.getElementById('calendarTitle') as HTMLInputElement).value = '';
+      (document.getElementById('calendarTeam') as HTMLInputElement).checked = false;
+      (document.getElementById('calendarSelectCat') as HTMLSelectElement).selectedIndex = -1;
+      // todo: figure out how to use tomselect type
+      // @ts-expect-error tomselect
+      document.getElementById('calendarSelectCat').tomselect.clear();
+      (document.getElementById('calendarSelectItem') as HTMLSelectElement).selectedIndex = -1;
+      // todo: figure out how to use tomselect type
+      // @ts-expect-error tomselect
+      document.getElementById('calendarSelectItem').tomselect.clear();
+
+      if (this.page === '/profile.php') {
+        (document.getElementById('calendarTodo') as HTMLInputElement).checked = false;
+        (document.getElementById('calendarUnfinishedSteps') as HTMLInputElement).checked = true;
+      }
+
+      (document.getElementById('calendarFeedUrl') as HTMLInputElement).value = '';
+      document.getElementById('calendarUrlDisplay').hidden = true;
+
+    });
+  }
+
+  private initializeTomSelect(): void {
+    ['calendarSelectCat', 'calendarSelectItem'].forEach(id => {
+      new TomSelect(`#${id}`, {
+        plugins: [
+          'dropdown_input',
+          'remove_button',
+          'checkbox_options',
+          'clear_button',
+          'no_active_items',
+        ],
+      });
+    });
+  }
+}

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -9,6 +9,7 @@ import {
   getNewIdFromPostRequest,
   notif,
   notifError,
+  relativeMoment,
   reloadElements,
   TomSelect,
   updateCatStat,
@@ -319,6 +320,12 @@ document.addEventListener('DOMContentLoaded', () => {
           notif({'res': true, 'msg': i18next.t('onboarding-email-sent')});
         }
       });
+
+    // DESTROY CALENDAR
+    } else if (el.matches('[data-action="destroy-calendar"]')) {
+      ApiC.delete(`calendars/${el.dataset.calendarid}`)
+        .then(() => reloadElements(['calendarTable']))
+        .then(() => relativeMoment());
     }
   });
 });

--- a/src/ts/profile.ts
+++ b/src/ts/profile.ts
@@ -7,7 +7,14 @@
  */
 import { Api } from './Apiv2.class';
 import Tab from './Tab.class';
-import { collectForm, relativeMoment, reloadElements, notif, notifError } from './misc';
+import Calendar from './Calendar.class';
+import {
+  collectForm,
+  notif,
+  notifError,
+  relativeMoment,
+  reloadElements,
+} from './misc';
 import i18next from 'i18next';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -16,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const ApiC = new Api();
+  const CalendarC = new Calendar();
 
   const TabMenu = new Tab();
   TabMenu.init(document.querySelector('.tabbed-menu'));
@@ -131,11 +139,23 @@ document.addEventListener('DOMContentLoaded', () => {
         changelog: urlParams.get('changelog'),
         pdfa: urlParams.get('pdfa'),
         json: urlParams.get('json'),
-      }).then(() => reloadElements(['exportedFilesTable']).then(() => relativeMoment()));
+      }).then(() => reloadElements(['exportedFilesTable'])).then(() => relativeMoment());
 
     // DESTROY EXPORT
     } else if (el.matches('[data-action="destroy-export"]')) {
-      ApiC.delete(`exports/${el.dataset.id}`).then(() => reloadElements(['exportedFilesTable']).then(() => relativeMoment()));
+      ApiC.delete(`exports/${el.dataset.id}`)
+        .then(() => reloadElements(['exportedFilesTable']))
+        .then(() => relativeMoment());
+
+    // DESTROY CALENDAR
+    } else if (el.matches('[data-action="destroy-calendar"]')) {
+      ApiC.delete(`calendars/${el.dataset.calendarid}`)
+        .then(() => reloadElements(['calendarTable']))
+        .then(() => relativeMoment());
+
+    // CREATE CALENDAR
+    } else if (el.matches('[data-action="create-calendar"]')) {
+      CalendarC.create();
     }
   });
 });

--- a/tests/unit/Make/MakeICalTest.php
+++ b/tests/unit/Make/MakeICalTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Make;
+
+use Elabftw\Enums\Action;
+use Elabftw\Enums\CalendarKeys;
+use Elabftw\Enums\Scope;
+use Elabftw\Exceptions\ResourceNotFoundException;
+use Elabftw\Models\Calendar;
+use Elabftw\Models\Items;
+use Elabftw\Models\Scheduler;
+use Elabftw\Models\Todolist;
+use Elabftw\Models\Users;
+use DateTime;
+use DateInterval;
+use Symfony\Component\HttpFoundation\Request;
+
+use function array_column;
+use function array_slice;
+use function str_repeat;
+
+class MakeICalTest extends \PHPUnit\Framework\TestCase
+{
+    private Calendar $Calendar;
+
+    private Request $Request;
+
+    private int $calId = 0;
+
+    protected function setUp(): void
+    {
+        $this->Calendar = new Calendar(new Users(1, 1));
+        // Mock a request with canbook parameter
+        $this->Request = Request::create('/database.php', 'GET', array('canbook' => '1'));
+
+    }
+
+    public function testGetFileName(): void
+    {
+        $this->assertEquals(
+            'eLabFTW-calendar.ics',
+            (new MakeICal('notARealToken'))->getFileName(),
+        );
+    }
+
+    public function testGetContentType(): void
+    {
+        $this->assertEquals(
+            'text/calendar; charset=utf-8',
+            (new MakeICal('notARealToken'))->getContentType(),
+        );
+    }
+
+    public function testNonExistingToken(): void
+    {
+        $token = str_repeat('0aA', 20);
+        $this->expectException(ResourceNotFoundException::class);
+        (new MakeICal($token))->getFileContent();
+    }
+
+    public function testAllOfTeam(): void
+    {
+        $Scheduler = new Scheduler(new Items(new Users(1, 1), 1));
+        $title = 'for MakeICal Test';
+        $Scheduler->postAction(Action::Create, array(
+            'title' => $title,
+            'start' => (new DateTime())->format(DateTime::ATOM),
+            'end' => (new DateTime())->add(new DateInterval('PT2H'))->format(DateTime::ATOM),
+        ));
+
+        $iCalString = $this->getICalString(array(CalendarKeys::AllEvents->value => true));
+        $this->assertIsCalendar($iCalString, 'VEVENT');
+        $this->assertStringContainsString($title, $iCalString);
+    }
+
+    public function testAllOfCategory(): void
+    {
+        $iCalString = $this->getICalString(array(
+            CalendarKeys::Categories->value => array(
+                (new Items(new Users(1, 1)))->readBookable($this->Request)[0]['category'],
+            ),
+        ));
+        $this->assertIsCalendar($iCalString, 'VEVENT');
+    }
+
+    public function testAllOfItem(): void
+    {
+        $iCalString = $this->getICalString(array(
+            CalendarKeys::Items->value => array_slice(
+                array_column((new Items(new Users(1, 1)))->readBookable($this->Request), 'id'),
+                0,
+                3,
+            ),
+        ));
+        $this->assertIsCalendar($iCalString, 'VEVENT');
+    }
+
+    public function testTodolist(): void
+    {
+        $todoBody = 'My first todo entry';
+        $todoid = (new Todolist(1))->postAction(Action::Create, array('content' => $todoBody));
+        $iCalString = $this->getICalString(array(CalendarKeys::Todo->value => true));
+        $this->assertIsCalendar($iCalString, 'VTODO');
+        $this->assertStringContainsString($todoBody, $iCalString);
+        (new Todolist(1, $todoid))->destroy();
+    }
+
+    public function testTodoUnfinishedStepsUser(): void
+    {
+        $iCalString = $this->getICalString(array(
+            CalendarKeys::UnfinishedStepsScope->value => Scope::User->toString(),
+        ));
+        $this->assertIsCalendar($iCalString, 'VTODO');
+    }
+
+    public function testTodoUnfinishedStepsTeam(): void
+    {
+        $iCalString = $this->getICalString(array(
+            CalendarKeys::UnfinishedStepsScope->value => Scope::Team->toString(),
+        ));
+        $this->assertIsCalendar($iCalString, 'VTODO');
+    }
+
+    public function testCombined(): void
+    {
+        $iCalString = $this->getICalString(array(
+            CalendarKeys::AllEvents->value => true,
+            CalendarKeys::Todo->value => true,
+            CalendarKeys::UnfinishedStepsScope->value => Scope::Team->toString(),
+        ));
+        $this->assertIsCalendar($iCalString, 'VTODO');
+        $this->assertIsCalendar($iCalString, 'VEVENT');
+    }
+
+    private function createCalendar(array $reqBody = array()): void
+    {
+        $this->calId = $this->Calendar->postAction(Action::Create, $reqBody);
+        $this->Calendar->setId($this->calId);
+    }
+
+    private function getICalString(array $reqBody = array()): string
+    {
+        $this->createCalendar($reqBody);
+        return (new MakeICal($this->Calendar->readOne()['token']))->getFileContent();
+    }
+
+    private function assertIsCalendar(string $iCalString, string $component): void
+    {
+        $this->assertIsString($iCalString);
+        $this->assertStringStartsWith('BEGIN:VCALENDAR', $iCalString);
+        $this->assertStringContainsString("BEGIN:$component", $iCalString);
+        $this->assertStringContainsString("END:$component", $iCalString);
+        $this->assertStringEndsWith("END:VCALENDAR\r\n", $iCalString);
+    }
+}

--- a/tests/unit/models/CalendarTest.php
+++ b/tests/unit/models/CalendarTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Enums\CalendarKeys;
+use Elabftw\Enums\Scope;
+use Elabftw\Exceptions\IllegalActionException;
+use Symfony\Component\HttpFoundation\Request;
+
+use function array_column;
+use function array_slice;
+use function strlen;
+
+class CalendarTest extends \PHPUnit\Framework\TestCase
+{
+    private Calendar $Calendar;
+
+    protected function setUp(): void
+    {
+        $this->Calendar = new Calendar(new Users(1, 1));
+    }
+
+    public function testGetApiPath(): void
+    {
+        $this->assertEquals('api/v2/calendar/', $this->Calendar->getApiPath());
+    }
+
+    public function testRandomAlphaNumericString(): void
+    {
+        $length = 10;
+        $this->assertEquals($length, strlen($this->Calendar::randomAlphaNumericString($length)));
+    }
+
+    public function testTokenLength(): void
+    {
+        $this->assertEquals(60, $this->Calendar::TOKEN_LENGTH);
+    }
+
+    public function testPostAction(): void
+    {
+        $fullTeam = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::AllEvents->value => true,
+            CalendarKeys::Title->value => 'All events',
+        ));
+        $this->assertIsInt($fullTeam);
+
+        // Mock a request with canbook parameter
+        $Request = Request::create('/database.php', 'GET', array('canbook' => '1'));
+        $bookableCat = array((new Items(new Users(1, 1)))->readBookable($Request)[0]['category']);
+        $bookableItems = array_slice(
+            array_column((new Items(new Users(1, 1)))->readBookable($Request), 'id'),
+            0,
+            5,
+        );
+
+        $category = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::Categories->value => $bookableCat,
+            CalendarKeys::Title->value => 'Cat 1',
+        ));
+        $this->assertIsInt($category);
+
+        $item = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::Items->value => $bookableItems,
+            CalendarKeys::Title->value => '5 Items',
+        ));
+        $this->assertIsInt($item);
+
+        $categoriesAndItems = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::Categories->value => $bookableCat,
+            CalendarKeys::Items->value => $bookableItems,
+            CalendarKeys::Title->value => '1 category and 5 items',
+        ));
+        $this->assertIsInt($categoriesAndItems);
+
+        $todo = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::Todo->value => true,
+            CalendarKeys::Title->value => 'Todolist',
+        ));
+        $this->assertIsInt($todo);
+
+        $user_steps = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::UnfinishedStepsScope->value => Scope::User->toString(),
+            CalendarKeys::Title->value => 'Unfinished steps of user',
+        ));
+        $this->assertIsInt($user_steps);
+
+        $team_steps = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::UnfinishedStepsScope->value => Scope::Team->toString(),
+            CalendarKeys::Title->value => 'Unfinished steps of team',
+
+        ));
+        $this->assertIsInt($team_steps);
+
+        $all = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::AllEvents->value => true,
+            CalendarKeys::Todo->value => true,
+            CalendarKeys::UnfinishedStepsScope->value => Scope::Team->toString(),
+            CalendarKeys::Title->value => 'Events and todos',
+        ));
+        $this->assertIsInt($all);
+    }
+
+    public function testReadAll(): void
+    {
+        $this->assertIsArray($this->Calendar->readAll());
+    }
+
+    public function testReadOne(): void
+    {
+        $this->Calendar->setId(10);
+        $this->assertIsArray($this->Calendar->readOne());
+
+        $this->Calendar->id = null;
+        $this->expectException(IllegalActionException::class);
+        $this->assertIsArray($this->Calendar->readOne());
+    }
+
+    public function testDestroy(): void
+    {
+        $newId = $this->Calendar->postAction(Action::Create, array(
+            CalendarKeys::AllEvents->value => true,
+        ));
+        $this->Calendar->setId($newId);
+        $this->assertTrue($this->Calendar->destroy());
+    }
+}

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Services\Check;
+use Symfony\Component\HttpFoundation\Request;
 
 use function date;
 
@@ -56,7 +57,9 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
 
     public function testReadBookable(): void
     {
-        $this->assertIsArray($this->Items->readBookable());
+        // Mock a request with canbook parameter
+        $Request = Request::create('/database.php', 'GET', array('canbook' => '1'));
+        $this->assertIsArray($this->Items->readBookable($Request));
     }
 
     public function testCanBookInPast(): void

--- a/tests/unit/models/ItemsTypesTest.php
+++ b/tests/unit/models/ItemsTypesTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Exceptions\ImproperActionException;
+use Symfony\Component\HttpFoundation\Request;
 
 class ItemsTypesTest extends \PHPUnit\Framework\TestCase
 {
@@ -53,5 +54,13 @@ class ItemsTypesTest extends \PHPUnit\Framework\TestCase
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/items_types/', $this->ItemsTypes->getApiPath());
+    }
+
+    public function testReadBookable(): void
+    {
+        // Mock a request with canbook parameter
+        $Request = Request::create('/database.php', 'GET', array('canbook' => '1'));
+        $bookableItemsArr = (new Items(new Users(1, 1)))->readBookable($Request);
+        $this->assertIsArray($this->ItemsTypes->readBookable($bookableItemsArr));
     }
 }

--- a/tests/unit/models/TodolistTest.php
+++ b/tests/unit/models/TodolistTest.php
@@ -36,7 +36,7 @@ class TodolistTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdate(): void
     {
-        $this->Todolist->setId(1);
+        $this->Todolist->setId(2);
         $this->assertIsArray($this->Todolist->patch(Action::Update, array('content' => 'write way more tests')));
     }
 
@@ -45,7 +45,7 @@ class TodolistTest extends \PHPUnit\Framework\TestCase
         $this->Todolist->postAction(Action::Create, array('content' => 'item 2'));
         $this->Todolist->postAction(Action::Create, array('content' => 'item 3'));
         $this->Todolist->postAction(Action::Create, array('content' => 'item 4'));
-        $OrderingParams = new OrderingParams(array('ordering' => array('test_3', 'test_2', 'test_1'), 'table' => 'todolist'));
+        $OrderingParams = new OrderingParams(array('ordering' => array('test_4', 'test_3', 'test_2'), 'table' => 'todolist'));
         $this->Todolist->updateOrdering($OrderingParams);
         $all = $this->Todolist->readAll();
         $this->assertEquals('item 4', $all[0]['body']);

--- a/web/admin.php
+++ b/web/admin.php
@@ -17,6 +17,7 @@ use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\FilesystemErrorException;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Calendar;
 use Elabftw\Models\ExperimentsCategories;
 use Elabftw\Models\ExperimentsStatus;
 use Elabftw\Models\ItemsStatus;
@@ -111,6 +112,8 @@ try {
     }
     $passwordComplexity = PasswordComplexity::from((int) $App->Config->configArr['password_complexity_requirement']);
 
+    $Calendar = new Calendar($App->Users);
+
     $template = 'admin.html';
     $renderArr = array(
         'Entity' => $ItemsTypes,
@@ -134,6 +137,7 @@ try {
         'teamStats' => $teamStats,
         'unvalidatedUsersArr' => $unvalidatedUsersArr,
         'usersArr' => $usersArr,
+        'calendars' => $Calendar->readAll(),
     );
 } catch (IllegalActionException $e) {
     $App->Log->notice('', array(array('userid' => $App->Session->get('userid')), array('IllegalAction', $e)));

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -93,6 +93,7 @@ try {
     $nologinArr = array(
         // the api can be access with session or token (or only token for v1) so we skip auth here to do it later with custom logic
         'ApiController.php',
+        'calendar.php',
         'change-pass.php',
         'index.php',
         'login.php',

--- a/web/calendar.php
+++ b/web/calendar.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Marcel Bolten <github@marcelbolten.de>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Controllers\CalendarController;
+use Elabftw\Exceptions\ResourceNotFoundException;
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Create an account
+ */
+require_once 'app/init.inc.php';
+
+/** @psalm-suppress UncaughtThrowInGlobalScope */
+$Response = new Response();
+$Response->prepare($App->Request);
+
+// calendar.php?token={alpha numeric string 60 characters}
+try {
+    if (!$App->Request->query->has('token') || strlen($App->Request->query->getString('token')) !== 60) {
+        throw new ResourceNotFoundException('Missing or invalid calendar token');
+    }
+
+    $Response = (new CalendarController($App->Request))->getResponse();
+
+} catch (ResourceNotFoundException $e) {
+    // log error and show general error message
+    $App->Log->error('', array('Exception' => $e));
+    $Response->setStatusCode(Response::HTTP_NOT_FOUND);
+} catch (Exception $e) {
+    // log error and show general error message
+    $App->Log->error('', array('Exception' => $e));
+    $Response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+} finally {
+    $Response->send();
+}

--- a/web/profile.php
+++ b/web/profile.php
@@ -18,7 +18,10 @@ use Elabftw\Exceptions\FilesystemErrorException;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Make\Exports;
+use Elabftw\Models\Calendar;
 use Elabftw\Models\ExperimentsCategories;
+use Elabftw\Models\Items;
+use Elabftw\Models\ItemsTypes;
 use Elabftw\Models\TeamGroups;
 use Elabftw\Models\Teams;
 use Elabftw\Models\UserUploads;
@@ -59,6 +62,9 @@ try {
     $UserUploads = new UserUploads($App->Users);
     $PermissionsHelper = new PermissionsHelper();
 
+    $bookableItemsArr = (new Items($App->Users))->readBookable($App->Request);
+    $bookableItemsTypes = (new ItemsTypes($App->Users))->readBookable($bookableItemsArr);
+
     $renderArr = array(
         'attachedFiles' => $UserUploads->readAll(),
         'count' => $count,
@@ -72,6 +78,9 @@ try {
         'uploadsTotal' => $UserUploads->countAll(),
         'usersArr' => $App->Users->readAllActiveFromTeam(),
         'visibilityArr' => $PermissionsHelper->getAssociativeArray(),
+        'bookableItemsTypes' => $bookableItemsTypes,
+        'itemsArr' => $bookableItemsArr,
+        'calendars' => (new Calendar($App->Users))->readAll(),
     );
     $Response->setContent($App->render($template, $renderArr));
 } catch (ImproperActionException $e) {

--- a/web/team.php
+++ b/web/team.php
@@ -48,14 +48,8 @@ try {
         $bookableItemData = $Scheduler->Items->readOne();
     }
 
-    // only the bookable categories
-    $bookableItemsArr = $Items->readBookable();
-    $categoriesOfBookableItems = array_column($bookableItemsArr, 'category');
-    $allItemsTypes = $ItemsTypes->readAll();
-    $bookableItemsTypes = array_filter(
-        $allItemsTypes,
-        fn($a): bool => in_array($a['id'], $categoriesOfBookableItems, true),
-    );
+    $bookableItemsArr = $Items->readBookable($App->Request);
+    $bookableItemsTypes = $ItemsTypes->readBookable($bookableItemsArr);
 
     $ProcurementRequests = new ProcurementRequests($Teams);
 


### PR DESCRIPTION
This PR implements calendar feeds, compare to #5081.

Users can create custom calendar feeds with either **all events of their team** or individually select **bookable categories** and/or **bookable items**. Additionally, a **users to-do list** and/or the **users unfinished steps** (experiments and resource items) or all **unfinished steps of the team** can be added to the feed.

Calendars can be created from the Scheduler tab on the teams page
![image](https://github.com/user-attachments/assets/91418323-3ecd-4ab8-b204-0f4e86e650c4)

or the new Calendar tab from the profile page

![image](https://github.com/user-attachments/assets/57952d61-8d71-4df3-ae9a-98ca6f83c410)
![image](https://github.com/user-attachments/assets/059a94b0-e94b-4390-9bd4-cd20dbf59c2a)

Admins will be able so see all active calendars of their team on the new Calendar tab in the admin panel.
![image](https://github.com/user-attachments/assets/053dce7c-a4ec-416a-b988-b0d4131efd39)

A user can subscribe to the calendar feed via `https://eln.example.org/calendar.php?token={token}`.

Calendars can also be created, listed, and deleted (soft) via the API.

The [eluceo/ical](https://github.com/markuspoerschke/iCal) library is used but the todo component was added at https://github.com/MarcelBolten/iCal/tree/vtodo.

Perhaps the tokens for calendars which contain unfinished steps should be hidden on the admin panel too as they provide access to the creators data that otherwise would not be accessible by an admin.

Everyone who has the token for a given calendar will be able to see the contend of the respective calendar. The token is like a password. However, data can only be read but not be modified.

New (missing) foreign keys will added to the `team_events` table.