### PR TITLE
feat/minor: ability to reset status on selected entities

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -303,6 +303,7 @@ components:
           type: string
         custom_id:
           type: integer
+          description: Cannot be negative. Can be reset with "0", null or empty string.
         date:
           type: string
         elabid:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -285,6 +285,7 @@ components:
         category:
           type: integer
           nullable: true
+          description: Cannot be negative nor empty string. Can be reset with "0" and null.
         category_color:
           type: string
           nullable: true
@@ -371,6 +372,7 @@ components:
         status:
           type: integer
           nullable: true
+          description: Cannot be negative nor empty string. Can be reset with "0" and null.
         status_color:
           type: string
           nullable: true

--- a/src/Params/ContentParams.php
+++ b/src/Params/ContentParams.php
@@ -64,9 +64,9 @@ class ContentParams implements ContentParamsInterface
         return (int) $this->content;
     }
 
-    protected function getIntOrNull(): ?int
+    protected function getPositiveIntOrNull(): ?int
     {
-        return $this->getInt() === 0 ? null : $this->getInt();
+        return $this->getInt() <= 0 ? null : $this->getInt();
     }
 
     protected function getUrl(): string

--- a/src/Params/EntityParams.php
+++ b/src/Params/EntityParams.php
@@ -31,7 +31,7 @@ class EntityParams extends ContentParams implements ContentParamsInterface
             'canread', 'canwrite', 'canbook', 'canread_target', 'canwrite_target' => Check::Visibility($this->content),
             'color' => Check::color($this->content),
             'is_bookable', 'book_can_overlap', 'book_users_can_in_past', 'book_max_minutes', 'book_max_slots', 'book_is_cancellable', 'book_cancel_minutes', 'content_type', 'is_procurable', 'proc_pack_qty', 'rating', 'userid', 'state' => $this->getInt(),
-            'custom_id', 'status', 'category' => $this->getIntOrNull(),
+            'custom_id', 'status', 'category' => $this->getPositiveIntOrNull(),
             default => throw new ImproperActionException('Invalid update target.'),
         };
     }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -349,12 +349,10 @@ abstract class AbstractEntity implements RestInterface
             'Content type' => $params['content_type'] ?? null,
             'Custom Id' => $params['customId'] ?? null,
         );
-
         foreach ($fieldsToValidate as $fieldName => $fieldValue) {
-            if (isset($fieldValue)) {
-                $this->validateField($fieldValue, $fieldName);
-            }
+            $this->validateField((int) $fieldValue, $fieldName);
         }
+
         // if there is an active exclusive edit mode, entity cannot be modified
         // only user who locked can do everything
         // (sys)admin can remove locks
@@ -759,9 +757,9 @@ abstract class AbstractEntity implements RestInterface
         }
     }
 
-    private function validateField(int $fieldValue, string $fieldName): void
+    private function validateField(?int $fieldValue, string $fieldName): void
     {
-        if ($fieldValue < 0) {
+        if ($fieldValue !== null && $fieldValue < 0) {
             throw new IllegalActionException("$fieldName must be a non-negative integer.");
         }
     }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -341,18 +341,6 @@ abstract class AbstractEntity implements RestInterface
         if ($action !== Action::Pin) {
             $this->canOrExplode('write');
         }
-
-        // Integer fields that need validation (cannot be negative)
-        $fieldsToValidate = array(
-            'Category' => $params['category'] ?? null,
-            'Status' => $params['status'] ?? null,
-            'Content type' => $params['content_type'] ?? null,
-            'Custom Id' => $params['customId'] ?? null,
-        );
-        foreach ($fieldsToValidate as $fieldName => $fieldValue) {
-            $this->validateField((int) $fieldValue, $fieldName);
-        }
-
         // if there is an active exclusive edit mode, entity cannot be modified
         // only user who locked can do everything
         // (sys)admin can remove locks
@@ -754,13 +742,6 @@ abstract class AbstractEntity implements RestInterface
         $searchError = $advancedQuery->getException();
         if (!empty($searchError)) {
             throw new ImproperActionException('Error with extended search: ' . $searchError);
-        }
-    }
-
-    private function validateField(?int $fieldValue, string $fieldName): void
-    {
-        if ($fieldValue !== null && $fieldValue < 0) {
-            throw new IllegalActionException("$fieldName must be a non-negative integer.");
         }
     }
 }

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -341,6 +341,20 @@ abstract class AbstractEntity implements RestInterface
         if ($action !== Action::Pin) {
             $this->canOrExplode('write');
         }
+
+        // Integer fields that need validation (cannot be negative)
+        $fieldsToValidate = array(
+            'Category' => $params['category'] ?? null,
+            'Status' => $params['status'] ?? null,
+            'Content type' => $params['content_type'] ?? null,
+            'Custom Id' => $params['customId'] ?? null,
+        );
+
+        foreach ($fieldsToValidate as $fieldName => $fieldValue) {
+            if (isset($fieldValue)) {
+                $this->validateField($fieldValue, $fieldName);
+            }
+        }
         // if there is an active exclusive edit mode, entity cannot be modified
         // only user who locked can do everything
         // (sys)admin can remove locks
@@ -742,6 +756,13 @@ abstract class AbstractEntity implements RestInterface
         $searchError = $advancedQuery->getException();
         if (!empty($searchError)) {
             throw new ImproperActionException('Error with extended search: ' . $searchError);
+        }
+    }
+
+    private function validateField(int $fieldValue, string $fieldName): void
+    {
+        if ($fieldValue < 0) {
+            throw new IllegalActionException("$fieldName must be a non-negative integer.");
         }
     }
 }

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -235,6 +235,7 @@
             <option selected disabled value=''>
               {{ 'Change category'|trans }}
             </option>
+            <option value='0'>{{ 'Not set'|trans }}</option>
             {% for category in categoryArr %}
                 <option value='{{ category.id }}'>{{ category.title }}</option>
             {% endfor %}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -244,6 +244,7 @@
             <option selected disabled value=''>
               {{ 'Change status'|trans }}
             </option>
+            <option value='0'>{{ 'Not set'|trans }}</option>
             {% for status in statusArr %}
                 <option value='{{ status.id }}'>{{ status.title }}</option>
             {% endfor %}

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -99,6 +99,14 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->Experiments->patch(Action::Update, array('category' => '3')));
     }
 
+    public function testUpdateWithNegativeInt(): void
+    {
+        $this->Experiments->setId(1);
+        $this->assertIsArray($this->Experiments->patch(Action::Update, array('category' => '-3', 'custom_id' => '-5')));
+        $this->assertNull($this->Experiments->entityData['category']);
+        $this->assertNull($this->Experiments->entityData['custom_id']);
+    }
+
     public function testSign(): void
     {
         $this->Experiments->setId(1);


### PR DESCRIPTION
Request #5377 
- Allow reseting status & category on entities multi-select
- Prevent invalid integers on API
- Add some related doc

![image](https://github.com/user-attachments/assets/a0d0588b-5b80-472f-b080-52f2c5a6d417)
![image](https://github.com/user-attachments/assets/07551b3d-53ee-4195-95db-1b45f6f4c42f)
![image](https://github.com/user-attachments/assets/ac22df67-2c1d-4ded-ac9e-80b330a451bf)

