### PR TITLE
feat: actions: add actions to changelog. fix #5842

### DIFF
--- a/src/AuditEvent/ActionRequested.php
+++ b/src/AuditEvent/ActionRequested.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+use Elabftw\Enums\EntityType;
+use Elabftw\Enums\RequestableAction;
+use Override;
+
+final class ActionRequested extends AbstractAuditEvent
+{
+    public function __construct(int $requesterUserid, int $targetUserid, private int $entityId, private EntityType $entityType, private RequestableAction $action)
+    {
+        parent::__construct($requesterUserid, $targetUserid);
+    }
+
+    #[Override]
+    public function getBody(): string
+    {
+        return sprintf('An action has been requested: %s on %s (id: %d)', $this->action->toHuman(), $this->entityType->value, $this->entityId);
+    }
+
+    #[Override]
+    public function getJsonBody(): string
+    {
+        $info = array_merge($this->getBaseInfo(), array(
+            'entity_id' => $this->entityId,
+            'entity_type' => $this->entityType->value,
+            'action' => $this->action->value,
+        ));
+        return json_encode($info, JSON_THROW_ON_ERROR);
+    }
+
+    #[Override]
+    public function getCategory(): AuditCategory
+    {
+        return AuditCategory::ActionRequested;
+    }
+}

--- a/src/Enums/AuditCategory.php
+++ b/src/Enums/AuditCategory.php
@@ -32,4 +32,5 @@ enum AuditCategory: int
     case OnboardingEmailSent = 90;
     case SignatureKeysCreated = 100;
     case SignatureCreated = 101;
+    case ActionRequested = 102;
 }

--- a/src/Enums/Messages.php
+++ b/src/Enums/Messages.php
@@ -17,6 +17,7 @@ enum Messages
     case CriticalError;
     case DatabaseError;
     case GenericError;
+    case UnauthorizedError;
     case InsufficientPermissions;
     case DemoMode;
 
@@ -26,6 +27,7 @@ enum Messages
             $this::CriticalError => 500,
             $this::DatabaseError => 500,
             $this::GenericError => 400,
+            $this::UnauthorizedError => 401,
             $this::InsufficientPermissions => 403,
             $this::DemoMode => 403,
         };
@@ -37,6 +39,7 @@ enum Messages
             $this::CriticalError => _('An internal error occurred. This should never happen! Please contact support with the following identifier:'),
             $this::DatabaseError => _('Sorry, there was an issue executing your request. Please try again later.'),
             $this::GenericError => _('An error occurred!'),
+            $this::UnauthorizedError => _('Authentication required'),
             $this::InsufficientPermissions => _('Sorry, you are not allowed to perform that action.'),
             $this::DemoMode => _('Sorry, this action is disabled in demo mode.'),
         };

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Exceptions;
 
+use Elabftw\Enums\Messages;
 use Exception;
 
 /**
@@ -19,10 +20,10 @@ use Exception;
  */
 final class UnauthorizedException extends AppException
 {
-    public function __construct(?string $message = null, int $code = 403, ?Exception $previous = null)
+    public function __construct(?string $message = null, int $code = 401, ?Exception $previous = null)
     {
         if ($message === null) {
-            $message = _('Authentication required');
+            $message = Messages::UnauthorizedError->toHuman();
         }
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -17,7 +17,7 @@ use Exception;
 /**
  * If user is not authorized to access this resource
  */
-final class UnauthorizedException extends Exception
+final class UnauthorizedException extends AppException
 {
     public function __construct(?string $message = null, int $code = 403, ?Exception $previous = null)
     {

--- a/src/Models/RequestActions.php
+++ b/src/Models/RequestActions.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\AuditEvent\ActionRequested as AuditEventActionRequested;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\RequestableAction;
 use Elabftw\Enums\State;
@@ -19,6 +20,7 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\Notifications\ActionRequested;
 use Elabftw\Models\Users\Users;
+use Elabftw\Params\ContentParams;
 use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
@@ -125,12 +127,18 @@ final class RequestActions extends AbstractRest
         $this->Db->execute($req);
         $actionId = $this->Db->lastInsertId();
 
+        $action = RequestableAction::from((int) $reqBody['target_action']);
+
         $Notifications = new ActionRequested(
             $this->requester,
-            RequestableAction::from((int) $reqBody['target_action']),
+            $action,
             $this->entity,
         );
         $Notifications->create((int) $reqBody['target_userid']);
+        $event = new AuditEventActionRequested($this->requester->userData['userid'], (int) $reqBody['target_userid'], $this->entity->id, $this->entity->entityType, $action);
+        AuditLogs::create($event);
+        $changelogValue = sprintf('%s (target userid: %d)', $event->getBody(), (int) $reqBody['target_userid']);
+        new Changelog($this->entity)->create(new ContentParams('action_requested', $changelogValue));
 
         return $actionId;
     }
@@ -156,7 +164,12 @@ final class RequestActions extends AbstractRest
         $req->bindValue(':action', $action->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->requester->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->entity->id, PDO::PARAM_INT);
-        return $this->Db->execute($req);
+        $returnId = $this->Db->execute($req);
+
+        $changelogValue = sprintf('Action done: %s by user with ID %d', $action->toHuman(), $this->requester->userData['userid']);
+        new Changelog($this->entity)->create(new ContentParams('action_done', $changelogValue));
+
+        return $returnId;
     }
 
     #[Override]

--- a/src/Models/RequestActions.php
+++ b/src/Models/RequestActions.php
@@ -164,12 +164,14 @@ final class RequestActions extends AbstractRest
         $req->bindValue(':action', $action->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->requester->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':entity_id', $this->entity->id, PDO::PARAM_INT);
-        $returnId = $this->Db->execute($req);
+        $res = $this->Db->execute($req);
 
-        $changelogValue = sprintf('Action done: %s by user with ID %d', $action->toHuman(), $this->requester->userData['userid']);
-        new Changelog($this->entity)->create(new ContentParams('action_done', $changelogValue));
+        if ($res && $req->rowCount() > 0) {
+            $changelogValue = sprintf('Action done: %s by user with ID %d', $action->toHuman(), $this->requester->userData['userid']);
+            new Changelog($this->entity)->create(new ContentParams('action_done', $changelogValue));
+        }
 
-        return $returnId;
+        return $res;
     }
 
     #[Override]

--- a/tests/unit/Enums/EnumsTest.php
+++ b/tests/unit/Enums/EnumsTest.php
@@ -71,4 +71,10 @@ class EnumsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ImproperActionException::class);
         $this->assertIsArray(ApiSubModels::validSubModelsForEndpoint(ApiEndpoint::Info));
     }
+
+    public function testMessages(): void
+    {
+        $this->assertSame(500, Messages::CriticalError->toHttpCode());
+        $this->assertSame(403, Messages::DemoMode->toHttpCode());
+    }
 }

--- a/tests/unit/models/RequestActionsTest.php
+++ b/tests/unit/models/RequestActionsTest.php
@@ -35,8 +35,9 @@ class RequestActionsTest extends \PHPUnit\Framework\TestCase
 
     public function testPostAction(): void
     {
+        $targetUser = $this->getUserInTeam(2);
         $reqBody = array(
-            'target_userid' => 2,
+            'target_userid' => $targetUser->userid,
             'target_action' => RequestableAction::Archive->value,
         );
         $newRequestActionId = $this->RequestActions->postAction(
@@ -60,7 +61,33 @@ class RequestActionsTest extends \PHPUnit\Framework\TestCase
 
     public function testReadAllFull(): void
     {
+        $reqBody = array(
+            'target_userid' => 2,
+            'target_action' => RequestableAction::Archive->value,
+        );
+        $this->RequestActions->postAction(
+            Action::Create,
+            $reqBody,
+        );
         $this->assertIsArray($this->RequestActions->readAllFull());
+    }
+
+    public function testRemove(): void
+    {
+        $targetUser = $this->getUserInTeam(2);
+        $reqBody = array(
+            'target_userid' => $targetUser->userid,
+            'target_action' => RequestableAction::Archive->value,
+        );
+        $this->RequestActions->postAction(
+            Action::Create,
+            $reqBody,
+        );
+        $this->assertCount(1, $this->RequestActions->readAll());
+        // do the action
+        $RequestActions = new RequestActions($targetUser, $this->Experiments);
+        $RequestActions->remove(RequestableAction::Archive);
+        $this->assertEmpty($this->RequestActions->readAll());
     }
 
     public function testReadOne(): void


### PR DESCRIPTION
* add new ActionRequested audit event
* generate audit event + changelog on action request
* generate changelog on action complete

Also add UnauthorizedException into AppException so it displays the message correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Audit logs now record when a user requests an action on an item, with clear human-readable details.
  - Changelog entries are added when an action is requested and when it is completed/removed, showing requester and performer.

- **Bug Fixes / UX**
  - Unauthorized responses now use the standard "Authentication required" message and HTTP 401 for unauthenticated requests.

- **Tests**
  - RequestActions tests expanded with a removal test and updated data-driven setups.
  - Added enum tests verifying message → HTTP code mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->