### PR TITLE
fix: creating a calendar item draws an empty event

### DIFF
--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -149,9 +149,9 @@ document.addEventListener('DOMContentLoaded', () => {
         end: info.endStr,
       };
       ApiC.post(`events/${itemid}`, postParams).then(()=> {
-        // note: here the event is shown empty (without title), until the user clicks somewhere. Still better than a full page reload.
-        // FIXME: this should be addressed eventually
         calendar.refetchEvents();
+        // refresh item with its title by triggering unselect (see #5265)
+        calendar.unselect();
       }).catch(() => {
         calendar.unselect();
         return;


### PR DESCRIPTION
Fix #5265 
creating an event in the calendar caused an empty event waiting for the user to click elsewhere before refreshing the element ([unselectAuto](https://fullcalendar.io/docs/unselectAuto): true by default).

- this fix allows the item to update instantly so that when you create your event, the title is directly set instead of an empty value.
- 
![Capture d’écran du 2025-03-25 12-25-36](https://github.com/user-attachments/assets/2049d2c9-a88d-472c-bd15-91a1a8fe900c)
