### PR TITLE
ui: notifications: error and warning must be closed

### DIFF
--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -102,6 +102,23 @@
     transform: translateX(-100%);
   }
 }
+/* only slide in */
+@keyframes slideIn {
+  0% {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+
+  10% {
+    opacity: 0.9;
+    transform: translateX(0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
 
 /** small spinner for buttons */
 @keyframes spin {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -633,7 +633,6 @@ tr:first-child td {
 
 /* class for a single notification */
 .overlay {
-  animation: slideInOut 3.5s ease-in-out forwards;
   border-radius: 5px;
   display: flex;
   line-height: 50px;
@@ -648,11 +647,31 @@ tr:first-child td {
 .overlay p {
   color: $white;
   font-weight: bold;
-  vertical-align: middle;
+  margin-bottom: 0;
+}
+
+.overlay span {
+  vertical-align: bottom;
 }
 
 .overlay-success {
+  animation: slideInOut 3.5s ease-in-out forwards;
   background-color: $elabblue;
+}
+
+.overlay-error,
+.overlay-warning {
+  animation: slideIn 3.5s ease-in forwards;
+
+  span > i {
+    color: $strongest;
+  }
+
+  &:hover {
+    span > i {
+      color: $darkred;
+    }
+  }
 }
 
 .overlay-error {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -650,10 +650,6 @@ tr:first-child td {
   margin-bottom: 0;
 }
 
-.overlay span {
-  vertical-align: bottom;
-}
-
 .overlay-success {
   animation: slideInOut 3.5s ease-in-out forwards;
   background-color: $elabblue;

--- a/src/ts/Notifications.class.ts
+++ b/src/ts/Notifications.class.ts
@@ -66,18 +66,27 @@ export class Notification {
     // create overlay
     const overlay = document.createElement('div');
     overlay.classList.add('overlay', `overlay-${type}`);
+    const closeEl = document.createElement('span');
+    const closeIcon = document.createElement('i');
+    if (type === NotificationType.Success) {
+      // success gets removed on animation end
+      overlay.addEventListener('animationend', () => {
+        overlay.remove();
+      });
+    } else { // warning and error get a button to close them
+      closeEl.classList.add('clickable', 'ml-3', 'float-right');
+      closeIcon.classList.add('fas', 'fa-xmark');
+      closeEl.append(closeIcon);
+      closeEl.addEventListener('click', () => overlay.remove());
+    }
     // create overlay content
     const p = document.createElement('p');
     // "status" role: see WCAG2.1 4.1.3
     p.role = 'status';
     p.innerText = message;
-    // show the overlay
     overlay.appendChild(p);
+    p.appendChild(closeEl);
     container.appendChild(overlay);
 
-    // overlay animation: fades in and out. Remove element when ended
-    overlay.addEventListener('animationend', () => {
-      overlay.remove();
-    });
   }
 }


### PR DESCRIPTION
this makes it easier to grab the error message, as end users won't open the console.

* add a slide in only animation
* rework css to make it work
* change notifications ts code to add the clickable element to close notif
