### PR TITLE
bug/minor: attachments: display number corresponds to active files

### DIFF
--- a/src/models/UserUploads.php
+++ b/src/models/UserUploads.php
@@ -70,15 +70,17 @@ final class UserUploads extends AbstractRest
         return $req->fetchAll();
     }
 
-    public function countAll(): int
+    public function countAll(?QueryParamsInterface $queryParams = null): int
     {
-        $sql = 'SELECT COUNT(uploads.id) FROM uploads WHERE userid = :userid AND (state = :state_normal OR state = :state_archived)';
+        $queryParams ??= $this->getQueryParams();
+        $statesSql = $queryParams->getStatesSql('uploads');
+        $sql = sprintf(
+            'SELECT COUNT(uploads.id) FROM uploads WHERE userid = :userid %s',
+            $statesSql
+        );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->owner->userid, PDO::PARAM_INT);
-        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
-        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);
-
         return (int) $req->fetchColumn();
     }
 }

--- a/src/models/UserUploads.php
+++ b/src/models/UserUploads.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Orderby;
-use Elabftw\Enums\State;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Params\BaseQueryParams;
 use Override;

--- a/tests/unit/models/UserUploadsTest.php
+++ b/tests/unit/models/UserUploadsTest.php
@@ -46,7 +46,6 @@ class UserUploadsTest extends \PHPUnit\Framework\TestCase
         $q = $this->UserUploads->getQueryParams($queryParams);
         $countArchived = $this->UserUploads->countAll($q);
         $this->assertIsInt($countArchived);
-        // Assert the counts are different (you can also assert expected logical relationship)
         $this->assertNotEquals($countAll, $countArchived, 'Total count and archived count should differ');
     }
 

--- a/tests/unit/models/UserUploadsTest.php
+++ b/tests/unit/models/UserUploadsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
+use Symfony\Component\HttpFoundation\InputBag;
 
 class UserUploadsTest extends \PHPUnit\Framework\TestCase
 {
@@ -37,7 +38,16 @@ class UserUploadsTest extends \PHPUnit\Framework\TestCase
 
     public function testCountAll(): void
     {
+        // count All without filter (normal, archived, deleted)
+        $countAll = $this->UserUploads->countAll();
         $this->assertIsInt($this->UserUploads->countAll());
+        // count only archived
+        $queryParams = new InputBag(array('state' => 2));
+        $q = $this->UserUploads->getQueryParams($queryParams);
+        $countArchived = $this->UserUploads->countAll($q);
+        $this->assertIsInt($countArchived);
+        // Assert the counts are different (you can also assert expected logical relationship)
+        $this->assertNotEquals($countAll, $countArchived, 'Total count and archived count should differ');
     }
 
     public function testRead(): void

--- a/web/profile.php
+++ b/web/profile.php
@@ -23,6 +23,7 @@ use Elabftw\Models\Teams;
 use Elabftw\Models\UserUploads;
 use Elabftw\Services\UsersHelper;
 use Exception;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -57,8 +58,9 @@ try {
     $UserUploads = new UserUploads($App->Users);
     $PermissionsHelper = new PermissionsHelper();
 
+    $queryParams = $UserUploads->getQueryParams(new InputBag($App->Request->query->all()));
     $renderArr = array(
-        'attachedFiles' => $UserUploads->readAll(),
+        'attachedFiles' => $UserUploads->readAll($queryParams),
         'count' => $count,
         'exportedFiles' => $Export->readAll(),
         'experimentsCategoryArr' => $ExperimentsCategories->readAll(),
@@ -68,7 +70,7 @@ try {
         'pieDataCss' => $UserStats->getFormattedPieData(),
         'teamGroupsArr' => $teamGroupsArr,
         'teamsArr' => $teams,
-        'uploadsTotal' => $UserUploads->countAll(),
+        'uploadsTotal' => $UserUploads->countAll($queryParams),
         'usersArr' => $App->Users->readAllActiveFromTeam(),
         'visibilityArr' => $PermissionsHelper->getAssociativeArray(),
     );


### PR DESCRIPTION
### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Display number of attachments (in profile) correspond to existing (non-archived/non-deleted) files

fix #5672
- take queryParams into account for attachments
- fix displayed totalCount
- additional tests
