### PR TITLE
bug/medium: fix switch teams

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -53,6 +53,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 
 use function setcookie;
+use function json_encode;
 
 /**
  * For all your authentication/login needs
@@ -180,7 +181,7 @@ final class LoginController implements ControllerInterface
         // if the user is in several teams, we need to redirect to the team selection
         if ($AuthResponse->isInSeveralTeams) {
             $this->Session->set('team_selection_required', true);
-            $this->Session->set('team_selection', $AuthResponse->selectableTeams);
+            $this->Session->set('team_selection', json_encode($AuthResponse->selectableTeams));
             $this->Session->set('auth_userid', $AuthResponse->userid);
             // carry over the cookie
             $this->Session->set('rememberme', $icanhazcookies);

--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -64,7 +64,7 @@
       {%- endif %}
       <label for='team_selection_select'>{{ 'Your account is linked to several teams. Select in which team you want to log in'|trans }}</label>
       <select name='selected_team' id='team_selection_select' class='form-control'>
-        {% for team in App.Session.get('team_selection') %}
+        {% for team in App.Session.get('team_selection')|default('[]')|jsonDecode %}
           <option value='{{ team.id }}'>{{ team.name }}</option>
         {% endfor %}
       </select>

--- a/web/index.php
+++ b/web/index.php
@@ -25,6 +25,8 @@ use OneLogin\Saml2\Settings as SamlSettings;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
+use function json_encode;
+
 require_once 'app/init.inc.php';
 
 $Response = new Response();
@@ -80,7 +82,7 @@ try {
             // if the user is in several teams, we need to redirect to the team selection
         } elseif ($AuthResponse->isInSeveralTeams) {
             $App->Session->set('team_selection_required', true);
-            $App->Session->set('team_selection', $AuthResponse->selectableTeams);
+            $App->Session->set('team_selection', json_encode($AuthResponse->selectableTeams));
             $App->Session->set('auth_userid', $AuthResponse->userid);
             $location = '/login.php';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of team selection during login for users in multiple teams. The list now loads consistently and gracefully handles missing session data, preventing blank or broken screens.
  - Hardened session handling in the login flow to avoid errors and edge-case failures, ensuring a smoother sign-in experience.
  - Enhanced template logic to correctly decode and display the available teams, providing a more robust and predictable team selection step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->