### PR TITLE
New default value: users should NOT be allowed to change identity

### DIFF
--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -193,7 +193,7 @@ final class Config implements RestInterface
             ('onboarding_email_different_for_admins', '0'),
             ('onboarding_email_admins_subject', NULL),
             ('onboarding_email_admins_body', NULL),
-            ('allow_users_change_identity', '1')";
+            ('allow_users_change_identity', '0')";
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':schema', $schema);

--- a/src/sql/schema162.sql
+++ b/src/sql/schema162.sql
@@ -1,3 +1,3 @@
 -- schema 162
-INSERT INTO config (conf_name, conf_value) VALUES ('allow_users_change_identity', '1');
+INSERT INTO config (conf_name, conf_value) VALUES ('allow_users_change_identity', '0');
 UPDATE config SET conf_value = 162 WHERE conf_name = 'schema';


### PR DESCRIPTION
This changes the default introduced in https://github.com/elabftw/elabftw/pull/5202 (see description in [the 5.1 release notes](https://www.deltablot.com/posts/release-50100/#new-sysconfig-setting-to-prevent-users-from-changing-their-identity)).

The new default is to _disallow_ users from changing their name and email. The change in default affects
* new instances and
* instances that upgrade (starting with whichever version the current hypernext becomes).

It does not change the state of systems that have upgraded to 5.1.0.