### PR TITLE
Api: Add archived files to uploads endpoint

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -4090,6 +4090,12 @@ paths:
         required: true
         schema:
           type: integer
+      - name: archived
+        in: query
+        description: Include archived uploads in the response.
+        required: false
+        schema:
+          type: string
     get:
       tags: ['Uploads']
       summary: Read attached files of that entity.

--- a/tests/apiv2/Entity2Cest.php
+++ b/tests/apiv2/Entity2Cest.php
@@ -202,4 +202,12 @@ class Entity2Cest
         $I->seeResponseIsJson();
         $I->seeResponseContainsJson(array('description' => 'Linking an item to itself is not allowed. Please select a different target.'));
     }
+
+    public function includeArchivedUploads(Apiv2Tester $I)
+    {
+        $I->wantTo('Include archived uploads in the response');
+        $I->sendGet('/experiments/1/uploads?archived=on');
+        $I->seeResponseCodeIs(HttpCode::OK);
+        $I->seeResponseIsJson();
+    }
 }


### PR DESCRIPTION
By default the current behavior to not include archived files is retained.
However, when the query parameter `archived` is added the archived files will be included in the response. Any value will work as long as the `archived` parameter is present.

I don't fully understand why I have to ensure the type of the `$this->model` inside the closure but without it the static analyzers explode.

closes #5323 