### PR TITLE
bug/minor: editor: fix tinymce image plugin missing on mobile devices

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -210,7 +210,7 @@ export function getTinymceBaseConfig(page: string): object {
       },
     },
     mobile: {
-      plugins: [ 'save', 'lists', 'link', 'autolink' ],
+      plugins: [ 'autolink', 'image', 'link', 'lists', 'save' ],
     },
     // use a custom function for the save button in toolbar
     save_onsavecallback: (): Promise<void> => updateEntityBody(),


### PR DESCRIPTION
Fix #5338 
- adds the tinymce image plugin to mobile devices
![image](https://github.com/user-attachments/assets/ba5001ac-bc75-4d26-b80c-0a5213926484)
