### PR TITLE
feat: qrcode: add options for qr code generation

### DIFF
--- a/src/Make/MakeQrPng.php
+++ b/src/Make/MakeQrPng.php
@@ -23,7 +23,7 @@ use RobThree\Auth\Providers\Qr\IQRCodeProvider;
 use function strlen;
 
 /**
- * Generate a PNG image with a QR Code pointing to the URL of the Entity, and possibly the title below it
+ * Generate a PNG image with a QR Code pointing to the URL of the Entity, and optionally include the title
  */
 class MakeQrPng extends AbstractMake implements StringMakerInterface
 {

--- a/src/Make/MakeQrPng.php
+++ b/src/Make/MakeQrPng.php
@@ -37,6 +37,8 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
 
     private const int DEFAULT_MAX_LINES = 2;
 
+    private const int SPACE_UNDER_QR = 15;
+
     protected string $contentType = 'image/png';
 
     private int $fontSize = 16;
@@ -78,16 +80,14 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
         // Create a new image to hold the qrcode + text
         $newImage = new Imagick();
         $qrCodeWidth = $qrCode->getImageWidth();
-        //$title = mb_substr($this->entity->entityData['title'], 0, $this->maxLineChars);
-        //$titleLength = mb_strlen($title);
 
-        //$splitTitle = mb_str_split($this->entity->entityData['title'], $this->getTitleSplitSize());
-        $splitTitle = $this->splitTitle($this->entity->entityData['title']);
-        if (!$this->withTitle) {
-            $splitTitle = array();
+        $splitTitle = array();
+        $titleWidth = 0;
+        if ($this->withTitle) {
+            $splitTitle = $this->splitTitle($this->entity->entityData['title']);
+            $titleWidth =  mb_strlen($splitTitle[0]) * self::CHAR_WIDTH_PX;
         }
 
-        $titleWidth =  mb_strlen($splitTitle[0]) * self::CHAR_WIDTH_PX;
         if ($titleWidth < $qrCodeWidth) {
             $titleWidth = $qrCodeWidth;
         }
@@ -97,14 +97,12 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
         // Copy the original image to the new image
         $newImage->compositeImage($qrCode, Imagick::COMPOSITE_OVER, 0, 0);
         // Draw the text on the new image
-        $spaceUnderQr = 10;
         $titleMarginLeft = 10;
         if ($this->size < 100) {
-            $spaceUnderQr = 15;
             $titleMarginLeft = 5;
         }
         foreach ($splitTitle as $key => $line) {
-            $newImage->annotateImage($draw, $titleMarginLeft, $qrCode->getImageHeight() + (((int) $key + 1) * $spaceUnderQr), 0, $line);
+            $newImage->annotateImage($draw, $titleMarginLeft, $qrCode->getImageHeight() + (((int) $key + 1) * self::SPACE_UNDER_QR), 0, $line);
         }
         $newImage->setImageFormat('png');
 

--- a/src/Make/MakeQrPng.php
+++ b/src/Make/MakeQrPng.php
@@ -23,15 +23,19 @@ use RobThree\Auth\Providers\Qr\IQRCodeProvider;
 use function strlen;
 
 /**
- * Make a PNG from one or several experiments or db items showing only minimal info with QR codes
+ * Generate a PNG image with a QR Code pointing to the URL of the Entity, and possibly the title below it
  */
 class MakeQrPng extends AbstractMake implements StringMakerInterface
 {
     private const int DEFAULT_IMAGE_SIZE_PX = 250;
 
+    private const int CHAR_WIDTH_PX = 8;
+
     private const int LINE_HEIGHT_PX = 20;
 
-    private const int SPLIT_FACTOR = 8;
+    private const int DEFAULT_MAX_LINE_CHARS = 42;
+
+    private const int DEFAULT_MAX_LINES = 2;
 
     protected string $contentType = 'image/png';
 
@@ -42,14 +46,15 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
         private AbstractEntity $entity,
         private int $size,
         private bool $withTitle = true,
+        private int $maxLines = 0,
+        private int $maxLineChars = 0,
     ) {
         // 0 means no query parameter for size
         $this->size = $this->size > 0 ? $this->size : self::DEFAULT_IMAGE_SIZE_PX;
+        $this->maxLineChars = $this->maxLineChars > 0 ? $this->maxLineChars : self::DEFAULT_MAX_LINE_CHARS;
+        $this->maxLines = $this->maxLines > 0 ? $this->maxLines : self::DEFAULT_MAX_LINES;
     }
 
-    /**
-     * Get the name of the generated file
-     */
     public function getFileName(): string
     {
         return sprintf(
@@ -69,20 +74,37 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
         $draw->setFont(dirname(__DIR__, 2) . '/vendor/mpdf/mpdf/ttfonts/Sun-ExtA.ttf');
         $draw->setFontSize($this->fontSize);
 
-        $splitTitle = mb_str_split($this->entity->entityData['title'], $this->getTitleSplitSize());
-        if (!$this->withTitle) {
-            $splitTitle = array();
-        }
-        $fullHeight = $qrCode->getImageHeight() + (count($splitTitle) * self::LINE_HEIGHT_PX);
 
         // Create a new image to hold the qrcode + text
         $newImage = new Imagick();
-        $newImage->newImage($qrCode->getImageWidth(), $fullHeight, new ImagickPixel('white'));
+        $qrCodeWidth = $qrCode->getImageWidth();
+        //$title = mb_substr($this->entity->entityData['title'], 0, $this->maxLineChars);
+        //$titleLength = mb_strlen($title);
+
+        //$splitTitle = mb_str_split($this->entity->entityData['title'], $this->getTitleSplitSize());
+        $splitTitle = $this->splitTitle($this->entity->entityData['title']);
+        if (!$this->withTitle) {
+            $splitTitle = array();
+        }
+
+        $titleWidth =  mb_strlen($splitTitle[0]) * self::CHAR_WIDTH_PX;
+        if ($titleWidth < $qrCodeWidth) {
+            $titleWidth = $qrCodeWidth;
+        }
+        $qrCodeWidth += $titleWidth - $qrCodeWidth;
+        $height = $qrCode->getImageHeight() + (count($splitTitle) * self::LINE_HEIGHT_PX);
+        $newImage->newImage($qrCodeWidth, $height, new ImagickPixel('white'));
         // Copy the original image to the new image
         $newImage->compositeImage($qrCode, Imagick::COMPOSITE_OVER, 0, 0);
         // Draw the text on the new image
+        $spaceUnderQr = 10;
+        $titleMarginLeft = 10;
+        if ($this->size < 100) {
+            $spaceUnderQr = 15;
+            $titleMarginLeft = 5;
+        }
         foreach ($splitTitle as $key => $line) {
-            $newImage->annotateImage($draw, 10, $qrCode->getImageHeight() + ($key * 20), 0, $line);
+            $newImage->annotateImage($draw, $titleMarginLeft, $qrCode->getImageHeight() + (((int) $key + 1) * $spaceUnderQr), 0, $line);
         }
         $newImage->setImageFormat('png');
 
@@ -92,16 +114,17 @@ class MakeQrPng extends AbstractMake implements StringMakerInterface
         return $blob;
     }
 
-    /**
-     * @return positive-int
-     */
-    private function getTitleSplitSize(): int
+    private function splitTitle(string $title): array
     {
-        $res = abs(intdiv($this->size, self::SPLIT_FACTOR));
-        if ($res <= 1) {
-            return 1;
+        $result = array();
+        $length = mb_strlen($title);
+
+        for ($i = 0; $i < $length; $i += $this->maxLineChars) {
+            $result[] = mb_substr($title, $i, $this->maxLineChars);
+            if (count($result) === $this->maxLines) {
+                break;
+            }
         }
-        // remove one to fix swallowed up characters
-        return $res - 1;
+        return $result;
     }
 }

--- a/src/controllers/MakeController.php
+++ b/src/controllers/MakeController.php
@@ -109,7 +109,14 @@ class MakeController extends AbstractController
                 if (count($this->entityArr) !== 1) {
                     throw new ImproperActionException('QR PNG format is only suitable for one ID.');
                 }
-                return (new MakeQrPng(new MpdfQrProvider(), $this->entityArr[0], $this->Request->query->getInt('size'), $withTitle))->getResponse();
+                return (new MakeQrPng(
+                    new MpdfQrProvider(),
+                    $this->entityArr[0],
+                    $this->Request->query->getInt('size'),
+                    $withTitle,
+                    $this->Request->query->getInt('titleLines'),
+                    $this->Request->query->getInt('titleChars'),
+                ))->getResponse();
 
             case ExportFormat::SchedulerReport:
                 return $this->makeSchedulerReport();

--- a/src/templates/export-menu.html
+++ b/src/templates/export-menu.html
@@ -85,6 +85,24 @@
           </label>
         </div>
 
+        {# MAX LINES #}
+        <div class='d-flex justify-content-between mb-2'>
+          <div>
+            <label class='d-inline mr-1' for='qrpng_exportTitleLines'>{{ 'Number of lines for title'|trans }}</label>
+            <p class='smallgray'>{{ 'Split the title into this many lines'|trans }}</p>
+          </div>
+          <input type='number' min='1' max='1337' class='form-control col-md-3' value='2' id='qrpng_exportTitleLines'>
+        </div>
+
+        {# MAX LINE SIZE #}
+        <div class='d-flex justify-content-between mb-2'>
+          <div>
+            <label class='d-inline mr-1' for='qrpng_exportTitleChars'>{{ 'Number of characters per line'|trans }}</label>
+            <p class='smallgray'>{{ 'Adjust how the title is displayed'|trans }}</p>
+          </div>
+          <input type='number' min='1' max='1337' class='form-control col-md-3' value='29' id='qrpng_exportTitleChars'>
+        </div>
+
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -189,7 +189,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="export-to-qrpng"]')) {
       const size = (document.getElementById('qrpng_exportSize') as HTMLInputElement).value;
       const title = (document.getElementById('qrpng_exportTitle') as HTMLInputElement).checked ? 1: 0;
-      window.open(`/api/v2/${el.dataset.type}/${el.dataset.id}?format=qrpng&size=${size}&withTitle=${title}`, '_blank');
+      const titleLines = (document.getElementById('qrpng_exportTitleLines') as HTMLInputElement).value;
+      const titleChars = (document.getElementById('qrpng_exportTitleChars') as HTMLInputElement).value;
+      window.open(`/api/v2/${el.dataset.type}/${el.dataset.id}?format=qrpng&size=${size}&withTitle=${title}&titleLines=${titleLines}&titleChars=${titleChars}`, '_blank');
     // CANCEL REQUEST ACTION
     } else if (el.matches('[data-action="cancel-requestable-action"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {


### PR DESCRIPTION
Address issue with shrunk title for small qr code sizes. Add options to control the number of lines and characters for title. Fix #5442

## New options in export modal:

![2025-01-28-102242_496x430_scrot](https://github.com/user-attachments/assets/16eddca6-50d2-448a-9e89-84684830a12a)

## Various examples with different settings
![1](https://github.com/user-attachments/assets/51bd5682-9739-4195-bc08-42a7518e2b0a)

![1-42](https://github.com/user-attachments/assets/5c7e3489-54e9-45f5-8e75-76e2239a063f)

![1-6](https://github.com/user-attachments/assets/cfa477a7-83c2-4ff7-8381-59fa048020e9)

![4-8](https://github.com/user-attachments/assets/06ddb8da-e58d-451e-8216-9a6ae25ad4fa)

![1-80](https://github.com/user-attachments/assets/b22dd825-8b92-496e-8030-94102c20966d)





