### PR TITLE
ui: add info about uploaded files storage backend on sysconfig page

### DIFF
--- a/src/Services/UploadsChecker.php
+++ b/src/Services/UploadsChecker.php
@@ -40,9 +40,13 @@ final class UploadsChecker
             COUNT(id) AS count_all,
             SUM(filesize) AS filesize_all,
             COUNT(CASE WHEN hash IS NULL THEN 1 END) AS count_null_hash,
-            COUNT(CASE WHEN filesize IS NULL THEN 1 END) AS count_null_filesize
+            COUNT(CASE WHEN filesize IS NULL THEN 1 END) AS count_null_filesize,
+            COUNT(CASE WHEN storage = :storage_local THEN 1 END) AS count_storage_local,
+            COUNT(CASE WHEN storage = :storage_s3 THEN 1 END) AS count_storage_s3
             FROM uploads';
         $req = $Db->prepare($sql);
+        $req->bindValue(':storage_local', Storage::LOCAL->value, PDO::PARAM_INT);
+        $req->bindValue(':storage_s3', Storage::S3->value, PDO::PARAM_INT);
         $Db->execute($req);
         return $req->fetch();
     }

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -525,6 +525,7 @@
       {{ 'Warning: %d files are missing a filesize value. Fix it with %sbin/console uploads:check%s command.'|format(uploadsStats.count_null_filesize, '<code>', '</code>')|msg('warning', false) }}
     {% endif %}
     {{ 'This instance has %d files uploaded using %s of disk space.'|trans|format(uploadsStats.count_all, uploadsStats.filesize_all|default(0)|formatBytes) }}
+    {{ '%d files are stored on local filesystem and %d files are stored on S3.'|trans|format(uploadsStats.count_storage_local, uploadsStats.count_storage_s3) }}
   </div>
 
   <h3 class='p-2 pl-3 section-title'>{{ 'Configuration'|trans }}</h3>

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -32,6 +32,7 @@ use Exception;
 use GuzzleHttp\Client;
 use PDO;
 use Symfony\Component\HttpFoundation\Response;
+use ValueError;
 
 use function array_walk;
 
@@ -100,7 +101,10 @@ try {
     $elabimgVersion = getenv('ELABIMG_VERSION') ?: 'Not in Docker';
     $auditLogsArr = AuditLogs::read($App->Request->query->getInt('limit', AuditLogs::DEFAULT_LIMIT), $App->Request->query->getInt('offset'));
     array_walk($auditLogsArr, function (array &$event) {
-        $event['category'] = AuditCategory::from($event['category'])->name;
+        try {
+            $event['category'] = AuditCategory::from($event['category'])->name;
+        } catch (ValueError) {
+        }
     });
     $passwordComplexity = PasswordComplexity::from((int) $App->Config->configArr['password_complexity_requirement']);
     $StorageUnits = new StorageUnits($App->Users);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System configuration now shows how many uploaded files are stored locally versus on S3, alongside existing disk usage details.

* **Bug Fixes**
  * Improved resilience when displaying audit events: unexpected or invalid category values no longer disrupt the page and are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->