### PR TITLE
optim/minor: vertical separator on showpage table

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -425,7 +425,7 @@ button:disabled {
     &.with-top {
       border-top: 1px solid $firstlevel;
     }
-    
+
     th {
       border-bottom: $firstlevel 1px solid;
     }


### PR DESCRIPTION
### Pull Request Description

See #5681 

Vertical separator was hidden because of the `border-collapse: collapse;` property.
This addition allows for the border-right to be seen (as it was already in the code before).

### Screenshots

<details><summary>Before</summary>

![image](https://github.com/user-attachments/assets/de404435-adc8-4478-a7e3-e6c8d32a595c)
</details>

<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/b6bd0ef3-b817-4183-9d25-5915366e4ef4)
</details>
