### PR TITLE
feat: resources: changing setting refreshes the permissions div

### DIFF
--- a/src/templates/booking-params-modal.html
+++ b/src/templates/booking-params-modal.html
@@ -13,7 +13,7 @@
         <div class='d-flex justify-content-between mb-2'>
           <label class='d-inline mr-1' for='isBookableSwitch'>{{ 'Allow booking this resource'|trans }}</label>
           <label class='switch' title='{{ 'Allow booking this resource'|trans }}'>
-            <input type='checkbox' autocomplete='off' id='isBookableSwitch' data-reload='topToolbar' data-trigger='change' data-model='items/{{ Entity.id }}' data-target='is_bookable' {{ Entity.entityData.is_bookable == 1 ? 'checked="checked"' }}>
+            <input type='checkbox' autocomplete='off' id='isBookableSwitch' data-reload='topToolbar,permissionsDiv' data-trigger='change' data-model='items/{{ Entity.id }}' data-target='is_bookable' {{ Entity.entityData.is_bookable == 1 ? 'checked="checked"' }}>
             <span class='slider'></span>
           </label>
         </div>


### PR DESCRIPTION
### Pull Request Description

On a resource, select the `Modify booking parameters` option
 
![image](https://github.com/user-attachments/assets/4426f357-df8b-4ea6-a966-c79b32efa181)

Allow booking the resource

![image](https://github.com/user-attachments/assets/41dd5d95-0768-4aa6-ac60-f53d33b51644)

Check permissions div further below on the page.
