### PR TITLE
Fix handling of GHS Serious Health Hazard

### DIFF
--- a/src/classes/Compound.php
+++ b/src/classes/Compound.php
@@ -36,6 +36,7 @@ final class Compound
         public bool $isGasUnderPressure = false,
         public bool $isHazardous2env = false,
         public bool $isHazardous2health = false,
+        public bool $isSeriousHealthHazard = false,
         public bool $isOxidising = false,
         public bool $isToxic = false,
     ) {}
@@ -82,8 +83,11 @@ final class Compound
                             if ($ghs['Extra'] === 'Environmental Hazard') {
                                 $compound->isHazardous2env = true;
                             }
-                            if ($ghs['Extra'] === 'Health Hazard') {
+                            if ($ghs['Extra'] === 'Irritant') {
                                 $compound->isHazardous2health = true;
+                            }
+                            if ($ghs['Extra'] === 'Health Hazard') {
+                                $compound->isSeriousHealthHazard = true;
                             }
                             if ($ghs['Extra'] === 'Oxidizer') {
                                 $compound->isOxidising = true;

--- a/src/models/Compounds.php
+++ b/src/models/Compounds.php
@@ -330,6 +330,7 @@ final class Compounds extends AbstractRest
             isGasUnderPressure: $compound->isGasUnderPressure,
             isHazardous2env: $compound->isHazardous2env,
             isHazardous2health: $compound->isHazardous2health,
+            isSeriousHealthHazard: $compound->isSeriousHealthHazard,
             isOxidising: $compound->isOxidising,
             isToxic: $compound->isToxic,
         );

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -53,6 +53,7 @@ if (document.getElementById('compounds-table')) {
           { field: 'is_gas_under_pressure', headerName: 'Gas under pressure' },
           { field: 'is_hazardous2env', headerName: 'Hazardous to environment' },
           { field: 'is_hazardous2health', headerName: 'Hazardous to health' },
+          { field: 'is_serious_health_hazard', headerName: 'Serious health hazard' },
           { field: 'is_oxidising', headerName: 'Oxidising' },
           { field: 'is_toxic', headerName: 'Toxic' },
           { field: 'is_radioactive', headerName: 'Radioactive' },

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -742,6 +742,7 @@ export function toggleEditCompound(json: object): void {
     'is_gas_under_pressure',
     'is_hazardous2env',
     'is_hazardous2health',
+    'is_serious_health_hazard',
     'is_oxidising',
     'is_toxic',
     'is_radioactive',


### PR DESCRIPTION
On importing compounds from PubChem the hazardous to health (GHS07) and serious health hazard (GHS08) properties are not recognized correctly as described in https://github.com/elabftw/elabftw/discussions/5479#discussioncomment-12559741

This PR fixes the handling. In a test with multiple compounds all hazard properties were imported correctly.
