### PR TITLE
Fix german translation

### DIFF
--- a/src/langs/de_DE/LC_MESSAGES/messages.po
+++ b/src/langs/de_DE/LC_MESSAGES/messages.po
@@ -5461,7 +5461,7 @@ msgstr "Suche %s"
 
 #: src/templates/show.html:191
 msgid "Select state"
-msgstr "Bundesland auswählen"
+msgstr "Status auswählen"
 
 #: src/templates/show.html:193
 msgid "Normal"


### PR DESCRIPTION
Hey, 

the german translation uses "Bundesland" for state. Which is wrong. "Bundesland" means federal state. A better translation would be "Status".