### PR TITLE
fix: admin: create user disabled

### DIFF
--- a/src/ts/Notifications.class.ts
+++ b/src/ts/Notifications.class.ts
@@ -33,10 +33,10 @@ export class Notification {
     this.notify(translated, NotificationType.Success);
   }
 
-  // display the notification & log in the console for debugging.
-  public error(msg: string, options?: I18nOptions): void {
-    const translated = i18next.t(msg, options);
-    console.error(translated);
+  // log the error in console and show a translated readable notification.
+  public error(msg: string|Error, options?: I18nOptions): void {
+    console.error(msg);
+    const translated = i18next.t(String(msg), options);
     this.notify(translated, NotificationType.Error);
   }
 

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -11,7 +11,7 @@ import { InputType, Malle } from '@deltablot/malle';
 import { Api } from './Apiv2.class';
 import { Action, Model } from './interfaces';
 import $ from 'jquery';
-import { Notification } from "./Notifications.class";
+import { Notification } from './Notifications.class';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!['/sysconfig.php', '/admin.php'].includes(window.location.pathname)) {

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -11,6 +11,7 @@ import { InputType, Malle } from '@deltablot/malle';
 import { Api } from './Apiv2.class';
 import { Action, Model } from './interfaces';
 import $ from 'jquery';
+import { Notification } from "./Notifications.class";
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!['/sysconfig.php', '/admin.php'].includes(window.location.pathname)) {
@@ -26,49 +27,54 @@ document.addEventListener('DOMContentLoaded', () => {
       event.preventDefault();
       el.setAttribute('disabled', 'disabled');
 
-      const form = document.getElementById('createUserForm') as HTMLFormElement;
-      const values = collectForm(form);
-      if (el.dataset.checkArchived === '1') {
-        // look for an archived user with the same email address
-        const matchedArchivedUsers = [];
-        const archivedUsers = await ApiC.getJson(`users?onlyArchived=1&q=${values['email']}`);
-        archivedUsers.forEach(user => {
-          if (user.email === values['email']) {
-            matchedArchivedUsers.push(user);
-          }
-        });
-        if (matchedArchivedUsers.length > 0) {
-          const archivedUsersFoundList = (document.getElementById('archivedUsersFoundList') as HTMLUListElement);
-          matchedArchivedUsers.forEach(user => {
-            const archivedUser = document.createElement('li');
-            archivedUser.textContent = `${user.fullname} (${user.email})`;
-            archivedUser.classList.add('list-group-item');
-            const btn = document.createElement('button');
-            btn.classList.add('btn', 'btn-secondary', 'ml-3');
-            btn.dataset.action = 'unarchive-and-add-to-team';
-            btn.dataset.userid = user.userid;
-            // on admin panel, team select is disabled, so collectForm doesn't pickup the value
-            if (typeof(values['team']) !== 'undefined') {
-              btn.dataset.team = values['team'];
+      try {
+        const form = document.getElementById('createUserForm') as HTMLFormElement;
+        const values = collectForm(form);
+        if (el.dataset.checkArchived === '1') {
+          // look for an archived user with the same email address
+          const matchedArchivedUsers = [];
+          const archivedUsers = await ApiC.getJson(`users?onlyArchived=1&q=${values['email']}`);
+          archivedUsers.forEach(user => {
+            if (user.email === values['email']) {
+              matchedArchivedUsers.push(user);
             }
-            const teamSelect = document.getElementById('create-user-team') as HTMLSelectElement;
-            const team = teamSelect.options[teamSelect.selectedIndex].text;
-            btn.textContent = i18next.t('unarchive-and-add-to-team', { team: team });
-            archivedUser.append(btn);
-            archivedUsersFoundList.append(archivedUser);
           });
-          document.getElementById('archivedUsersFound').removeAttribute('hidden');
-          return;
+          if (matchedArchivedUsers.length > 0) {
+            const archivedUsersFoundList = (document.getElementById('archivedUsersFoundList') as HTMLUListElement);
+            matchedArchivedUsers.forEach(user => {
+              const archivedUser = document.createElement('li');
+              archivedUser.textContent = `${user.fullname} (${user.email})`;
+              archivedUser.classList.add('list-group-item');
+              const btn = document.createElement('button');
+              btn.classList.add('btn', 'btn-secondary', 'ml-3');
+              btn.dataset.action = 'unarchive-and-add-to-team';
+              btn.dataset.userid = user.userid;
+              // on admin panel, team select is disabled, so collectForm doesn't pickup the value
+              if (typeof(values['team']) !== 'undefined') {
+                btn.dataset.team = values['team'];
+              }
+              const teamSelect = document.getElementById('create-user-team') as HTMLSelectElement;
+              const team = teamSelect.options[teamSelect.selectedIndex].text;
+              btn.textContent = i18next.t('unarchive-and-add-to-team', { team: team });
+              archivedUser.append(btn);
+              archivedUsersFoundList.append(archivedUser);
+            });
+            document.getElementById('archivedUsersFound').removeAttribute('hidden');
+            return;
+          }
         }
-      }
 
-      ApiC.post('users', values).then(() => {
-        // use form.reset() so user-invalid pseudo-class isn't present
-        form.reset();
-        document.getElementById('archivedUsersFound').setAttribute('hidden', 'hidden');
-        document.getElementById('initialCreateUserBtn').removeAttribute('disabled');
-        reloadElements(['editUsersBox']);
-      });
+        ApiC.post('users', values).then(() => {
+          // use form.reset() so user-invalid pseudo-class isn't present
+          form.reset();
+          document.getElementById('archivedUsersFound').setAttribute('hidden', 'hidden');
+          document.getElementById('initialCreateUserBtn').removeAttribute('disabled');
+          reloadElements(['editUsersBox']);
+        });
+      } catch (error) {
+        el.removeAttribute('disabled');
+        new Notification().error(error);
+      }
 
     // CREATE USER(s) FROM REMOTE DIRECTORY
     } else if (el.matches('[data-action="create-user-from-remote"]')) {

--- a/src/ts/ove.ts
+++ b/src/ts/ove.ts
@@ -68,8 +68,7 @@ export function displayPlasmidViewer(about: DOMStringMap): void {
       }
 
       if (parsedData[0].success === false) {
-        const notif = new Notification();
-        notif.error(`Invalid DNA data in file: ${realName}`);
+        (new Notification()).error(`Invalid DNA data in file: ${realName}`);
       }
 
       const parsedSequence = parsedData[0].parsedSequence;

--- a/tests/cypress/integration/admin.cy.ts
+++ b/tests/cypress/integration/admin.cy.ts
@@ -19,9 +19,5 @@ describe('admin page', () => {
       cy.get('#loading-spinner').should('not.exist');
       cy.get(`div[data-tabcontent="${i}"]`).htmlvalidate();
     }
-
-    // Search user
-    cy.visit('/admin.php?tab=3&q=toto');
-    cy.get('#editUsersBox').should('contain', 'Le sysadmin');
   });
 });

--- a/tests/cypress/integration/admin_users.cy.ts
+++ b/tests/cypress/integration/admin_users.cy.ts
@@ -1,0 +1,50 @@
+describe('Users tab in Admin page', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.enableCodeCoverage(Cypress.currentTest.titlePath.join(' '));
+    cy.visit('/admin.php?tab=3&q=toto');
+  });
+
+  it('has valid html', () => {
+    // Search user
+    cy.get('#editUsersBox').should('contain', 'Le sysadmin');
+  });
+
+  it('cannot create user with empty fields', () => {
+    // create user without filling
+    cy.get('#initialCreateUserBtn').should('exist').click();
+    cy.get('.overlay').first().should('be.visible').should('contain', 'Invalid input found! Aborting');
+  });
+
+  it('creates user', () => {
+    // Team & Permission group are already filled on this form, by default
+    cy.get('input[name=firstname]').type('theNewToto');
+    cy.get('input[name=lastname]').type('notSysAdmin');
+    cy.get('input[name=email]').type('totonew@yopmail.com');
+    // create the user
+    cy.get('#initialCreateUserBtn').should('exist').click();
+    cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
+  });
+
+  it('deletes user', () => {
+    // if there's a second user, target the dropdown and delete target
+    cy.get('button[aria-label="More options"]').then(($buttons) => {
+      if ($buttons.length > 1) {
+        // target the 2nd dropdown to delete target user and not the admin
+        cy.wrap($buttons.eq(1)).click();
+
+        // confirm modal for deletion
+        cy.on('window:confirm', (text) => {
+          expect(text).to.contain('Are you sure you want to remove permanently');
+          return true; // clicks 'OK' on the modal
+        });
+
+        // click the 'Delete user' from dropdown
+        cy.get('[data-action="destroy-user"]:visible').click();
+        cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
+      } else {
+        cy.log('Second dropdown not found, skipping deletion');
+      }
+    });
+  });
+});

--- a/tests/cypress/integration/admin_users.cy.ts
+++ b/tests/cypress/integration/admin_users.cy.ts
@@ -17,12 +17,16 @@ describe('Users tab in Admin page', () => {
   });
 
   it('creates user', () => {
+    cy.intercept('POST', '/api/v2/users').as('apiPOST');
+
     // Team & Permission group are already filled on this form, by default
     cy.get('input[name=firstname]').type('theNewToto');
     cy.get('input[name=lastname]').type('notSysAdmin');
     cy.get('input[name=email]').type('totonew@yopmail.com');
+
     // create the user
     cy.get('#initialCreateUserBtn').should('exist').click();
+    cy.wait('@apiPOST');
     cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
   });
 
@@ -30,6 +34,8 @@ describe('Users tab in Admin page', () => {
     // if there's a second user, target the dropdown and delete target
     cy.get('button[aria-label="More options"]').then(($buttons) => {
       if ($buttons.length > 1) {
+        cy.intercept('DELETE', '/api/v2/users/**').as('apiDELETE');
+
         // target the 2nd dropdown to delete target user and not the admin
         cy.wrap($buttons.eq(1)).click();
 
@@ -41,6 +47,7 @@ describe('Users tab in Admin page', () => {
 
         // click the 'Delete user' from dropdown
         cy.get('[data-action="destroy-user"]:visible').click();
+        cy.wait('@apiDELETE');
         cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
       } else {
         cy.log('Second dropdown not found, skipping deletion');


### PR DESCRIPTION
### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

- **What issue or need does this PR address?**

On admin panel, when creating a user with no input in the form, it would disable the button and never re-enable it.
We need it to be re-enabled to try again, and point to the missing fields if needed.

- **How did you approach the solution?**

Apply a try catch on that API call. If there's an error, it shows it with a notification and logs more info in the console. The button's disable attribute is removed.

Some changes on notifications : 
It **notifies** with translatable/readable information, and **logs** full errors in the console for debugging.

New cypress tests for:
- creating a user
- deleting a user
- creating a user with a wrong form

### If applicable, screenshots or examples

![Capture d’écran du 2025-05-27 11-11-10](https://github.com/user-attachments/assets/a43e03df-0aad-4d3b-a76c-1c75e3cdac30)

