### PR TITLE
Schema: remove default value not in enum

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3238,7 +3238,6 @@ paths:
           schema:
             type: string
             enum: ['instance', 'team']
-            default: json
           description: |
             Select the scope. Instance is for sysadmins only. Team will generate report for the current team.
           examples:


### PR DESCRIPTION
I was trying to use openapi-python-client to replace swagger;
doing so, this schema error came up (along many other errors related to the use of "default" keyword).
This PR just fixes the mistake by removing the default value.
Maybe it's not the right thing - maybe the defaut value should be "team" here.