### PR TITLE
Admins permissions to archive/unarchive a user

### DIFF
--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -369,7 +369,7 @@ class Users extends AbstractRest
             Action::Disable2fa => $this->disable2fa(),
             Action::PatchUser2Team => (new Users2Teams($this->requester))->patchUser2Team($params),
             Action::Unreference => (new Users2Teams($this->requester))->destroy($this->userData['userid'], (int) $params['team']),
-            Action::Archive => (new UserArchiver($this->requester, $this))->toggleArchive((bool) ($params['with_exp'] ?? false)),
+            Action::Lock, Action::Archive => (new UserArchiver($this->requester, $this))->toggleArchive((bool) ($params['with_exp'] ?? false)),
             Action::UpdatePassword => $this->updatePassword($params),
             Action::Update => (
                 function () use ($params) {

--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -369,7 +369,7 @@ class Users extends AbstractRest
             Action::Disable2fa => $this->disable2fa(),
             Action::PatchUser2Team => (new Users2Teams($this->requester))->patchUser2Team($params),
             Action::Unreference => (new Users2Teams($this->requester))->destroy($this->userData['userid'], (int) $params['team']),
-            Action::Lock, Action::Archive => (new UserArchiver($this->requester, $this))->toggleArchive((bool) ($params['with_exp'] ?? false)),
+            Action::Archive => (new UserArchiver($this->requester, $this))->toggleArchive((bool) ($params['with_exp'] ?? false)),
             Action::UpdatePassword => $this->updatePassword($params),
             Action::Update => (
                 function () use ($params) {

--- a/src/services/UserArchiver.php
+++ b/src/services/UserArchiver.php
@@ -50,14 +50,12 @@ final class UserArchiver
 
     private function archive(bool $lockExp = false): bool
     {
+        $this->checkArchivePermission();
         if ($this->target->userData['validated'] === 0) {
             throw new ImproperActionException(_('You are trying to archive an unvalidated user. Maybe you want to delete the account?'));
         }
         if ($this->target->userData['is_sysadmin'] === 1) {
             throw new ImproperActionException(_('A sysadmin account cannot be archived.'));
-        }
-        if (Config::getConfig()->configArr['admins_archive_users'] === '0' && $this->requester->userData['is_sysadmin'] !== 1) {
-            throw new ImproperActionException(_('This instance configuration only permits Sysadmin users to archive a user.'));
         }
         $this->target->invalidateToken();
         // if we are archiving a user, also lock all experiments (if asked)
@@ -66,6 +64,7 @@ final class UserArchiver
 
     private function unarchive(): bool
     {
+        $this->checkArchivePermission();
         if ($this->getUnarchivedCount() > 0) {
             throw new ImproperActionException('Cannot unarchive this user because they have another active account with the same email!');
         }
@@ -103,5 +102,16 @@ final class UserArchiver
         $req->bindParam(':lockedby', $this->requester->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':userid', $this->target->userData['userid'], PDO::PARAM_INT);
         return $this->Db->execute($req);
+    }
+
+    // check if the admin can archive/unarchive a user
+    private function checkArchivePermission(): void
+    {
+        if (Config::getConfig()->configArr['admins_archive_users'] === '0' &&
+            $this->requester->userData['is_sysadmin'] !== 1) {
+            throw new ImproperActionException(
+                _('This instance configuration only permits Sysadmin users to archive/unarchive a user.')
+            );
+        }
     }
 }

--- a/src/services/UserArchiver.php
+++ b/src/services/UserArchiver.php
@@ -14,6 +14,7 @@ namespace Elabftw\Services;
 
 use Elabftw\AuditEvent\UserAttributeChanged;
 use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\AuditLogs;
@@ -109,9 +110,7 @@ final class UserArchiver
     {
         if (Config::getConfig()->configArr['admins_archive_users'] === '0' &&
             $this->requester->userData['is_sysadmin'] !== 1) {
-            throw new ImproperActionException(
-                _('This instance configuration only permits Sysadmin users to archive/unarchive a user.')
-            );
+            throw new ImproperActionException(Tools::error(true));
         }
     }
 }

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (document.getElementById(`lockSwitch_${el.dataset.userid}`)) {
         lockExp = (document.getElementById(`lockSwitch_${el.dataset.userid}`) as HTMLInputElement).checked;
       }
-      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElements(['editUsersBox']));
+      ApiC.patch(`users/${el.dataset.userid}`, {action: Action.Archive, with_exp: lockExp}).then(() => reloadElements(['editUsersBox', `archiveUserModal_${el.dataset.userid}`]));
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -222,7 +222,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         // tata in bravo
         $Admin = new Users(5, 2);
         $Users = new Users(6, 2, $Admin);
-        $this->assertIsArray($Users->patch(Action::Lock, array()));
+        $this->assertIsArray($Users->patch(Action::Archive, array()));
     }
 
     public function testCreateUser(): void
@@ -235,7 +235,7 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt($this->Users->createOne('blahblah2@yop.fr', array('Bravo'), 'blah2', 'yop', 'somePassword!', Usergroup::Admin, true, false));
     }
 
-    public function testUnArchiveButAnotherUserExists(): void
+    public function testUnarchiveButAnotherUserExists(): void
     {
         // this user is archived already
         $Admin = new Users(5, 2);
@@ -244,7 +244,19 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         ExistingUser::fromScratch($Users->userData['email'], array('Alpha'), 'f', 'l', Usergroup::User, false, false);
         // try to unarchive
         $this->expectException(ImproperActionException::class);
-        $Users->patch(Action::Lock, array());
+        $Users->patch(Action::Archive, array());
+    }
+
+    public function testArchiveWithoutPermission(): void
+    {
+        $Admin = new Users(5, 2);
+        $Users = new Users(6, 2, $Admin);
+        $Config = Config::getConfig();
+        $Config->patch(Action::Update, array('admins_archive_users' => 0));
+        $this->expectException(ImproperActionException::class);
+        $Users->patch(Action::Archive, array());
+
+        $Config->patch(Action::Update, array('admins_archive_users' => 1));
     }
 
     public function testReadAllActiveFromTeam(): void


### PR DESCRIPTION
Fix #5497 

- If admins aren't allowed to archive users, they cannot unarchive either
- Additional test
- replace Lock action (unused) with Archive
