### PR TITLE
feat:minor: mask colon (:) for autocomplete searches

### DIFF
--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -558,7 +558,7 @@ export function escapeExtendedQuery(searchTerm: string): string {
   });
 
   // 2) mask special characters of extended search query by single character wildcard
-  ['!', '|', '&', '(', ')', '"', '\''].forEach(specialChar => {
+  ['!', '|', '&', '(', ')', '"', '\'', ':'].forEach(specialChar => {
     searchTerm = searchTerm.replaceAll(specialChar, '_');
   });
 


### PR DESCRIPTION
Closes #5376

Note: We are not actually searching for `:` but we replace it with a wildcard (`_`) that matches any character so the search result might also contain additional results.

![image](https://github.com/user-attachments/assets/b902a81c-c64f-4f25-967e-2eeced3f0321)

![image](https://github.com/user-attachments/assets/e5b46b04-0d01-462c-8a1c-dbe2143c074a)


![image](https://github.com/user-attachments/assets/d00585c3-0691-4212-aaae-60d82a5c60e1)

![image](https://github.com/user-attachments/assets/0c1fa4d5-e3c8-4f6b-98cd-9b84c882fb1b)


![image](https://github.com/user-attachments/assets/b97a15bb-76d8-4a1f-b982-b77bed44b5ae)

![image](https://github.com/user-attachments/assets/367a3263-4ac5-49cf-bc30-00623d7da9d7)
