### PR TITLE
fix: metadata: fieldname processing

### DIFF
--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -157,8 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="metadata-rm-field"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         MetadataC.read().then(metadata => {
-          const rawName = el.parentElement.parentElement.closest('div').querySelector('label').innerText.trim();
-          const name = normalizeFieldName(rawName);
+          const name = el.parentElement.parentElement.closest('div').querySelector('label').innerText.trim();
           delete metadata.extra_fields[name];
           MetadataC.update(metadata as ValidMetadata).then(() => document.getElementById('metadataDiv').scrollIntoView());
         });

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -9,6 +9,7 @@ import {
   getEntity,
   notifError,
   addAutocompleteToExtraFieldsKeyInputs,
+  normalizeFieldName,
 } from './misc';
 import { Metadata } from './Metadata.class';
 import { ValidMetadata, ExtraFieldInputType } from './metadataInterfaces';
@@ -156,7 +157,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (el.matches('[data-action="metadata-rm-field"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {
         MetadataC.read().then(metadata => {
-          const name = el.parentElement.parentElement.closest('div').querySelector('label').innerText.trim();
+          const rawName = el.parentElement.parentElement.closest('div').querySelector('label').innerText.trim();
+          const name = normalizeFieldName(rawName);
           delete metadata.extra_fields[name];
           MetadataC.update(metadata as ValidMetadata).then(() => document.getElementById('metadataDiv').scrollIntoView());
         });
@@ -193,6 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   addAutocompleteToExtraFieldsKeyInputs();
+
 
   function toggleContentDiv(key: string) {
     const keys = ['classic', 'selectradio', 'checkbox', 'number'];
@@ -280,7 +283,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const fieldKey = (document.getElementById('newFieldKeyInput') as HTMLInputElement).value.trim();
+      const fieldKeyValue = (document.getElementById('newFieldKeyInput') as HTMLInputElement).value.trim();
+      const fieldKey = normalizeFieldName(fieldKeyValue);
 
       let json = {};
       // get the current metadata
@@ -366,7 +370,8 @@ document.addEventListener('DOMContentLoaded', () => {
       // get field to update's current value
       const fieldNameInput = document.getElementById('newFieldKeyInput') as HTMLInputElement;
       const originalFieldKey = fieldNameInput.dataset.name; // store previous key
-      const newFieldKey = fieldNameInput.value.trim(); // new key from input
+      const newFieldKeyValue = fieldNameInput.value.trim(); // new key from input
+      const newFieldKey = normalizeFieldName(newFieldKeyValue);
 
       let json = {};
       MetadataC.read().then(metadata => {

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -479,6 +479,11 @@ export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// used in metadata.ts to normalize field names only by trimming out double and simple quotes, causing to SQL issues
+export function normalizeFieldName(input: string): string {
+  return input.replace(/['"]/g, '').trim().replace(/\s+/g, ' ');
+}
+
 function removeEmpty(params: object): object {
   for (const [key, value] of Object.entries(params)) {
     if (value === '') {


### PR DESCRIPTION
- having an extra field like `this "is" the 'field'` would impact SQL queries
- normalize() function to validate inputs before save, edit and delete
- if you already have extra fields with the names containing " and that won't upload, just click edit and save so the input gets normalized