### PR TITLE
Fix Cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           name: Run Cypress e2e tests and extract artifacts
           # have to save cypress exit code to first extract artifacts
           command: |
-            docker exec -it elab-cypress cypress run
+            docker exec -it elab-cypress cypress run --headed --browser electron
             cypressExitCode=$?
             docker cp elab-cypress:/home/node/tests/cypress/screenshots/. cypress/screenshots
             docker cp elab-cypress:/home/node/tests/cypress/videos/. cypress/videos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           name: Run Cypress e2e tests and extract artifacts
           # have to save cypress exit code to first extract artifacts
           command: |
-            docker exec -it elab-cypress cypress run --headed --browser electron
+            docker exec -it elab-cypress cypress run
             cypressExitCode=$?
             docker cp elab-cypress:/home/node/tests/cypress/screenshots/. cypress/screenshots
             docker cp elab-cypress:/home/node/tests/cypress/videos/. cypress/videos

--- a/builder.js
+++ b/builder.js
@@ -138,8 +138,8 @@ module.exports = (env) => {
           ],
         },
         {
-        test: /\.jsx?$/,
-        use: ["babel-loader"]
+          test: /\.jsx?$/,
+          use: ["babel-loader"]
         },
         { // SASS loader
           test: /\.scss$/,

--- a/tests/cypress/integration/admin_items_types.cy.ts
+++ b/tests/cypress/integration/admin_items_types.cy.ts
@@ -13,6 +13,7 @@ describe('Items Types', () => {
       });
     }).as('create');
     cy.intercept('DELETE', '/api/v2/items_types/*').as('delete');
+    cy.intercept('GET', '/api/v2/items_types/*').as('apiGET');
     cy.window().then(win => {
       // create
       cy.stub(win, 'prompt').returns(newname);
@@ -20,14 +21,16 @@ describe('Items Types', () => {
       cy.wait('@create').then(() => {
         cy.url().should('include', 'templateid=');
         cy.get('#itemsTypesName').should('have.value', newname);
+        cy.wait('@apiGET');
+        cy.wait('@apiGET');
       });
 
       // delete
       cy.stub(win, 'confirm').returns(true);
       cy.get('[data-action="itemstypes-destroy"]').click();
       cy.wait('@delete').then(() => {
-        cy.contains(newname).should('not.exist');
         cy.url().should('not.include', 'templateid=');
+        cy.get('#itemsCategoriesDiv').scrollIntoView().contains(newname).should('not.exist');
       });
     });
   });

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -44,11 +44,13 @@ describe('Experiments', () => {
     cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('be.visible');
     cy.get('[data-action="destroy-comment"]').click();
     cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('not.exist');
-    cy.htmlvalidate({
-      rules: {
-        'prefer-native-element': 'off',
-      },
-    });
+    cy.htmlvalidate(
+      // {
+      //   rules: {
+      //     'prefer-native-element': 'off',
+      //   },
+      // },
+    );
     // go back in edit mode for destroy action
     cy.get('[title="Edit"]').click();
   };

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -4,45 +4,59 @@ describe('Experiments', () => {
     cy.enableCodeCoverage(Cypress.currentTest.titlePath.join(' '));
   });
 
-  const entityEdit = () => {
+  const entityEdit = (endpoint: string) => {
     cy.url().should('include', 'mode=edit');
+
     // update date
+    cy.intercept('PATCH', `/api/v2/${endpoint}/**`).as('apiPATCH');
     cy.get('#date_input').type('2021-05-01').blur();
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
 
     // create Tag
+    cy.intercept('POST', `/api/v2/${endpoint}/**`).as('apiPOST');
     cy.get('#createTagInput').type('some tag').blur();
+    cy.wait('@apiPOST');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('div.tags').contains('some tag').should('exist');
 
     // delete tag
     cy.on('window:confirm', () => { return true; });
     cy.contains('some tag').click();
+    cy.wait('@apiPATCH');
     cy.get('div.tags').contains('some tag').should('not.exist');
 
     // create step
     cy.get('.stepinput').type('some step');
     cy.get('[data-action="create-step"').click();
+    cy.wait('@apiPOST');
     cy.get('.step-static').should('contain', 'some step');
 
     // complete step
     cy.get('.stepbox').click();
+    cy.wait('@apiPATCH');
     cy.get('.text-muted').should('contain', 'completed');
 
     //cy.htmlvalidate();
 
     // delete step
+    cy.intercept('DELETE', `/api/v2/${endpoint}/**`).as('apiDELETE');
     cy.get('[data-action="destroy-step"]').click();
+    cy.wait('@apiDELETE');
     cy.contains('some step').should('not.exist');
   };
 
   const entityComment = () => {
     // go in view mode
     cy.get('[title="View mode"]').click();
+    cy.url().should('include', 'mode=view');
+
     cy.get('#commentsCreateArea').type('This is a very nice experiment');
     cy.get('[data-action="create-comment"]').click();
+    cy.wait('@apiPOST');
     cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('be.visible');
     cy.get('[data-action="destroy-comment"]').click();
+    cy.wait('@apiDELETE');
     cy.get('#commentsDiv').contains('Toto Le sysadmin commented').should('not.exist');
     cy.htmlvalidate(
       // {
@@ -51,19 +65,18 @@ describe('Experiments', () => {
       //   },
       // },
     );
-    // go back in edit mode for destroy action
-    cy.get('[title="Edit"]').click();
   };
 
   const entityDuplicate = () => {
     // keep the original entity url in memory
     cy.url().then(url => {
       cy.log(url);
-      // go in view mode
-      cy.get('[title="View mode"]').click();
-      cy.get('[data-target="duplicateModal"]').click();
-      cy.get('[data-action="duplicate-entity"]').click();
-      cy.get('#documentTitle').should('be.visible');
+      cy.get('[data-target="duplicateModal"]').click()
+        .get('[data-action="duplicate-entity"]').click();
+      cy.wait('@apiGET');
+      cy.wait('@apiGET');
+      cy.wait('@apiPOST');
+      cy.get('#documentTitle').should('be.visible').should('contain', 'Untitled I');
       // destroy the duplicated entity now
       entityDestroy();
       // go back to the original entity
@@ -72,17 +85,24 @@ describe('Experiments', () => {
   };
 
   const entityDestroy = () => {
-    cy.get('button[title="More options"]').click().get('button[data-action="destroy"]').click();
+    cy.get('button[title="More options"]').click()
+      .get('button[data-action="destroy"]').click();
+    cy.wait('@apiDELETE');
   };
 
   it('Create and edit an experiment', () => {
+    const endpoint = 'experiments';
     cy.visit('/experiments.php');
     cy.htmlvalidate();
     cy.contains('Create').click();
+    cy.intercept('GET', `/api/v2/${endpoint}/**`).as('apiGET');
     cy.get('#createModal_experiments').should('be.visible').should('contain', 'Default template').contains('Default template').click();
-    entityEdit();
+    cy.wait('@apiGET');
+    cy.wait('@apiGET');
+    entityEdit(endpoint);
     // change status
     cy.get('#status_select').select('Success').blur();
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     entityComment();
     entityDuplicate();
@@ -90,11 +110,15 @@ describe('Experiments', () => {
   });
 
   it('Create and edit an item', () => {
+    const endpoint = 'items';
     cy.visit('/database.php');
     cy.htmlvalidate();
     cy.contains('Create').click();
+    cy.intercept('GET', `/api/v2/${endpoint}/**`).as('apiGET');
     cy.get('#createModal_database').should('be.visible').should('contain', 'Microscope').contains('Microscope').click();
-    entityEdit();
+    cy.wait('@apiGET');
+    cy.wait('@apiGET');
+    entityEdit(endpoint);
     cy.get('#category_select').select('Plasmid').blur();
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     entityComment();

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -8,30 +8,31 @@ describe('Exclusive edit mode', () => {
   const setupEntityWithExclusiveEditMode = () => {
     cy.visit('/experiments.php');
     cy.contains('Create').click();
-    cy.intercept('GET', '/api/v2/experiments/**').as('get');
+    cy.intercept('GET', '/api/v2/experiments/**').as('apiGet');
     cy.get('#createModal_experiments').should('be.visible').should('contain', 'Default template').contains('Default template').click();
     cy.url().should('include', 'mode=edit');
-    cy.wait('@get');
-    cy.intercept('PATCH', '/api/v2/experiments/**').as('api');
+    cy.wait('@apiGet');
+    cy.wait('@apiGet');
+    cy.intercept('PATCH', '/api/v2/experiments/**').as('apiPATCH');
     cy.get('#documentTitle').click();
     cy.get('h1.text-dark').find('input').clear().type(title).blur();
-    cy.wait('@api');
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
-    /*
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');
+    cy.intercept('GET', '/experiments.php?mode=edit*').as('getPage');
     cy.get('#exclusiveEditModeBtn').click();
-    cy.wait('@api');
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
+    cy.wait('@getPage');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock').should('not.have.class', 'fa-lock-open');
     cy.get('#exclusiveEditModeInfo').should('be.visible');
-   */
     cy.get('#date_input').type('2024-04-20').blur();
-    cy.wait('@api');
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('[title="Select who can edit this entry"]').click();
     cy.get('#canwrite_select_base').should('be.visible').select('Only members of the team');
     cy.get('[data-identifier="canwrite"][data-action="save-permissions"]').click();
-    cy.wait('@api');
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     // log out Toto
     cy.request('/app/logout.php');
@@ -50,18 +51,19 @@ describe('Exclusive edit mode', () => {
     }).as('redirect');
     cy.get('[aria-label="Edit"]').click();
     cy.wait('@redirect');
+    cy.intercept('POST', '/api/v2/experiments/**').as('apiPost');
     cy.get('[class="alert alert-warning"]')
       .should('contain', 'This entry is opened by Toto Le sysadmin in exclusive edit mode since')
       .should('contain', 'You cannot edit it before') // rephrased as "before 'locked_until' time"
       .should('contain', 'Request exclusive edit mode removal')
       .get('[data-action="request-exclusive-edit-mode-removal"]')
       .click();
+    cy.wait('@apiPost');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     // request twice to test request rejection
     cy.get('[data-action="request-exclusive-edit-mode-removal"]').click();
+    cy.wait('@apiPost');
     cy.get('#overlay').should('be.visible').should('contain', 'Error: This action has been requested already');
-    // silence 303 redirect intercept
-    cy.intercept('experiments.php?mode=edit&id=*', req => req.continue());
     // log out Titi
     cy.request('/app/logout.php');
   };
@@ -71,16 +73,18 @@ describe('Exclusive edit mode', () => {
     cy.login();
     cy.visit('/experiments.php');
     cy.contains('is requesting removal of exclusive edit mode for').should('be.visible');
+    // deactivate 303 redirect intercept
+    cy.intercept('GET', 'experiments.php*', req => req.continue());
     cy.get('#showModeContent').contains(title).should('be.visible').click();
     cy.get('[aria-label="Edit"]').click();
+    cy.wait('@apiGet');
+    cy.wait('@apiGet');
     cy.contains('You opened this entry in exclusive edit mode at').should('be.visible');
-    /*
     cy.get('#exclusiveEditModeBtn').click();
-    cy.wait('@api');
+    cy.wait('@apiPATCH');
     cy.get('#overlay').should('be.visible').should('contain', 'Saved');
     cy.get('#exclusiveEditModeBtn span i').should('have.class', 'fa-lock-open').should('not.have.class', 'fa-lock');
     cy.contains('You opened this entry in exclusive edit mode at').should('not.exist');
-   */
   };
 
   it('Try to open entity with exclusive edit mode', () => {


### PR DESCRIPTION
Seems like the main problem is that the api requests take too long for the pre-defined cypress timeouts.
I chose to intercept and wait for them as it seems to me like the more robust approach compared to increasing the timeouts. This way we ensure a more synchronous interaction with the web interface despite the asyncronous nature of cypress.