### PR TITLE
feat/minor: allow adding extra fields to undefined group

### DIFF
--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -30,9 +30,7 @@
               <hr>
             </div>
             <select id='newFieldGroupSelect' class='form-control' autocomplete='off'>
-              {% if not metadataGroups or metadataGroups[0].id == -1 %}
-                <option value='-1'>{{ 'Undefined group'|trans }}</option>
-              {% endif %}
+              <option value='-1'>{{ 'Undefined group'|trans }}</option>
               {% for group in metadataGroups %}
                 <option value='{{ group.id }}'>{{ group.name }}</option>
               {% endfor %}

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -29,12 +29,14 @@
               {# TODO delete a group #}
               <hr>
             </div>
-            <select id='newFieldGroupSelect' class='form-control' autocomplete='off'>
-              <option value='-1'>{{ 'Undefined group'|trans }}</option>
-              {% for group in metadataGroups %}
-                <option value='{{ group.id }}'>{{ group.name }}</option>
-              {% endfor %}
-            </select>
+          <select id='newFieldGroupSelect' class='form-control' autocomplete='off'>
+            {% if not metadataGroups or metadataGroups|filter(group => group.id == -1)|length == 0 %}
+             <option value='-1'>{{ 'Undefined group'|trans }}</option>
+            {% endif %}
+            {% for group in metadataGroups %}
+              <option value='{{ group.id }}'>{{ group.name }}</option>
+            {% endfor %}
+          </select>
             <label for='newFieldTypeSelect'>{{ 'Field type'|trans }}</label>
             <select id='newFieldTypeSelect' class='form-control' autocomplete='off'>
               <option value='text'>{{ 'Text'|trans }}</option>

--- a/src/templates/field-builder-modal.html
+++ b/src/templates/field-builder-modal.html
@@ -29,14 +29,14 @@
               {# TODO delete a group #}
               <hr>
             </div>
-          <select id='newFieldGroupSelect' class='form-control' autocomplete='off'>
-            {% if not metadataGroups or metadataGroups|filter(group => group.id == -1)|length == 0 %}
-             <option value='-1'>{{ 'Undefined group'|trans }}</option>
-            {% endif %}
-            {% for group in metadataGroups %}
-              <option value='{{ group.id }}'>{{ group.name }}</option>
-            {% endfor %}
-          </select>
+            <select id='newFieldGroupSelect' class='form-control' autocomplete='off'>
+              {% if not metadataGroups or metadataGroups|filter(group => group.id == -1)|length == 0 %}
+                <option value='-1'>{{ 'Undefined group'|trans }}</option>
+              {% endif %}
+              {% for group in metadataGroups %}
+                <option value='{{ group.id }}'>{{ group.name }}</option>
+              {% endfor %}
+            </select>
             <label for='newFieldTypeSelect'>{{ 'Field type'|trans }}</label>
             <select id='newFieldTypeSelect' class='form-control' autocomplete='off'>
               <option value='text'>{{ 'Text'|trans }}</option>


### PR DESCRIPTION
Enhancement #5360 

Previously, extra fields went to Undefined group only when no groups existed. When a group is created in the extra fields, the "Undefined group" would no longer be available.

- Allows adding new extra fields to the undefined group when other groups already exist

