### PR TITLE
fix: larger width images cause UI abnormalities

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -641,14 +641,19 @@ tr:nth-child(odd) {
 
 /* ENTITIES */
 .entity {
+  min-width: 100%;
+  max-width: 100%;
   background-color: $white;
   border: 1px solid $firstlevel;
   border-left: 6px solid var(--left-color);
   border-radius: 5px;
   margin: 5px auto;
-  min-width: 100%;
   opacity: var(--opacity);
   padding: 5px 10px 5px 5px;
+
+  img {
+    max-width: 100%;
+  }
 
   p {
     margin-bottom: 0;


### PR DESCRIPTION
Fix #5415 

- Container now maintains width
- images inside won't go beyond main container

before
![Capture d’écran du 2025-03-05 15-31-10](https://github.com/user-attachments/assets/cc104419-d898-40f8-9291-25697b0d4865)
after
![Capture d’écran du 2025-03-05 15-48-21](https://github.com/user-attachments/assets/6a4d0d60-c5c8-4841-b790-c28e42c3c8e3)

