### PR TITLE
ui: user menu: use initals instead of a generic icon

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -878,6 +878,8 @@ components:
           type: string
         lastname:
           type: string
+        initials:
+          type: string
         email:
           type: string
         validated:

--- a/src/models/AnonymousUser.php
+++ b/src/models/AnonymousUser.php
@@ -47,5 +47,6 @@ final class AnonymousUser extends Users
         $this->userData['pdf_format'] = 'A4';
         $this->userData['userid'] = 0;
         $this->userData['entrypoint'] = 1;
+        $this->userData['initials'] = '웃';
     }
 }

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -236,6 +236,10 @@ class Users implements RestInterface
             users.firstname, users.lastname, users.created_at, users.orgid, users.email, users.mfa_secret IS NOT NULL AS has_mfa_enabled,
             users.validated, users.archived, users.last_login, users.valid_until, users.is_sysadmin,
             CONCAT(users.firstname, ' ', users.lastname) AS fullname,
+            CONCAT(
+                LEFT(IFNULL(users.firstname, 'Anonymous'), 1),
+                LEFT(IFNULL(users.lastname, 'Anonymous'), 1)
+            ) AS initials,
             users.orcid, users.auth_service, sig_keys.pubkey AS sig_pubkey
             FROM users
             LEFT JOIN sig_keys ON (sig_keys.userid = users.userid AND state = :state)
@@ -578,7 +582,11 @@ class Users implements RestInterface
     protected function readOneFull(): array
     {
         $sql = "SELECT users.*, sig_keys.privkey AS sig_privkey, sig_keys.pubkey AS sig_pubkey,
-            CONCAT(users.firstname, ' ', users.lastname) AS fullname
+            CONCAT(users.firstname, ' ', users.lastname) AS fullname,
+            CONCAT(
+                LEFT(IFNULL(users.firstname, 'Anonymous'), 1),
+                LEFT(IFNULL(users.lastname, 'Anonymous'), 1)
+            ) AS initials
             FROM users
             LEFT JOIN sig_keys ON (sig_keys.userid = users.userid AND state = :state)
             WHERE users.userid = :userid";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1559,3 +1559,10 @@ input:checked + .slider::before {
     }
   }
 }
+
+/* top right button */
+.initials {
+  font-weight: bold;
+  color: $secondlevel;
+  font-size: 1.5rem;
+}

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -122,7 +122,7 @@
 
         {# User dropdown #}
         <div class='nav-item dropdown'>
-          <button class='btn nav-link border-0' id='navbarDropdown' type='button' aria-label='{{ 'User menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><i class='fas fa-user fa-2x'></i></button>
+          <button class='btn nav-link border-0' id='navbarDropdown' type='button' aria-label='{{ 'User menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><span class='initials'>{{ App.Users.userData.initials }}</span></button>
           <div class='dropdown-menu dropdown-menu-right' aria-labelledby='navbarDropdown'><h6 class='dropdown-header'>{{ 'Logged in as %s in:'|trans|format(App.Users.userData.firstname|default('Anonymous')) }}<br>{{ App.teamArr.name }}</h6>
             {% if App.Users.userData.teams|length > 1 %}
               <a href='login.php?switch_team=1' class='dropdown-item'><i class='fas fa-repeat fa-fw'></i> {{ 'Switch team'|trans }}</a>


### PR DESCRIPTION
Having initials in the top right menu facilitates the identification of the current user and could prevent incorrect usage. Fix #5342

