### PR TITLE
feat: tests: add tests to cover for model Template's edits in #5872

### DIFF
--- a/tests/unit/models/TemplatesTest.php
+++ b/tests/unit/models/TemplatesTest.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\EntityType;
+use Elabftw\Enums\State;
 use Elabftw\Models\Users\Users;
+use Elabftw\Params\DisplayParams;
 
 class TemplatesTest extends \PHPUnit\Framework\TestCase
 {
@@ -32,6 +35,16 @@ class TemplatesTest extends \PHPUnit\Framework\TestCase
     {
         $this->Templates->setId(1);
         $this->assertIsArray($this->Templates->readOne());
+    }
+
+    public function testReadAllSimpleReturnsActiveOnly(): void
+    {
+        $DisplayParams = new DisplayParams(new Users(1, 1), EntityType::Experiments);
+        $templates = $this->Templates->readAllSimple($DisplayParams);
+        foreach ($templates as $template) {
+            $this->assertIsArray($template);
+            $this->assertEquals(State::Normal->value, $template['state']);
+        }
     }
 
     public function testDuplicate(): void


### PR DESCRIPTION
#5872 introduced a small addition to fix the fact that `readAllSimple` always includes Archived // deleted templates on the results.

Missing tests (due to my conflicted settings that day), this PR adds them and allows `hypernext` to be ![green](https://img.shields.io/badge/green-brightgreen) again :muscle: 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure template lists return only active items, improving reliability of displayed data and reducing regression risk.
  * Strengthens confidence in consistent results across environments.
  * No changes to features, settings, or UI.
  * Performance, functionality, and compatibility remain unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->