### PR TITLE
allow timestamp on template entities

### DIFF
--- a/src/classes/ItemsTypesSqlBuilder.php
+++ b/src/classes/ItemsTypesSqlBuilder.php
@@ -43,7 +43,10 @@ final class ItemsTypesSqlBuilder extends EntitySqlBuilder
             entity.lockedby,
             entity.locked_at,
             entity.metadata,
-            entity.state';
+            entity.state,
+            entity.timestamped,
+            entity.timestamped_at,
+            entity.timestampedby';
     }
 
     #[Override]

--- a/src/classes/TemplatesSqlBuilder.php
+++ b/src/classes/TemplatesSqlBuilder.php
@@ -46,6 +46,9 @@ final class TemplatesSqlBuilder extends EntitySqlBuilder
             entity.metadata,
             entity.rating,
             entity.state,
+            entity.timestamped,
+            entity.timestamped_at,
+            entity.timestampedby,
             (pin_experiments_templates2users.entity_id IS NOT NULL) AS is_pinned';
         $this->joinsSql[] = 'LEFT JOIN pin_experiments_templates2users
                 ON (entity.id = pin_experiments_templates2users.entity_id

--- a/src/controllers/AbstractEntityController.php
+++ b/src/controllers/AbstractEntityController.php
@@ -22,7 +22,6 @@ use Elabftw\Enums\Orderby;
 use Elabftw\Enums\RequestableAction;
 use Elabftw\Enums\Sort;
 use Elabftw\Interfaces\ControllerInterface;
-use Elabftw\Models\AbstractConcreteEntity;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Changelog;
 use Elabftw\Models\ExtraFieldsKeys;
@@ -202,9 +201,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'teamsArr' => $Teams->readAll(),
             'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             'templatesArr' => $this->templatesArr,
-            ...$this->Entity instanceof AbstractConcreteEntity
-                    ? array('timestamperFullname' => $this->Entity->getTimestamperFullname())
-                    : array(),
+            'timestamperFullname' => $this->Entity->getTimestamperFullname(),
             'lockerFullname' => $this->Entity->getLockerFullname(),
             'meaningArr' => $this->meaningArr,
             'requestableActionArr' => $this->requestableActionArr,

--- a/src/models/AbstractConcreteEntity.php
+++ b/src/models/AbstractConcreteEntity.php
@@ -12,42 +12,19 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
-use Elabftw\AuditEvent\SignatureCreated;
-use Elabftw\Elabftw\CreateUpload;
 use Elabftw\Elabftw\EntitySqlBuilder;
-use Elabftw\Elabftw\FsTools;
-use Elabftw\Elabftw\TimestampResponse;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
-use Elabftw\Enums\ExportFormat;
-use Elabftw\Enums\Meaning;
-use Elabftw\Enums\RequestableAction;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Factories\LinksFactory;
-use Elabftw\Interfaces\MakeTrustedTimestampInterface;
 use Elabftw\Interfaces\QueryParamsInterface;
-use Elabftw\Make\MakeBloxberg;
-use Elabftw\Make\MakeCustomTimestamp;
-use Elabftw\Make\MakeDfnTimestamp;
-use Elabftw\Make\MakeDgnTimestamp;
-use Elabftw\Make\MakeDigicertTimestamp;
-use Elabftw\Make\MakeFullJson;
-use Elabftw\Make\MakeGlobalSignTimestamp;
-use Elabftw\Make\MakeSectigoTimestamp;
-use Elabftw\Make\MakeUniversignTimestamp;
-use Elabftw\Make\MakeUniversignTimestampDev;
 use Elabftw\Params\DisplayParams;
-use Elabftw\Services\HttpGetter;
-use Elabftw\Services\SignatureHelper;
-use Elabftw\Services\TimestampUtils;
-use GuzzleHttp\Client;
 use PDO;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
-use ZipArchive;
 use Override;
 
 use function is_string;
@@ -98,19 +75,6 @@ abstract class AbstractConcreteEntity extends AbstractEntity
             ),
             Action::Duplicate => $this->duplicate((bool) ($reqBody['copyFiles'] ?? false), (bool) ($reqBody['linkToOriginal'] ?? false)),
             default => throw new ImproperActionException('Invalid action parameter.'),
-        };
-    }
-
-    #[Override]
-    public function patch(Action $action, array $params): array
-    {
-        // was "write" previously, but let's make timestamping/signing only require read access
-        $this->canOrExplode('read');
-        return match ($action) {
-            Action::Bloxberg => $this->bloxberg(),
-            Action::Sign => $this->sign($params['passphrase'], Meaning::from((int) $params['meaning'])),
-            Action::Timestamp => $this->timestamp(),
-            default => parent::patch($action, $params),
         };
     }
 
@@ -222,117 +186,6 @@ abstract class AbstractConcreteEntity extends AbstractEntity
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
-    }
-
-    /**
-     * Get timestamper full name for display in view mode
-     */
-    #[Override]
-    public function getTimestamperFullname(): string
-    {
-        if ($this->entityData['timestamped'] === 0) {
-            return 'Unknown';
-        }
-        return $this->getFullnameFromUserid($this->entityData['timestampedby']);
-    }
-
-    public function timestamp(): array
-    {
-        $Config = Config::getConfig();
-
-        // the source data can be in any format, here it defaults to json but can be pdf too
-        $dataFormat = ExportFormat::Json;
-        // if we do keeex we want to timestamp a pdf so we can keeex it
-        // there might be other options impacting this condition later
-        if ($Config->configArr['keeex_enabled'] === '1') {
-            $dataFormat = ExportFormat::Pdf;
-        }
-
-        // select the timestamp service and do the timestamp request to TSA
-        $Maker = $this->getTimestampMaker($Config->configArr, $dataFormat);
-        $TimestampUtils = new TimestampUtils(
-            new Client(),
-            $Maker->generateData(),
-            $Maker->getTimestampParameters(),
-            new TimestampResponse(),
-        );
-
-        // save the token and data in a zip archive
-        $zipName = $Maker->getFileName();
-        $zipPath = FsTools::getCacheFile() . '.zip';
-        $comment = sprintf(_('Timestamp archive by %s'), $this->Users->userData['fullname']);
-        $Maker->saveTimestamp(
-            $TimestampUtils->timestamp(),
-            new CreateUpload($zipName, $zipPath, $comment, immutable: 1, state: State::Archived),
-        );
-
-        // decrement the balance
-        $Config->decrementTsBalance();
-
-        // clear any request action
-        $RequestActions = new RequestActions($this->Users, $this);
-        $RequestActions->remove(RequestableAction::Timestamp);
-
-        return $this->readOne();
-    }
-
-    protected function bloxberg(): array
-    {
-        $configArr = Config::getConfig()->configArr;
-        $HttpGetter = new HttpGetter(new Client(), $configArr['proxy']);
-        $Maker = new MakeBloxberg(
-            $this->Users,
-            $this,
-            $configArr,
-            $HttpGetter,
-        );
-        $Maker->timestamp();
-        return $this->readOne();
-    }
-
-    protected function getTimestampMaker(array $config, ExportFormat $dataFormat): MakeTrustedTimestampInterface
-    {
-        //$entitySlugs = array(new EntitySlug($this->entityType, $this->id ?? 0));
-        return match ($config['ts_authority']) {
-            'dfn' => new MakeDfnTimestamp($this->Users, $this, $config, $dataFormat),
-            'dgn' => new MakeDgnTimestamp($this->Users, $this, $config, $dataFormat),
-            'universign' => $config['debug'] ? new MakeUniversignTimestampDev($this->Users, $this, $config, $dataFormat) : new MakeUniversignTimestamp($this->Users, $this, $config, $dataFormat),
-            'digicert' => new MakeDigicertTimestamp($this->Users, $this, $config, $dataFormat),
-            'sectigo' => new MakeSectigoTimestamp($this->Users, $this, $config, $dataFormat),
-            'globalsign' => new MakeGlobalSignTimestamp($this->Users, $this, $config, $dataFormat),
-            'custom' => new MakeCustomTimestamp($this->Users, $this, $config, $dataFormat),
-            default => throw new ImproperActionException('Incorrect timestamp authority configuration.'),
-        };
-    }
-
-    protected function sign(string $passphrase, Meaning $meaning): array
-    {
-        $Sigkeys = new SignatureHelper($this->Users);
-        $Maker = new MakeFullJson(array($this));
-        $message = $Maker->getFileContent();
-        $signature = $Sigkeys->serializeSignature($this->Users->userData['sig_privkey'], $passphrase, $message, $meaning);
-        $SigKeys = new SigKeys($this->Users);
-        $SigKeys->touch();
-        $Comments = new ImmutableComments($this);
-        $comment = sprintf(_('Signed by %s (%s)'), $this->Users->userData['fullname'], $meaning->name);
-        $Comments->postAction(Action::Create, array('comment' => $comment));
-        // save the signature and data in a zip archive
-        $zipPath = FsTools::getCacheFile() . '.zip';
-        $comment = sprintf(_('Signature archive by %s (%s)'), $this->Users->userData['fullname'], $meaning->name);
-        $ZipArchive = new ZipArchive();
-        $ZipArchive->open($zipPath, ZipArchive::CREATE);
-        $ZipArchive->addFromString('data.json.minisig', $signature);
-        $ZipArchive->addFromString('data.json', $message);
-        $ZipArchive->addFromString('key.pub', $this->Users->userData['sig_pubkey']);
-        $ZipArchive->addFromString('verify.sh', "#!/bin/sh\nminisign -H -V -p key.pub -m data.json\n");
-        $ZipArchive->close();
-        // allow uploading a file to that entity because sign action only requires read access
-        $this->Uploads->Entity->bypassWritePermission = true;
-        $this->Uploads->create(new CreateUpload('signature archive.zip', $zipPath, $comment, immutable: 1, state: State::Archived));
-        $RequestActions = new RequestActions($this->Users, $this);
-        $RequestActions->remove(RequestableAction::Sign);
-        AuditLogs::create(new SignatureCreated($this->Users->userData['userid'], $this->id ?? 0, $this->entityType));
-        return $this->readOne();
     }
 
     protected function getNextCustomId(?int $category): ?int

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -338,11 +338,8 @@ abstract class AbstractEntity extends AbstractRest
     {
         // a Review action doesn't do anything: TODO leave a comment
         if ($action === Action::Review) {
-            // clear any request action - skip for templates
-            if ($this instanceof AbstractConcreteEntity) {
-                $RequestActions = new RequestActions($this->Users, $this);
-                $RequestActions->remove(RequestableAction::Review);
-            }
+            $RequestActions = new RequestActions($this->Users, $this);
+            $RequestActions->remove(RequestableAction::Review);
             return $this->readOne();
         }
         // the toggle pin action doesn't require write access to the entity

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use DateTimeImmutable;
+use Elabftw\AuditEvent\SignatureCreated;
+use Elabftw\Elabftw\CreateUpload;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\EntitySqlBuilder;
+use Elabftw\Elabftw\FsTools;
 use Elabftw\Elabftw\Permissions;
 use Elabftw\Elabftw\TemplatesSqlBuilder;
+use Elabftw\Elabftw\TimestampResponse;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\EntityType;
+use Elabftw\Enums\ExportFormat;
+use Elabftw\Enums\Meaning;
 use Elabftw\Enums\Metadata as MetadataEnum;
 use Elabftw\Enums\RequestableAction;
 use Elabftw\Enums\State;
@@ -29,6 +35,17 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Factories\LinksFactory;
 use Elabftw\Interfaces\ContentParamsInterface;
+use Elabftw\Interfaces\MakeTrustedTimestampInterface;
+use Elabftw\Make\MakeBloxberg;
+use Elabftw\Make\MakeCustomTimestamp;
+use Elabftw\Make\MakeDfnTimestamp;
+use Elabftw\Make\MakeDgnTimestamp;
+use Elabftw\Make\MakeDigicertTimestamp;
+use Elabftw\Make\MakeFullJson;
+use Elabftw\Make\MakeGlobalSignTimestamp;
+use Elabftw\Make\MakeSectigoTimestamp;
+use Elabftw\Make\MakeUniversignTimestamp;
+use Elabftw\Make\MakeUniversignTimestampDev;
 use Elabftw\Params\ContentParams;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Params\EntityParams;
@@ -37,11 +54,16 @@ use Elabftw\Services\AccessKeyHelper;
 use Elabftw\Services\AdvancedSearchQuery;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
 use Elabftw\Services\Filter;
+use Elabftw\Services\HttpGetter;
+use Elabftw\Services\SignatureHelper;
+use Elabftw\Services\TimestampUtils;
 use Elabftw\Traits\EntityTrait;
+use GuzzleHttp\Client;
 use PDO;
 use PDOStatement;
 use Override;
 use Symfony\Component\HttpFoundation\InputBag;
+use ZipArchive;
 
 use function array_column;
 use function array_merge;
@@ -314,7 +336,7 @@ abstract class AbstractEntity extends AbstractRest
     #[Override]
     public function patch(Action $action, array $params): array
     {
-        // a Review action doesn't do anything
+        // a Review action doesn't do anything: TODO leave a comment
         if ($action === Action::Review) {
             // clear any request action - skip for templates
             if ($this instanceof AbstractConcreteEntity) {
@@ -349,13 +371,17 @@ abstract class AbstractEntity extends AbstractRest
                     $RequestActions->remove(RequestableAction::Archive);
                 }
             )(),
+            Action::Bloxberg => $this->bloxberg(),
             Action::Destroy => $this->destroy(),
             Action::Lock => $this->toggleLock(),
             Action::ForceLock => $this->lock(),
             Action::ForceUnlock => $this->unlock(),
             Action::Pin => $this->Pins->togglePin(),
+            Action::RemoveExclusiveEditMode => $this->ExclusiveEditMode->destroy(),
             Action::SetCanread => $this->update(new EntityParams('canread', $params['can'])),
             Action::SetCanwrite => $this->update(new EntityParams('canwrite', $params['can'])),
+            Action::Sign => $this->sign($params['passphrase'], Meaning::from((int) $params['meaning'])),
+            Action::Timestamp => $this->timestamp(),
             Action::UpdateMetadataField => (
                 function () use ($params) {
                     foreach ($params as $key => $value) {
@@ -373,7 +399,6 @@ abstract class AbstractEntity extends AbstractRest
                     }
                 }
             )(),
-            Action::RemoveExclusiveEditMode => $this->ExclusiveEditMode->destroy(),
             default => throw new ImproperActionException('Invalid action parameter.'),
         };
         return $this->readOne();
@@ -589,6 +614,46 @@ abstract class AbstractEntity extends AbstractRest
         }
     }
 
+    public function timestamp(): array
+    {
+        $Config = Config::getConfig();
+
+        // the source data can be in any format, here it defaults to json but can be pdf too
+        $dataFormat = ExportFormat::Json;
+        // if we do keeex we want to timestamp a pdf so we can keeex it
+        // there might be other options impacting this condition later
+        if ($Config->configArr['keeex_enabled'] === '1') {
+            $dataFormat = ExportFormat::Pdf;
+        }
+
+        // select the timestamp service and do the timestamp request to TSA
+        $Maker = $this->getTimestampMaker($Config->configArr, $dataFormat);
+        $TimestampUtils = new TimestampUtils(
+            new Client(),
+            $Maker->generateData(),
+            $Maker->getTimestampParameters(),
+            new TimestampResponse(),
+        );
+
+        // save the token and data in a zip archive
+        $zipName = $Maker->getFileName();
+        $zipPath = FsTools::getCacheFile() . '.zip';
+        $comment = sprintf(_('Timestamp archive by %s'), $this->Users->userData['fullname']);
+        $Maker->saveTimestamp(
+            $TimestampUtils->timestamp(),
+            new CreateUpload($zipName, $zipPath, $comment, immutable: 1, state: State::Archived),
+        );
+
+        // decrement the balance
+        $Config->decrementTsBalance();
+
+        // clear any request action
+        $RequestActions = new RequestActions($this->Users, $this);
+        $RequestActions->remove(RequestableAction::Timestamp);
+
+        return $this->readOne();
+    }
+
     protected function checkToggleLockPermissions(): void
     {
         $this->getPermissions();
@@ -631,6 +696,65 @@ abstract class AbstractEntity extends AbstractRest
         }
 
         return (new Permissions($this->Users, $this->entityData))->forEntity();
+    }
+
+    protected function bloxberg(): array
+    {
+        $configArr = Config::getConfig()->configArr;
+        $HttpGetter = new HttpGetter(new Client(), $configArr['proxy']);
+        $Maker = new MakeBloxberg(
+            $this->Users,
+            $this,
+            $configArr,
+            $HttpGetter,
+        );
+        $Maker->timestamp();
+        return $this->readOne();
+    }
+
+    protected function getTimestampMaker(array $config, ExportFormat $dataFormat): MakeTrustedTimestampInterface
+    {
+        //$entitySlugs = array(new EntitySlug($this->entityType, $this->id ?? 0));
+        return match ($config['ts_authority']) {
+            'dfn' => new MakeDfnTimestamp($this->Users, $this, $config, $dataFormat),
+            'dgn' => new MakeDgnTimestamp($this->Users, $this, $config, $dataFormat),
+            'universign' => $config['debug'] ? new MakeUniversignTimestampDev($this->Users, $this, $config, $dataFormat) : new MakeUniversignTimestamp($this->Users, $this, $config, $dataFormat),
+            'digicert' => new MakeDigicertTimestamp($this->Users, $this, $config, $dataFormat),
+            'sectigo' => new MakeSectigoTimestamp($this->Users, $this, $config, $dataFormat),
+            'globalsign' => new MakeGlobalSignTimestamp($this->Users, $this, $config, $dataFormat),
+            'custom' => new MakeCustomTimestamp($this->Users, $this, $config, $dataFormat),
+            default => throw new ImproperActionException('Incorrect timestamp authority configuration.'),
+        };
+    }
+
+    protected function sign(string $passphrase, Meaning $meaning): array
+    {
+        $Sigkeys = new SignatureHelper($this->Users);
+        $Maker = new MakeFullJson(array($this));
+        $message = $Maker->getFileContent();
+        $signature = $Sigkeys->serializeSignature($this->Users->userData['sig_privkey'], $passphrase, $message, $meaning);
+        $SigKeys = new SigKeys($this->Users);
+        $SigKeys->touch();
+        $Comments = new ImmutableComments($this);
+        $comment = sprintf(_('Signed by %s (%s)'), $this->Users->userData['fullname'], $meaning->name);
+        $Comments->postAction(Action::Create, array('comment' => $comment));
+        // save the signature and data in a zip archive
+        $zipPath = FsTools::getCacheFile() . '.zip';
+        $comment = sprintf(_('Signature archive by %s (%s)'), $this->Users->userData['fullname'], $meaning->name);
+        $ZipArchive = new ZipArchive();
+        $ZipArchive->open($zipPath, ZipArchive::CREATE);
+        $ZipArchive->addFromString('data.json.minisig', $signature);
+        $ZipArchive->addFromString('data.json', $message);
+        $ZipArchive->addFromString('key.pub', $this->Users->userData['sig_pubkey']);
+        $ZipArchive->addFromString('verify.sh', "#!/bin/sh\nminisign -H -V -p key.pub -m data.json\n");
+        $ZipArchive->close();
+        // allow uploading a file to that entity because sign action only requires read access
+        $this->Uploads->Entity->bypassWritePermission = true;
+        $this->Uploads->create(new CreateUpload('signature archive.zip', $zipPath, $comment, immutable: 1, state: State::Archived));
+        $RequestActions = new RequestActions($this->Users, $this);
+        $RequestActions->remove(RequestableAction::Sign);
+        AuditLogs::create(new SignatureCreated($this->Users->userData['userid'], $this->id ?? 0, $this->entityType));
+        return $this->readOne();
     }
 
     protected function getFullnameFromUserid(int $userid): string

--- a/src/models/AbstractEntity.php
+++ b/src/models/AbstractEntity.php
@@ -714,7 +714,6 @@ abstract class AbstractEntity extends AbstractRest
 
     protected function getTimestampMaker(array $config, ExportFormat $dataFormat): MakeTrustedTimestampInterface
     {
-        //$entitySlugs = array(new EntitySlug($this->entityType, $this->id ?? 0));
         return match ($config['ts_authority']) {
             'dfn' => new MakeDfnTimestamp($this->Users, $this, $config, $dataFormat),
             'dgn' => new MakeDgnTimestamp($this->Users, $this, $config, $dataFormat),

--- a/src/models/Templates.php
+++ b/src/models/Templates.php
@@ -241,10 +241,4 @@ final class Templates extends AbstractTemplateEntity
         // delete from pinned too
         return parent::destroy() && $this->Pins->cleanup();
     }
-
-    #[Override]
-    public function getTimestamperFullname(): string
-    {
-        return '';
-    }
 }

--- a/src/sql/schema179-down.sql
+++ b/src/sql/schema179-down.sql
@@ -1,3 +1,9 @@
 -- revert schema 179
 DROP TABLE IF EXISTS experiments_templates_comments;
+ALTER TABLE `experiments_templates` DROP COLUMN `timestamped`;
+ALTER TABLE `experiments_templates` DROP COLUMN `timestampedby`;
+ALTER TABLE `experiments_templates` DROP COLUMN `timestamped_at`;
+ALTER TABLE `items_types` DROP COLUMN `timestamped`;
+ALTER TABLE `items_types` DROP COLUMN `timestampedby`;
+ALTER TABLE `items_types` DROP COLUMN `timestamped_at`;
 UPDATE config SET conf_value = 178 WHERE conf_name = 'schema';

--- a/src/sql/schema179.sql
+++ b/src/sql/schema179.sql
@@ -13,3 +13,15 @@ CREATE TABLE `experiments_templates_comments` (
   CONSTRAINT `fk_experiments_templates_comments_experiments_templates_id` FOREIGN KEY (`item_id`) REFERENCES `experiments_templates` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `fk_experiments_templates_comments_users_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+ALTER TABLE `experiments_templates` ADD
+  `timestamped` tinyint UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE `experiments_templates` ADD
+  `timestampedby` int(11) NULL DEFAULT NULL;
+ALTER TABLE `experiments_templates` ADD
+  `timestamped_at` timestamp NULL DEFAULT NULL;
+ALTER TABLE `items_types` ADD
+  `timestamped` tinyint UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE `items_types` ADD
+  `timestampedby` int(11) NULL DEFAULT NULL;
+ALTER TABLE `items_types` ADD
+  `timestamped_at` timestamp NULL DEFAULT NULL;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -328,6 +328,9 @@ CREATE TABLE `experiments_templates` (
   `metadata` json NULL DEFAULT NULL,
   `state` int(10) UNSIGNED NOT NULL DEFAULT 1,
   `status` INT UNSIGNED NULL DEFAULT NULL,
+  `timestamped` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  `timestampedby` int(11) NULL DEFAULT NULL,
+  `timestamped_at` timestamp NULL DEFAULT NULL,
   `access_key` varchar(36) NULL DEFAULT NULL,
   `rating` tinyint UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
@@ -771,6 +774,9 @@ CREATE TABLE `items_types` (
   `metadata` json NULL DEFAULT NULL,
   `state` int(10) UNSIGNED NOT NULL DEFAULT 1,
   `status` INT UNSIGNED NULL DEFAULT NULL,
+  `timestamped` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  `timestampedby` int(11) NULL DEFAULT NULL,
+  `timestamped_at` timestamp NULL DEFAULT NULL,
   `access_key` varchar(36) NULL DEFAULT NULL,
   `rating` tinyint UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)

--- a/tests/unit/models/TemplatesTest.php
+++ b/tests/unit/models/TemplatesTest.php
@@ -52,9 +52,4 @@ class TemplatesTest extends \PHPUnit\Framework\TestCase
         $this->Templates->setId(1);
         $this->assertTrue($this->Templates->destroy());
     }
-
-    public function testGetTimestamperFullname(): void
-    {
-        $this->assertEquals('', $this->Templates->getTimestamperFullname());
-    }
 }


### PR DESCRIPTION
the items types are missing ui but they'll get it after nico-verticality is merged
now that templates have comments we can move the sign/bloxberg/timestamp methods up to homogeneize it all

Note: the sql is piggybacking the schema 179 thas was freshly merged

