### PR TITLE
bug: minor: fix styling inconsistency in main body

### DIFF
--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -251,6 +251,7 @@ final class Filter
             'color',
             'display', // see #3368
             'font-family',
+            'font-size', // see #5873
             'height',
             'line-height',
             'margin-left',


### PR DESCRIPTION
Fix #5873 

- Some styling was missing when creating/patching the main body.

<img width="947" height="568" alt="image" src="https://github.com/user-attachments/assets/c1079a68-170b-462a-a665-adcae78a918c" />
