### PR TITLE
bug: minor: handle graphemes on autocomplete inputs

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -96,7 +96,7 @@ const TodolistC = new Todolist();
 
 const TableSortingC = new TableSorting();
 // for searching inputs, allow specific triggers for East & South East Asian characters
-const hasEastSEAsian = (s) => (
+const hasEastSEAsian = (s: string): boolean => (
   /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|\p{Script=Thai}|\p{Script=Lao}|\p{Script=Khmer}|\p{Script=Myanmar}/u.test(s)
 );
 
@@ -1172,19 +1172,19 @@ on('autocomplete', (el: HTMLElement) => {
     appendTo: el.dataset.identifier ? `#autocompleteAnchorDiv_${el.dataset.identifier}` : '',
     source: function(request: Record<string, string>, response: (data: Array<string>) => void): void {
       const term = (request.term || '').trim();
-      // if we're using East/SouthEast Asian terms, we allow search with 1 'letter'
+      // for East/Southeast Asian terms, we allow search with 1 grapheme
       const isShortScript = hasEastSEAsian(term);
       const minChars = isShortScript ? 1 : 3;
       if (countGraphemes(term) < minChars) {
-        response([]);
-        // TODO make it unselectable/grayed out or something, maybe once we use homegrown autocomplete
-        if (!isShortScript) response([i18next.t('type-3-chars')]);
+        const msg = isShortScript ? [] : [i18next.t('type-3-chars')];
+        response(msg);
         return;
+        // TODO make it unselectable/grayed out or something, maybe once we use homegrown autocomplete
       }
-      if (['experiments', 'items'].includes(el.dataset.completeTarget)) {
-        request.term = escapeExtendedQuery(term);
-      }
-      ApiC.getJson(`${el.dataset.target}/?q=${encodeURIComponent(term)}`).then(json => {
+      const queryTerm = ['experiments', 'items'].includes(el.dataset.completeTarget)
+        ? escapeExtendedQuery(term)
+        : term;
+      ApiC.getJson(`${el.dataset.target}/?q=${encodeURIComponent(queryTerm)}`).then(json => {
         response(json.map(entry => transformer(entry)));
       });
     },

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -100,16 +100,9 @@ const hasEastSEAsian = (s: string): boolean => (
   /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|\p{Script=Thai}|\p{Script=Lao}|\p{Script=Khmer}|\p{Script=Myanmar}/u.test(s)
 );
 
-// helper to count how many characters in the string are visible characters (grapheme)
-let graphemeSegmenter: Intl.Segmenter | null = null;
-if (typeof Intl !== 'undefined' && Intl.Segmenter) {
-  graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
-}
-
 const countGraphemes = (text: string): number => {
-  if (!graphemeSegmenter) {
-    return [...text].length;
-  }
+  // use Intl.Segmenter to handle locale-sensitive text segmentation (graphemes, sentences, etc.,)
+  const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
   return Array.from(graphemeSegmenter.segment(text)).length;
 };
 

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -97,7 +97,7 @@ const TodolistC = new Todolist();
 const TableSortingC = new TableSorting();
 // for searching inputs, allow specific triggers for East & South East Asian characters
 const hasEastSEAsian = (s: string): boolean => (
-  /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|\p{Script=Thai}|\p{Script=Lao}|\p{Script=Khmer}|\p{Script=Myanmar}/u.test(s)
+  /\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Hangul}|\p{Script=Thai}|\p{Script=Lao}|\p{Script=Khmer}|\p{Script=Myanmar}|\p{Script=Bopomofo}/u.test(s)
 );
 
 const countGraphemes = (text: string): number => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "lib": ["es2022", "dom"]
+    "lib": ["es2022", "es2022.intl", "dom"]
   },
   "include": [
     "src/ts/**/*"


### PR DESCRIPTION
fix #5869

This bug fix (or missing feature) introduces the handling of CJK & other Asian countries characters to provide a better autocomplete on inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Language-aware search for East/Southeast Asian input, allowing single-grapheme queries when appropriate.
  - Grapheme-aware input counting for more accurate query eligibility and results.

- Bug Fixes
  - Autocomplete shows the “type 3 characters” hint only for non–East Asian scripts.
  - Trims input and properly encodes queries to reduce whitespace/special-character errors.

- Refactor
  - Unified handling for autocomplete thresholds and query preparation while preserving non–East Asian behavior.

- Chores
  - Added Intl typings to improve internationalization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->