### PR TITLE
Small additions on #5717 "Improve view and edit pages organization"

### DIFF
--- a/src/Enums/EntityType.php
+++ b/src/Enums/EntityType.php
@@ -29,10 +29,10 @@ enum EntityType: string
     public function toInstance(Users $users, ?int $entityId = null, ?bool $bypassReadPermission = null, ?bool $bypassWritePermission = null): AbstractEntity
     {
         return match ($this) {
-            $this::Experiments => new Experiments($users, $entityId, $bypassReadPermission, $bypassWritePermission),
-            $this::Items => new Items($users, $entityId, $bypassReadPermission, $bypassWritePermission),
-            $this::Templates => new Templates($users, $entityId, $bypassReadPermission, $bypassWritePermission),
-            $this::ItemsTypes => new ItemsTypes($users, $entityId, $bypassReadPermission, $bypassWritePermission),
+            self::Experiments => new Experiments($users, $entityId, $bypassReadPermission, $bypassWritePermission),
+            self::Items => new Items($users, $entityId, $bypassReadPermission, $bypassWritePermission),
+            self::Templates => new Templates($users, $entityId, $bypassReadPermission, $bypassWritePermission),
+            self::ItemsTypes => new ItemsTypes($users, $entityId, $bypassReadPermission, $bypassWritePermission),
         };
     }
 
@@ -40,20 +40,20 @@ enum EntityType: string
     public function toGenre(): string
     {
         return match ($this) {
-            $this::Experiments => 'experiment',
-            $this::Items => 'resource',
-            $this::Templates => 'experiment template',
-            $this::ItemsTypes => 'resource template',
+            self::Experiments => 'experiment',
+            self::Items => 'resource',
+            self::Templates => 'experiment template',
+            self::ItemsTypes => 'resource template',
         };
     }
 
     public function toPage(): string
     {
         return match ($this) {
-            $this::Experiments => 'experiments.php',
-            $this::Items => 'database.php',
-            $this::Templates => 'templates.php',
-            $this::ItemsTypes => 'resources-templates.php',
+            self::Experiments => 'experiments.php',
+            self::Items => 'database.php',
+            self::Templates => 'templates.php',
+            self::ItemsTypes => 'resources-templates.php',
         };
     }
 }

--- a/src/templates/catstat-view-edit.html
+++ b/src/templates/catstat-view-edit.html
@@ -1,8 +1,12 @@
+{% set entityPage = entityPage|default(App.Request.getScriptName|split('/')|last|replace({'.php': ''})) %}
 <div class='d-flex mb-2 align-items-center'>
   {# ID #}
   <span class='mr-1'><i class='fas fa-hashtag'></i>{{ Entity.entityData.id }}</span>
   {# CATEGORY #}
-  <button id='categoryBtn' style='--bg: #{{ Entity.entityData.category_color|default('bdbdbd') }}' type='button' data-target='category' data-id='{{ Entity.entityData.category }}' class='mr-2 btn catstat-btn category-btn malleableCategory lh-normal border-0'>{{ Entity.entityData.category_title|default('Add category'|trans) }}</button>
+  {# Do not show when on a resource category. Resource category can't have a resource category #}
+  {% if entityPage != 'resources-templates' %}
+    <button id='categoryBtn' style='--bg: #{{ Entity.entityData.category_color|default('bdbdbd') }}' type='button' data-target='category' data-id='{{ Entity.entityData.category }}' class='mr-2 btn catstat-btn category-btn malleableCategory lh-normal border-0'>{{ Entity.entityData.category_title|default('Add category'|trans) }}</button>
+  {% endif %}
   {# STATUS #}
   <button data-target='status' type='button' class='btn catstat-btn status-btn malleableStatus lh-normal border-0'><i class='fas fa-circle fa-fw' style='--bg: #{{ Entity.entityData.status_color|default('bdbdbd') }}'></i> {{ Entity.entityData.status_title|default('Add status'|trans) }}</button>
 </div>

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -46,8 +46,8 @@
             {% endfor %}
           </div>
           {# show add button to admin, for items #}
-          {% if entityPage == 'items' and App.Users.isAdmin %}
-            <a style='color:#343434; border: 1px #ccc solid;' class='btn btn-light mt-1' href='/admin.php?tab=4#{{ entityPage }}CategoriesAnchor'>{{ 'Add category…'|trans }}</a>
+          {% if entityPage == 'database' and App.Users.isAdmin %}
+            <a style='color:#343434; border: 1px #ccc solid;' class='btn btn-light mt-1' href='/resources-templates.php'>{{ 'Add template…'|trans }}</a>
           {% endif %}
         {% endif %}
       </div>

--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -1,7 +1,9 @@
 {# dim the experiment a bit if it's not yours #}
 {% set randomId = random() %}
+{% set label = Entity.entityType.value == 'items_types' ? 'Create resource from template'|trans : 'Create experiment from template'|trans %}
+{% set dataType = Entity.entityType.value == 'experiments_templates' ? 'experiments' : 'database' %}
 
-<section class='entity {{ Entity.entityType.value == 'experiments_templates' ? 'entity-template' }} pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
+<section class='entity {{ Entity.entityType.value in ['experiments_templates', 'items_types'] ? 'entity-template' }} pl-3 d-flex' id='parent_{{ randomId }}' style='--left-color: #{{ item.category_color|default('bdbdbd') }};' aria-label='{{ 'Entry'|trans }}_{{ randomId }}'>
 
   {# left part, full height: checkbox #}
   <div class='d-flex align-items-center'>
@@ -10,8 +12,8 @@
     <div class='d-flex'>
 
       {# for templates: create from button #}
-      {% if Entity.entityType.value == 'experiments_templates' %}
-      <a data-action='create-entity' data-type='experiments' data-tplid='{{ item.id }}' href='#' class='left-icon rounded mr-3 my-1 hl-hover-gray bgnd-blue' title='{{ 'Create experiment from template'|trans }}' aria-label='{{ 'Create experiment from template'|trans }}'>
+      {% if Entity.entityType.value in ['experiments_templates', 'items_types'] %}
+      <a data-action='create-entity' data-type={{ dataType }} data-tplid='{{ item.id }}' href='#' class='left-icon rounded mr-3 my-1 hl-hover-gray bgnd-blue' title='{{ label }}' aria-label='{{ label }}'>
         <i class='fas fa-file-circle-plus fa-fw'></i>
       </a>
       {% endif %}


### PR DESCRIPTION
- "add category" button on creating a category was not visible. page check: items.php -> database.php
![Capture d’écran du 2025-06-16 12-09-45](https://github.com/user-attachments/assets/370f332b-2537-47b3-aa61-d4f050249a8a)

- add "create from template" button for the resources.
![Capture d’écran du 2025-06-16 12-08-44](https://github.com/user-attachments/assets/e04a4193-89c4-4071-b229-6dc163813f04)

- apply template style for the item in resource-template show page
![image](https://github.com/user-attachments/assets/7e2f4623-0f93-4f14-b3bb-6a3ac275d799)
->
![image](https://github.com/user-attachments/assets/8c2e2df3-2a3e-4b3b-9f5d-08197b6922b9)

- enums : replace $this:: with self::