### PR TITLE
Fix Dataset URLs in Ro-Crate

### DIFF
--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -14,6 +14,7 @@ namespace Elabftw\Make;
 
 use DateTimeImmutable;
 use Elabftw\Elabftw\Tools;
+use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Metadata;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Models\AbstractEntity;
@@ -175,7 +176,7 @@ class MakeEln extends AbstractMakeEln
             'temporal' => (new DateTimeImmutable($e['date'] ?? date('Y-m-d')))->format(DateTimeImmutable::ATOM),
             'name' => $e['title'],
             'encodingFormat' => ($e['content_type'] ?? 1) === 1 ? 'text/html' : 'text/markdown',
-            'url' => Config::fromEnv('SITE_URL') . '/' . $entity->entityType->toPage() . '.php?mode=view&id=' . $e['id'],
+            'url' => Config::fromEnv('SITE_URL') . '/' . $entity->entityType->toPage() . ($entity->entityType == EntityType::ItemsTypes ? '&' : '?') . 'mode=view&id=' . $e['id'],
             'genre' => $entity->entityType->toGenre(),
         );
         $datasetNode = self::addIfNotEmpty(


### PR DESCRIPTION
Fixes #5494 
Now the Dataset URLs in the ro-crate-metadata.json of the ELN export are correct.