### PR TITLE
storage listing fix

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -573,7 +573,7 @@ components:
               type: string
             fullname:
               type: string
-            has_attachement:
+            has_attachment:
               type: integer
             id:
               type: integer

--- a/src/models/StorageUnits.php
+++ b/src/models/StorageUnits.php
@@ -441,6 +441,7 @@ final class StorageUnits extends AbstractRest
                     entity.id AS entity_id,
                     entity.title AS entity_title,
                     'database' AS page,
+                    c2i.id AS container2item_id,
                     c2i.qty_stored,
                     c2i.qty_unit,
                     c2i.created_at,
@@ -497,13 +498,14 @@ final class StorageUnits extends AbstractRest
                     users AS u ON (u.userid = entity.userid)
                 WHERE
                     -- can sql AND query or storage_id
-                    1=1 %s AND %s
+                    1=1 AND %s %s
 
             UNION
                 SELECT
                     entity.id AS entity_id,
                     entity.title AS entity_title,
                     'experiments' AS page,
+                    c2e.id AS container2experiment_id,
                     c2e.qty_stored,
                     c2e.qty_unit,
                     c2e.created_at,
@@ -560,15 +562,15 @@ final class StorageUnits extends AbstractRest
                     users AS u ON (u.userid = entity.userid)
                 WHERE
                     -- can sql AND query or storage_id
-                    1=1 %s AND %s",
+                    1=1 AND %s %s",
             $userid,
             $team,
-            $canFilter,
             $discriminator,
+            $canFilter,
             $userid,
             $team,
-            $canFilter,
             $discriminator,
+            $canFilter,
         );
     }
 }

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -14,9 +14,12 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Traits\TestsUtilsTrait;
 
 class StorageUnitsTest extends \PHPUnit\Framework\TestCase
 {
+    use TestsUtilsTrait;
+
     private StorageUnits $StorageUnits;
 
     protected function setUp(): void
@@ -60,6 +63,20 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->StorageUnits->readCount());
     }
 
+    public function testReadAllFromStorage(): void
+    {
+        // create 3 containers with the same qty/unit/storage
+        $Item = $this->getFreshItem();
+        $storageId = $this->StorageUnits->create('A place with multiple similar containers');
+        $Container2Items = new Containers2ItemsLinks($Item, $storageId);
+        $Container2Items->createWithQuantity(100.0, 'mL');
+        $Container2Items->createWithQuantity(100.0, 'mL');
+        $Container2Items->createWithQuantity(100.0, 'mL');
+        // now list them and verify we can see them all
+        $res = $this->StorageUnits->readAllFromStorage($storageId);
+        $this->assertTrue(count($res) === 3);
+    }
+
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/storage_units/', $this->StorageUnits->getApiPath());
@@ -68,8 +85,8 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
     public function testCreateImmutable(): void
     {
         $locations = array('Parent 1', 'Middle 1', '', 'Leaf 1');
-        $this->assertEquals(9, $this->StorageUnits->createImmutable($locations));
+        $resultsNumber = $this->StorageUnits->createImmutable($locations);
         // a second time to ensure we get the same number
-        $this->assertEquals(9, $this->StorageUnits->createImmutable($locations));
+        $this->assertEquals($resultsNumber, $this->StorageUnits->createImmutable($locations));
     }
 }

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -74,7 +74,8 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $Container2Items->createWithQuantity(100.0, 'mL');
         // now list them and verify we can see them all
         $res = $this->StorageUnits->readAllFromStorage($storageId);
-        $this->assertTrue(count($res) === 3);
+        $this->assertCount(3, $res);
+        $this->assertNotEmpty($res[0]['container2item_id']);
     }
 
     public function testGetApiPath(): void


### PR DESCRIPTION
[bug/minor: inventory: fix inventory storage location listing missing](https://github.com/elabftw/elabftw/commit/1f45ca42e00485dbf48a3f573dc1fbeb59b4bbcf)

duplicate containers. If two or more containers have the same quantity
and unit, they would be collapsed.

Another approach was to use UNION ALL instead of UNION, but here
selecting a unique c2i.id and c2e.id was enough to deduplicate them. The
ALL was previously removed in another commit so we don't want to
re-introduce it.

Also add the id discriminator before the permissions checks in WHERE.