### PR TITLE
Add support for multiple LDAP hosts

### DIFF
--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -250,7 +250,7 @@ class LoginController implements ControllerInterface
                 }
                 $ldapConfig = array(
                     'protocol' => $c['ldap_scheme'] . '://',
-                    'hosts' => array($c['ldap_host']),
+                    'hosts' => explode(',', $c['ldap_host']),
                     'port' => (int) $c['ldap_port'],
                     'base_dn' => $c['ldap_base_dn'],
                     'username' => $c['ldap_username'],

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -855,7 +855,7 @@
       <label for='ldap_host' class='col-form-label'>{{ 'LDAP Host'|trans }}</label>
       <input class='form-control col-md-3' type='text' data-trigger='blur' data-model='config' data-target='ldap_host' placeholder='ldap' value='{{ App.Config.configArr.ldap_host }}' id='ldap_host' />
     </div>
-    <p class='smallgray'>{{ 'Domain name or IP address'|trans }}</p>
+    <p class='smallgray'>{{ 'Domain name or IP address. You can specify multiple entries for redundancy, separated by commas.'|trans }}</p>
     <hr>
 
     <div class='d-flex justify-content-between'>


### PR DESCRIPTION
Inspired by the `ldap_search_attr` field, which supports multiple attributes separated by commas, this change introduces support for multiple hostnames or IPs in the `ldap_host` field, also separated by commas.

This enhancement enables the use of several LDAP servers, improving redundancy and reliability.

Make sure to read [the contributing documentation](https://doc.elabftw.net/contributing.html).

IMPORTANT: Base your PR off the 'hypernext' branch for a feature, and branch `next` for a bugfix.

IMPORTANT: all new features MUST be have tests added.

Also please note that working on a PR doesn't automatically means that your code will be merged.
