### PR TITLE
ux: exclusive edit: always show warning in view mode

### DIFF
--- a/src/models/ExclusiveEditMode.php
+++ b/src/models/ExclusiveEditMode.php
@@ -93,7 +93,7 @@ final class ExclusiveEditMode
         ) {
             /** @psalm-suppress PossiblyNullArgument */
             return new RedirectResponse(sprintf(
-                '%s%sid=%d&openedInExclusiveEditMode',
+                '%s%sid=%d',
                 $this->Entity->entityType->toPage(),
                 $this->Entity->entityType === EntityType::Templates
                     ? '&mode=view&template'

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -29,7 +29,7 @@
 {# Exclusive edit mode notification #}
 <div id='exclusiveEditModeInfo'>
 {% if Entity.ExclusiveEditMode.isActive %}
-  {% if App.Request.query.has('openedInExclusiveEditMode') and Entity.ExclusiveEditMode.dataArr.locked_by != Entity.Users.userData.userid %}
+  {% if Entity.ExclusiveEditMode.dataArr.locked_by != Entity.Users.userData.userid %}
     {% set writeLockNotice = 'This entry is opened by %s in exclusive edit mode since %s. You cannot edit it before %s. %sRequest exclusive edit mode removal%s'|trans|format(
         Entity.ExclusiveEditMode.dataArr.fullname,
         Entity.ExclusiveEditMode.dataArr.locked_at,

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -49,7 +49,6 @@ describe('Exclusive edit mode', () => {
     }).as('redirect');
     cy.get('[aria-label="Edit"]').click();
     cy.wait('@redirect');
-    cy.url().should('include', 'mode=view').should('include', 'openedInExclusiveEditMode');
     cy.get('[class="alert alert-warning"]')
       .should('contain', 'This entry is opened by Toto Le sysadmin in exclusive edit mode since')
       .should('contain', 'You cannot edit it before') // rephrased as "before 'locked_until' time"


### PR DESCRIPTION
remove unnecessary need to click Edit button to see the warning
