### PR TITLE
feat: pdf: better readability on exports

### DIFF
--- a/src/scss/_tinymce-custom.css
+++ b/src/scss/_tinymce-custom.css
@@ -8,3 +8,7 @@ figure {
   display: block;
   text-align: center;
 }
+
+body {
+    line-height: 1;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -254,36 +254,28 @@ blockquote::before {
 }
 
 /* TITLES */
-h1 {
+h1,
+h2,
+h3,
+h4,
+h5 {
   color: $medium;
-  font-size: 200%;
   font-weight: normal;
   margin-top: 0;
 }
 
-h2 {
-  color: $medium;
-  font-size: 180%;
-  font-weight: normal;
-  margin-top: 0;
-}
+h1 { font-size: 200%; }
+
+h2 { font-size: 180%; }
 
 h3 {
-  color: $medium;
   font-size: 160%;
   margin: 0 auto;
 }
 
-h4 {
-  color: $medium;
-  font-size: 150%;
-  font-weight: normal;
-}
+h4 { font-size: 150%; }
 
-h5 {
-  color: $medium;
-  font-size: 130%;
-}
+h5 { font-size: 130%; }
 
 /* HEAD */
 

--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -19,6 +19,27 @@ body {
   font-kerning: normal;
 }
 
+/* TITLES */
+h1 {
+  font-size: 150%;
+}
+
+h2 {
+  font-size: 140%;
+}
+
+h3 {
+  font-size: 130%;
+}
+
+h4 {
+  font-size: 120%;
+}
+
+h5 {
+  font-size: 110%;
+}
+
 a {
   color: variables.$elabblue;
   text-decoration: none;
@@ -124,6 +145,22 @@ tr:nth-child(odd) {
 
 #header {
   border-bottom: 1px solid #dcdddc;
+  margin-bottom: 1em;
+  overflow: hidden;
+  position: relative;
+}
+
+// use floats as mPDF does not allow display flex
+.entry-title {
+  float: left;
+  width: 60%;
+}
+
+.entry-meta {
+  float: right;
+  font-size: 90%;
+  text-align: right;
+  width: 35%;
 }
 
 .footer-block {

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -21,25 +21,26 @@
   </htmlpagefooter>
 
   <div id='header'>
-    <h1>{{ entityData.title }}</h1>
-    <p>
-    {{ entityDate }}
-      <strong>{{ 'Date'|trans }}:</strong> {{ date }}<br>
-      {% if entityData.tags %}
-        {% set tags = entityData.tags|split('|') %}
-        <strong>{{ 'Tags'|trans }}:</strong>
-        {% for tag in tags %}
-          <span class='tag'>{{ tag }}</span>
-        {% endfor %}<br>
-      {% endif %}
-      {% if entityData.category_title %}
-      <strong>{{ 'Category'|trans }}:</strong> {{ entityData.category_title }}<br>
-      {% endif %}
-      {% if entityData.status_title %}
-      <strong>{{ 'Status'|trans }}:</strong> {{ entityData.status_title }}<br>
-      {% endif %}
-      <strong>{{ 'Created by'|trans }}:</strong> {{ entityData.fullname }}<br>
-    </p>
+      <h1 class='entry-title'>{{ entityData.title }}</h1>
+    <div class="entry-meta">
+      <p>
+        <strong>{{ 'Date'|trans }}:</strong> {{ date }}<br>
+        {% if entityData.tags %}
+          {% set tags = entityData.tags|split('|') %}
+          <strong>{{ 'Tags'|trans }}:</strong>
+          {% for tag in tags %}
+            <span class='tag'>{{ tag }}</span>
+          {% endfor %}<br>
+        {% endif %}
+        {% if entityData.category_title %}
+          <strong>{{ 'Category'|trans }}:</strong> {{ entityData.category_title }}<br>
+        {% endif %}
+        {% if entityData.status_title %}
+          <strong>{{ 'Status'|trans }}:</strong> {{ entityData.status_title }}<br>
+        {% endif %}
+        <strong>{{ 'Created by'|trans }}:</strong> {{ entityData.fullname }}<br>
+      </p>
+    </div>
   </div>
 
   {% if timestamped %}


### PR DESCRIPTION
### Pull Request Description

When editing an entry, the main text had a default line height at 1.4. This was considered too important, bringing lots of empty spaces.
The pdf exports' text (especially titles) were taking a lot of spaces, and there was also too much space in between the paragraphs.

This PR
- reduces the line height for the main text (1.4 -> 1)
- reduces font-size for titles in PDF exports
- moves the entity's header metadata to the right to bring back up the rest of the content

<img width="2003" height="848" alt="image" src="https://github.com/user-attachments/assets/05a07448-cc5a-4743-b1ae-870600a2ba04" />

<img width="508" height="305" alt="image" src="https://github.com/user-attachments/assets/60ad8de5-4596-4da0-a29e-ba9c7d173c65" />

