### PR TITLE
bug: minor: fix deleted templates still visible when creating new entities

### DIFF
--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -16,6 +16,7 @@ use DateTimeImmutable;
 use Elabftw\Elabftw\PermissionsHelper;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Orderby;
+use Elabftw\Enums\State;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\ExperimentsStatus;
 use Elabftw\Models\Items;
@@ -80,6 +81,7 @@ final class DashboardController extends AbstractHtmlController
             $this->app->Users,
             EntityType::Templates,
             limit: 9999,
+            states: array(State::Normal)
         );
 
         return array_merge(

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -594,7 +594,7 @@ abstract class AbstractEntity extends AbstractRest
             $idSql = 'OR entity.id = :intQuery OR entity.custom_id = :intQuery';
         }
 
-        $sql = 'SELECT entity.id, entity.title, entity.custom_id,
+        $sql = 'SELECT entity.id, entity.title, entity.custom_id, entity.state,
             categoryt.color AS category_color,
             categoryt.title AS category_title,
             statust.color AS status_color,
@@ -612,6 +612,7 @@ abstract class AbstractEntity extends AbstractRest
                 entity.title LIKE :query ' . $idSql . '
             ' . $canFilter . '
             ' . $displayParams->getFilterSql() . '
+            ' . $displayParams->getStatesSql('entity') . '
             ' . $displayParams->getSql();
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->Users->requester->userid, PDO::PARAM_INT);


### PR DESCRIPTION
Fix #5870 
- include the state in results from `readAllSimple`
- DashboardController's `$DisplayParamsTemplates` now includes the states (specifically 'Normal') in results
- Displays correctly only available templates for creating new experiments or resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard template lists now show only active templates, hiding archived or disabled items for clearer browsing.
  * State-based visibility is applied consistently across all list views, preventing unexpected items from appearing in “simple” displays.
  * Aligns filtering behavior between different display modes to ensure uniform results throughout the app.
  * Reduces confusion by removing non-actionable templates from default views, improving focus and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->