### PR TITLE
Misc ui adjustments

### DIFF
--- a/src/templates/link-view-one.html
+++ b/src/templates/link-view-one.html
@@ -1,38 +1,40 @@
 {# required vars:
   link: the link to display
   mode: edit edit-template view etc... #}
-<div class='ml-3 mt-3 col-md-12 countable hl-hover-superlight p-1 rounded'>
-  {% set randomId = random() %}
-  <div class='d-flex mb-1 align-items-center' id='parent_{{ randomId }}'>
-    <i class='fas fa-link fa-fw mr-2'></i>
-    {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
-    {% if link.category_title %}
-      <span class='catstat-btn category-btn mr-1' style='--bg: #{{ link.category_color }}'>{{ link.category_title }}</span>
-    {% endif %}
-    {% if link.status_title %}
-      <span class='catstat-btn status-btn mr-1' style='--bg: #{{ link.status_color }}'>{{ link.status_title }}</span>
-    {% endif %}
-    {% if link.custom_id %}
-      <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
-    {% endif %}
-    <a href='{{ link.page }}?mode=view&amp;id={{ link.entityid }}' class='text-dark mr-auto hl-hover-gray p-1 rounded'>{{ link.title }}</a>
-    {# toggle body #}
-    <button type='button' data-type='{{ link.type }}' data-action='toggle-body' data-toggle-plus-icon='1' data-id='{{ link.entityid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
-      <i class='fas fa-fw fa-square-plus'></i>
-    </button>
-    {% if mode == 'edit' %}
-      <button type='button' data-action='import-links' data-target='{{ link.entityid }}' aria-label='{{ 'Import links'|trans }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-        <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
-      <button type='button' data-action='import-link-body' data-endpoint='{{ link.type }}' data-target='{{ link.entityid }}' aria-label='{{ 'Import'|trans }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-        <i class='fas fa-fw fa-lg fa-file-import'></i></button>
-    {% endif %}
-    <button type='button' data-action='destroy-{{ isRelated|default(false) ? 'related-' }}link' data-endpoint='{{ link.type }}_links' data-target='{{ link.entityid }}' aria-label='{{ 'Delete'|trans }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
-      <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
-  </div>
-  {# container to hold the body of the entity if it is toggled with the +/- icon #}
-  {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
-  <div hidden id='{{ randomId }}'>
-    {# this div will hold the content #}
-    <div></div>
+<div class="col-md-12 ">
+  <div class='ml-3 mt-3 countable hl-hover-superlight p-1 rounded'>
+    {% set randomId = random() %}
+    <div class='d-flex mb-1 align-items-center' id='parent_{{ randomId }}'>
+      <i class='fas fa-link fa-fw mr-2'></i>
+      {% if link.link_state == 2 %}<i class='fas fa-fw fa-box-archive fa-fw mr-1'></i>{% endif %}
+      {% if link.category_title %}
+        <span class='catstat-btn category-btn mr-1' style='--bg: #{{ link.category_color }}'>{{ link.category_title }}</span>
+      {% endif %}
+      {% if link.status_title %}
+        <span class='catstat-btn status-btn mr-1' style='--bg: #{{ link.status_color }}'>{{ link.status_title }}</span>
+      {% endif %}
+      {% if link.custom_id %}
+        <span class='custom-id-badge' title='{{ 'Custom ID'|trans }}'>{{ link.custom_id }}</span>
+      {% endif %}
+      <a href='{{ link.page }}?mode=view&amp;id={{ link.entityid }}' class='text-dark mr-auto hl-hover-gray p-1 rounded'>{{ link.title }}</a>
+      {# toggle body #}
+      <button type='button' data-type='{{ link.type }}' data-action='toggle-body' data-toggle-plus-icon='1' data-id='{{ link.entityid }}' data-randid='{{ randomId }}' title='{{ 'Toggle content'|trans }}' aria-label='{{ 'Toggle content'|trans }}' class='btn p-2 hl-hover-gray mr-3 lh-normal border-0 my-n2'>
+        <i class='fas fa-fw fa-square-plus'></i>
+      </button>
+      {% if mode == 'edit' %}
+        <button type='button' data-action='import-links' data-target='{{ link.entityid }}' aria-label='{{ 'Import links'|trans }}' title='{{ 'Import links'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+          <i class='fas fa-fw fa-arrows-down-to-line'></i></button>
+        <button type='button' data-action='import-link-body' data-endpoint='{{ link.type }}' data-target='{{ link.entityid }}' aria-label='{{ 'Import'|trans }}' title='{{ 'Import'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+          <i class='fas fa-fw fa-lg fa-file-import'></i></button>
+      {% endif %}
+      <button type='button' data-action='destroy-{{ isRelated|default(false) ? 'related-' }}link' data-endpoint='{{ link.type }}_links' data-target='{{ link.entityid }}' aria-label='{{ 'Delete'|trans }}' title='{{ 'Delete'|trans }}' class='btn p-2 hl-hover-gray lh-normal border-0 my-n2'>
+        <i class='fas fa-fw fa-lg fa-trash-alt'></i></button>
+    </div>
+    {# container to hold the body of the entity if it is toggled with the +/- icon #}
+    {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
+    <div hidden id='{{ randomId }}'>
+      {# this div will hold the content #}
+      <div></div>
+    </div>
   </div>
 </div>

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -12,7 +12,7 @@
 {% set icon = 'eye' %}
 {% set label = 'Visibility'|trans %}
 {% set modalTitle = 'Select who can see this entry'|trans %}
-{% if rw == 'canwrite' %}
+{% if rw == 'canwrite' or rw == 'canwrite_target' %}
   {% set icon = 'pencil-alt' %}
   {% set label = 'Can write'|trans %}
   {% set modalTitle = 'Select who can edit this entry'|trans %}

--- a/src/ts/JsonEditorActions.class.ts
+++ b/src/ts/JsonEditorActions.class.ts
@@ -38,7 +38,9 @@ export class JsonEditorActions {
         } else if (el.matches('[data-action="json-save-file"]')) {
           JsonEditorHelperC.saveNewFile();
         } else if (el.matches('[data-action="json-saveas-file"]')) {
-          saveStringAsFile(JsonEditorHelperC.askFilename(), JSON.stringify(JsonEditorHelperC.editor.get()));
+          const realName = JsonEditorHelperC.askFilename();
+          if (!realName) return;
+          saveStringAsFile(realName, JSON.stringify(JsonEditorHelperC.editor.get()));
         } else if (el.matches('[data-action="json-save"]')) {
           JsonEditorHelperC.save();
           // make the save button stand out if the content is changed


### PR DESCRIPTION
- fix links block outside of parent
- wording on edit modal for template permissions - derived experiments
- json editor : when modal prompts, if you click "cancel" it would still download a file named undefined, no type (or json.txt on Chrom-)

![Capture d’écran du 2024-11-25 18-44-12](https://github.com/user-attachments/assets/c9fc8757-3089-42bb-9ef5-e3b6df0aa58f)
![Capture d’écran du 2024-11-25 18-44-26](https://github.com/user-attachments/assets/243e9d27-9012-41b5-92e8-78e3658caca7)


![Capture d’écran du 2024-11-25 18-41-07](https://github.com/user-attachments/assets/bab29d7d-d9f7-4ff2-90fb-3b668296e8c3)

![Capture d’écran du 2024-11-25 19-51-51](https://github.com/user-attachments/assets/942de5a7-8324-4260-bc48-714a010ba64b)
