### PR TITLE
ux: eln import: skip domain validation during trusted eln import

### DIFF
--- a/src/models/users/ExistingUser.php
+++ b/src/models/users/ExistingUser.php
@@ -39,9 +39,10 @@ class ExistingUser extends Users
         bool $alertAdmin = true,
         ?string $orgid = null,
         bool $allowTeamCreation = false,
+        bool $skipDomainValidation = false,
     ): Users {
         $Users = new self();
-        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid, allowTeamCreation: $allowTeamCreation);
+        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid, allowTeamCreation: $allowTeamCreation, skipDomainValidation: $skipDomainValidation);
         $fresh = new self($userid);
         // we need to report the needValidation flag into the new object
         $fresh->needValidation = $Users->needValidation;

--- a/src/models/users/Users.php
+++ b/src/models/users/Users.php
@@ -88,6 +88,7 @@ class Users extends AbstractRest
         ?string $validUntil = null,
         ?string $orgid = null,
         bool $allowTeamCreation = false,
+        bool $skipDomainValidation = false,
     ): int {
         $Config = Config::getConfig();
         $Teams = new Teams($this);
@@ -97,7 +98,7 @@ class Users extends AbstractRest
         $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teams, $allowTeamCreation);
         $TeamsHelper = new TeamsHelper($teams[0]['id']);
 
-        $EmailValidator = new EmailValidator($email, (bool) $Config->configArr['admins_import_users'], $Config->configArr['email_domain']);
+        $EmailValidator = new EmailValidator($email, (bool) $Config->configArr['admins_import_users'], $Config->configArr['email_domain'], skipDomainValidation: $skipDomainValidation);
         $EmailValidator->validate();
 
         $firstname = trim($firstname);

--- a/src/models/users/ValidatedUser.php
+++ b/src/models/users/ValidatedUser.php
@@ -38,12 +38,13 @@ final class ValidatedUser extends ExistingUser
         return parent::fromScratch($email, $teams, $firstname, $lastname, automaticValidationEnabled: true, orgid: $orgid, allowTeamCreation: $allowTeamCreation);
     }
 
-    public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, Usergroup $usergroup): Users
+    public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, Usergroup $usergroup, bool $skipDomainValidation = false): Users
     {
-        return parent::fromScratch($email, $teams, $firstname, $lastname, $usergroup, true, false);
+        return parent::fromScratch($email, $teams, $firstname, $lastname, $usergroup, true, false, skipDomainValidation: $skipDomainValidation);
     }
 
     // create a user from the information provided in a node of type Person (.eln)
+    // skip domain validation here to prevent running into an error while importing trusted eln
     public static function createFromPerson(array $person, int $team): Users
     {
         return self::fromAdmin(
@@ -52,6 +53,7 @@ final class ValidatedUser extends ExistingUser
             $person['givenName'] ?? 'Unknown',
             $person['familyName'] ?? 'Unknown',
             Usergroup::User,
+            skipDomainValidation: true,
         );
     }
 }

--- a/src/services/EmailValidator.php
+++ b/src/services/EmailValidator.php
@@ -28,8 +28,12 @@ final class EmailValidator
 
     private Db $Db;
 
-    public function __construct(private string $email, private bool $adminsImportUsers = false, ?string $emailDomain = null)
-    {
+    public function __construct(
+        private string $email,
+        private bool $adminsImportUsers = false,
+        ?string $emailDomain = null,
+        private readonly bool $skipDomainValidation = false,
+    ) {
         // if it's an empty string, make it null
         if ($emailDomain === '') {
             $emailDomain = null;
@@ -62,7 +66,7 @@ final class EmailValidator
 
     private function validateDomain(): void
     {
-        if ($this->emailDomain !== null) {
+        if ($this->emailDomain !== null && !$this->skipDomainValidation) {
             $splitEmail = explode('@', $this->email);
             $splitDomains = array_map('trim', explode(',', $this->emailDomain));
             if (!in_array($splitEmail[1], $splitDomains, true)) {

--- a/tests/unit/services/EmailValidatorTest.php
+++ b/tests/unit/services/EmailValidatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
  * @copyright 2012 Nicolas CARPi
@@ -12,12 +13,31 @@ declare(strict_types=1);
 namespace Elabftw\Services;
 
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Traits\TestsUtilsTrait;
 
 class EmailValidatorTest extends \PHPUnit\Framework\TestCase
 {
+    use TestsUtilsTrait;
+
     public function testValidEmail(): void
     {
         $EmailValidator = new EmailValidator('blah@example.com');
+        $EmailValidator->validate();
+    }
+
+    public function testDomainIsEmptyString(): void
+    {
+        $email = 'blah@example.com';
+        $EmailValidator = new EmailValidator($email, emailDomain: '');
+        $this->assertEquals($email, $EmailValidator->validate());
+    }
+
+    public function testAdminsImportUsers(): void
+    {
+        $user = $this->getRandomUserInTeam(1);
+        $email = $user->userData['email'];
+        $EmailValidator = new EmailValidator($email, adminsImportUsers: true);
+        $this->expectException(ImproperActionException::class);
         $EmailValidator->validate();
     }
 
@@ -46,5 +66,12 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $EmailValidator = new EmailValidator('yolololol@yopmail.com', false, 'yopmail.com');
         $EmailValidator->validate();
+    }
+
+    public function testSkipValidation(): void
+    {
+        $email = 'a@newdomain.com';
+        $EmailValidator = new EmailValidator($email, false, 'yopmail.com', skipDomainValidation: true);
+        $this->assertEquals($email, $EmailValidator->validate());
     }
 }


### PR DESCRIPTION
Targeting the demo branch to user the getRandomUser function.

To reproduce: create a .eln where the author doesn't exist (unzip it, edit ro-crate to change the email value and zip it back). Make sure to have domain validation in Sysconfig page.

Try import it fails. Switch to this branch, no issues.