### PR TITLE
admin batch tags revamp

### DIFF
--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -33,12 +33,7 @@ class Batch implements RestInterface
     {
         $action = Action::from($reqBody['action']);
         if ($reqBody['items_tags']) {
-            $model = new Items($this->requester);
-            $Tags2Entity = new Tags2Entity($model->entityType);
-            $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['items_tags']);
-            // Format tags as associative array to be processed same way as other entries
-            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
-            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
+            $this->processTags($reqBody['items_tags'], new Items($this->requester), $action, $reqBody);
         }
         if ($reqBody['items_types']) {
             $model = new Items($this->requester);
@@ -57,11 +52,7 @@ class Batch implements RestInterface
             $this->processEntities($reqBody['experiments_status'], $model, FilterableColumn::Status, $action, $reqBody);
         }
         if ($reqBody['experiments_tags']) {
-            $model = new Experiments($this->requester);
-            $Tags2Entity = new Tags2Entity($model->entityType);
-            $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['experiments_tags']);
-            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
-            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
+            $this->processTags($reqBody['experiments_tags'], new Experiments($this->requester), $action, $reqBody);
         }
         if ($reqBody['users']) {
             // only process experiments
@@ -100,6 +91,15 @@ class Batch implements RestInterface
     {
         $entries = $this->getEntriesByIds($idArr, $model, $column);
         $this->loopOverEntries($entries, $model, $action, $params);
+    }
+
+    private function processTags(array $tags, AbstractConcreteEntity $model, Action $action, array $params): void
+    {
+        $Tags2Entity = new Tags2Entity($model->entityType);
+        $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $tags);
+        // Format tags as associative array to be processed the same way as other entries
+        $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
+        $this->loopOverEntries($tagEntries, $model, $action, $params);
     }
 
     private function getEntriesByIds(array $idArr, AbstractConcreteEntity $model, FilterableColumn $column): array

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -32,6 +32,14 @@ class Batch implements RestInterface
     public function postAction(Action $action, array $reqBody): int
     {
         $action = Action::from($reqBody['action']);
+        if ($reqBody['items_tags']) {
+            $model = new Items($this->requester);
+            $Tags2Entity = new Tags2Entity($model->entityType);
+            $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['items_tags']);
+            // Format tags as associative array to be processed same way as other entries
+            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
+            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
+        }
         if ($reqBody['items_types']) {
             $model = new Items($this->requester);
             $this->processEntities($reqBody['items_types'], $model, FilterableColumn::Category, $action, $reqBody);
@@ -48,18 +56,12 @@ class Batch implements RestInterface
             $model = new Experiments($this->requester);
             $this->processEntities($reqBody['experiments_status'], $model, FilterableColumn::Status, $action, $reqBody);
         }
-        if ($reqBody['tags']) {
-            $models = array(
-                'Experiments' => new Experiments($this->requester),
-                'Items' => new Items($this->requester),
-            );
-            foreach ($models as $model) {
-                $Tags2Entity = new Tags2Entity($model->entityType);
-                $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['tags']);
-                // Format tags as associative array to be processed same way as other entries
-                $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
-                $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
-            }
+        if ($reqBody['experiments_tags']) {
+            $model = new Experiments($this->requester);
+            $Tags2Entity = new Tags2Entity($model->entityType);
+            $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['experiments_tags']);
+            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
+            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
         }
         if ($reqBody['users']) {
             // only process experiments

--- a/src/models/Batch.php
+++ b/src/models/Batch.php
@@ -49,12 +49,17 @@ class Batch implements RestInterface
             $this->processEntities($reqBody['experiments_status'], $model, FilterableColumn::Status, $action, $reqBody);
         }
         if ($reqBody['tags']) {
-            $model = new Experiments($this->requester);
-            $Tags2Entity = new Tags2Entity($model->entityType);
-            $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['tags']);
-            // Format tags as associative array to be processed same way as other entries
-            $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
-            $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
+            $models = array(
+                'Experiments' => new Experiments($this->requester),
+                'Items' => new Items($this->requester),
+            );
+            foreach ($models as $model) {
+                $Tags2Entity = new Tags2Entity($model->entityType);
+                $targetIds = $Tags2Entity->getEntitiesIdFromTags('id', $reqBody['tags']);
+                // Format tags as associative array to be processed same way as other entries
+                $tagEntries = array_map(fn($id) => array('id' => $id), $targetIds);
+                $this->loopOverEntries($tagEntries, $model, $action, $reqBody);
+            }
         }
         if ($reqBody['users']) {
             // only process experiments

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -721,6 +721,20 @@
     </div>
 
   <hr>
+  <button type='button' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2' data-toggle-plus-icon='1' data-action='toggle-next' data-keep-icon='1' title='{{ 'Toggle display'|trans }}' aria-label='{{ 'Toggle display'|trans }}'><i class='fas fa-square-plus fa-fw link-like mr-2'></i>{{ 'Resources tags'|trans }} (<span class='counterValue'>0</span> {{ 'selected'|trans }})</button>
+  <div hidden class='mt-2'>
+    {% for tag in tagsArr %}
+      <div class='d-flex justify-content-between p-1 rounded hl-hover-gray'>
+        <label for='batch-itemsTags-{{ tag.id }}' class='col-form-label clickable'>{{ tag.tag }}</label>
+        <label class='switch ucp-align'>
+          <input type='checkbox' name='items_tags' value='{{ tag.id }}' autocomplete='off' data-action='update-counter-value' id='batch-itemsTags-{{ tag.id }}'>
+          <span class='slider'></span>
+        </label>
+      </div>
+    {% endfor %}
+  </div>
+
+  <hr>
   <button type='button' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2' data-toggle-plus-icon='1' data-action='toggle-next' data-keep-icon='1' title='{{ 'Toggle display'|trans }}' aria-label='{{ 'Toggle display'|trans }}'><i class='fas fa-square-plus fa-fw link-like mr-2'></i>{{ 'Experiments categories'|trans }} (<span class='counterValue'>0</span> {{ 'selected'|trans }})</button>
   <div hidden class='mt-2'>
   {% for experimentsCategory in experimentsCategoriesArr %}
@@ -749,13 +763,13 @@
     </div>
 
   <hr>
-  <button type='button' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2' data-toggle-plus-icon='1' data-action='toggle-next' data-keep-icon='1' title='{{ 'Toggle display'|trans }}' aria-label='{{ 'Toggle display'|trans }}'><i class='fas fa-square-plus fa-fw link-like mr-2'></i>{{ 'Tags'|trans }} (<span class='counterValue'>0</span> {{ 'selected'|trans }})</button>
+  <button type='button' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2' data-toggle-plus-icon='1' data-action='toggle-next' data-keep-icon='1' title='{{ 'Toggle display'|trans }}' aria-label='{{ 'Toggle display'|trans }}'><i class='fas fa-square-plus fa-fw link-like mr-2'></i>{{ 'Experiments tags'|trans }} (<span class='counterValue'>0</span> {{ 'selected'|trans }})</button>
   <div hidden class='mt-2'>
     {% for tag in tagsArr %}
       <div class='d-flex justify-content-between p-1 rounded hl-hover-gray'>
-        <label for='batch-tags-{{ tag.id }}' class='col-form-label clickable'>{{ tag.tag }}</label>
+        <label for='batch-experimentsTags-{{ tag.id }}' class='col-form-label clickable'>{{ tag.tag }}</label>
         <label class='switch ucp-align'>
-          <input type='checkbox' name='tags' value='{{ tag.id }}' autocomplete='off' data-action='update-counter-value' id='batch-tags-{{ tag.id }}'>
+          <input type='checkbox' name='experiments_tags' value='{{ tag.id }}' autocomplete='off' data-action='update-counter-value' id='batch-experimentsTags-{{ tag.id }}'>
           <span class='slider'></span>
         </label>
       </div>

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -77,9 +77,10 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       items_types: collectSelectable('items_types'),
       items_status: collectSelectable('items_status'),
+      items_tags: collectSelectable('items_tags'),
       experiments_status: collectSelectable('experiments_status'),
       experiments_categories: collectSelectable('experiments_categories'),
-      tags: collectSelectable('tags'),
+      experiments_tags: collectSelectable('experiments_tags'),
       users: collectSelectable('users'),
       target_owner: collectTargetOwner(),
       can: collectCan(),

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -47,7 +47,8 @@ interface Selected {
   experiments_status: number[];
   items_status: number[];
   items_types: number[];
-  tags: number[];
+  items_tags: number[];
+  experiments_tags: number[];
   users: number[];
   target_owner: number;
   can: string;

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -27,11 +27,12 @@ class BatchTest extends \PHPUnit\Framework\TestCase
         // Default values for $reqBody
         $this->baseReqBody = array(
             'action' => Action::Create->value,
+            'items_tags' => array(),
             'items_types' => array(),
             'items_status' => array(),
             'experiments_categories' => array(),
             'experiments_status' => array(),
-            'tags' => array(),
+            'experiments_tags' => array(),
             'users' => array(),
             // Only used if Action::UpdateOwner
             'target_owner' => null,
@@ -42,11 +43,12 @@ class BatchTest extends \PHPUnit\Framework\TestCase
     {
         $reqBody = $this->baseReqBody;
         $reqBody['action'] = Action::ForceUnlock->value;
+        $reqBody['items_tags'] = array(1, 2);
         $reqBody['items_types'] = array(1, 2);
         $reqBody['items_status'] = array(1, 2);
         $reqBody['experiments_categories'] = array(1, 2);
         $reqBody['experiments_status'] = array(1, 2);
-        $reqBody['tags'] = array(1, 2);
+        $reqBody['experiments_tags'] = array(1, 2);
         $reqBody['users'] = array(1, 2);
         $this->assertIsInt($this->Batch->postAction(Action::Create, $reqBody));
     }

--- a/web/admin.php
+++ b/web/admin.php
@@ -66,6 +66,12 @@ try {
         $ItemsTypes->canOrExplode('write');
     }
     $statusArr = $Status->readAll();
+    $sortedTags = (function () use ($TeamTags) {
+        $tagsArr = $TeamTags->readFull();
+        // return array sorted alphabetically, case-insensitive
+        usort($tagsArr, fn($a, $b) => strcasecmp($a['tag'], $b['tag']));
+        return $tagsArr;
+    })();
     $teamGroupsArr = $TeamGroups->readAll();
     $teamsArr = $Teams->readAll();
     $allTeamUsersArr = $App->Users->readAllFromTeam();
@@ -116,7 +122,7 @@ try {
         'Entity' => $ItemsTypes,
         'allTeamUsersArr' => $allTeamUsersArr,
         // all the tags for the team
-        'tagsArr' => $TeamTags->readFull(),
+        'tagsArr' => $sortedTags,
         'isSearching' => $isSearching,
         'itemsCategoryArr' => $itemsCategoryArr,
         'metadataGroups' => $metadataGroups,


### PR DESCRIPTION
- On batch actions, tags now act individually on either experiments or resources.
- On admin panel, tags are ordered alphabetically.

 :warning: edit : Draft 
-> one batch action for tags, will let user choose between either experiments, resources or both (default).

edit : reworking on some other stuff as well for all batch actions, to be updated

![image](https://github.com/user-attachments/assets/0151e877-010a-41ce-82bd-2e9f85c1b1ec)
![image](https://github.com/user-attachments/assets/37af5bb3-b893-4e9c-8e9d-4295c7aec149)
