### PR TITLE
Add settings to only allow sysadmins to authenticate

### DIFF
--- a/src/Auth/Anon.php
+++ b/src/Auth/Anon.php
@@ -24,9 +24,9 @@ final class Anon implements AuthInterface
 {
     private AuthResponse $AuthResponse;
 
-    public function __construct(array $configArr, int $team)
+    public function __construct(bool $isAnonAllowed, int $team)
     {
-        if (!$configArr['anon_users']) {
+        if (!$isAnonAllowed) {
             throw new IllegalActionException('Cannot login as anon because it is not allowed by sysadmin!');
         }
         $this->AuthResponse = new AuthResponse();

--- a/src/classes/Auth.php
+++ b/src/classes/Auth.php
@@ -90,7 +90,7 @@ final class Auth implements AuthInterface
                 if ($team === 0) {
                     throw new UnauthorizedException();
                 }
-                return new Anon($this->Config->configArr, $team);
+                return new Anon((bool) $this->Config->configArr['anon_users'], $team);
             case 'open':
                 // don't do it if we have elabid in url
                 // only autologin on selected pages and if we are not authenticated with an account
@@ -99,7 +99,7 @@ final class Auth implements AuthInterface
                     Entrypoint::Database->toPage(),
                 );
                 if (in_array(basename($this->Request->getScriptName()), $autoAnon, true)) {
-                    return new Anon($this->Config->configArr, (int) ($this->Config->configArr['open_team'] ?? 1));
+                    return new Anon((bool) $this->Config->configArr['anon_users'], (int) ($this->Config->configArr['open_team'] ?? 1));
                 }
                 // no break
             default:

--- a/src/classes/Update.php
+++ b/src/classes/Update.php
@@ -36,7 +36,7 @@ use function sprintf;
 final class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 176;
+    public const int REQUIRED_SCHEMA = 177;
 
     private Db $Db;
 

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -280,7 +280,11 @@ final class LoginController implements ControllerInterface
                 $this->validateDeviceToken();
                 return new Local(
                     $this->App->Request->request->getString('email'),
-                    $this->App->Request->request->getString('password')
+                    $this->App->Request->request->getString('password'),
+                    (bool) $this->App->Config->configArr['local_login'],
+                    (bool) $this->App->Config->configArr['local_login_hidden_only_sysadmin'],
+                    (bool) $this->App->Config->configArr['local_login_only_sysadmin'],
+                    (int) $this->App->Config->configArr['max_password_age_days'],
                 );
 
                 // AUTH WITH SAML

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -315,7 +315,7 @@ final class LoginController implements ControllerInterface
                 // AUTH AS ANONYMOUS USER
             case 'anon':
                 $this->Session->set('auth_service', self::AUTH_ANON);
-                return new Anon($this->Config->configArr, $this->Request->request->getInt('team_id'));
+                return new Anon((bool) $this->Config->configArr['anon_users'], $this->Request->request->getInt('team_id'));
 
                 // AUTH in a team (after the team selection page)
                 // we are already authenticated

--- a/src/models/Config.php
+++ b/src/models/Config.php
@@ -118,6 +118,8 @@ final class Config extends AbstractRest
             ('saml_user_default', '1'),
             ('saml_allowrepeatattributename', '0'),
             ('local_login', '1'),
+            ('local_login_hidden_only_sysadmin', '0'),
+            ('local_login_only_sysadmin', '0'),
             ('local_auth_enabled', '1'),
             ('local_register', '1'),
             ('admins_create_users', '1'),

--- a/src/sql/schema177-down.sql
+++ b/src/sql/schema177-down.sql
@@ -1,0 +1,4 @@
+-- revert schema 177
+DELETE FROM config WHERE conf_name = 'local_login_hidden_only_sysadmin';
+DELETE FROM config WHERE conf_name = 'local_login_only_sysadmin';
+UPDATE config SET conf_value = 176 WHERE conf_name = 'schema';

--- a/src/sql/schema177.sql
+++ b/src/sql/schema177.sql
@@ -1,0 +1,4 @@
+-- schema 177
+-- add local_login_hidden_only_sysadmin and local_login_only_sysadmin config keys
+INSERT INTO config (conf_name, conf_value) VALUES ('local_login_hidden_only_sysadmin', '0');
+INSERT INTO config (conf_name, conf_value) VALUES ('local_login_only_sysadmin', '0');

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -603,6 +603,8 @@
     {% include 'binary-setting.html' with {'label': 'Enable local authentication'|trans, 'slug': 'local_auth_enabled', 'help': 'Toggle local authentication method (email + password). Warning: disabling this method might lock you out!'|trans} %}
     {% include 'binary-setting.html' with {'label': 'Enable local account creation'|trans, 'slug': 'local_register', 'help': 'Allow users to create accounts through the registration page. You probably want to disable this if you use an external authentication/provisioning method.'|trans} %}
     {% include 'binary-setting.html' with {'label': 'Show local login form'|trans, 'slug': 'local_login', 'help': 'This setting will hide the local authentication fields from the login page, but one can still display them by appending ?letmein to the login page URL.'|trans} %}
+    {% include 'binary-setting.html' with {'label': 'Only allow a Sysadmin to login when local login form is hidden'|trans, 'slug': 'local_login_hidden_only_sysadmin', 'help': 'Enable this setting to prevent non-sysadmin users to authenticate using local auth when the form is hidden.'|trans} %}
+    {% include 'binary-setting.html' with {'label': 'Only allow a Sysadmin to login with local login form'|trans, 'slug': 'local_login_only_sysadmin', 'help': 'Only a Sysadmin account can use the local login regardless if the local login form is hidden or not. Only activate it if you have another authentication method enabled for users.'|trans} %}
   </div>
 
   <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Password policy'|trans }}</h3>

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -68,7 +68,10 @@ if ($ci); then
     docker exec -it elabtmp yarn static
 fi
 # populate the database
-docker exec -it elabtmp bin/init db:populate src/tools/populate-config.yml.dist -y
+if [ "${SKIP_POPULATE:-0}" -ne 1 ]; then
+    echo "Running populate script. Use SKIP_POPULATE=1 to disable."
+    docker exec -it elabtmp bin/init db:populate src/tools/populate-config.yml.dist -y
+fi
 # RUN TESTS
 if ($ci); then
     # fix permissions on test output and uploads

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -57,7 +57,10 @@ if ($ci); then
 else
     # we need to add the parser because it's in cache/ and it's tmpfs mounted now
     docker exec -it elabtmp yarn buildparser
-    docker exec -it elabtmp yarn twigcs
+    if [ "${SKIP_TWIGCS:-0}" -ne 1 ]; then
+        echo "Running twigcs. Use SKIP_TWIGCS=1 to disable."
+        docker exec -it elabtmp yarn twigcs
+    fi
 fi
 # fix permissions on cache folders
 docker exec -it elabtmp mkdir -p cache/purifier/{HTML,CSS,URI} cache/{elab,mpdf,twig}

--- a/tests/unit/Auth/AnonTest.php
+++ b/tests/unit/Auth/AnonTest.php
@@ -16,32 +16,14 @@ use Elabftw\Exceptions\IllegalActionException;
 
 class AnonTest extends \PHPUnit\Framework\TestCase
 {
-    private array $configArr;
-
-    private Anon $AnonAuth;
-
-    protected function setUp(): void
-    {
-        $this->configArr = array(
-            'anon_users' => '1',
-        );
-        $this->AnonAuth = new Anon(
-            $this->configArr,
-            1,
-        );
-    }
-
     public function testTryAuth(): void
     {
-        $authResponse = $this->AnonAuth->tryAuth();
+        $authResponse = new Anon(true, 1)->tryAuth();
         $this->assertInstanceOf(AuthResponse::class, $authResponse);
         $this->assertTrue($authResponse->isAnonymous);
 
         // now try anon login but it's disabled by sysadmin
         $this->expectException(IllegalActionException::class);
-        new Anon(
-            array('anon_users' => '0'),
-            1,
-        );
+        new Anon(false, 1);
     }
 }

--- a/tests/unit/controllers/LoginControllerTest.php
+++ b/tests/unit/controllers/LoginControllerTest.php
@@ -18,6 +18,7 @@ use Elabftw\Models\Users;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class LoginControllerTest extends \PHPUnit\Framework\TestCase
@@ -49,5 +50,60 @@ class LoginControllerTest extends \PHPUnit\Framework\TestCase
         );
         $res = $LoginController->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $res);
+        $this->assertSame('/login.php', $res->headers->get('Location'));
+    }
+
+    public function testGetResponseCancelMfa(): void
+    {
+        $Session = new Session();
+        $Session->set('enable_mfa', 'hell yeah');
+        $Request = Request::create('/login.php', 'POST', array('Cancel' => 'cancel'));
+        $LoginController = new LoginController(
+            Config::getConfig(),
+            $Request,
+            $Session,
+            new Logger('test'),
+            new Users(1, 1),
+        );
+        $res = $LoginController->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $res);
+        $this->assertSame('/login.php', $res->headers->get('Location'));
+    }
+
+    public function testAuthLocalButDisabled(): void
+    {
+        $Request = Request::createFromGlobals();
+        $Request->request->set('auth_type', 'local');
+        $Config = Config::getConfig();
+        // disable local auth
+        $Config->configArr['local_auth_enabled'] = '0';
+        $LoginController = new LoginController(
+            $Config,
+            $Request,
+            new Session(),
+            new Logger('test'),
+            new Users(1, 1),
+        );
+        $this->expectException(ImproperActionException::class);
+        $LoginController->getResponse();
+    }
+
+    public function testAuthTeam(): void
+    {
+        $Session = new Session();
+        $Session->set('auth_userid', 1);
+        $Request = Request::createFromGlobals();
+        $Request->request->set('auth_type', 'team');
+        $Request->request->set('selected_team', 1);
+        $LoginController = new LoginController(
+            Config::getConfig(),
+            $Request,
+            $Session,
+            new Logger('test'),
+            new Users(1, 1),
+        );
+        $res = $LoginController->getResponse();
+        $this->assertInstanceOf(Response::class, $res);
+        $this->assertSame('/index.php', $res->headers->get('Location'));
     }
 }

--- a/tests/unit/controllers/LoginControllerTest.php
+++ b/tests/unit/controllers/LoginControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi @ Deltablot
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Config;
+use Elabftw\Models\Users;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class LoginControllerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetResponseNoMethodProvided(): void
+    {
+        $LoginController = new LoginController(
+            Config::getConfig(),
+            Request::createFromGlobals(),
+            new Session(),
+            new Logger('test'),
+            new Users(1, 1),
+        );
+        $this->expectException(ImproperActionException::class);
+        $LoginController->getResponse();
+    }
+
+    public function testGetResponseMustEnableMfa(): void
+    {
+        $Session = new Session();
+        $Session->set('enable_mfa', 'hell yeah');
+        $Session->set('mfa_secret', 'EXAMPLE2FASECRET234567ABCDEFGHIJ');
+        $LoginController = new LoginController(
+            Config::getConfig(),
+            Request::createFromGlobals(),
+            $Session,
+            new Logger('test'),
+            new Users(1, 1),
+        );
+        $res = $LoginController->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $res);
+    }
+}

--- a/web/app/controllers/LoginController.php
+++ b/web/app/controllers/LoginController.php
@@ -33,7 +33,7 @@ $location = '/login.php';
 $Response = new RedirectResponse($location);
 
 try {
-    $Controller = new LoginController($App);
+    $Controller = new LoginController($App->Config, $App->Request, $App->Session, $App->Log, $App->Users);
     $Response = $Controller->getResponse();
 } catch (QuantumException | InvalidCredentialsException | InvalidMfaCodeException $e) {
     $loginTries = (int) $App->Config->configArr['login_tries'];


### PR DESCRIPTION
### Pull Request Checklist

- [ X] I have added **tests** for any new features.
- no corresponding issue but this line in my `ideas` file: `the letmein backdoor should only be for sysadmin`
- doc update not needed
---

### Pull Request Description

Add two new sysconfig settings to control if only sysadmins should be allowed to use local auth, when local auth is hidden or regardless.

Also refactor some code so we can test the LoginController.

Add `SKIP_POPULATE` and `SKIP_TWIGCS` to speed up local testing, useful when testing only one file and we don't need a fresh db or to check twig files again and again. It also displays its existence so it can be discovered without needing documentation.