### PR TITLE
Delete user orcid via API

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3668,16 +3668,6 @@ paths:
                     content:
                       type: integer
                       description: Binary value for `is_owner`, integer for `group` (2 for Admin, 4 for User)
-                - type: object
-                  description: Modify identity for user or `me`
-                  properties:
-                    firstname:
-                      type: string
-                    lastname:
-                      type: string
-                    orcid:
-                      type: string
-                      description: The ORCID of the user. It will be cleared if an empty string is provided.
       responses:
         '200':
           description: Public properties of a user.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3677,7 +3677,7 @@ paths:
                       type: string
                     orcid:
                       type: string
-                      description: The orcid of the user. Is cleared when empty string is sent
+                      description: The ORCID of the user. It will be cleared if an empty string is provided.
       responses:
         '200':
           description: Public properties of a user.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3668,6 +3668,16 @@ paths:
                     content:
                       type: integer
                       description: Binary value for `is_owner`, integer for `group` (2 for Admin, 4 for User)
+                - type: object
+                  description: Modify identity for user or `me`
+                  properties:
+                    firstname:
+                      type: string
+                    lastname:
+                      type: string
+                    orcid:
+                      type: string
+                      description: The orcid of the user. Is cleared when empty string is sent
       responses:
         '200':
           description: Public properties of a user.

--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -307,7 +307,7 @@ class MakeEln extends AbstractMakeEln
             'email' => $author->userData['email'],
         );
         // only add an identifier property if there is an orcid
-        if ($author->userData['orcid'] !== null) {
+        if (!empty($author->userData['orcid'])) {
             $node['identifier'] = 'https://orcid.org/' . $author->userData['orcid'];
         }
         // only add it if it doesn't exist yet in our list of authors

--- a/src/Params/UserParams.php
+++ b/src/Params/UserParams.php
@@ -48,7 +48,7 @@ final class UserParams extends ContentParams implements ContentParamsInterface
             )(),
             // return the hash of the password
             'password' => $this->validateAndHashPassword(),
-            'orcid' => $this->filterOrcid(),
+            'orcid' => $this->getOrcid(),
             'limit_nb' => (string) Check::limit((int) $this->content),
             'display_mode' => (DisplayMode::tryFrom($this->content) ?? DisplayMode::Normal)->value,
             'sort' => (Sort::tryFrom($this->content) ?? Sort::Desc)->value,
@@ -73,6 +73,15 @@ final class UserParams extends ContentParams implements ContentParamsInterface
         $PasswordValidator->validate($this->content);
 
         return password_hash($this->content, PASSWORD_DEFAULT);
+    }
+
+    private function getOrcid(): string
+    {
+        if (empty($this->content)) {
+            return '';
+        }
+
+        return $this->filterOrcid();
     }
 
     private function filterOrcid(): string

--- a/src/ts/ucp.ts
+++ b/src/ts/ucp.ts
@@ -96,8 +96,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     } else if (el.matches('[data-action="patch-account"]')) {
       const params = collectForm(document.getElementById('ucp-account-form'), false);
-      if (params['orcid'] === '') {
-        delete params['orcid'];
+      // Allow clearing the field when sending empty orcid param
+      if (!params['orcid']) {
+        params['orcid'] = null;
       }
       ApiC.patch(`${Model.User}/me`, params);
 

--- a/tests/unit/Params/UserParamsTest.php
+++ b/tests/unit/Params/UserParamsTest.php
@@ -33,6 +33,9 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $orcid = '1234-5678-1212-0001';
         $params = new UserParams('orcid', $orcid);
         $this->assertEquals($orcid, $params->getContent());
+        // Remove orcid
+        $params = new UserParams('orcid', '');
+        $this->assertEmpty($params->getContent(), message: 'orcid is not empty');
     }
 
     public function testInvalidOrcidFormat(): void
@@ -49,12 +52,5 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $params = new UserParams('orcid', $orcid);
         $this->expectException(ImproperActionException::class);
         $params->getContent();
-    }
-
-    public function testClearOrcid(): void
-    {
-        $orcid = '';
-        $params = new UserParams('orcid', $orcid);
-        $this->assertSame('', $params->getContent());
     }
 }

--- a/tests/unit/Params/UserParamsTest.php
+++ b/tests/unit/Params/UserParamsTest.php
@@ -33,9 +33,6 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $orcid = '1234-5678-1212-0001';
         $params = new UserParams('orcid', $orcid);
         $this->assertEquals($orcid, $params->getContent());
-        // Remove orcid
-        $params = new UserParams('orcid', '');
-        $this->assertEmpty($params->getContent(), message: 'orcid is not empty');
     }
 
     public function testInvalidOrcidFormat(): void

--- a/tests/unit/Params/UserParamsTest.php
+++ b/tests/unit/Params/UserParamsTest.php
@@ -35,7 +35,7 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($orcid, $params->getContent());
     }
 
-    public function testInvalidOrcidForamt(): void
+    public function testInvalidOrcidFormat(): void
     {
         $orcid = '1234-5678-1212-001';
         $params = new UserParams('orcid', $orcid);
@@ -49,5 +49,12 @@ class UserParamsTest extends \PHPUnit\Framework\TestCase
         $params = new UserParams('orcid', $orcid);
         $this->expectException(ImproperActionException::class);
         $params->getContent();
+    }
+
+    public function testClearOrcid(): void
+    {
+        $orcid = '';
+        $params = new UserParams('orcid', $orcid);
+        $this->assertSame('', $params->getContent());
     }
 }

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -79,11 +79,13 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     public function testClearOrcid(): void
     {
-        $this->assertEmpty($this->Users->userData['orcid']);
         $this->Users->patch(Action::Update, array('orcid' => '0000-0002-7494-5555'));
         $this->assertEquals('0000-0002-7494-5555', $this->Users->userData['orcid']);
 
         $this->Users->patch(Action::Update, array('orcid' => null));
+        $this->assertEmpty($this->Users->userData['orcid'], message: 'Orcid is not empty.');
+
+        $this->Users->patch(Action::Update, array('orcid' => ''));
         $this->assertEmpty($this->Users->userData['orcid'], message: 'Orcid is not empty.');
     }
 

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -77,6 +77,16 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         (new Users(4, 2, new Users(4, 2)))->patch(Action::Update, array('orcid' => 'blah'));
     }
 
+    public function testClearOrcid(): void
+    {
+        $this->assertEmpty($this->Users->userData['orcid']);
+        $this->Users->patch(Action::Update, array('orcid' => '0000-0002-7494-5555'));
+        $this->assertEquals('0000-0002-7494-5555', $this->Users->userData['orcid']);
+
+        $this->Users->patch(Action::Update, array('orcid' => null));
+        $this->assertEmpty($this->Users->userData['orcid'], message: 'Orcid is not empty.');
+    }
+
     public function testUpdatePreferences(): void
     {
         $prefsArr = array(


### PR DESCRIPTION
Feature req #5291 
- Allow sending null orcid to api
- test

No param api output:
![image](https://github.com/user-attachments/assets/dbf4a626-a041-44c8-9ade-8069c0310dfc)

Emptied : 

![image](https://github.com/user-attachments/assets/1f30d4c9-e72f-4eeb-a849-4d3e46733689)

