### PR TITLE
bug/minor: exports: fix report header missing one column title

### DIFF
--- a/src/Make/MakeReport.php
+++ b/src/Make/MakeReport.php
@@ -28,6 +28,28 @@ class MakeReport extends AbstractMakeCsv
 {
     protected array $users;
 
+    public const array CSV_HEADERS = array(
+        'userid',
+        'firstname',
+        'lastname',
+        'created_at',
+        'orgid',
+        'email',
+        'has_mfa_enabled',
+        'validated',
+        'archived',
+        'last_login',
+        'valid_until',
+        'is_sysadmin',
+        'full_name',
+        'initials',
+        'team(s)',
+        'diskusage_in_bytes',
+        'diskusage_formatted',
+        'exp_total',
+        'exp_timestamped_total',
+    );
+
     public function __construct(protected Users $requester)
     {
         parent::__construct();
@@ -61,26 +83,7 @@ class MakeReport extends AbstractMakeCsv
     #[Override]
     protected function getHeader(): array
     {
-        return array(
-            'userid',
-            'firstname',
-            'lastname',
-            'created_at',
-            'orgid',
-            'email',
-            'has_mfa_enabled',
-            'validated',
-            'archived',
-            'last_login',
-            'valid_until',
-            'is_sysadmin',
-            'full_name',
-            'team(s)',
-            'diskusage_in_bytes',
-            'diskusage_formatted',
-            'exp_total',
-            'exp_timestamped_total',
-        );
+        return self::CSV_HEADERS;
     }
 
     /**

--- a/tests/unit/Make/MakeReportTest.php
+++ b/tests/unit/Make/MakeReportTest.php
@@ -32,4 +32,22 @@ class MakeReportTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertIsString($this->Make->getFileContent());
     }
+
+    public function testCsvHeaderIsCorrect(): void
+    {
+        // getHeaders is protected so get them from the file content
+        $csvContent = $this->Make->getFileContent();
+
+        // first line of csv contains headers
+        $lines = explode("\n", $csvContent);
+        $headerLine = trim($lines[0]);
+        // due to a UTF-8 BOM, strip the BOM before comparing
+        $headerLine = preg_replace('/^\xEF\xBB\xBF/', '', $headerLine);
+
+        $expectedHeaders = MakeReport::CSV_HEADERS;
+        // csv escapes special characters so make sure we compare the correct string
+        $expectedLine = implode(',', $expectedHeaders);
+
+        $this->assertSame($expectedLine, $headerLine);
+    }
 }


### PR DESCRIPTION
fix #5747

### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Add the missing column title to the csv export.
Additional tests for MakeReport