### PR TITLE
ux: extra fields: scroll new/edited element into view

### DIFF
--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -363,6 +363,8 @@ document.addEventListener('DOMContentLoaded', () => {
           grpSel.value = selectedGroup;
           // and finally close the modal
           $('#fieldBuilderModal').modal('toggle');
+          // focus on the newly added element
+          document.querySelector(`[data-name="${fieldKey}"`).scrollIntoView();
         });
       });
     // EDIT EXTRA FIELD
@@ -445,6 +447,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         MetadataC.update(json as ValidMetadata).then(() => {
           $('#fieldBuilderModal').modal('toggle');
+          // focus on the newly added element
+          document.querySelector(`[data-name="${newFieldKey}"`).scrollIntoView();
         });
       });
     // ADD OPTION FOR SELECT OR RADIO


### PR DESCRIPTION
To reproduce issue: add enough extra fields to get a long list. Then add a new one, you get scrolled to uploaded files. With the patch the newly added/edited field gets right on top of the screen.

Idea for later: have a `flash()` function to briefly highlight an element by flashing the border in elabblue for highlight.