### PR TITLE
Import links in a cross-type way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
             mkdir cypress-coverage-html && tar -xf cypress-coverage.tar -C cypress-coverage-html
             docker cp elabtmp:/elabftw/tests/_output/c3tmp/codecoverage.clover.xml cypress-coverage.clover.xml
             exit "$cypressExitCode"
+          no_output_timeout: 30m
       - run :
           name: Merge both coverage reports
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
             mkdir cypress-coverage-html && tar -xf cypress-coverage.tar -C cypress-coverage-html
             docker cp elabtmp:/elabftw/tests/_output/c3tmp/codecoverage.clover.xml cypress-coverage.clover.xml
             exit "$cypressExitCode"
-          no_output_timeout: 30m
       - run :
           name: Merge both coverage reports
           command: |

--- a/src/models/links/AbstractContainersLinks.php
+++ b/src/models/links/AbstractContainersLinks.php
@@ -254,6 +254,18 @@ abstract class AbstractContainersLinks extends AbstractLinks
     abstract protected function getImportTargetTable(): string;
 
     #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return '';
+    }
+
+    #[Override]
+    protected function getOtherImportTargetTable(): string
+    {
+        return '';
+    }
+
+    #[Override]
     protected function getTemplateTable(): string
     {
         if ($this->Entity instanceof Items || $this->Entity instanceof ItemsTypes) {

--- a/src/models/links/AbstractExperimentsLinks.php
+++ b/src/models/links/AbstractExperimentsLinks.php
@@ -45,6 +45,12 @@ abstract class AbstractExperimentsLinks extends AbstractLinks
     }
 
     #[Override]
+    protected function getOtherImportTargetTable(): string
+    {
+        return 'experiments2items';
+    }
+
+    #[Override]
     protected function getTemplateTable(): string
     {
         if ($this->Entity instanceof Items || $this->Entity instanceof ItemsTypes) {

--- a/src/models/links/AbstractItemsLinks.php
+++ b/src/models/links/AbstractItemsLinks.php
@@ -45,6 +45,12 @@ abstract class AbstractItemsLinks extends AbstractLinks
     }
 
     #[Override]
+    protected function getOtherImportTargetTable(): string
+    {
+        return 'items2experiments';
+    }
+
+    #[Override]
     protected function getTemplateTable(): string
     {
         if ($this->Entity instanceof Experiments || $this->Entity instanceof Templates) {

--- a/src/models/links/AbstractLinks.php
+++ b/src/models/links/AbstractLinks.php
@@ -33,10 +33,17 @@ abstract class AbstractLinks extends AbstractRest
 {
     use SetIdTrait;
 
+    /**
+     * The id of the target (link_id)
+     */
+    public ?int $id;
+
+    /**
+     * @param ?int $id The id of the target (link_id)
+     */
     public function __construct(public AbstractEntity $Entity, ?int $id = null)
     {
         parent::__construct();
-        // this field corresponds to the target id (link_id)
         $this->setId($id);
     }
 
@@ -72,9 +79,6 @@ abstract class AbstractLinks extends AbstractRest
      */
     public function duplicate(int $id, int $newId, $fromTpl = false): int
     {
-        // Todo: Import across entity types, so far exp import exp and res imports res
-        //       but res has to also import exp and exp also has to import res
-        //       Research: How does it behave for exp_temps?
         $table = $this->getTable();
         if ($fromTpl) {
             $table = $this->getTemplateTable();
@@ -144,11 +148,15 @@ abstract class AbstractLinks extends AbstractRest
 
     abstract protected function getTable(): string;
 
+    abstract protected function getOtherImportTypeTable(): string;
+
     abstract protected function getRelatedTable(): string;
 
     abstract protected function getTemplateTable(): string;
 
     abstract protected function getImportTargetTable(): string;
+
+    abstract protected function getOtherImportTargetTable(): string;
 
     /**
      * Add a link to an entity
@@ -175,24 +183,48 @@ abstract class AbstractLinks extends AbstractRest
     }
 
     /**
-     * Copy the links of an item into our entity
-     * Also copy links of an experiment into our entity unless it is a template
+     * Copy the links of one entity into another entity
+     * The linked entity can have links to experiments and/or resources, both need to be imported
      */
     private function import(): int
     {
         $this->Entity->canOrExplode('write');
 
-        // the :item_id of the SELECT will be the same for all rows: our current entity id
-        // use IGNORE to avoid failure due to a key constraint violations
-        $sql = 'INSERT IGNORE INTO ' . $this->getTable() . ' (item_id, link_id)
-            SELECT :item_id, link_id
-            FROM ' . $this->getImportTargetTable() . '
-            WHERE item_id = :link_id';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
-        $req->bindParam(':link_id', $this->id, PDO::PARAM_INT);
+        $tableTypes = array(
+            // same entity type: exp2exp, res2res
+            'same-entity' => array(
+                'table' => $this->getTable(),
+                'import-target' => $this->getImportTargetTable(),
+            ),
+            // other entity type: exp2res, res2exp
+            'other-entity' => array(
+                'table' => $this->getOtherImportTypeTable(),
+                'import-target' => $this->getOtherImportTargetTable(),
+            ),
+        );
 
-        return (int) $this->Db->execute($req);
+        $res = array();
+        foreach ($tableTypes as $tables) {
+            // the :item_id of the SELECT will be the same for all rows: our current entity id
+            // use IGNORE to avoid failure due to a key constraint violations
+            $sql = sprintf(
+                'INSERT IGNORE INTO %s (item_id, link_id)
+                    SELECT :item_id, link_id
+                    FROM %s
+                    WHERE item_id = :link_id',
+                $tables['table'],
+                $tables['import-target'],
+            );
+            $req = $this->Db->prepare($sql);
+            /** @psalm-suppress InaccessibleProperty Seems like a bug as $this->Entity->id is accessible */
+            $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
+            /** @psalm-suppress InaccessibleProperty Seems like a bug as $this->id is accessible */
+            $req->bindParam(':link_id', $this->id, PDO::PARAM_INT);
+
+            $res[] = $this->Db->execute($req);
+        }
+
+        return (int) array_all($res, fn($v) => $v);
     }
 
     // Yes, the boolean is code smell, but it avoids a lot of code duplication

--- a/src/models/links/AbstractLinks.php
+++ b/src/models/links/AbstractLinks.php
@@ -72,6 +72,9 @@ abstract class AbstractLinks extends AbstractRest
      */
     public function duplicate(int $id, int $newId, $fromTpl = false): int
     {
+        // Todo: Import across entity types, so far exp import exp and res imports res
+        //       but res has to also import exp and exp also has to import res
+        //       Research: How does it behave for exp_temps?
         $table = $this->getTable();
         if ($fromTpl) {
             $table = $this->getTemplateTable();

--- a/src/models/links/Experiments2ExperimentsLinks.php
+++ b/src/models/links/Experiments2ExperimentsLinks.php
@@ -24,4 +24,10 @@ final class Experiments2ExperimentsLinks extends AbstractExperimentsLinks
     {
         return 'experiments2experiments';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'experiments2items';
+    }
 }

--- a/src/models/links/Experiments2ItemsLinks.php
+++ b/src/models/links/Experiments2ItemsLinks.php
@@ -24,4 +24,10 @@ final class Experiments2ItemsLinks extends AbstractItemsLinks
     {
         return 'experiments2items';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'experiments2experiments';
+    }
 }

--- a/src/models/links/ExperimentsTemplates2ExperimentsLinks.php
+++ b/src/models/links/ExperimentsTemplates2ExperimentsLinks.php
@@ -24,4 +24,10 @@ final class ExperimentsTemplates2ExperimentsLinks extends AbstractExperimentsLin
     {
         return 'experiments_templates2experiments';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'experiments_templates2items';
+    }
 }

--- a/src/models/links/ExperimentsTemplates2ItemsLinks.php
+++ b/src/models/links/ExperimentsTemplates2ItemsLinks.php
@@ -24,4 +24,10 @@ final class ExperimentsTemplates2ItemsLinks extends AbstractItemsLinks
     {
         return 'experiments_templates2items';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'experiments_templates2experiments';
+    }
 }

--- a/src/models/links/Items2ExperimentsLinks.php
+++ b/src/models/links/Items2ExperimentsLinks.php
@@ -24,4 +24,10 @@ final class Items2ExperimentsLinks extends AbstractExperimentsLinks
     {
         return 'items2experiments';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'items2items';
+    }
 }

--- a/src/models/links/Items2ItemsLinks.php
+++ b/src/models/links/Items2ItemsLinks.php
@@ -24,4 +24,10 @@ final class Items2ItemsLinks extends AbstractItemsLinks
     {
         return 'items2items';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'items2experiments';
+    }
 }

--- a/src/models/links/ItemsTypes2ExperimentsLinks.php
+++ b/src/models/links/ItemsTypes2ExperimentsLinks.php
@@ -24,4 +24,10 @@ final class ItemsTypes2ExperimentsLinks extends AbstractExperimentsLinks
     {
         return 'items_types2experiments';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'items_types2items';
+    }
 }

--- a/src/models/links/ItemsTypes2ItemsLinks.php
+++ b/src/models/links/ItemsTypes2ItemsLinks.php
@@ -24,4 +24,10 @@ final class ItemsTypes2ItemsLinks extends AbstractItemsLinks
     {
         return 'items_types2items';
     }
+
+    #[Override]
+    protected function getOtherImportTypeTable(): string
+    {
+        return 'items_types2experiments';
+    }
 }

--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -10,7 +10,15 @@ import 'jquery-ui/ui/widgets/autocomplete';
 import { Malle } from '@deltablot/malle';
 import Step from './Step.class';
 import i18next from 'i18next';
-import { relativeMoment, makeSortableGreatAgain, reloadElements, addAutocompleteToLinkInputs, addAutocompleteToCompoundsInputs, getEntity, adjustHiddenState } from './misc';
+import {
+  addAutocompleteToCompoundsInputs,
+  addAutocompleteToLinkInputs,
+  adjustHiddenState,
+  getEntity,
+  makeSortableGreatAgain,
+  relativeMoment,
+  reloadElements,
+} from './misc';
 import { Action, Target } from './interfaces';
 import { Api } from './Apiv2.class';
 
@@ -48,7 +56,10 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(() => reloadElements(['stepsDiv']));
     // IMPORT LINK(S) OF LINK
     } else if (el.matches('[data-action="import-links"]')) {
-      Promise.allSettled(['items_links', 'experiments_links'].map(endpoint => ApiC.post(`${entity.type}/${entity.id}/${endpoint}/${el.dataset.target}`, {'action': Action.Duplicate}))).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
+      Promise.allSettled(['items_links', 'experiments_links'].map(endpoint => ApiC.post(
+        `${entity.type}/${entity.id}/${endpoint}/${el.dataset.target}`,
+        {'action': Action.Duplicate},
+      ))).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
     // DESTROY LINK
     } else if (el.matches('[data-action="destroy-link"]')) {
       if (confirm(i18next.t('link-delete-warning'))) {
@@ -104,7 +115,11 @@ document.addEventListener('DOMContentLoaded', () => {
     inputClasses: ['form-control'],
     fun: async (value, original) => {
       return StepC.update(parseInt(original.dataset.stepid, 10), value, original.dataset.target as Target)
-        .then(resp => resp.json()).then(json => original.dataset.target === Target.Body ? json.body : json.deadline);
+        .then(resp => resp.json())
+        .then(json => original.dataset.target === Target.Body
+          ? json.body
+          : json.deadline,
+        );
     },
     listenOn: '.step.editable',
     returnedValueIsTrustedHtml: false,

--- a/tests/cypress/integration/links.cy.ts
+++ b/tests/cypress/integration/links.cy.ts
@@ -39,15 +39,16 @@ describe('Import links', () => {
 
     // link exp A to exp B and res b
     cy.visit('/experiments.php');
-    cy.get('#itemList').contains('Links test-A').click();
+    const targetA = 'Links test-A';
+    cy.get('#itemList').contains(targetA).click();
     cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
-    let target = 'Links test-B';
+    const targetB = 'Links test-B';
     cy.intercept('POST', '/api/v2/experiments/*/experiments_links/*').as('postExpLinkExpApi');
-    cy.get('#addLinkExpInput').type(target, {delay: 0});
+    cy.get('#addLinkExpInput').type(targetB, {delay: 0});
     cy.wait('@getExpQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetB}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
 
@@ -55,52 +56,54 @@ describe('Import links', () => {
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkExpApi');
       cy.wait('@getExpPage');
-      cy.get('#linksExpDiv').should('contain', target);
+      cy.get('#linksExpDiv').should('contain', targetB);
     });
 
+    const targetb = 'Links test-b';
     cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
     cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
-    cy.get('#addLinkItemsInput').type(target, {delay: 0});
+    cy.get('#addLinkItemsInput').type(targetb, {delay: 0});
     cy.wait('@getResQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetb}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkResApi');
       cy.wait('@getExpPage');
-      cy.get('#linksDiv').should('contain', target);
+      cy.get('#linksDiv').should('contain', targetb);
     });
 
     // link res a to exp D and res d
-    target = 'Links test-D';
+    const targetD = 'Links test-D';
     cy.visit('/database.php');
-    cy.get('#itemList').contains('Links test-a').click();
+    const targeta = 'Links test-a';
+    cy.get('#itemList').contains(targeta).click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
     cy.intercept('GET', '/database.php?mode=edit*').as('getResPage');
     cy.intercept('POST', '/api/v2/items/*/experiments_links/*').as('postResLinkExpApi');
-    cy.get('#addLinkExpInput').type(target, {delay: 0});
+    cy.get('#addLinkExpInput').type(targetD, {delay: 0});
     cy.wait('@getExpQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetD}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkExpApi');
       cy.wait('@getResPage');
-      cy.get('#linksExpDiv').should('contain', target);
+      cy.get('#linksExpDiv').should('contain', targetD);
     });
 
-    target = 'Links test-d';
+    const targetd = 'Links test-d';
     cy.intercept('POST', '/api/v2/items/*/items_links/*').as('postResLinkResApi');
-    cy.get('#addLinkItemsInput').type(target, {delay: 0});
+    cy.get('#addLinkItemsInput').type(targetd, {delay: 0});
     cy.wait('@getResQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetd}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkResApi');
       cy.wait('@getResPage');
-      cy.get('#linksDiv').should('contain', target);
+      cy.get('#linksDiv').should('contain', targetd);
     });
 
     // link exp C to exp A and res a
@@ -108,75 +111,81 @@ describe('Import links', () => {
     cy.get('#itemList').contains('Links test-C').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
-    target = 'Links test-A';
-    cy.get('#addLinkExpInput').type(target);
+    cy.get('#addLinkExpInput').type(targetA);
     cy.wait('@getExpQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetA}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkExpApi');
       cy.wait('@getExpPage');
-      cy.get('#linksExpDiv').should('contain', target);
+      cy.get('#linksExpDiv').should('contain', targetA);
     });
 
-    target = 'Links test-a';
-    cy.get('#addLinkItemsInput').type(target);
+    cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkResApi');
       cy.wait('@getExpPage');
-      cy.get('#linksDiv').should('contain', target);
+      cy.get('#linksDiv').should('contain', targeta);
     });
 
     // import links from exp A and res a
-    cy.get('#linksExpDiv [data-action="import-links"]').click();
-    cy.get('#linksExpDiv').should('contain', 'Links test-B');
-    cy.get('#linksDiv').should('contain', 'Links test-b');
-
-    cy.get('#linksDiv [data-action="import-links"]').click();
-    cy.get('#linksExpDiv').should('contain', 'Links test-D');
-    cy.get('#linksDiv').should('contain', 'Links test-d');
+    cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => { //, '@getExpPage'
+        cy.get('#linksExpDiv').should('contain', targetB);
+        cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
+      });
+    });
+    cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', targetD);
+        cy.get('#linksDiv').should('contain', targetd);
+      });
+    });
 
     // link res c to exp A and res a
     cy.visit('/database.php');
     cy.get('#itemList').contains('Links test-c').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
-    target = 'Links test-A';
-    cy.get('#addLinkExpInput').type(target);
+    cy.get('#addLinkExpInput').type(targetA);
     cy.wait('@getExpQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetA}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkExpApi');
       cy.wait('@getResPage');
-      cy.get('#linksExpDiv').should('contain', target);
+      cy.get('#linksExpDiv').should('contain', targetA);
     });
 
-    target = 'Links test-a';
-    cy.get('#addLinkItemsInput').type(target);
+    cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
-      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkResApi');
       cy.wait('@getResPage');
-      cy.get('#linksDiv').should('contain', target);
+      cy.get('#linksDiv').should('contain', targeta);
     });
 
     // import links from exp A and res a
-    cy.get('#linksExpDiv [data-action="import-links"]').click();
-    cy.get('#linksExpDiv').should('contain', 'Links test-B');
-    cy.get('#linksDiv').should('contain', 'Links test-b');
-
-    cy.get('#linksDiv [data-action="import-links"]').click();
-    cy.get('#linksExpDiv').should('contain', 'Links test-D');
-    cy.get('#linksDiv').should('contain', 'Links test-d');
+    cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', targetB);
+        cy.get('#linksDiv').should('contain', targetb);
+      });
+    });
+    cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', targetD);
+        cy.get('#linksDiv').should('contain', targetd);
+      });
+    });
   });
 });

--- a/tests/cypress/integration/links.cy.ts
+++ b/tests/cypress/integration/links.cy.ts
@@ -22,114 +22,151 @@ describe('Import links', () => {
     });
   };
 
-  it('can import from experiments and resources', () => {
-    // create 4 exp via API
+  // create all necessary entities via API
+  before(() => {
+    cy.login().as('csrfToken');
+
+    // create 4 exp
     ['A', 'B', 'C', 'D'].forEach(title => {
       postRequest('experiments', {
         title: `Links test-${title}`,
       }).then(res => expect(res.status).to.equal(201));
     });
 
-    // create 4 res via API
+    // create 4 res
     ['a', 'b', 'c', 'd'].forEach(title => {
       postRequest('items', {
         title: `Links test-${title}`,
       }).then(res => expect(res.status).to.equal(201));
     });
 
-    // link exp A to exp B
+    // create a template
+    postRequest('experiments_templates', {
+      title: 'Links test-template',
+    }).then(res => expect(res.status).to.equal(201));
+  });
+
+  it('experiments can have links to experiments and resources', () => {
     cy.visit('/experiments.php');
-    const targetA = 'Links test-A';
-    cy.get('#itemList').contains(targetA).click();
-    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+    cy.get('#itemList').contains('Links test-A').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+
+    // link to exp B
     const targetB = 'Links test-B';
-    cy.intercept('POST', '/api/v2/experiments/*/experiments_links/*').as('postExpLinkExpApi');
     cy.get('#addLinkExpInput').type(targetB, {delay: 0});
     cy.wait('@getExpQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetB}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
 
+    cy.intercept('POST', '/api/v2/experiments/*/experiments_links/*').as('postExpLinkExpApi');
     cy.intercept('GET', '/experiments.php?mode=edit*').as('getExpPage');
+
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkExpApi');
       cy.wait('@getExpPage');
       cy.get('#linksExpDiv').should('contain', targetB);
     });
 
-    // link exp A to res b
-    const targetb = 'Links test-b';
     cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
-    cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
+
+    // link to res b
+    const targetb = 'Links test-b';
     cy.get('#addLinkItemsInput').type(targetb, {delay: 0});
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetb}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
+
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkResApi');
       cy.wait('@getExpPage');
       cy.get('#linksDiv').should('contain', targetb);
     });
+  });
 
-    // link res a to exp D
-    const targetD = 'Links test-D';
+  it('resources can have links to experiments and resources', () => {
     cy.visit('/database.php');
-    const targeta = 'Links test-a';
-    cy.get('#itemList').contains(targeta).click();
+    cy.get('#itemList').contains('Links test-a').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
-    cy.intercept('GET', '/database.php?mode=edit*').as('getResPage');
-    cy.intercept('POST', '/api/v2/items/*/experiments_links/*').as('postResLinkExpApi');
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+
+    // link to exp D
+    const targetD = 'Links test-D';
     cy.get('#addLinkExpInput').type(targetD, {delay: 0});
     cy.wait('@getExpQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetD}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/items/*/experiments_links/*').as('postResLinkExpApi');
+    cy.intercept('GET', '/database.php?mode=edit*').as('getResPage');
+
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkExpApi');
       cy.wait('@getResPage');
       cy.get('#linksExpDiv').should('contain', targetD);
     });
 
-    // link res a to res d
-    const targetd = 'Links test-d';
+    cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
     cy.intercept('POST', '/api/v2/items/*/items_links/*').as('postResLinkResApi');
+
+    // link to res d
+    const targetd = 'Links test-d';
     cy.get('#addLinkItemsInput').type(targetd, {delay: 0});
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetd}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
+
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkResApi');
       cy.wait('@getResPage');
       cy.get('#linksDiv').should('contain', targetd);
     });
+  });
 
-    // link exp C to exp A
+  it('experiments can import links from experiments and resources', () => {
     cy.visit('/experiments.php');
     cy.get('#itemList').contains('Links test-C').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+
+    // link to exp A
+    const targetA = 'Links test-A';
     cy.get('#addLinkExpInput').type(targetA);
     cy.wait('@getExpQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetA}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/experiments/*/experiments_links/*').as('postExpLinkExpApi');
+    cy.intercept('GET', '/experiments.php?mode=edit*').as('getExpPage');
+
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkExpApi');
       cy.wait('@getExpPage');
       cy.get('#linksExpDiv').should('contain', targetA);
     });
 
-    // link exp C to res a
+    cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
+
+    // link to res a
+    const targeta = 'Links test-a';
     cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
+
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postExpLinkResApi');
       cy.wait('@getExpPage');
@@ -139,41 +176,56 @@ describe('Import links', () => {
     // import links from exp A
     cy.get('#linksExpDiv > :first-child [data-action="import-links"]').click().then(() => {
       cy.wait(['@postExpLinkExpApi', '@postExpLinkResApi', '@getExpPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetB);
-        cy.get('#linksDiv').should('contain', targetb);
+        cy.get('#linksExpDiv').should('contain', 'Links test-B');
+        cy.get('#linksDiv').should('contain', 'Links test-b');
       });
     });
 
     // import links from res a
     cy.get('#linksDiv > :first-child [data-action="import-links"]').click().then(() => {
       cy.wait(['@postExpLinkExpApi', '@postExpLinkResApi', '@getExpPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetD);
-        cy.get('#linksDiv').should('contain', targetd);
+        cy.get('#linksExpDiv').should('contain', 'Links test-D');
+        cy.get('#linksDiv').should('contain', 'Links test-d');
       });
     });
+  });
 
-    // link res c to exp A
+  it('resources can import links from experiments and resources', () => {
     cy.visit('/database.php');
     cy.get('#itemList').contains('Links test-c').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
 
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+
+    // link to exp A
+    const targetA = 'Links test-A';
     cy.get('#addLinkExpInput').type(targetA);
     cy.wait('@getExpQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetA}`).should('be.visible');
       cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/items/*/experiments_links/*').as('postResLinkExpApi');
+    cy.intercept('GET', '/database.php?mode=edit*').as('getResPage');
+
     cy.get('#linksExpDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkExpApi');
       cy.wait('@getResPage');
       cy.get('#linksExpDiv').should('contain', targetA);
     });
 
-    // link res c to res a
+    cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
+
+    // link to res a
+    const targeta = 'Links test-a';
     cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
       cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
     });
+
+    cy.intercept('POST', '/api/v2/items/*/items_links/*').as('postResLinkResApi');
+
     cy.get('#linksDiv').contains('Add').click().then(() => {
       cy.wait('@postResLinkResApi');
       cy.wait('@getResPage');
@@ -183,16 +235,75 @@ describe('Import links', () => {
     // import links from exp A
     cy.get('#linksExpDiv > :first-child [data-action="import-links"]').click().then(() => {
       cy.wait(['@postResLinkExpApi', '@postResLinkResApi', '@getResPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetB);
-        cy.get('#linksDiv').should('contain', targetb);
+        cy.get('#linksExpDiv').should('contain', 'Links test-B');
+        cy.get('#linksDiv').should('contain', 'Links test-b');
       });
     });
 
     // import links from res a
     cy.get('#linksDiv > :first-child [data-action="import-links"]').click().then(() => {
       cy.wait(['@postResLinkExpApi', '@postResLinkResApi', '@getResPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetD);
-        cy.get('#linksDiv').should('contain', targetd);
+        cy.get('#linksExpDiv').should('contain', 'Links test-D');
+        cy.get('#linksDiv').should('contain', 'Links test-d');
+      });
+    });
+  });
+
+  it('experiment templates can import links from experiments and resources', () => {
+    cy.visit('/templates.php');
+    cy.get('#itemList').contains('Links test-template').click();
+    cy.get('#topToolbar').get('[title="Edit"]').click();
+
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+
+    // link to exp A
+    const targetA = 'Links test-A';
+    cy.get('#addLinkExpInput').type(targetA);
+    cy.wait('@getExpQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targetA}`).should('be.visible');
+      cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
+    });
+
+    cy.intercept('POST', '/api/v2/experiments_templates/*/experiments_links/*').as('postTempLinkExpApi');
+    cy.intercept('GET', '/templates.php?mode=edit*').as('getTempPage');
+
+    cy.get('#linksExpDiv').contains('Add').click().then(() => {
+      cy.wait('@postTempLinkExpApi');
+      cy.wait('@getTempPage');
+      cy.get('#linksExpDiv').should('contain', targetA);
+    });
+
+    cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
+
+    // link to res a
+    const targeta = 'Links test-a';
+    cy.get('#addLinkItemsInput').type(targeta);
+    cy.wait('@getResQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
+      cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
+    });
+
+    cy.intercept('POST', '/api/v2/experiments_templates/*/items_links/*').as('postTempLinkResApi');
+
+    cy.get('#linksDiv').contains('Add').click().then(() => {
+      cy.wait('@postTempLinkResApi');
+      cy.wait('@getTempPage');
+      cy.get('#linksDiv').should('contain', targeta);
+    });
+
+    // import links from exp A
+    cy.get('#linksExpDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postTempLinkExpApi', '@postTempLinkResApi', '@getTempPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', 'Links test-B');
+        cy.get('#linksDiv').should('contain', 'Links test-b');
+      });
+    });
+
+    // import links from res a
+    cy.get('#linksDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postTempLinkExpApi', '@postTempLinkResApi', '@getTempPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', 'Links test-D');
+        cy.get('#linksDiv').should('contain', 'Links test-d');
       });
     });
   });

--- a/tests/cypress/integration/links.cy.ts
+++ b/tests/cypress/integration/links.cy.ts
@@ -1,0 +1,182 @@
+describe('Import links', () => {
+  beforeEach(() => {
+    cy.login().as('csrfToken');
+    cy.enableCodeCoverage(Cypress.currentTest.titlePath.join(' '));
+  });
+
+  const postRequest = (endpoint: string, body: object): Cypress.Chainable => {
+    return cy.get('@csrfToken').then(token => {
+      return cy.request({
+        url: `/api/v2/${endpoint}`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': token,
+        },
+        body: JSON.stringify(body),
+        failOnStatusCode: false,
+        followRedirect: false,
+      });
+    });
+  };
+
+  it('can import from experiments and resources', () => {
+    // create 4 exp via API
+    ['A', 'B', 'C', 'D'].forEach(title => {
+      postRequest('experiments', {
+        title: `Links test-${title}`,
+      }).then(res => expect(res.status).to.equal(201));
+    });
+
+    // create 4 res via API
+    ['a', 'b', 'c', 'd'].forEach(title => {
+      postRequest('items', {
+        title: `Links test-${title}`,
+      }).then(res => expect(res.status).to.equal(201));
+    });
+
+    // link exp A to exp B and res b
+    cy.visit('/experiments.php');
+    cy.get('#itemList').contains('Links test-A').click();
+    cy.intercept('GET', /\/api\/v2\/experiments\/\?.+$/).as('getExpQueryApi');
+    cy.get('#topToolbar').get('[title="Edit"]').click();
+
+    let target = 'Links test-B';
+    cy.intercept('POST', '/api/v2/experiments/*/experiments_links/*').as('postExpLinkExpApi');
+    cy.get('#addLinkExpInput').type(target, {delay: 0});
+    cy.wait('@getExpQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
+    });
+
+    cy.intercept('GET', '/experiments.php?mode=edit*').as('getExpPage');
+    cy.get('#linksExpDiv').contains('Add').click().then(() => {
+      cy.wait('@postExpLinkExpApi');
+      cy.wait('@getExpPage');
+      cy.get('#linksExpDiv').should('contain', target);
+    });
+
+    cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
+    cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
+    cy.get('#addLinkItemsInput').type(target, {delay: 0});
+    cy.wait('@getResQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksDiv').contains('Add').click().then(() => {
+      cy.wait('@postExpLinkResApi');
+      cy.wait('@getExpPage');
+      cy.get('#linksDiv').should('contain', target);
+    });
+
+    // link res a to exp D and res d
+    target = 'Links test-D';
+    cy.visit('/database.php');
+    cy.get('#itemList').contains('Links test-a').click();
+    cy.get('#topToolbar').get('[title="Edit"]').click();
+
+    cy.intercept('GET', '/database.php?mode=edit*').as('getResPage');
+    cy.intercept('POST', '/api/v2/items/*/experiments_links/*').as('postResLinkExpApi');
+    cy.get('#addLinkExpInput').type(target, {delay: 0});
+    cy.wait('@getExpQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksExpDiv').contains('Add').click().then(() => {
+      cy.wait('@postResLinkExpApi');
+      cy.wait('@getResPage');
+      cy.get('#linksExpDiv').should('contain', target);
+    });
+
+    target = 'Links test-d';
+    cy.intercept('POST', '/api/v2/items/*/items_links/*').as('postResLinkResApi');
+    cy.get('#addLinkItemsInput').type(target, {delay: 0});
+    cy.wait('@getResQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksDiv').contains('Add').click().then(() => {
+      cy.wait('@postResLinkResApi');
+      cy.wait('@getResPage');
+      cy.get('#linksDiv').should('contain', target);
+    });
+
+    // link exp C to exp A and res a
+    cy.visit('/experiments.php');
+    cy.get('#itemList').contains('Links test-C').click();
+    cy.get('#topToolbar').get('[title="Edit"]').click();
+
+    target = 'Links test-A';
+    cy.get('#addLinkExpInput').type(target);
+    cy.wait('@getExpQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksExpDiv').contains('Add').click().then(() => {
+      cy.wait('@postExpLinkExpApi');
+      cy.wait('@getExpPage');
+      cy.get('#linksExpDiv').should('contain', target);
+    });
+
+    target = 'Links test-a';
+    cy.get('#addLinkItemsInput').type(target);
+    cy.wait('@getResQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksDiv').contains('Add').click().then(() => {
+      cy.wait('@postExpLinkResApi');
+      cy.wait('@getExpPage');
+      cy.get('#linksDiv').should('contain', target);
+    });
+
+    // import links from exp A and res a
+    cy.get('#linksExpDiv [data-action="import-links"]').click();
+    cy.get('#linksExpDiv').should('contain', 'Links test-B');
+    cy.get('#linksDiv').should('contain', 'Links test-b');
+
+    cy.get('#linksDiv [data-action="import-links"]').click();
+    cy.get('#linksExpDiv').should('contain', 'Links test-D');
+    cy.get('#linksDiv').should('contain', 'Links test-d');
+
+    // link res c to exp A and res a
+    cy.visit('/database.php');
+    cy.get('#itemList').contains('Links test-c').click();
+    cy.get('#topToolbar').get('[title="Edit"]').click();
+
+    target = 'Links test-A';
+    cy.get('#addLinkExpInput').type(target);
+    cy.wait('@getExpQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkExpInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksExpDiv').contains('Add').click().then(() => {
+      cy.wait('@postResLinkExpApi');
+      cy.wait('@getResPage');
+      cy.get('#linksExpDiv').should('contain', target);
+    });
+
+    target = 'Links test-a';
+    cy.get('#addLinkItemsInput').type(target);
+    cy.wait('@getResQueryApi').then(() => {
+      cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${target}`).should('be.visible');
+      cy.get('#addLinkItemsInput').type('{downArrow}', {delay: 500});
+    });
+    cy.get('#linksDiv').contains('Add').click().then(() => {
+      cy.wait('@postResLinkResApi');
+      cy.wait('@getResPage');
+      cy.get('#linksDiv').should('contain', target);
+    });
+
+    // import links from exp A and res a
+    cy.get('#linksExpDiv [data-action="import-links"]').click();
+    cy.get('#linksExpDiv').should('contain', 'Links test-B');
+    cy.get('#linksDiv').should('contain', 'Links test-b');
+
+    cy.get('#linksDiv [data-action="import-links"]').click();
+    cy.get('#linksExpDiv').should('contain', 'Links test-D');
+    cy.get('#linksDiv').should('contain', 'Links test-d');
+  });
+});

--- a/tests/cypress/integration/links.cy.ts
+++ b/tests/cypress/integration/links.cy.ts
@@ -137,12 +137,12 @@ describe('Import links', () => {
     cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
       cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => { //, '@getExpPage'
         cy.get('#linksExpDiv').should('contain', targetB);
-        cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
+        // cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
       });
     });
     cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
       cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetD);
+        // cy.get('#linksExpDiv').should('contain', targetD); // Todo: this is not working, the link is not imported
         cy.get('#linksDiv').should('contain', targetd);
       });
     });
@@ -178,12 +178,12 @@ describe('Import links', () => {
     cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
       cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
         cy.get('#linksExpDiv').should('contain', targetB);
-        cy.get('#linksDiv').should('contain', targetb);
+        // cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
       });
     });
     cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
       cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
-        cy.get('#linksExpDiv').should('contain', targetD);
+        // cy.get('#linksExpDiv').should('contain', targetD); // Todo: this is not working, the link is not imported
         cy.get('#linksDiv').should('contain', targetd);
       });
     });

--- a/tests/cypress/integration/links.cy.ts
+++ b/tests/cypress/integration/links.cy.ts
@@ -37,7 +37,7 @@ describe('Import links', () => {
       }).then(res => expect(res.status).to.equal(201));
     });
 
-    // link exp A to exp B and res b
+    // link exp A to exp B
     cy.visit('/experiments.php');
     const targetA = 'Links test-A';
     cy.get('#itemList').contains(targetA).click();
@@ -59,6 +59,7 @@ describe('Import links', () => {
       cy.get('#linksExpDiv').should('contain', targetB);
     });
 
+    // link exp A to res b
     const targetb = 'Links test-b';
     cy.intercept('GET', /api\/v2\/items\/\?.+$/).as('getResQueryApi');
     cy.intercept('POST', '/api/v2/experiments/*/items_links/*').as('postExpLinkResApi');
@@ -73,7 +74,7 @@ describe('Import links', () => {
       cy.get('#linksDiv').should('contain', targetb);
     });
 
-    // link res a to exp D and res d
+    // link res a to exp D
     const targetD = 'Links test-D';
     cy.visit('/database.php');
     const targeta = 'Links test-a';
@@ -93,6 +94,7 @@ describe('Import links', () => {
       cy.get('#linksExpDiv').should('contain', targetD);
     });
 
+    // link res a to res d
     const targetd = 'Links test-d';
     cy.intercept('POST', '/api/v2/items/*/items_links/*').as('postResLinkResApi');
     cy.get('#addLinkItemsInput').type(targetd, {delay: 0});
@@ -106,7 +108,7 @@ describe('Import links', () => {
       cy.get('#linksDiv').should('contain', targetd);
     });
 
-    // link exp C to exp A and res a
+    // link exp C to exp A
     cy.visit('/experiments.php');
     cy.get('#itemList').contains('Links test-C').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
@@ -122,6 +124,7 @@ describe('Import links', () => {
       cy.get('#linksExpDiv').should('contain', targetA);
     });
 
+    // link exp C to res a
     cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
@@ -133,21 +136,23 @@ describe('Import links', () => {
       cy.get('#linksDiv').should('contain', targeta);
     });
 
-    // import links from exp A and res a
-    cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
-      cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => { //, '@getExpPage'
+    // import links from exp A
+    cy.get('#linksExpDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postExpLinkExpApi', '@postExpLinkResApi', '@getExpPage'], {timeout: 60000}).then(() => {
         cy.get('#linksExpDiv').should('contain', targetB);
-        // cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
+        cy.get('#linksDiv').should('contain', targetb);
       });
     });
-    cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
-      cy.wait(['@postExpLinkExpApi', '@getExpPage'], {timeout: 60000}).then(() => {
-        // cy.get('#linksExpDiv').should('contain', targetD); // Todo: this is not working, the link is not imported
+
+    // import links from res a
+    cy.get('#linksDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postExpLinkExpApi', '@postExpLinkResApi', '@getExpPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', targetD);
         cy.get('#linksDiv').should('contain', targetd);
       });
     });
 
-    // link res c to exp A and res a
+    // link res c to exp A
     cy.visit('/database.php');
     cy.get('#itemList').contains('Links test-c').click();
     cy.get('#topToolbar').get('[title="Edit"]').click();
@@ -163,6 +168,7 @@ describe('Import links', () => {
       cy.get('#linksExpDiv').should('contain', targetA);
     });
 
+    // link res c to res a
     cy.get('#addLinkItemsInput').type(targeta);
     cy.wait('@getResQueryApi').then(() => {
       cy.get('.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front').contains(`- ${targeta}`).should('be.visible');
@@ -174,16 +180,18 @@ describe('Import links', () => {
       cy.get('#linksDiv').should('contain', targeta);
     });
 
-    // import links from exp A and res a
-    cy.get('#linksExpDiv [data-action="import-links"]').click().then(() => {
-      cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
+    // import links from exp A
+    cy.get('#linksExpDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postResLinkExpApi', '@postResLinkResApi', '@getResPage'], {timeout: 60000}).then(() => {
         cy.get('#linksExpDiv').should('contain', targetB);
-        // cy.get('#linksDiv').should('contain', targetb); // Todo: this is not working, the link is not imported
+        cy.get('#linksDiv').should('contain', targetb);
       });
     });
-    cy.get('#linksDiv [data-action="import-links"]').click().then(() => {
-      cy.wait(['@postResLinkExpApi', '@getResPage'], {timeout: 60000}).then(() => {
-        // cy.get('#linksExpDiv').should('contain', targetD); // Todo: this is not working, the link is not imported
+
+    // import links from res a
+    cy.get('#linksDiv > :first-child [data-action="import-links"]').click().then(() => {
+      cy.wait(['@postResLinkExpApi', '@postResLinkResApi', '@getResPage'], {timeout: 60000}).then(() => {
+        cy.get('#linksExpDiv').should('contain', targetD);
         cy.get('#linksDiv').should('contain', targetd);
       });
     });


### PR DESCRIPTION
As pointed out in #4326 currently the "import links" feature only works partially.

This PR implements the full import approach. No additional button, no modal. Just import all linked entities.

The added cypress test links entities as visualized in the picture.
![links_expected](https://github.com/user-attachments/assets/dc8a8cd6-7a07-4d13-9538-2084b857c75f)
