### PR TITLE
feat: attachments: enhance filtering

### DIFF
--- a/src/Enums/Orderby.php
+++ b/src/Enums/Orderby.php
@@ -19,6 +19,7 @@ enum Orderby: string
     case CreatedAt = 'created_at';
     case Customid = 'customid';
     case Date = 'date';
+    case Filename = 'filename';
     case Filesize = 'filesize';
     case Id = 'id';
     case Lastchange = 'lastchange';
@@ -36,6 +37,7 @@ enum Orderby: string
             self::CreatedAt => 'created_at',
             self::Customid => 'entity.custom_id',
             self::Date => 'date',
+            self::Filename => 'real_name',
             self::Filesize => 'filesize',
             self::Id => 'entity.id',
             self::Lastchange => 'entity.modified_at',

--- a/src/models/UserUploads.php
+++ b/src/models/UserUploads.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Orderby;
-use Elabftw\Enums\State;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Params\BaseQueryParams;
 use Override;
@@ -70,15 +69,17 @@ final class UserUploads extends AbstractRest
         return $req->fetchAll();
     }
 
-    public function countAll(): int
+    public function countAll(?QueryParamsInterface $queryParams = null): int
     {
-        $sql = 'SELECT COUNT(uploads.id) FROM uploads WHERE userid = :userid AND (state = :state_normal OR state = :state_archived)';
+        $queryParams ??= $this->getQueryParams();
+        $statesSql = $queryParams->getStatesSql('uploads');
+        $sql = sprintf(
+            'SELECT COUNT(uploads.id) FROM uploads WHERE userid = :userid %s',
+            $statesSql
+        );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->owner->userid, PDO::PARAM_INT);
-        $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
-        $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);
-
         return (int) $req->fetchColumn();
     }
 }

--- a/src/templates/filter-input-snippet.html
+++ b/src/templates/filter-input-snippet.html
@@ -3,8 +3,6 @@
 <div class='input-group'>
   <input type='text' aria-label='{{ 'Filter'|trans }}' placeholder='{{ 'Filter'|trans }}' data-filter-target='{{ target }}' data-target-type='{{ targetType|default('tr') }}' class='form-control form-inline' />
   <div class='input-group-append'>
-    <button class='btn btn-outline-secondary' type='button' title='{{ 'Clear'|trans }}' aria-label='{{ 'Clear'|trans }}'>
-      <i class='fas fa-times fa-fw'></i>
-    </button>
+    <button type='button' class='btn btn-secondary bg-medium border-secondlevel' title='{{ 'Clear'|trans }}' aria-label='{{ 'Clear'|trans }}' data-action='toggle-modal' data-target='advancedSearchModal'><i class='color-white fas fa-times fa-fw'></i></button>
   </div>
 </div>

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -97,15 +97,41 @@
   <h3 class='p-2 pl-3 section-title' id='attachedFiles'>{{ 'Attached files'|trans }}</h3>
   <div class='pl-3 mt-2'>
     {% set currentLimit = App.Request.query.get('limit')|default(42) %}
-    <p>{{ 'Displaying %d of %d attached files.'|trans|format(min(currentLimit, uploadsTotal), uploadsTotal) }}
-      <a href='?tab=2&limit={{ uploadsTotal }}' class='ml-3 btn btn-sm btn-secondary {{ currentLimit == uploadsTotal ? 'disabled' }}'>
-        {{ 'Show all'|trans }}
-      </a>
+    {% set currentLimit = App.Request.query.get('order')|default('created_at') %}
+    <p id='countDisplay'>{{ 'Displaying %d of %d attached files.'|trans|format(min(currentLimit, uploadsTotal), uploadsTotal) }}</p>
+    {# FILTERS #}
+    <div class='d-flex form-group form-inline'>
+      {# FILTER BY NAME #}
+      {% include 'filter-input-snippet.html' with {'target': 'attachedFilesTable'} %}
+
+      {# FILTER BY STATE #}
+      <div class="ml-2">
+        {% include 'select-state.html' with {'dataAction': 'set-state-and-reload'} %}
+      </div>
+
+      {# ORDER BY FILTER #}
+      <select name='orderby' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Order by'|trans }}'>
+        <option value=''>{{ 'Sort'|trans }}</option>
+        <option data-action='set-orderby-and-reload' value='filesize' {{ App.Request.query.get('order') == 'filesize' ? 'selected' }}>{{ 'File size'|trans }}</option>
+        <option data-action='set-orderby-and-reload' value='created_at' {{ App.Request.query.get('order') == file.created_at ? 'selected' }}>{{ 'Created'|trans }}</option>
+        <option data-action='set-orderby-and-reload' value='filename' {{ App.Request.query.get('order') == file.realname ? 'selected' }}>{{ 'File name'|trans }}</option>
+      </select>
+
       <a href='?tab=2&limit={{ uploadsTotal }}&order=filesize&sort=desc' class='ml-3 btn btn-sm btn-secondary {{ App.Request.query.get('order') == 'filesize' ? 'disabled' }}'>{{ 'List biggest files first'|trans }}
       </a>
-    </p>
-    {% include 'filter-input-snippet.html' with {'target': 'attachedFilesTable'} %}
-    <table class='table' aria-describedby='attachedFiles' data-table-sort='true'>
+
+      {# LIMIT NUMBER OF RESULTS #}
+      <select name='limit' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Results per page'|trans }}'>
+        <option value=''>{{ 'Results per page'|trans }}</option>
+        <option data-action='set-limit-and-reload' value='5' {{ currentLimit == '5' ? 'selected' }}>5</option>
+        <option data-action='set-limit-and-reload' value='10' {{ currentLimit == '10' ? 'selected' }}>10</option>
+        <option data-action='set-limit-and-reload' value='15' {{ currentLimit == '15' ? 'selected' }}>15</option>
+        <option data-action='set-limit-and-reload' value='20' {{ currentLimit == '20' ? 'selected' }}>20</option>
+        <option data-action='set-limit-and-reload' value='{{ uploadsTotal }}' {{ currentLimit == uploadsTotal ? 'selected' }}>{{ 'Show all'|trans }}</option>
+      </select>
+    </div>
+
+    <table class='table' aria-describedby='attachedFiles' data-table-sort='true' id='attachmentsTable'>
       <thead>
         <tr>
           <th scope='col'>{{ 'File name'|trans }}</th>

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -119,8 +119,9 @@
       </select>
 
       {# SORT FILTER #}
-      <select name='sort' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Sort'|trans }}'>
-        <option value='' data-action='clear'>{{ 'Sort'|trans }}</option>
+      <select name='sort' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Order by'|trans }}'>
+        {# TODO: FIXME: sort should mean 'filter by entity', and order by 'order asc/desc'. Label is 'Order By' for the user understanding #}
+        <option value='' data-action='clear'>{{ 'Order by'|trans }}</option>
         <option data-action='set-filter-and-reload' data-target='sort' value='asc' {{ currentSort == 'asc' ? 'selected' }}>{{ 'Asc'|trans }}</option>
         <option data-action='set-filter-and-reload' data-target='sort' value='desc' {{ currentSort == 'desc' ? 'selected' }}>{{ 'Desc'|trans }}</option>
       </select>
@@ -128,10 +129,9 @@
       {# LIMIT NUMBER OF RESULTS #}
       <select name='limit' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Results per page'|trans }}'>
         <option value='' data-action='clear'>{{ 'Results per page'|trans }}</option>
-        <option data-action='set-filter-and-reload' data-target='limit' value='5' {{ currentLimit == '5' ? 'selected' }}>5</option>
-        <option data-action='set-filter-and-reload' data-target='limit' value='10' {{ currentLimit == '10' ? 'selected' }}>10</option>
-        <option data-action='set-filter-and-reload' data-target='limit' value='15' {{ currentLimit == '15' ? 'selected' }}>15</option>
-        <option data-action='set-filter-and-reload' data-target='limit' value='20' {{ currentLimit == '20' ? 'selected' }}>20</option>
+        {% for option in limitOptions(75) %}
+          <option data-action='set-filter-and-reload' data-target='limit' value='{{ option }}' {{ currentLimit == option ? 'selected' }}>{{ option }}</option>
+        {% endfor %}
         <option data-action='set-filter-and-reload' data-target='limit' value='{{ uploadsTotal }}' {{ currentLimit == uploadsTotal ? 'selected' }}>{{ 'Show all'|trans }}</option>
       </select>
     </div>

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -97,7 +97,8 @@
   <h3 class='p-2 pl-3 section-title' id='attachedFiles'>{{ 'Attached files'|trans }}</h3>
   <div class='pl-3 mt-2'>
     {% set currentLimit = App.Request.query.get('limit')|default(42) %}
-    {% set currentLimit = App.Request.query.get('order')|default('created_at') %}
+    {% set currentOrderBy = App.Request.query.get('order')|default('created_at') %}
+    {% set currentSort = App.Request.query.get('sort')|default('desc') %}
     <p id='countDisplay'>{{ 'Displaying %d of %d attached files.'|trans|format(min(currentLimit, uploadsTotal), uploadsTotal) }}</p>
     {# FILTERS #}
     <div class='d-flex form-group form-inline'>
@@ -106,28 +107,32 @@
 
       {# FILTER BY STATE #}
       <div class="ml-2">
-        {% include 'select-state.html' with {'dataAction': 'set-state-and-reload'} %}
+        {% include 'select-state.html' with {'dataAction': 'set-filter-and-reload', 'dataTarget': 'state'} %}
       </div>
 
       {# ORDER BY FILTER #}
       <select name='orderby' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Order by'|trans }}'>
-        <option value=''>{{ 'Sort'|trans }}</option>
-        <option data-action='set-orderby-and-reload' value='filesize' {{ App.Request.query.get('order') == 'filesize' ? 'selected' }}>{{ 'File size'|trans }}</option>
-        <option data-action='set-orderby-and-reload' value='created_at' {{ App.Request.query.get('order') == file.created_at ? 'selected' }}>{{ 'Created'|trans }}</option>
-        <option data-action='set-orderby-and-reload' value='filename' {{ App.Request.query.get('order') == file.realname ? 'selected' }}>{{ 'File name'|trans }}</option>
+        <option value='' data-action='clear'>{{ 'Sort'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='order' value='filesize' {{ currentOrderBy == 'filesize' ? 'selected' }}>{{ 'File size'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='order' value='created_at' {{ currentOrderBy == 'created_at' ? 'selected' }}>{{ 'Created'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='order' value='filename' {{ currentOrderBy == 'filename' ? 'selected' }}>{{ 'File name'|trans }}</option>
       </select>
 
-      <a href='?tab=2&limit={{ uploadsTotal }}&order=filesize&sort=desc' class='ml-3 btn btn-sm btn-secondary {{ App.Request.query.get('order') == 'filesize' ? 'disabled' }}'>{{ 'List biggest files first'|trans }}
-      </a>
+      {# SORT FILTER #}
+      <select name='sort' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Sort'|trans }}'>
+        <option value='' data-action='clear'>{{ 'Sort'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='sort' value='asc' {{ currentSort == 'asc' ? 'selected' }}>{{ 'Asc'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='sort' value='desc' {{ currentSort == 'desc' ? 'selected' }}>{{ 'Desc'|trans }}</option>
+      </select>
 
       {# LIMIT NUMBER OF RESULTS #}
       <select name='limit' class='form-control filterHelper filterAuto ml-2' aria-label='{{ 'Results per page'|trans }}'>
-        <option value=''>{{ 'Results per page'|trans }}</option>
-        <option data-action='set-limit-and-reload' value='5' {{ currentLimit == '5' ? 'selected' }}>5</option>
-        <option data-action='set-limit-and-reload' value='10' {{ currentLimit == '10' ? 'selected' }}>10</option>
-        <option data-action='set-limit-and-reload' value='15' {{ currentLimit == '15' ? 'selected' }}>15</option>
-        <option data-action='set-limit-and-reload' value='20' {{ currentLimit == '20' ? 'selected' }}>20</option>
-        <option data-action='set-limit-and-reload' value='{{ uploadsTotal }}' {{ currentLimit == uploadsTotal ? 'selected' }}>{{ 'Show all'|trans }}</option>
+        <option value='' data-action='clear'>{{ 'Results per page'|trans }}</option>
+        <option data-action='set-filter-and-reload' data-target='limit' value='5' {{ currentLimit == '5' ? 'selected' }}>5</option>
+        <option data-action='set-filter-and-reload' data-target='limit' value='10' {{ currentLimit == '10' ? 'selected' }}>10</option>
+        <option data-action='set-filter-and-reload' data-target='limit' value='15' {{ currentLimit == '15' ? 'selected' }}>15</option>
+        <option data-action='set-filter-and-reload' data-target='limit' value='20' {{ currentLimit == '20' ? 'selected' }}>20</option>
+        <option data-action='set-filter-and-reload' data-target='limit' value='{{ uploadsTotal }}' {{ currentLimit == uploadsTotal ? 'selected' }}>{{ 'Show all'|trans }}</option>
       </select>
     </div>
 

--- a/src/templates/select-state.html
+++ b/src/templates/select-state.html
@@ -1,16 +1,17 @@
 {# select state filter #}
 {# If not in show page, the behaviour is conducted by the 'set-state-and-reload' data-action. #}
 {% set dataAction = dataAction|default(1) %}
+{% set dataTarget = dataTarget|default(1) %}
 <select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterAuto'>
-  <option data-action={{ dataAction }} value='' data-action='clear'>{{ 'Select state'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='' data-action='clear'>{{ 'Select state'|trans }}</option>
   {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value %}
-  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal'|trans }}</option>
   {% set stateValue = enum('Elabftw\\Enums\\State').Archived.value %}
-  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Archived'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Archived'|trans }}</option>
   {% set stateValue = enum('Elabftw\\Enums\\State').Deleted.value %}
-  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Deleted'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Deleted'|trans }}</option>
   {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value %}
-  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
   {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value ~ ',' ~ enum('Elabftw\\Enums\\State').Deleted.value %}
-  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Any'|trans }}</option>
+  <option data-action={{ dataAction }} data-target={{ dataTarget }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Any'|trans }}</option>
 </select>

--- a/src/templates/select-state.html
+++ b/src/templates/select-state.html
@@ -1,0 +1,16 @@
+{# select state filter #}
+{# If not in show page, the behaviour is conducted by the 'set-state-and-reload' data-action. #}
+{% set dataAction = dataAction|default(1) %}
+<select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterAuto'>
+  <option data-action={{ dataAction }} value='' data-action='clear'>{{ 'Select state'|trans }}</option>
+  {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value %}
+  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal'|trans }}</option>
+  {% set stateValue = enum('Elabftw\\Enums\\State').Archived.value %}
+  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Archived'|trans }}</option>
+  {% set stateValue = enum('Elabftw\\Enums\\State').Deleted.value %}
+  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Deleted'|trans }}</option>
+  {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value %}
+  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
+  {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value ~ ',' ~ enum('Elabftw\\Enums\\State').Deleted.value %}
+  <option data-action={{ dataAction }} value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Any'|trans }}</option>
+</select>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -186,21 +186,7 @@
       <input type='hidden' name='mode' value='show' />
 
       <div>
-        {# STATE #}
-        <select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterAuto'>
-          <option value='' data-action='clear'>{{ 'Select state'|trans }}</option>
-          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value %}
-          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal'|trans }}</option>
-          {% set stateValue = enum('Elabftw\\Enums\\State').Archived.value %}
-          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Archived'|trans }}</option>
-          {% set stateValue = enum('Elabftw\\Enums\\State').Deleted.value %}
-          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Deleted'|trans }}</option>
-          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value %}
-          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Normal or Archived'|trans }}</option>
-          {% set stateValue = enum('Elabftw\\Enums\\State').Normal.value ~ ',' ~ enum('Elabftw\\Enums\\State').Archived.value ~ ',' ~ enum('Elabftw\\Enums\\State').Deleted.value %}
-          <option value='{{ stateValue }}' {{- Request.query.get('state') == stateValue ? ' selected' }}>{{ 'Any'|trans }}</option>
-        </select>
-        {# END STATE #}
+        {% include 'select-state.html' %}
 
         {# LOCK #}
         <select name='locked' aria-label='{{ 'Select lock status'|trans }}' class='form-control filterHelper'>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -388,27 +388,20 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="switch-editor"]')) {
       getEditor().switch(getEntity()).then(() => window.location.reload());
 
-    // TODO-attachments: refacto
-    // ORDER BY FILTER
-    } else if (el.matches('[data-action="set-orderby-and-reload"]')) {
+    // SELECT FILTERS - state, orderby...
+    } else if (el.matches('[data-action="set-filter-and-reload"]')) {
+      const target = el.getAttribute('data-target');
       const params = new URLSearchParams(document.location.search.slice(1));
-      params.set('order', (el as HTMLSelectElement).value);
+      const value = (el as HTMLSelectElement).value;
+      if (target) {
+        if (value) {
+          params.set(target, value);
+        } else {
+          params.delete(target);
+        }
+      }
       window.history.replaceState({}, '', `?${params.toString()}`);
-      reloadElements(['attachmentsTable','countDisplay']);
-
-    // LIMIT FILTER
-    } else if (el.matches('[data-action="set-limit-and-reload"]')) {
-      const params = new URLSearchParams(document.location.search.slice(1));
-      params.set('limit', (el as HTMLSelectElement).value);
-      window.history.replaceState({}, '', `?${params.toString()}`);
-      reloadElements(['attachmentsTable','countDisplay']);
-
-    // STATE FILTER
-    } else if (el.matches('[data-action="set-state-and-reload"]')) {
-      const params = new URLSearchParams(document.location.search.slice(1));
-      params.set('state', (el as HTMLSelectElement).value);
-      window.history.replaceState({}, '', `?${params.toString()}`);
-      reloadElements(['attachmentsTable','countDisplay']);
+      reloadElements(['attachmentsTable', 'countDisplay']);
 
     } else if (el.matches('[data-action="insert-param-and-reload-show"]')) {
       const params = new URLSearchParams(document.location.search.slice(1));

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -401,7 +401,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
       window.history.replaceState({}, '', `?${params.toString()}`);
-      reloadElements(['attachmentsTable', 'countDisplay']);
+      reloadElements(['attachedFilesTable', 'countDisplay']).then(() => relativeMoment());
 
     } else if (el.matches('[data-action="insert-param-and-reload-show"]')) {
       const params = new URLSearchParams(document.location.search.slice(1));

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -388,6 +388,28 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (el.matches('[data-action="switch-editor"]')) {
       getEditor().switch(getEntity()).then(() => window.location.reload());
 
+    // TODO-attachments: refacto
+    // ORDER BY FILTER
+    } else if (el.matches('[data-action="set-orderby-and-reload"]')) {
+      const params = new URLSearchParams(document.location.search.slice(1));
+      params.set('order', (el as HTMLSelectElement).value);
+      window.history.replaceState({}, '', `?${params.toString()}`);
+      reloadElements(['attachmentsTable','countDisplay']);
+
+    // LIMIT FILTER
+    } else if (el.matches('[data-action="set-limit-and-reload"]')) {
+      const params = new URLSearchParams(document.location.search.slice(1));
+      params.set('limit', (el as HTMLSelectElement).value);
+      window.history.replaceState({}, '', `?${params.toString()}`);
+      reloadElements(['attachmentsTable','countDisplay']);
+
+    // STATE FILTER
+    } else if (el.matches('[data-action="set-state-and-reload"]')) {
+      const params = new URLSearchParams(document.location.search.slice(1));
+      params.set('state', (el as HTMLSelectElement).value);
+      window.history.replaceState({}, '', `?${params.toString()}`);
+      reloadElements(['attachmentsTable','countDisplay']);
+
     } else if (el.matches('[data-action="insert-param-and-reload-show"]')) {
       const params = new URLSearchParams(document.location.search.slice(1));
       params.set(el.dataset.key, el.dataset.value);

--- a/tests/unit/models/UserUploadsTest.php
+++ b/tests/unit/models/UserUploadsTest.php
@@ -46,7 +46,6 @@ class UserUploadsTest extends \PHPUnit\Framework\TestCase
         $q = $this->UserUploads->getQueryParams($queryParams);
         $countArchived = $this->UserUploads->countAll($q);
         $this->assertIsInt($countArchived);
-
         // Assert the counts are different (you can also assert expected logical relationship)
         $this->assertNotEquals($countAll, $countArchived, 'Total count and archived count should differ');
     }

--- a/tests/unit/models/UserUploadsTest.php
+++ b/tests/unit/models/UserUploadsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
+use Symfony\Component\HttpFoundation\InputBag;
 
 class UserUploadsTest extends \PHPUnit\Framework\TestCase
 {
@@ -37,7 +38,17 @@ class UserUploadsTest extends \PHPUnit\Framework\TestCase
 
     public function testCountAll(): void
     {
+        // count All without filter (normal, archived, deleted)
+        $countAll = $this->UserUploads->countAll();
         $this->assertIsInt($this->UserUploads->countAll());
+        // count only archived
+        $queryParams = new InputBag(array('state' => 2));
+        $q = $this->UserUploads->getQueryParams($queryParams);
+        $countArchived = $this->UserUploads->countAll($q);
+        $this->assertIsInt($countArchived);
+
+        // Assert the counts are different (you can also assert expected logical relationship)
+        $this->assertNotEquals($countAll, $countArchived, 'Total count and archived count should differ');
     }
 
     public function testRead(): void

--- a/web/profile.php
+++ b/web/profile.php
@@ -23,6 +23,7 @@ use Elabftw\Models\Teams;
 use Elabftw\Models\UserUploads;
 use Elabftw\Services\UsersHelper;
 use Exception;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -57,8 +58,9 @@ try {
     $UserUploads = new UserUploads($App->Users);
     $PermissionsHelper = new PermissionsHelper();
 
+    $queryParams = $UserUploads->getQueryParams(new InputBag($App->Request->query->all()));
     $renderArr = array(
-        'attachedFiles' => $UserUploads->readAll(),
+        'attachedFiles' => $UserUploads->readAll($queryParams),
         'count' => $count,
         'exportedFiles' => $Export->readAll(),
         'experimentsCategoryArr' => $ExperimentsCategories->readAll(),
@@ -68,7 +70,7 @@ try {
         'pieDataCss' => $UserStats->getFormattedPieData(),
         'teamGroupsArr' => $teamGroupsArr,
         'teamsArr' => $teams,
-        'uploadsTotal' => $UserUploads->countAll(),
+        'uploadsTotal' => $UserUploads->countAll($queryParams),
         'usersArr' => $App->Users->readAllActiveFromTeam(),
         'visibilityArr' => $PermissionsHelper->getAssociativeArray(),
     );


### PR DESCRIPTION
### Pull Request Description

![gif](https://s8.ezgif.com/tmp/ezgif-86abd364de577d.gif)

Enhancement for the Profile > uploads page.

- improve filtering and reactivity
- more option (state, limit results) -> remove "show all" and "list biggest files first" buttons
- remove "load more" button as the limit results is flexible
- remove translations for "list biggest files first" as it's only occurence and should not be needed anymore with the "select limit" filter -> they are reusable elsewhere
- fix filter-input-snippet -> on hover, the cross was not visible (black on black). I reused the interrogation button from the main show page to avoid rewriting.

previously:

![Capture d’écran du 2025-06-17 10-45-29](https://github.com/user-attachments/assets/9e9b2d1a-0184-45aa-8083-e3d0e7f5f9ff)

now:
![Capture d’écran du 2025-06-17 10-45-38](https://github.com/user-attachments/assets/7583e5b5-ab10-4665-913f-5f2b2d81469f)

(can't record the mouse..)

![gif](https://s8.ezgif.com/tmp/ezgif-872ade285ea147.gif)
![gif](https://s8.ezgif.com/tmp/ezgif-8f98aa41d4a3d6.gif)

