### PR TITLE
bug: minor: fix switch teams' select not loading 

### DIFF
--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -64,7 +64,7 @@
       {%- endif %}
       <label for='team_selection_select'>{{ 'Your account is linked to several teams. Select in which team you want to log in'|trans }}</label>
       <select name='selected_team' id='team_selection_select' class='form-control'>
-        {% for team in App.Session.get('team_selection') %}
+        {% for team in App.Session.get('team_selection')|jsonDecode %}
           <option value='{{ team.id }}'>{{ team.name }}</option>
         {% endfor %}
       </select>


### PR DESCRIPTION
On switching team, the list of available teams would appear like this:
<img width="567" height="409" alt="Capture d’écran du 2025-08-20 11-57-57" src="https://github.com/user-attachments/assets/1b41beac-9eaa-4d2e-bbd0-b424dd562e49" />

App.Session.get('team_selection') is a string containing JSON, not a decoded array/object. jsonDecode fixes this issue.

<img width="567" height="409" alt="Capture d’écran du 2025-08-20 11-57-47" src="https://github.com/user-attachments/assets/045f7abc-3c4a-4c75-a42c-30fdfa1bb188" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team selection dropdown on the login page now correctly displays available teams by decoding stored data before rendering.
  * Resolves cases where the dropdown could appear empty due to improperly parsed team information.

* **User Experience**
  * Improved reliability of team options during login, with graceful handling when no valid team data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->