### PR TITLE
misc UX on show pages

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1093,11 +1093,11 @@ paths:
                     Set the content type for main text: 1 for HTML (default) and 2 for Markdown
                   example: 1
                 metadata:
-                  type: string
+                  type: object
                   nullable: true
                   description: The metadata in JSON format
                   default: null
-                  example: '{ "extra_fields": { "For example": { "type": "text", "value": "With a value", "required": true, "description": "An extra field of type text" } } }'
+                  example: { "extra_fields": { "For example": { "type": "text", "value": "With a value", "required": true, "description": "An extra field of type text" } } }
                 rating:
                   type: integer
                   nullable: true

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -11,8 +11,8 @@
 
       {# for templates: create from button #}
       {% if Entity.entityType.value == 'experiments_templates' %}
-      <a data-action='create-entity' data-type='experiments' data-tplid='{{ item.id }}' href='#' class='left-icon rounded mr-2 hl-hover-gray my-1' title='{{ 'Create experiment from template'|trans }}' aria-label='{{ 'Create experiment from template'|trans }}'>
-        <i class='color-blue fas fa-splotch fa-fw'></i>
+      <a data-action='create-entity' data-type='experiments' data-tplid='{{ item.id }}' href='#' class='left-icon rounded mr-3 my-1 hl-hover-gray bgnd-blue' title='{{ 'Create experiment from template'|trans }}' aria-label='{{ 'Create experiment from template'|trans }}'>
+        <i class='fas fa-file-circle-plus fa-fw'></i>
       </a>
       {% endif %}
       {# lock icon #}

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -451,7 +451,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const el = document.getElementById(id);
         const scroll = el.classList.contains('d-none');
         el.classList.remove('d-none');
-        if (id === 'withSelected' && scroll && el.getBoundingClientRect().bottom > 0) {
+        if (scroll && el.getBoundingClientRect().bottom > 0) {
           window.scrollBy({top: el.offsetHeight, behavior: 'instant'});
         }
       });
@@ -460,9 +460,14 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         (el.closest('.entity') as HTMLElement).style.backgroundColor = '';
       }
-      // Remove withSelected actions if there are no more checked checkboxes
+      // show invert select if any checkbox is selected
       const anyChecked = document.querySelectorAll('[data-action="checkbox-entity"]:checked').length > 0;
-      if (!anyChecked) {
+      const invertSelections = document.querySelector('a[data-action="invert-entities-selection"]') as HTMLAnchorElement;
+      if (anyChecked) {
+        invertSelections?.removeAttribute('hidden');
+      } else {
+        invertSelections?.setAttribute('hidden', 'hidden');
+        // Remove withSelected actions if there are no more checked checkboxes
         document.getElementById('withSelected')?.classList.add('d-none');
       }
 
@@ -499,9 +504,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         document.getElementById('withSelected').classList.remove('d-none');
         el.dataset.target = 'unselect';
-
       } else {
-
         document.querySelectorAll('.entity input[type=checkbox]').forEach(box => {
           (box as HTMLInputElement).checked = false;
           (box.closest('.entity') as HTMLElement).style.backgroundColor = '';
@@ -525,6 +528,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         (box.closest('.entity') as HTMLElement).style.backgroundColor = newBgColor;
       });
+      // Remove withSelected actions if there are no more checked checkboxes
+      const anyChecked = document.querySelectorAll('[data-action="checkbox-entity"]:checked').length > 0;
+      const withSelected = document.getElementById('withSelected') as HTMLDivElement;
+      anyChecked ? withSelected.classList.remove('d-none') : withSelected.classList.add('d-none');
 
     // PATCH ACTIONS FOR CHECKED BOXES : lock, unlock, timestamp, archive
     } else if (el.matches('[data-action="patch-selected-entities"]')) {

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -447,7 +447,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // CHECK AN ENTITY BOX
     } else if (el.matches('[data-action="checkbox-entity"]')) {
-      ['advancedSelectOptions', 'withSelected'].forEach(id => {
+      ['withSelected'].forEach(id => {
         const el = document.getElementById(id);
         const scroll = el.classList.contains('d-none');
         el.classList.remove('d-none');
@@ -459,6 +459,11 @@ document.addEventListener('DOMContentLoaded', () => {
         (el.closest('.entity') as HTMLElement).style.backgroundColor = bgColor;
       } else {
         (el.closest('.entity') as HTMLElement).style.backgroundColor = '';
+      }
+      // Remove withSelected actions if there are no more checked checkboxes
+      const anyChecked = document.querySelectorAll('[data-action="checkbox-entity"]:checked').length > 0;
+      if (!anyChecked) {
+        document.getElementById('withSelected')?.classList.add('d-none');
       }
 
     // EXPAND ALL


### PR DESCRIPTION
There was a little issue when you select some entities and click **invert selection,** it would sometimes appear differed :

<details><summary>Show actual state</summary>

![Capture d’écran du 2025-02-20 12-02-40](https://github.com/user-attachments/assets/c93ac30d-34c1-42cd-958d-3f0241b20d3f)
![Capture d’écran du 2025-02-20 12-02-34](https://github.com/user-attachments/assets/920ca38b-a1d2-40ff-b9af-7cb6e630d924)

</details>


- Invert selection is now displayed once you click any checkbox
- "With selected" (container with actions) appears once you click any checkbox, and disappears if all are unchecked
![image](https://github.com/user-attachments/assets/bf3cba38-adbe-4a82-b81c-98b8b9a95abc)
- api spec swagger sends an object for metadata instead of a string
![Capture d’écran du 2025-02-20 11-25-45](https://github.com/user-attachments/assets/58ab6bc3-c440-4bd3-a7aa-7e7ac743a8dd)
- suggestion for "create from template" button
![image](https://github.com/user-attachments/assets/268f9e76-13c5-49a0-ad0d-94c95dfa8d33)


