### PR TITLE
Enable tinymce mention plugin in mobile mode

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -322,7 +322,7 @@ export function getTinymceBaseConfig(page: string): object {
       },
     },
     mobile: {
-      plugins: [ 'autolink', 'image', 'link', 'lists', 'save' ],
+      plugins: [ 'autolink', 'image', 'link', 'lists', 'save', 'mention' ],
     },
     // use a custom function for the save button in toolbar
     save_onsavecallback: (): Promise<void> => updateEntityBody(),


### PR DESCRIPTION
Unlike stated in #5481, I was not able to trigger the plugin with # in the Responsive Design Mode (on Windows 11 with Firefox 135.0.1) before applying this patch. However, I did not try all devices listed.

Closes #5481.
