### PR TITLE
Add missing entityData key to templates

### DIFF
--- a/src/classes/TemplatesSqlBuilder.php
+++ b/src/classes/TemplatesSqlBuilder.php
@@ -25,6 +25,7 @@ final class TemplatesSqlBuilder extends EntitySqlBuilder
             entity.userid,
             entity.created_at,
             entity.modified_at,
+            entity.lastchangeby,
             entity.team,
             entity.title,
             entity.status,

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -27,7 +27,7 @@
 
 {# show message if it was recently modified #}
 {% set lastchangeDiff = 'now'|date('U') - Entity.entityData.modified_at|date('U') %}
-{% if (lastchangeDiff < 600) and not Entity.entityData.lastchangeby is null and Entity.entityData.lastchangeby != Entity.Users.userData.userid %}
+{% if (lastchangeDiff < 600) and Entity.entityData.lastchangeby is not null and Entity.entityData.lastchangeby != Entity.Users.userData.userid %}
   {{ 'Warning: this entry was modified %s seconds ago by %s.'|trans|format(lastchangeDiff, lastModifierFullname)|msg('warning', false) }}
 {% endif %}
 


### PR DESCRIPTION
I noticed the following entry in the PHP logs:
```
[error] 197#197: *302 FastCGI sent in stderr: "
PHP message: PHP Warning:  Undefined array key "lastchangeby" in /elabftw/src/controllers/AbstractEntityController.php on line 263;
PHP message: PHP Stack trace:;
PHP message: PHP   1. {main}() /elabftw/web/templates.php:0;
PHP message: PHP   2. Elabftw\Controllers\AbstractEntityController->getResponse() /elabftw/web/templates.php:36;
PHP message: PHP   3. Elabftw\Controllers\AbstractEntityController->edit() /elabftw/src/controllers/AbstractEntityController.php:93
" while reading response header from upstream, client: 172.20.0.5, server: localhost,
request: "GET /templates.php?mode=edit&id=27 HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "elabtmp"
```