### PR TITLE
A can_manage_users2teams-check that will definitely be super quick to review

### DIFF
--- a/src/models/users/Users.php
+++ b/src/models/users/Users.php
@@ -580,7 +580,7 @@ class Users extends AbstractRest
             Filter::email($params->getStringContent());
         }
 
-        // special case for is_sysadmin: only a sysadmin can affect this column
+        // special case for is_sysadmin and can_manage_users2teams: only a sysadmin can affect this column
         if ($params->getTarget() === 'is_sysadmin' || $params->getTarget() === 'can_manage_users2teams') {
             if ($this->requester->userData['is_sysadmin'] === 0) {
                 throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin or can_manage_users2teams column of a user');

--- a/src/models/users/Users.php
+++ b/src/models/users/Users.php
@@ -581,9 +581,9 @@ class Users extends AbstractRest
         }
 
         // special case for is_sysadmin: only a sysadmin can affect this column
-        if ($params->getTarget() === 'is_sysadmin') {
+        if ($params->getTarget() === 'is_sysadmin' || $params->getTarget() === 'can_manage_users2teams') {
             if ($this->requester->userData['is_sysadmin'] === 0) {
-                throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin column of a user');
+                throw new IllegalActionException('Non sysadmin user tried to edit the is_sysadmin or can_manage_users2teams column of a user');
             }
         }
 


### PR DESCRIPTION
I stumbled upon [A very small PR that will definitely be super quick to review](https://github.com/elabftw/elabftw/pull/5796/) and - given the name - naturally had a quick scan through the code. I believe that a check for who is allowed to grant the new `can_manage_users2teams` capability might have been missed in the model. This quick-and-dirty PR should limit this to the same users who can grant `is_sysadmin`. If I understand the capability correctly, it allows the management of who is in which team, including if they are an admin of the team or not, which seems to be a capability that only a sysadmin (as opposed to a mere team admin) should be able to grant.