### PR TITLE
feat: initials: replace 웃 with generic fallback for anonymous users

### DIFF
--- a/src/models/users/AnonymousUser.php
+++ b/src/models/users/AnonymousUser.php
@@ -48,7 +48,7 @@ final class AnonymousUser extends Users
         $this->userData['pdf_format'] = 'A4';
         $this->userData['userid'] = 0;
         $this->userData['entrypoint'] = 1;
-        $this->userData['initials'] = '웃';
+        $this->userData['initials'] = '☉'; // generic character utf &#9737. see issue #5778
         $this->userData['show_weekends'] = 0;
         $this->userData['enforce_exclusive_edit_mode'] = 0;
         $this->userData['scheduler_layout'] = 0;

--- a/src/models/users/AnonymousUser.php
+++ b/src/models/users/AnonymousUser.php
@@ -50,7 +50,8 @@ final class AnonymousUser extends Users
         $this->userData['pdf_format'] = 'A4';
         $this->userData['userid'] = 0;
         $this->userData['entrypoint'] = 1;
-        $this->userData['initials'] = json_decode('"\u2609"'); // ☉
+        // initials Hex code 2609
+        $this->userData['initials'] = '☉';
         $this->userData['show_weekends'] = 0;
         $this->userData['enforce_exclusive_edit_mode'] = 0;
         $this->userData['scheduler_layout'] = 0;

--- a/src/models/users/AnonymousUser.php
+++ b/src/models/users/AnonymousUser.php
@@ -14,6 +14,8 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Scope;
 
+use function json_decode;
+
 /**
  * An anonymous user is "logged in" in a team and has default settings
  * With a userid of 0
@@ -48,7 +50,7 @@ final class AnonymousUser extends Users
         $this->userData['pdf_format'] = 'A4';
         $this->userData['userid'] = 0;
         $this->userData['entrypoint'] = 1;
-        $this->userData['initials'] = '☉'; // generic character utf &#9737. see issue #5778
+        $this->userData['initials'] = json_decode('"\u2609"'); // ☉
         $this->userData['show_weekends'] = 0;
         $this->userData['enforce_exclusive_edit_mode'] = 0;
         $this->userData['scheduler_layout'] = 0;

--- a/src/models/users/AnonymousUser.php
+++ b/src/models/users/AnonymousUser.php
@@ -14,8 +14,6 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Scope;
 
-use function json_decode;
-
 /**
  * An anonymous user is "logged in" in a team and has default settings
  * With a userid of 0
@@ -50,7 +48,8 @@ final class AnonymousUser extends Users
         $this->userData['pdf_format'] = 'A4';
         $this->userData['userid'] = 0;
         $this->userData['entrypoint'] = 1;
-        // initials Hex code 2609
+        // use a neutral utf-8 character instead of initials for anonymous user
+        // U+2609 Sun character does the job
         $this->userData['initials'] = '☉';
         $this->userData['show_weekends'] = 0;
         $this->userData['enforce_exclusive_edit_mode'] = 0;

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -128,7 +128,7 @@
         {% endif %}
 
         {# Help/Community dropdown #}
-        <div class='nav-item dropdown'>
+        <div class='nav-item dropdown {{ App.Session.has('is_anon') ? 'ml-auto' }}'>
           <button class='btn nav-link border-0' id='navbarDropdownHelp' type='button' aria-label='{{ 'Help menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><i class='fas fa-circle-question fa-2x'></i></button>
           <div class='dropdown-menu dropdown-menu-right' aria-labelledby='navbarDropdownHelp'>
             <a class='dropdown-item' href='{{ App.getWhatsnewLink(constant('Elabftw\\Elabftw\\App::INSTALLED_VERSION_INT')) }}' target='_blank' rel='noopener'><i class='fas fa-newspaper fa-fw'></i> {{ "What's new"|trans }}</a>


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

feature req https://github.com/elabftw/elabftw/issues/5778

use less confusing character than the korean syllable 웃
move the icons to the right when in anon navigation

<img width="1428" height="94" alt="image" src="https://github.com/user-attachments/assets/20f01cb2-04e2-4143-8a28-a8774637c44b" />
