### PR TITLE
Center figures

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1289,6 +1289,12 @@ figure figcaption {
   text-align: center;
 }
 
+.image figure,
+figure {
+  display: block;
+  text-align: center;
+}
+
 /* make the markdown editor full width */
 .markdown-textarea {
   width: 100%;

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -219,6 +219,8 @@ export function getTinymceBaseConfig(page: string): object {
     // location of the skin directory
     skin_url: '/assets/tinymce_skins',
     content_css: '/assets/tinymce_content.min.css',
+    // Ensure that figures with captions are centered
+    content_style: '.image figure,figure {display: block; text-align: center;}',
     emoticons_database_url: 'assets/tinymce_emojis.js',
     // remove the "Upgrade" button
     promotion: false,


### PR DESCRIPTION
This is a partial fix for #5422. The figures in the html output are now centered, but the figures in tinyMCE are not. I haven't figured out yet how to patch the CSS that ends up in content.min.css.
Any pointers?