### PR TITLE
Archive entity in edit mode allows editions in retrospect

### DIFF
--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -138,9 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="do-requestable-action"]')) {
       switch (el.dataset.target) {
       case Action.Archive:
+        // reload the page to avoid further actions on the entity (in edit mode), also refreshing gets to "You cannot edit it!" page. (See #5552)
         ApiC.patch(`${entity.type}/${entity.id}`, {action: Action.Archive})
-          .then(() => reloadElements(['isArchivedDiv', 'requestActionsDiv']))
-          .then(() => relativeMoment());
+          .then(() => window.location.href = `?mode=view&id=${entity.id}`);
         break;
       case Action.Lock:
         // reload the page to change the icon and make the edit button disappear (#1897)


### PR DESCRIPTION
If in edit mode, archiving an entry displays the save message.
![Capture d’écran du 2025-03-26 16-43-19](https://github.com/user-attachments/assets/fe42fd24-3176-47ad-adf3-fdceb48566a5)
![Capture d’écran du 2025-03-26 16-43-31](https://github.com/user-attachments/assets/a5ecf026-ee0a-4763-97b9-cc985df7e09a)

Then, you can still keep editing the entry and those changes will still be saved while it has been archived.
Plus, if you refresh, it would display you the "you cannot edit" message. (which is normal, but since you were editing a second ago validly it seems weird)
![Capture d’écran du 2025-03-26 16-44-27](https://github.com/user-attachments/assets/7fa21aee-3550-4988-98cb-2ff826ee04e8)

This change redirects to the entity in view mode, so that the "lock" and "archive" take effect instantly.