### PR TITLE
bug/minor: anon: fix anonymous login blank page

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -118,7 +118,7 @@ abstract class AbstractEntityController implements ControllerInterface
         }
 
         // must be before the call to readShow
-        if ($this->App->Users->userData['always_show_owned'] === 1) {
+        if (($this->App->Users->userData['always_show_owned'] ?? null) === 1) {
             $this->Entity->alwaysShowOwned = true;
         }
 

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -165,7 +165,7 @@
         <div class='nav-item dropdown'>
           <button class='btn nav-link border-0' id='navbarDropdown' type='button' aria-label='{{ 'User menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><span class='initials'>{{ App.Users.userData.initials }}</span></button>
           <div class='dropdown-menu dropdown-menu-right' aria-labelledby='navbarDropdown'><h6 class='dropdown-header'>{{ 'Logged in as %s in:'|trans|format(App.Users.userData.firstname|default('Anonymous')) }}<br>{{ App.Teams.teamArr.name }}</h6>
-            {% if App.Users.userData.teams|jsonDecode|length > 1 %}
+            {% if App.Users.userData.teams|default('[]')|jsonDecode|length > 1 %}
               <a href='login.php?switch_team=1' class='dropdown-item'><i class='fas fa-repeat fa-fw'></i> {{ 'Switch team'|trans }}</a>
             {% endif %}
             <div class='dropdown-divider'></div>

--- a/src/tools/populate-config.yml.dist
+++ b/src/tools/populate-config.yml.dist
@@ -20,6 +20,8 @@ config:
   admin_validate: 0
   ldap_base_dn: dc=example,dc=org
   ldap_host: ldap
+  # log in as anonymous users
+  anon_users: 1
   # this is the default password of osixia/openldap docker container
   ldap_password: admin
   ldap_username: cn=admin,dc=example,dc=org

--- a/tests/cypress/integration/login.cy.ts
+++ b/tests/cypress/integration/login.cy.ts
@@ -46,4 +46,13 @@ describe('Login page', () => {
     fillEmailAddress('toto@yopmail.com{enter}');
     cy.get('div.alert.alert-success').should('contain', answer);
   });
+
+  it ('logs in as anonymous user', () => {
+    cy.visit('/login.php');
+    cy.get('button[name="submit"]').last().click();
+    // check we're logged in correctly as anonymous user
+    cy.location('pathname').should('eq', '/experiments.php');
+    cy.htmlvalidate();
+    cy.request('/app/logout.php');
+  });
 });

--- a/tests/cypress/integration/login.cy.ts
+++ b/tests/cypress/integration/login.cy.ts
@@ -49,8 +49,9 @@ describe('Login page', () => {
 
   it ('logs in as anonymous user', () => {
     cy.visit('/login.php');
-    cy.get('button[name="submit"]').last().click();
-    // check we're logged in correctly as anonymous user
+    cy.get('#anon-login').should('exist');
+    cy.get('#anon_login_select').select(0);
+    cy.get('#anon-login button[type="submit"]').click();
     cy.location('pathname').should('eq', '/experiments.php');
     cy.htmlvalidate();
     cy.request('/app/logout.php');


### PR DESCRIPTION
### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Logs (resulting in a blank page when trying to log in as an anon user):
```bash
2025/07/29 07:16:40 [error] 209#209: "PHP message: PHP Warning:  Undefined array key "always_show_owned" in /elabftw/src/Controllers/AbstractEntityController.php on line 121; PHP message
```
```bash
An exception has been thrown during the rendering of a template (\"Elabftw\\Elabftw\\TwigFilters::jsonDecode(): Argument #1 ($json) must be of type string, null given, called in /elabftw/cache/...
```