### PR TITLE
fix: pdf: table layout unstable on pdf export

### DIFF
--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -35,6 +35,8 @@ code {
 
 table {
   border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
 }
 
 table,

--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -33,6 +33,7 @@ code {
   list-style-type: none;
 }
 
+/* fix table being collapsed on export */
 table {
   border-collapse: collapse;
   table-layout: fixed;

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -378,6 +378,10 @@ export function getTinymceBaseConfig(page: string): object {
           }, 50);
         }
       });
+      // prevent tables width from being set to "auto" and cause pdf export issues (see #5601)
+      editor.on('GetContent', (e) => {
+        e.content = e.content.replace(/(<table[^>]*?)\sstyle="[^"]*?width\s*:\s*auto;?[^"]*?"([^>]*?>)/gi, '$1$2');
+      });
 
       // floppy disk icon from COLLECTION: Zest Interface Icons LICENSE: MIT License AUTHOR: zest
       editor.ui.registry.addIcon('customSave', '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 5a1 1 0 0 1 1-1h2v3a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V4h.172a1 1 0 0 1 .707.293l2.828 2.828a1 1 0 0 1 .293.707V19a1 1 0 0 1-1 1h-1v-7a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v7H5a1 1 0 0 1-1-1V5Zm4 15h8v-6H8v6Zm6-16H9v2h5V4ZM5 2a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7.828a3 3 0 0 0-.879-2.12l-2.828-2.83A3 3 0 0 0 16.172 2H5Z" /></svg>'), // eslint-disable-line

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -211,7 +211,6 @@ export function getTinymceBaseConfig(page: string): object {
     selector: '.mceditable',
     table_default_styles: {
       'min-width':'25%',
-      'width':'auto',
     },
     // The table width is changed when manipulating columns, the size of other columns is maintained.
     table_column_resizing: 'resizetable',


### PR DESCRIPTION
Fix #5601 

Some tables are edited with a fixed size, resized manually (drag and drop), %, etc.
![image](https://github.com/user-attachments/assets/f15bceb7-e53f-4e3c-bbb9-b71cb865f51b)

- table layout set to fixed and width in pdf exports to take enough space
- regex to prevent (on the GetContent step) the table to be set to auto.