### PR TITLE
Miscellaneous atomic changes

### DIFF
--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -26,4 +26,13 @@ enum Scope: int
             Scope::Everything => 'globe',
         };
     }
+
+    public static function toHuman(self $value): string
+    {
+        return match ($value) {
+            Scope::User => 'Self',
+            Scope::Team => 'Team',
+            Scope::Everything => 'Everything',
+        };
+    }
 }

--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -27,12 +27,12 @@ enum Scope: int
         };
     }
 
-    public static function toHuman(self $value): string
+    public function toHuman(): string
     {
-        return match ($value) {
-            Scope::User => 'Self',
-            Scope::Team => 'Team',
-            Scope::Everything => 'Everything',
+        return match ($this) {
+            self::User => _('Self'),
+            self::Team => _('Team'),
+            self::Everything => _('Everything'),
         };
     }
 }

--- a/src/classes/CanSqlBuilder.php
+++ b/src/classes/CanSqlBuilder.php
@@ -126,8 +126,7 @@ final class CanSqlBuilder
      */
     protected function canTeams(): string
     {
-        // FIXME why is userid a string here sometimes??
-        $UsersHelper = new UsersHelper((int) $this->requester->userid);
+        $UsersHelper = new UsersHelper($this->requester->userid ?? 0);
         $teamsOfUser = $UsersHelper->getTeamsIdFromUserid();
         if (!empty($teamsOfUser)) {
             // JSON_OVERLAPS checks for the intersection of two arrays

--- a/src/classes/EntitySlugsSqlBuilder.php
+++ b/src/classes/EntitySlugsSqlBuilder.php
@@ -47,7 +47,7 @@ final class EntitySlugsSqlBuilder
             $req->bindParam(':userid', $this->targetUser->userid, PDO::PARAM_INT);
         }
         if (str_contains($sql, ':team')) {
-            $req->bindValue(':team', $this->targetUser->team);
+            $req->bindParam(':team', $this->targetUser->team, PDO::PARAM_INT);
         }
         $req->bindValue(':start', $this->start->format('Y-m-d'));
         $req->bindValue(':end', $this->end->format('Y-m-d'));

--- a/src/models/AbstractCompoundsLinks.php
+++ b/src/models/AbstractCompoundsLinks.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\State;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Traits\SetIdTrait;
@@ -48,9 +49,11 @@ abstract class AbstractCompoundsLinks extends AbstractRest
         $sql = 'SELECT compound_id AS id, compounds.*
             FROM ' . $this->getTable() . ' AS main
             LEFT JOIN compounds ON compounds.id = main.compound_id
-            WHERE main.entity_id = :entity_id AND compounds.state IN (1,2)';
+            WHERE main.entity_id = :entity_id AND compounds.state IN (:state_normal, :state_archived)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':entity_id', $this->Entity->id, PDO::PARAM_INT);
+        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);
 
         return $req->fetchAll();

--- a/src/models/AbstractContainersLinks.php
+++ b/src/models/AbstractContainersLinks.php
@@ -56,12 +56,14 @@ abstract class AbstractContainersLinks extends AbstractLinks
             FROM ' . $this->getTable() . ' AS main
             LEFT JOIN ' . $this->getTargetType()->value . ' AS entity ON (main.item_id = entity.id)
             LEFT JOIN storage_units ON (main.storage_id = storage_units.id)
-            WHERE main.item_id = :item_id AND entity.state IN (1,2)
+            WHERE main.item_id = :item_id AND entity.state IN (:state_normal, :state_archived)
             ORDER by main.created_at ASC, entity.title ASC';
 
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
+        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);
 
         $results = $req->fetchAll();

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -155,7 +155,7 @@ abstract class AbstractEntity extends AbstractRest
         $sql = sprintf('UPDATE %s SET modified_at = NOW(), lastchangeby = :userid WHERE id = :id', $this->entityType->value);
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-        $req->bindParam(':userid', $this->Users->requester->userid);
+        $req->bindParam(':userid', $this->Users->requester->userid, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }
 

--- a/src/models/Compounds.php
+++ b/src/models/Compounds.php
@@ -223,8 +223,8 @@ final class Compounds extends AbstractRest
             :is_corrosive, :is_serious_health_hazard, :is_explosive, :is_flammable, :is_gas_under_pressure, :is_hazardous2env, :is_hazardous2health, :is_oxidising, :is_toxic)';
 
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':requester', $this->requester->userid);
-        $req->bindParam(':team', $this->requester->team);
+        $req->bindParam(':requester', $this->requester->userid, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->requester->team, PDO::PARAM_INT);
         $req->bindParam(':name', $name);
         $req->bindParam(':inchi', $inchi);
         $req->bindParam(':inchi_key', $inchiKey);

--- a/src/models/Compounds.php
+++ b/src/models/Compounds.php
@@ -68,7 +68,7 @@ final class Compounds extends AbstractRest
             $q = $queryParams->getQuery();
             return $this->searchFingerprint($this->getFingerprintFromSmiles($q->getString('search_fp_smi')), $q->getBoolean('exact'));
         }
-        $sql = $this->getSelectBeforeWhere() . ' WHERE 1=1 AND entity.state IN (1,2)';
+        $sql = $this->getSelectBeforeWhere() . ' WHERE 1=1 AND entity.state IN (:state_normal, :state_archived)';
         if ($queryParams->getQuery()->get('q')) {
             $sql .= ' AND (
                 entity.cas_number LIKE :query OR
@@ -108,6 +108,8 @@ final class Compounds extends AbstractRest
         if ($queryParams->getQuery()->get('q')) {
             $req->bindValue(':query', '%' . $queryParams->getQuery()->getString('q') . '%');
         }
+        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);
 
         return $req->fetchAll();
@@ -328,7 +330,7 @@ final class Compounds extends AbstractRest
 
         $sql .= 'FROM compounds_fingerprints AS cf
             LEFT JOIN compounds AS c ON cf.id = c.id';
-        $sql .= ' WHERE 1=1 AND c.state IN (1,2)';
+        $sql .= ' WHERE 1=1 AND c.state IN (:state_normal, :state_archived)';
         foreach ($fp['data'] as $key => $value) {
             if ($value == 0) {
                 continue;
@@ -343,6 +345,8 @@ final class Compounds extends AbstractRest
 
         $sql .= ' ORDER BY similarity_score, id DESC LIMIT 500';
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $req->execute();
         return $req->fetchAll();
     }

--- a/src/models/users/Users.php
+++ b/src/models/users/Users.php
@@ -632,9 +632,7 @@ class Users extends AbstractRest
     private function canReadOrExplode(): void
     {
         // it's ourself or we are sysadmin
-
-        // FIXME To investigate: $this->requester->userid is a string here!!!
-        if ($this->requester->userData['userid'] === $this->userid || $this->requester->userData['is_sysadmin'] === 1) {
+        if ($this->requester->userid === $this->userid || $this->requester->userData['is_sysadmin'] === 1) {
             return;
         }
         if (!$this->requester->isAdmin && $this->userid !== $this->userData['userid']) {

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -62,7 +62,7 @@
                 <summary class='p-2 rounded hl-hover-gray'>{{ 'Set scope'|trans }}</summary>
                 <select aria-label='{{ 'Set scope'|trans }}' data-trigger='change' data-model='users/me' data-reload='{{ identifier }}_select_teamgroups' data-target='scope_teamgroups' class='form-control'>
                   {% for case in enum('Elabftw\\Enums\\Scope').cases %}
-                    <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ enum('Elabftw\\Enums\\Scope').toHuman(case)|trans }}</option>
+                    <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ case.toHuman() }}</option>
                   {% endfor %}
                 </select>
               </details>

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -61,10 +61,9 @@
               <details closed>
                 <summary class='p-2 rounded hl-hover-gray'>{{ 'Set scope'|trans }}</summary>
                 <select aria-label='{{ 'Set scope'|trans }}' data-trigger='change' data-model='users/me' data-reload='{{ identifier }}_select_teamgroups' data-target='scope_teamgroups' class='form-control'>
-                  {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
-                  <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>
-                  <option value='2' {{ App.Users.userData.scope_teamgroups == 2 ? ' selected' }}>{{ 'Team'|trans }}</option>
-                  <option value='3' {{ App.Users.userData.scope_teamgroups == 3 ? ' selected' }}>{{ 'Everything'|trans }}</option>
+                  {% for case in enum('Elabftw\\Enums\\Scope').cases %}
+                    <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ enum('Elabftw\\Enums\\Scope').toHuman(case)|trans }}</option>
+                  {% endfor %}
                 </select>
               </details>
             </div>

--- a/src/templates/show-item-table.html
+++ b/src/templates/show-item-table.html
@@ -21,7 +21,7 @@
       <i class='fas fa-lock fa-fw' style='color:#29AEB9'></i>
     {% endif %}
     {# archived icon #}
-    {% if item.state == constant('Elabftw\\Enums\\State::Archived').value %}
+    {% if item.state == enum('Elabftw\\Enums\\State').Archived.value %}
       <i class='fas fa-box-archive fa-fw'></i>
     {% endif %}
     {# toggle body #}

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -50,11 +50,11 @@
         <i style='color:#{{ item.category_color|default('bdbdbd') }}' class='far fa-calendar-check fa-fw'></i>
       {% endif %}
       {# archived icon #}
-      {% if item.state == constant('Elabftw\\Enums\\State::Archived').value %}
+      {% if item.state == enum('Elabftw\\Enums\\State').Archived.value %}
         <i class='fas fa-box-archive fa-fw'></i>
       {% endif %}
       {# deleted icon #}
-      {% if item.state == constant('Elabftw\\Enums\\State::Deleted').value %}
+      {% if item.state == enum('Elabftw\\Enums\\State').Deleted.value %}
         <i class='fas fa-ban fa-fw color-danger'></i>
       {% endif %}
       {# category #}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -165,12 +165,14 @@
           {# METADATA SEARCH END #}
 
       {# GROUPS filter: disabled because not working FIXME #}
+      {#
       <!--select name='group' class='mx-1 form-control filterHelper filterAuto' aria-label='{{ 'Filter group'|trans }}'>
         <option value='' data-action='clear'>{{ 'Select group'|trans }}</option>
         {% for group in scopedTeamgroupsArr %}
           <option value='{{ group.name|e('html_attr') }}' {{- Request.query.get('searchonly') == 'group:' ~ group ? ' selected' }}>{{ group.name }}</option>
         {% endfor %}
       </select-->
+      #}
 
       {# VISIBILITY filter #}
       <select name='visibility' class='mx-1 form-control filterHelper filterAuto' aria-label='{{ 'Filter visibility'|trans }}'>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -189,11 +189,16 @@
         {# STATE #}
         <select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterAuto'>
           <option value='' data-action='clear'>{{ 'Select state'|trans }}</option>
-          <option value='1' {{- Request.query.get('state') == '1' ? ' selected' }}>{{ 'Normal'|trans }}</option>
-          <option value='2' {{- Request.query.get('state') == '2' ? ' selected' }}>{{ 'Archived'|trans }}</option>
-          <option value='3' {{- Request.query.get('state') == '3' ? ' selected' }}>{{ 'Deleted'|trans }}</option>
-          <option value='1,2' {{- Request.query.get('state') == '1,2' ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
-          <option value='1,2,3' {{- Request.query.get('state') == '1,2,3' ? ' selected' }}>{{ 'Any'|trans }}</option>
+          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value %}
+          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal'|trans }}</option>
+          {% set stateValue = enum('Elabftw\\Enums\\State').Archived.value %}
+          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Archived'|trans }}</option>
+          {% set stateValue = enum('Elabftw\\Enums\\State').Deleted.value %}
+          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Deleted'|trans }}</option>
+          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value %}
+          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
+          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value ~ ',' ~ enum('Elabftw\\Enums\\State').Deleted.value %}
+          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Any'|trans }}</option>
         </select>
         {# END STATE #}
 

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -16,7 +16,7 @@
 <div data-tabcontent='1' hidden>
   <div class='alert alert-success'><i class='fas fa-info-circle fa-fw color-success'></i>
   {{ 'You belong to the %s team.'|trans|format(App.teamArr.name) }}
-  {{ 'Members'|trans }}: {{ teamsStats.totusers }} &ndash; {% trans %}Experiment{% plural teamStats.totxp %}Experiments{% endtrans %}: {{ teamsStats.totxp }} ({{ teamsStats.totxpts }} timestamped) &ndash; {{ 'Resources'|trans }}: {{ teamsStats.totdb }}
+  {{ 'Members'|trans }}: {{ teamsStats.totusers }} &ndash; {% trans %}Experiment{% plural teamsStats.totxp %}Experiments{% endtrans %}: {{ teamsStats.totxp }} ({{ teamsStats.totxpts }} timestamped) &ndash; {{ 'Resources'|trans }}: {{ teamsStats.totdb }}
   </div>
 
   <h3 class='p-2 pl-3 mb-3 section-title'>{{ 'Members'|trans }}</h3>

--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -133,8 +133,7 @@
               <td data-label='{{ 'State'|trans }}'><span class='hl-hover-gray p-1 rounded malleableState' data-id='{{ req.id }}'>{{ req.state_human }}</span></td>
               {# delete will actually cancel it #}
               <td data-label='{{ 'Actions'|trans }}'>
-                {# TODO hardcoded enum value #}
-                {% if req.state != 60 %}
+                {% if req.state != enum('Elabftw\\Enums\\ProcurementState').Cancelled.value %}
                   <button class='btn hl-hover-gray p-1 rounded hover-danger lh-normal' title='{{ 'Cancel order'|trans }}' data-action='cancel-procurement-request' aria-label='{{ 'Cancel order'|trans }}' type='button' data-id='{{ req.id }}'>
                     <i class='fas fa-trash-alt'></i>
                   </button>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -296,10 +296,9 @@
         <p class='smallgray'>{{ 'This setting controls which teamgroups will be listed in the permission settings window.'|trans }}</p>
       </div>
       <select id='scope_teamgroups' data-trigger='change' data-model='users/me' data-target='scope_teamgroups' class='form-control col-md-3'>
-        {# NOTE: it is currently not practical to use enums in twig. So we hardcode the value for now. FIXME. See: https://github.com/twigphp/Twig/issues/3681 #}
-        <option value='1' {{ App.Users.userData.scope_teamgroups == 1 ? ' selected' }}>{{ 'Self'|trans }}</option>
-        <option value='2' {{ App.Users.userData.scope_teamgroups == 2 ? ' selected' }}>{{ 'Team'|trans }}</option>
-        <option value='3' {{ App.Users.userData.scope_teamgroups == 3 ? ' selected' }}>{{ 'Everything'|trans }}</option>
+        {% for case in enum('Elabftw\\Enums\\Scope').cases %}
+          <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ enum('Elabftw\\Enums\\Scope').toHuman(case)|trans }}</option>
+        {% endfor %}
       </select>
     </div>
   </div>

--- a/src/templates/ucp.html
+++ b/src/templates/ucp.html
@@ -297,7 +297,7 @@
       </div>
       <select id='scope_teamgroups' data-trigger='change' data-model='users/me' data-target='scope_teamgroups' class='form-control col-md-3'>
         {% for case in enum('Elabftw\\Enums\\Scope').cases %}
-          <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ enum('Elabftw\\Enums\\Scope').toHuman(case)|trans }}</option>
+          <option value='{{ case.value }}' {{ App.Users.userData.scope_teamgroups == case.value ? ' selected' }}>{{ case.toHuman() }}</option>
         {% endfor %}
       </select>
     </div>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -75,7 +75,7 @@
                 <button type='button' class='btn lh-normal hl-hover-gray p-1 mr-1' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='moreinfoDiv_{{ upload.id }}' aria-expanded='false' title='{{ 'More information'|trans }}' aria-label='{{ 'More information'|trans }}'>
                   <i class='fas fa-caret-right fa-fw'></i>
                 </button>
-                {% if upload.state == constant('Elabftw\\Enums\\State::Archived').value %}
+                {% if upload.state == enum('Elabftw\\Enums\\State').Archived.value %}
                   {# use a span as title doesn't work directly on i element #}
                   <span title='{{ 'Archived'|trans }}'><i class='fas fa-box-archive mr-1'></i></span>
                 {% endif %}
@@ -135,9 +135,9 @@
           {% if loop.first %}
             <div id='last-uploaded-link' data-url='app/download.php?f={{ upload.long_name }}' hidden></div>
           {% endif %}
-          <div class='thumbnail box {{ upload.state == constant('Elabftw\\Enums\\State::Archived').value ? 'bg-light' }}' data-type='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}' style='overflow: visible'>
+          <div class='thumbnail box {{ upload.state == enum('Elabftw\\Enums\\State').Archived.value ? 'bg-light' }}' data-type='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}' style='overflow: visible'>
             {% include('upload-dropdown-menu.html') %}
-            {% if upload.state == constant('Elabftw\\Enums\\State::Archived').value %}
+            {% if upload.state == enum('Elabftw\\Enums\\State').Archived.value %}
             <p class='mb-0'><i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Archived'|trans }}</p>
             {% endif %}
 

--- a/src/templates/view-edit.html
+++ b/src/templates/view-edit.html
@@ -12,7 +12,7 @@
 {% include('procurement-params-modal.html') %}
 
 <div id='isArchivedDiv'>
-{% if Entity.entityData.state == constant('Elabftw\\Enums\\State::Archived').value %}
+{% if Entity.entityData.state == enum('Elabftw\\Enums\\State').Archived.value %}
   {{ 'This entry is archived: it will not appear in the listings by default.'|trans|msg('ok', false) }}
 {% endif %}
 </div>


### PR DESCRIPTION
A few things I recently stumbled upon.
Each commit should be working on its own.

Primarily enum stuff in twig templates. It is working as of version 3.15 https://twig.symfony.com/doc/3.x/functions/enum.html

Please note that `bindParam()` might change the type of the variable, hence casting from `int` to `string` without `PDO::PARAM_INT`.
I might have broken some functions and it would perhaps be better to use `bindValue()` for the variables that can be `int|null`.