### PR TITLE
bug/minor: add missing compounds field to experiment object in openapi

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -522,6 +522,10 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/comment'
+            compounds:
+              type: array
+              items:
+                $ref: '#/components/schemas/compound'
             created_at:
               type: string
             elabid:


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Please provide **clear context** for your proposed change:

This adds the missing `compounds` field to the `experiment` object in the OpenAPI specification. See also https://matrix.to/#/!XFiKmLsnbDwLircZtT:gitter.im/$7X9RNoxScICqYtwFbZzyZEWGNgHisrJ7Z5WhZr4kuNc
This is mainly relevant for generated client libraries, which otherwise will not be able to retrieve the compounds of an experiment.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/contributing.html).

**IMPORTANT**: Base your PR off the `hypernext` branch for a feature, and the `next` branch for a bugfix.

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.
