### PR TITLE
fix: metadata: sending data via json editor updates group select in b…

### DIFF
--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -444,6 +444,8 @@ export class Metadata {
         groupWrapperDiv.append(document.createElement('hr'));
         this.metadataDiv.append(groupWrapperDiv);
       });
+      // refresh the existing groups select on update (see 5611)
+      reloadElements(['newFieldGroupSelect', 'fieldsGroup']);
     }).then (() => {
       replaceWithTitle();
     });
@@ -511,8 +513,9 @@ export class Metadata {
   edit(): Promise<void> {
     return this.read().then(json => {
       this.editor.refresh(json as ValidMetadata);
-      // do nothing more if there is no extra_fields in our json
+      // clean groups field if they're removed via json editor
       if (!Object.prototype.hasOwnProperty.call(json, 'extra_fields')) {
+        reloadElements(['newFieldGroupSelect', 'fieldsGroup']);
         return;
       }
 
@@ -647,6 +650,7 @@ export class Metadata {
       });
 
       this.metadataDiv.append(wrapperDiv);
+      reloadElements(['newFieldGroupSelect', 'fieldsGroup']);
     }).then(() => {
       makeSortableGreatAgain();
       replaceWithTitle();

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -370,7 +370,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       let json = {};
       MetadataC.read().then(metadata => {
-        if (metadata) json = metadata;
+        if (metadata) {
+          json = metadata;
+        }
         // If the key (name) is being changed, remove previous field else it will create two separate ones
         if (originalFieldKey && originalFieldKey !== newFieldKey) {
           delete json['extra_fields'][originalFieldKey];


### PR DESCRIPTION
Fix #5611 

- metadata update in json refreshes the groups select in the modal
- when clearing/resetting to an empty json `{}` in the editor, it clears the groups select as well. Before, it would remove the groups from UI but in the modal they'd stay clickable and prompt errors.

**How to reproduce**

- Paste a json object following the metadata schema in the JSON Editor.
Example schema
```json
{ "elabftw": { "extra_fields_groups": [ { "id": 1, "name": "Laser Wavelength" }, { "id": 2, "name": "Laser Power" }, { "id": 3, "name": "Accumulation" }, { "id": 4, "name": "Integration Time" }, { "id": 5, "name": "Resolution" }, { "id": 6, "name": "Objective" } ] }, "extra_fields": { "laserWavelength": { "type": "number", "value":"", "group_id":1 }, "laserWavelengthUnit":{ "type":"select", "value":"", "options":[ "nm", "cm⁻¹" ], "group_id":1 }, "laserPower": { "type": "number", "value":"", "group_id":2 }, "laserPowerUnit":{ "type":"select", "value":"", "options":[ "W", "kW", "mW" ], "group_id":2 }, "accumulation": { "type": "number", "value":"", "group_id":3 }, "duration": { "type": "number", "value":"", "group_id":4 }, "durationUnit":{ "type":"select", "value":"", "options":[ "s", "ms" ], "group_id":4 }, "resolution": { "type": "number", "value":"", "group_id":5 }, "resolutionUnit":{ "type":"select", "value":"", "options":[ "cm⁻", "nm" ], "group_id":5 }, "objective": { "type": "number", "value":"", "group_id":6 } } } 
```
- Save the changes
- Check that the UI updates with the groups & fields.
- Check that, on the builder modal (click `Add field` or the `edit` button of an item) that the groups selection list is refreshed.
![image](https://github.com/user-attachments/assets/efb54886-af7c-4610-91bc-7db17d7c2f04)

- empty the json editor with an empty value `{}`
- check that it resets to default group only
