### PR TITLE
feat: uploads: always show archived files section

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -4302,12 +4302,20 @@ paths:
         required: true
         schema:
           type: integer
-      - name: archived
+      - name: state
         in: query
-        description: Include archived uploads in the response if the value is truthy.
-        required: false
         schema:
           type: string
+          default: "1"
+        examples:
+          first:
+            summary: Display only archived uploads
+            value: "2"
+          second:
+            summary: Display archived and deleted uploads
+            value: "2,3"
+        description: |
+          Filter results based on their state: 1 (Normal), 2 (Archived), 3 (Deleted). Supports comma separated values.
     get:
       tags: ['Uploads']
       summary: Read attached files of that entity.

--- a/src/Params/BaseQueryParams.php
+++ b/src/Params/BaseQueryParams.php
@@ -81,6 +81,7 @@ class BaseQueryParams implements QueryParamsInterface
         );
     }
 
+    #[Override]
     public function getStatesSql(string $tableName): string
     {
         return sprintf(' AND %s.state IN (%s)', $tableName, implode(', ', array_map(fn($state) => $state->value, $this->states)));

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -79,9 +79,6 @@ abstract class AbstractEntityController implements ControllerInterface
         $this->scopedTeamgroupsArr = $TeamGroups->readScopedTeamgroups();
         $Templates = new Templates($this->Entity->Users);
         $this->templatesArr = $Templates->Pins->readAll();
-        if ($App->Request->query->has('archived') && $Entity instanceof AbstractConcreteEntity) {
-            $Entity->Uploads->includeArchived = true;
-        }
     }
 
     #[Override]

--- a/src/controllers/Apiv2Controller.php
+++ b/src/controllers/Apiv2Controller.php
@@ -343,7 +343,7 @@ final class Apiv2Controller extends AbstractApiController
                 ),
                 ApiSubModels::Steps => new Steps($this->Model, $this->subId),
                 ApiSubModels::Tags => new Tags($this->Model, $this->subId),
-                ApiSubModels::Uploads => new Uploads($this->Model, $this->subId, includeArchived: $this->Request->query->getBoolean('archived')),
+                ApiSubModels::Uploads => new Uploads($this->Model, $this->subId),
                 default => throw new InvalidApiSubModelException(ApiEndpoint::from($this->Model->entityType->value)),
             };
         }

--- a/src/interfaces/QueryParamsInterface.php
+++ b/src/interfaces/QueryParamsInterface.php
@@ -21,4 +21,6 @@ interface QueryParamsInterface
     public function getQuery(): InputBag;
 
     public function getLimit(): int;
+
+    public function getStatesSql(string $tableName): string;
 }

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -116,6 +116,8 @@ abstract class AbstractConcreteEntity extends AbstractEntity
         if ($this->id === null) {
             throw new IllegalActionException('No id was set!');
         }
+        // build query params for Uploads
+        $queryParams = $this->getQueryParams(Request::createFromGlobals()->query);
         $EntitySqlBuilder = new EntitySqlBuilder($this);
         $sql = $EntitySqlBuilder->getReadSqlBeforeWhere(true, true);
 
@@ -134,7 +136,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity
         $this->entityData['items_links'] = $this->ItemsLinks->readAll();
         $this->entityData['related_experiments_links'] = $this->ExperimentsLinks->readRelated();
         $this->entityData['related_items_links'] = $this->ItemsLinks->readRelated();
-        $this->entityData['uploads'] = $this->Uploads->readAll();
+        $this->entityData['uploads'] = $this->Uploads->readAll($queryParams);
         $this->entityData['comments'] = $this->Comments->readAll();
         $this->entityData['page'] = substr($this->entityType->toPage(), 0, -4);
         $CompoundsLinks = LinksFactory::getCompoundsLinks($this);

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -135,7 +135,6 @@ abstract class AbstractConcreteEntity extends AbstractEntity
         $this->entityData['related_experiments_links'] = $this->ExperimentsLinks->readRelated();
         $this->entityData['related_items_links'] = $this->ItemsLinks->readRelated();
         $this->entityData['uploads'] = $this->Uploads->readAll();
-        $this->entityData['uploadsCount'] = $this->Uploads->getUploadCounts();
         $this->entityData['comments'] = $this->Comments->readAll();
         $this->entityData['page'] = substr($this->entityType->toPage(), 0, -4);
         $CompoundsLinks = LinksFactory::getCompoundsLinks($this);

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -135,6 +135,7 @@ abstract class AbstractConcreteEntity extends AbstractEntity
         $this->entityData['related_experiments_links'] = $this->ExperimentsLinks->readRelated();
         $this->entityData['related_items_links'] = $this->ItemsLinks->readRelated();
         $this->entityData['uploads'] = $this->Uploads->readAll();
+        $this->entityData['uploadsCount'] = $this->Uploads->getUploadCounts();
         $this->entityData['comments'] = $this->Comments->readAll();
         $this->entityData['page'] = substr($this->entityType->toPage(), 0, -4);
         $CompoundsLinks = LinksFactory::getCompoundsLinks($this);

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -380,7 +380,6 @@ abstract class AbstractEntity extends AbstractRest
 
     public function readOneFull(): array
     {
-        $this->Uploads->includeArchived = true;
         $base = $this->readOne();
         // items types don't have this yet
         if ($this instanceof AbstractConcreteEntity || $this instanceof Templates) {

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -41,6 +41,7 @@ use Elabftw\Traits\EntityTrait;
 use PDO;
 use PDOStatement;
 use Override;
+use Symfony\Component\HttpFoundation\InputBag;
 
 use function array_column;
 use function array_merge;
@@ -385,6 +386,10 @@ abstract class AbstractEntity extends AbstractRest
         if ($this instanceof AbstractConcreteEntity || $this instanceof Templates) {
             $base['revisions'] = (new Revisions($this))->readAll();
             $base['changelog'] = (new Changelog($this))->readAll();
+            // we want to include ALL uploaded files
+            $base['uploads'] = (new Uploads($this))->readAll(
+                $this->getQueryParams(new InputBag(array('state' => '1,2,3')))
+            );
         }
         ksort($base);
         return $base;

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -27,6 +27,7 @@ use Elabftw\Services\Filter;
 use Elabftw\Traits\SortableTrait;
 use Override;
 use PDO;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * All about the templates
@@ -163,6 +164,7 @@ final class Templates extends AbstractTemplateEntity
         if ($this->id === null) {
             throw new IllegalActionException('No id was set!');
         }
+        $queryParams = $this->getQueryParams(Request::createFromGlobals()->query);
         $builder = new TemplatesSqlBuilder($this);
         $sql = $builder->getReadSqlBeforeWhere(getTags: true, fullSelect: true);
         $sql .= sprintf(' WHERE entity.id = %d', $this->id);
@@ -194,7 +196,7 @@ final class Templates extends AbstractTemplateEntity
         if (!empty($this->entityData['metadata'])) {
             $this->entityData['metadata_decoded'] = json_decode($this->entityData['metadata']);
         }
-        $this->entityData['uploads'] = $this->Uploads->readAll();
+        $this->entityData['uploads'] = $this->Uploads->readAll($queryParams);
         $this->entityData['exclusive_edit_mode'] = $this->ExclusiveEditMode->readOne();
         return $this->entityData;
     }

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -255,6 +255,28 @@ final class Uploads extends AbstractRest
         return $req->fetchAll();
     }
 
+    // Retrieves the number of uploads for current entity.
+    // Returns an array with 'normal_' and 'archived_' count.
+    public function getUploadCounts(): array
+    {
+        $sql = 'SELECT
+            SUM(CASE WHEN state = :normal THEN 1 ELSE 0 END) AS normal_count,
+            SUM(CASE WHEN state = :archived THEN 1 ELSE 0 END) AS archived_count
+            FROM uploads WHERE item_id = :id AND type = :type';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
+        $req->bindValue(':type', $this->Entity->entityType->value);
+        $req->bindValue(':normal', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':archived', State::Archived->value, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $result = $req->fetch(PDO::FETCH_ASSOC);
+        if (!$result) {
+            return array('normal_count' => 0, 'archived_count' => 0);
+        }
+        return $result;
+    }
+
     #[Override]
     public function patch(Action $action, array $params): array
     {

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -255,8 +255,9 @@ final class Uploads extends AbstractRest
         return $req->fetchAll();
     }
 
-    // Retrieves the number of uploads for current entity.
-    // Returns an array with 'normal_' and 'archived_' count.
+    /**
+     * Retrieves the number of uploads for current entity as an associative array.
+    */
     public function getUploadCounts(): array
     {
         $sql = 'SELECT

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -33,7 +33,6 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use Override;
 use PDO;
 use RuntimeException;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 use function hash_file;
@@ -236,10 +235,8 @@ final class Uploads extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
-        $Request = Request::createFromGlobals();
-        $queryParams = $this->getQueryParams($Request->query);
+        $queryParams ??= $this->getQueryParams();
         $statesSql = $queryParams->getStatesSql('uploads');
-
         $sql = sprintf(
             'SELECT uploads.*, CONCAT (users.firstname, " ", users.lastname) AS fullname
             FROM uploads LEFT JOIN users ON (uploads.userid = users.userid)

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -33,6 +33,7 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use Override;
 use PDO;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 use function hash_file;
@@ -229,20 +230,33 @@ final class Uploads extends AbstractRest
     }
 
     /**
-     * Read only the normal ones (not archived/deleted)
+     * Read all uploads except deleted ones.
+     * Includes 'archived' only if set in queryParams.
      */
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        $Request = Request::createFromGlobals();
+        $queryParams = $this->getQueryParams($Request->query);
+        $this->includeArchived = $queryParams->getQuery()->getBoolean('archived');
+
+        $state = 'state = :normal';
         if ($this->includeArchived) {
-            return $this->readNormalAndArchived();
+            $state = '(state = :normal OR uploads.state = :archived)';
         }
-        $sql = 'SELECT uploads.*, CONCAT (users.firstname, " ", users.lastname) AS fullname
-            FROM uploads LEFT JOIN users ON (uploads.userid = users.userid) WHERE item_id = :id AND type = :type AND state = :state ORDER BY created_at DESC';
+        $sql = sprintf(
+            "SELECT uploads.*, CONCAT (users.firstname, ' ', users.lastname) AS fullname
+            FROM uploads LEFT JOIN users ON (uploads.userid = users.userid) WHERE item_id = :id AND type = :type AND %s ORDER BY created_at DESC",
+            $state
+        );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $req->bindValue(':type', $this->Entity->entityType->value);
-        $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
+        $req->bindValue(':normal', State::Normal->value, PDO::PARAM_INT);
+
+        if ($this->includeArchived) {
+            $req->bindValue(':archived', State::Archived->value, PDO::PARAM_INT);
+        }
         $this->Db->execute($req);
 
         return $req->fetchAll();
@@ -376,21 +390,6 @@ final class Uploads extends AbstractRest
         $req->bindValue(':content', $params->getContent());
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
-    }
-
-    private function readNormalAndArchived(): array
-    {
-        $sql = 'SELECT uploads.*, CONCAT (users.firstname, " ", users.lastname) AS fullname
-            FROM uploads LEFT JOIN users ON (uploads.userid = users.userid) WHERE item_id = :id AND type = :type AND (state = :normal OR state = :archived) ORDER BY uploads.created_at DESC';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
-        $req->bindValue(':type', $this->Entity->entityType->value);
-        $req->bindValue(':normal', State::Normal->value, PDO::PARAM_INT);
-        $req->bindValue(':archived', State::Archived->value, PDO::PARAM_INT);
-        $this->Db->execute($req);
-
-        return $req->fetchAll();
-
     }
 
     /**

--- a/src/models/Uploads.php
+++ b/src/models/Uploads.php
@@ -255,29 +255,6 @@ final class Uploads extends AbstractRest
         return $req->fetchAll();
     }
 
-    /**
-     * Retrieves the number of uploads for current entity as an associative array.
-    */
-    public function getUploadCounts(): array
-    {
-        $sql = 'SELECT
-            SUM(CASE WHEN state = :normal THEN 1 ELSE 0 END) AS normal_count,
-            SUM(CASE WHEN state = :archived THEN 1 ELSE 0 END) AS archived_count
-            FROM uploads WHERE item_id = :id AND type = :type';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
-        $req->bindValue(':type', $this->Entity->entityType->value);
-        $req->bindValue(':normal', State::Normal->value, PDO::PARAM_INT);
-        $req->bindValue(':archived', State::Archived->value, PDO::PARAM_INT);
-        $this->Db->execute($req);
-
-        $result = $req->fetch(PDO::FETCH_ASSOC);
-        if (!$result) {
-            return array('normal_count' => 0, 'archived_count' => 0);
-        }
-        return $result;
-    }
-
     #[Override]
     public function patch(Action $action, array $params): array
     {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1119,7 +1119,7 @@ the form-control fails to do that so we do the border ourselves */
   nav,
   footer,
   #menu,
-  #filesdiv,
+  #filesDiv,
   #commentsDiv,
   #withSelected,
   .item-info > .clickable,

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -24,7 +24,7 @@
   {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
-      <h3 id='filesCount' title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -22,7 +22,6 @@
 {# UPLOADED FILES #}
 <div id='filesDiv'>
   {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
-{#  {% if (mode == 'view' and (Entity.entityData.uploadsCount.normal_count > 0 or Entity.entityData.uploadsCount.archived_count > 0)) or mode == 'edit' %}#}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
       <h3 id='filesCount' title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
@@ -39,7 +38,7 @@
         <i class='fas fa-fw fa-list fa-flip-horizontal'></i>
         <i class='fas fa-fw fa-table-cells'></i>
       </button>
-      <button type='button' title='{{ 'Show archived'|trans }}' aria-label='{{ 'Show archived'|trans }}' class='btn hl-hover-gray p-1 lh-normal border-0 my-n1 {{- App.Request.query.has('archived') ? ' bgnd-gray' }}' data-action='toggle-uploads-show-archived'>
+      <button type='button' title='{{ 'Show archived'|trans }}' aria-label='{{ 'Show archived'|trans }}' class='btn hl-hover-gray p-1 lh-normal border-0 my-n1 {{- App.Request.query.has('state') ? ' bgnd-gray' }}' data-action='toggle-uploads-show-archived'>
         <i class='fas fa-fw fa-box-archive'></i>
       </button>
     </div>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -21,7 +21,6 @@
 
 {# UPLOADED FILES #}
 <div id='filesDiv'>
-  {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
       <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
@@ -268,5 +267,4 @@
     {% endif %}
   </div>
   <hr>
-  {% endif %}
 </div>{# #filesDiv #}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -20,15 +20,20 @@
 </div>
 
 {# UPLOADED FILES #}
-<div id='filesdiv'>
-  {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
+<div id='filesDiv'>
+  {% if (mode == 'view' and (Entity.entityData.uploadsCount.normal_count > 0 or Entity.entityData.uploadsCount.archived_count > 0)) or mode == 'edit' %}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
+      <h3 id='filesCount' title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files
-        {% endtrans %} (<span id='uploadsCount'>{{ Entity.entityData.uploads|length }}</span>)
+        {% endtrans %} (
+          <span id='uploadsCount'>{{ Entity.entityData.uploadsCount.normal_count }}</span>
+          {% if Entity.entityData.uploadsCount.archived_count > 0 %}
+            , {{ 'Archived'|trans }}: {{ Entity.entityData.uploadsCount.archived_count }}
+          {% endif %}
+        )
       </h3>
     </div>
 
@@ -269,4 +274,4 @@
   </div>
   <hr>
   {% endif %}
-</div>{# #filesdiv #}
+</div>{# #filesDiv #}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -21,19 +21,15 @@
 
 {# UPLOADED FILES #}
 <div id='filesDiv'>
-  {% if (mode == 'view' and (Entity.entityData.uploadsCount.normal_count > 0 or Entity.entityData.uploadsCount.archived_count > 0)) or mode == 'edit' %}
+  {% if (mode == 'view' and Entity.entityData.uploads) or mode == 'edit' %}
+{#  {% if (mode == 'view' and (Entity.entityData.uploadsCount.normal_count > 0 or Entity.entityData.uploadsCount.archived_count > 0)) or mode == 'edit' %}#}
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
       <h3 id='filesCount' title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' data-toggle-target-extra='uploadsViewToggler' class='d-inline togglable-section-title' tabindex='0' role='button'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files
-        {% endtrans %} (
-          <span id='uploadsCount'>{{ Entity.entityData.uploadsCount.normal_count }}</span>
-          {% if Entity.entityData.uploadsCount.archived_count > 0 %}
-            , {{ 'Archived'|trans }}: {{ Entity.entityData.uploadsCount.archived_count }}
-          {% endif %}
-        )
+        {% endtrans %} (<span id='uploadsCount'>{{ Entity.entityData.uploads|length }}</span>)
       </h3>
     </div>
 

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // REPLACE UPLOADED FILE
   // this should be in uploads but there is no good way so far to interact with the two editors there
-  document.getElementById('filesdiv').addEventListener('submit', event => {
+  document.getElementById('filesDiv').addEventListener('submit', event => {
     const el = event.target as HTMLElement;
     if (el.matches('[data-action="replace-uploaded-file"]')) {
       event.preventDefault();

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Update the query parameters in the URL
       url.search = queryParams.toString();
-      url.hash = 'filesdiv';
+      url.hash = 'filesDiv';
       const modifiedUrl = url.toString();
       window.location.replace(modifiedUrl);
 
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="archive-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive})
-        .then(() => reloadElements(['uploadsDiv']));
+        .then(() => reloadElements(['uploadsDiv','filesCount']));
 
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -130,11 +130,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const url = new URL(window.location.href);
       const queryParams = new URLSearchParams(url.search);
 
-      // toggle "archived" query parameter
-      if (queryParams.has('archived')) {
-        queryParams.delete('archived');
+      // toggle "archived" query parameter: display normal and archived
+      if (queryParams.has('state')) {
+        queryParams.delete('state');
       } else {
-        queryParams.set('archived', 'on');
+        queryParams.set('state', '1,2');
       }
 
       // Update the query parameters in the URL
@@ -193,7 +193,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       if (confirm(i18next.t('generic-delete-warning'))) {
         ApiC.delete(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`)
-          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove());
+          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove())
+          .then(() => reloadElements(['filesCount']));
       }
     }
   });

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -193,8 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       if (confirm(i18next.t('generic-delete-warning'))) {
         ApiC.delete(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`)
-          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove())
-          .then(() => reloadElements(['filesCount']));
+          .then(() => document.getElementById(`uploadDiv_${uploadid}`).remove());
       }
     }
   });

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const url = new URL(window.location.href);
       const queryParams = new URLSearchParams(url.search);
 
-      // toggle "archived" query parameter: display normal and archived
+      // set the state query param to include normal and archived
       if (queryParams.has('state')) {
         queryParams.delete('state');
       } else {
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="archive-upload"]')) {
       const uploadid = parseInt(el.dataset.uploadid, 10);
       ApiC.patch(`${entity.type}/${entity.id}/${Model.Upload}/${uploadid}`, {action: Action.Archive})
-        .then(() => reloadElements(['uploadsDiv','filesCount']));
+        .then(() => reloadElements(['uploadsDiv']));
 
     // DESTROY UPLOAD
     } else if (el.matches('[data-action="destroy-upload"]')) {

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -19,7 +19,7 @@ use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use RuntimeException;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
 class UploadsTest extends \PHPUnit\Framework\TestCase
@@ -169,13 +169,9 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
 
     public function testReadAll(): void
     {
-        $this->assertIsArray($this->Entity->Uploads->readAll());
-        // include archived uploads
-        $queryParams = array('state' => '2');
-        $req = new Request($queryParams);
-        $q = $this->Entity->Uploads->getQueryParams($req->query);
+        // display only archived uploads
+        $q = $this->Entity->Uploads->getQueryParams(new InputBag(array('state' => '2')));
         $archivedUploads = $this->Entity->Uploads->readAll($q);
-
         $this->assertIsArray($archivedUploads);
         $this->assertNotEmpty($archivedUploads);
         foreach ($archivedUploads as $upload) {

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -19,6 +19,7 @@ use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class UploadsTest extends \PHPUnit\Framework\TestCase
@@ -169,6 +170,22 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
     public function testReadAll(): void
     {
         $this->assertIsArray($this->Entity->Uploads->readAll());
+        // include archived uploads
+        $queryParams = array('state' => '2');
+        $req = new Request($queryParams);
+        $q = $this->Entity->Uploads->getQueryParams($req->query);
+        $archivedUploads = $this->Entity->Uploads->readAll($q);
+
+        $this->assertIsArray($archivedUploads);
+        $this->assertNotEmpty($archivedUploads);
+        foreach ($archivedUploads as $upload) {
+            $this->assertEquals(State::Archived->value, $upload['state'], 'Upload state should be archived (2)');
+        }
+        $this->assertGreaterThanOrEqual(
+            count($archivedUploads),
+            count($this->Entity->Uploads->readAll()),
+            'All uploads should be more than or equal to archived (but not fewer).'
+        );
     }
 
     public function testDestroyAll(): void

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -169,9 +169,6 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
     public function testReadAll(): void
     {
         $this->assertIsArray($this->Entity->Uploads->readAll());
-        // same including archived uploads
-        $this->Entity->Uploads->includeArchived = true;
-        $this->assertIsArray($this->Entity->Uploads->readAll());
     }
 
     public function testDestroyAll(): void


### PR DESCRIPTION
#5617

Previously, in view mode, if the entity only had archived files, the files block would not even show.
Now, it shows and displays the count (in case entity has 0 files but `x` archived).

- create uploadsCount for archived and normal files
- update readAll function to include `includeArchived` from queryParams using QueryParamsInterface
- remove readAllAndArchived function
- reload file block's title when archiving/unarchiving 


![Capture d’écran du 2025-05-06 13-48-28](https://github.com/user-attachments/assets/7273a8ac-274c-4216-a82e-a1bfd1687fba)
![Capture d’écran du 2025-05-06 13-48-13](https://github.com/user-attachments/assets/1a2603b3-bfc8-4d50-b982-6cdaf38fc4ab)

