### PR TITLE
bug: login: fix password login when in multiple teams & switch as well

### DIFF
--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -64,7 +64,7 @@
       {%- endif %}
       <label for='team_selection_select'>{{ 'Your account is linked to several teams. Select in which team you want to log in'|trans }}</label>
       <select name='selected_team' id='team_selection_select' class='form-control'>
-        {% for team in App.Session.get('team_selection')|default('[]')|jsonDecode %}
+        {% for team in App.Session.get('team_selection')|default('[]') %}
           <option value='{{ team.id }}'>{{ team.name }}</option>
         {% endfor %}
       </select>

--- a/web/login.php
+++ b/web/login.php
@@ -70,9 +70,10 @@ try {
     }
 
     if ($App->Request->query->get('switch_team') === '1') {
+        $loggedInUser = new Users($App->Session->get('userid'));
         $App->Session->set('team_switch_required', true);
-        $App->Session->set('team_selection', $App->Users->userData['teams']);
-        $App->Session->set('auth_userid', $App->Users->userData['userid']);
+        $App->Session->set('team_selection', json_decode($loggedInUser->userData['teams']));
+        $App->Session->set('auth_userid', $loggedInUser->userData['userid']);
         $App->Session->remove('is_auth');
     }
 


### PR DESCRIPTION
fix #5904 - password login when in multiple teams


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed team selection list on the login screen to load reliably for all users.
  * Resolved issues where the team dropdown could appear empty or incomplete after logging in or switching teams.
  * Improved consistency of user and team data during login to prevent selection errors.

* **Chores**
  * Internal cleanup to streamline how user and team data are handled during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->