### PR TITLE
MINOR: compounds: table actions (restore compound)

### DIFF
--- a/src/templates/compounds.html
+++ b/src/templates/compounds.html
@@ -39,5 +39,6 @@
   <div id='compounds-table'></div>
   <div class='my-2'>
     <button type='button' id='deleteCompoundsBtn' disabled data-action='delete-compounds' class='btn btn-danger btn-sm'>{{ 'Delete selected compounds'|trans }}</button>
+    <button type='button' id='restoreCompoundsBtn' disabled data-action='restore-compounds' class='btn btn-primary btn-sm'>{{ 'Restore selected compounds'|trans }}</button>
   </div>
 {% endblock body %}

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -760,7 +760,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const idList = btn.dataset.target.split(',');
       idList.forEach(id => ApiC.patch(`compounds/${id}`, {state: 1}));
       document.dispatchEvent(new CustomEvent('dataReload'));
-      
+
     // PASSWORD VISIBILITY TOGGLE
     } else if (el.matches('[data-action="toggle-password"]')) {
       // toggle eye icon

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -755,7 +755,17 @@ document.addEventListener('DOMContentLoaded', () => {
         ApiC.delete(`compounds/${id}`);
       });
       document.dispatchEvent(new CustomEvent('dataReload'));
-
+    // RESTORE SELECTED COMPOUNDS
+    } else if (el.matches('[data-action="restore-compounds"]')) {
+      const btn = document.getElementById('restoreCompoundsBtn');
+      const idList = btn.dataset.target.split(',');
+      if (!confirm(`Restore ${idList.length} compound(s)?`)) {
+        return;
+      }
+      idList.forEach(id => {
+        ApiC.patch(`compounds/${id}`, {state: 1});
+      });
+      document.dispatchEvent(new CustomEvent('dataReload'));
     // PASSWORD VISIBILITY TOGGLE
     } else if (el.matches('[data-action="toggle-password"]')) {
       // toggle eye icon

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -751,21 +751,16 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!confirm(`Delete ${idList.length} compound(s)?`)) {
         return;
       }
-      idList.forEach(id => {
-        ApiC.delete(`compounds/${id}`);
-      });
+      idList.forEach(id => ApiC.delete(`compounds/${id}`));
       document.dispatchEvent(new CustomEvent('dataReload'));
+
     // RESTORE SELECTED COMPOUNDS
     } else if (el.matches('[data-action="restore-compounds"]')) {
       const btn = document.getElementById('restoreCompoundsBtn');
       const idList = btn.dataset.target.split(',');
-      if (!confirm(`Restore ${idList.length} compound(s)?`)) {
-        return;
-      }
-      idList.forEach(id => {
-        ApiC.patch(`compounds/${id}`, {state: 1});
-      });
+      idList.forEach(id => ApiC.patch(`compounds/${id}`, {state: 1}));
       document.dispatchEvent(new CustomEvent('dataReload'));
+      
     // PASSWORD VISIBILITY TOGGLE
     } else if (el.matches('[data-action="toggle-password"]')) {
       // toggle eye icon

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -17,7 +17,7 @@ import '@ag-grid-community/styles/ag-theme-alpine.css';
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Api } from './Apiv2.class';
-import { toggleEditCompound } from './misc';
+import { notif, toggleEditCompound } from './misc';
 import i18next from 'i18next';
 
 const ApiC = new Api();
@@ -110,8 +110,12 @@ if (document.getElementById('compounds-table')) {
       }
       // adding deleted flag to query
       const deletedParam = showDeleted ? '&state=3' : '';
-      const compounds = await ApiC.getJson(`compounds?limit=999999${searchString}${deletedParam}`);
-      setRowData(compounds);
+      try {
+        const compounds = await ApiC.getJson(`compounds?limit=999999${searchString}${deletedParam}`);
+        setRowData(compounds);
+      } catch (error) {
+        notif({'res': false, 'msg': 'Could not load compounds.'});
+      }
     };
 
       const defaultColDef = useMemo(() => {

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -83,11 +83,11 @@ if (document.getElementById('compounds-table')) {
       const deleteBtn = document.getElementById('deleteCompoundsBtn');
       const restoreBtn = document.getElementById('restoreCompoundsBtn');
       if (showDeleted) {
-        deleteBtn?.setAttribute('hidden', '');
+        deleteBtn?.setAttribute('hidden', 'hidden');
         restoreBtn?.removeAttribute('hidden');
       } else {
         deleteBtn?.removeAttribute('hidden');
-        restoreBtn?.setAttribute('hidden', '');
+        restoreBtn?.setAttribute('hidden', 'hidden');
       }
     };
 
@@ -114,7 +114,7 @@ if (document.getElementById('compounds-table')) {
         const compounds = await ApiC.getJson(`compounds?limit=999999${searchString}${deletedParam}`);
         setRowData(compounds);
       } catch (error) {
-        notif({'res': false, 'msg': 'Could not load compounds.'});
+        console.error(error);
       }
     };
 

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -17,7 +17,7 @@ import '@ag-grid-community/styles/ag-theme-alpine.css';
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Api } from './Apiv2.class';
-import { notif, toggleEditCompound } from './misc';
+import { toggleEditCompound } from './misc';
 import i18next from 'i18next';
 
 const ApiC = new Api();

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -17,7 +17,7 @@ import '@ag-grid-community/styles/ag-theme-alpine.css';
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Api } from './Apiv2.class';
-import { toggleEditCompound } from './misc';
+import { notifError, toggleEditCompound } from './misc';
 import i18next from 'i18next';
 
 const ApiC = new Api();
@@ -114,6 +114,7 @@ if (document.getElementById('compounds-table')) {
         const compounds = await ApiC.getJson(`compounds?limit=999999${searchString}${deletedParam}`);
         setRowData(compounds);
       } catch (error) {
+        notifError(error);
         console.error(`Could not load compounds: ${error}`);
       }
     };

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -114,7 +114,7 @@ if (document.getElementById('compounds-table')) {
         const compounds = await ApiC.getJson(`compounds?limit=999999${searchString}${deletedParam}`);
         setRowData(compounds);
       } catch (error) {
-        console.error(error);
+        console.error(`Could not load compounds: ${error}`);
       }
     };
 

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -83,11 +83,11 @@ if (document.getElementById('compounds-table')) {
       const deleteBtn = document.getElementById('deleteCompoundsBtn');
       const restoreBtn = document.getElementById('restoreCompoundsBtn');
       if (showDeleted) {
-        deleteBtn?.classList.add('d-none');
-        restoreBtn?.classList.remove('d-none');
+        deleteBtn?.setAttribute('hidden', '');
+        restoreBtn?.removeAttribute('hidden');
       } else {
-        deleteBtn?.classList.remove('d-none');
-        restoreBtn?.classList.add('d-none');
+        deleteBtn?.removeAttribute('hidden');
+        restoreBtn?.setAttribute('hidden', '');
       }
     };
 

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -78,8 +78,22 @@ if (document.getElementById('compounds-table')) {
     // filter by deleted compounds
     const [showDeleted, setShowDeleted] = useState(false);
 
+    // switch delete-compounds <=> restore-compounds buttons when showing deleted compounds
+    const showDeletedCompounds = (showDeleted) => {
+      const deleteBtn = document.getElementById('deleteCompoundsBtn');
+      const restoreBtn = document.getElementById('restoreCompoundsBtn');
+      if (showDeleted) {
+        deleteBtn?.classList.add('d-none');
+        restoreBtn?.classList.remove('d-none');
+      } else {
+        deleteBtn?.classList.remove('d-none');
+        restoreBtn?.classList.add('d-none');
+      }
+    };
+
     // Load data on component mount and refresh on showDeleted change
     useEffect(() => {
+        showDeletedCompounds(showDeleted);
         fetchData();
     }, [showDeleted]);
 
@@ -114,11 +128,21 @@ if (document.getElementById('compounds-table')) {
 
     // when a row is selected with the checkbox
     const selectionChanged = (event) => {
-      // we store the selected rows as data-target string on the delete button
-      const btn = document.getElementById('deleteCompoundsBtn');
-      btn.removeAttribute('disabled');
+      // we store the selected rows as data-target string on the delete and restore buttons
       const selectedRows = event.api.getSelectedRows();
-      btn.dataset.target = selectedRows.map(c => c.id).join(',');
+      const selectedIds = selectedRows.map(c => c.id).join(',');
+      const deleteBtn = document.getElementById('deleteCompoundsBtn');
+      const restoreBtn = document.getElementById('restoreCompoundsBtn');
+
+      // buttons are disabled if no rows are selected.
+      if (deleteBtn) {
+        deleteBtn.disabled = selectedRows.length === 0;
+        deleteBtn.dataset.target = selectedIds;
+      }
+      if (restoreBtn) {
+        restoreBtn.disabled = selectedRows.length === 0;
+        restoreBtn.dataset.target = selectedIds;
+      }
     };
 
     const cellDoubleClicked = (event) => {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [X] I have mentioned the related **PR** #5633 
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc). [WIP](https://github.com/elabftw/elabdoc/pull/46)
---

### Pull Request Description

Please provide **clear context** for your proposed change:

- add restore compounds button
- when showing deleted compounds, toggle between "delete compounds" and "restore compounds" button.
- when no rows selected, set back "disable" state to not perform a "delete" or "restore" on empty rows.
- handle bad request on searching smiles (500 from chem-plugin)

Previously, on selecting rows, the delete-compounds had "disable" removed but if you unselected the rows you could still click the button.

![restore-compounds](https://github.com/user-attachments/assets/a45472e8-8274-45a4-8ffb-90206404016f)

### previously (500 on search by smiles)
![Capture d’écran du 2025-05-19 15-05-45](https://github.com/user-attachments/assets/de70c905-1283-4aeb-9fa7-14d087c3ebaf)

### now
![image](https://github.com/user-attachments/assets/33b12d30-c7ac-4e3c-8cc8-5da212b1e534)

:exclamation:  _Translation for this notif is included in a PR coming soon! Translating all notifications._

