### PR TITLE
bug/major: login: fix multi-team login issues

### DIFF
--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -64,7 +64,7 @@
       {%- endif %}
       <label for='team_selection_select'>{{ 'Your account is linked to several teams. Select in which team you want to log in'|trans }}</label>
       <select name='selected_team' id='team_selection_select' class='form-control'>
-        {% for team in App.Session.get('team_selection')|default('[]')|jsonDecode %}
+        {% for team in App.Session.get('team_selection') %}
           <option value='{{ team.id }}'>{{ team.name }}</option>
         {% endfor %}
       </select>

--- a/web/index.php
+++ b/web/index.php
@@ -28,8 +28,6 @@ use OneLogin\Saml2\Settings as SamlSettings;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
-use function json_encode;
-
 require_once 'app/init.inc.php';
 
 $Response = new Response();
@@ -115,7 +113,7 @@ try {
             // if the user is in several teams, we need to redirect to the team selection
         } elseif ($AuthResponse->isInSeveralTeams()) {
             $App->Session->set('team_selection_required', true);
-            $App->Session->set('team_selection', json_encode($AuthResponse->getSelectableTeams()));
+            $App->Session->set('team_selection', $AuthResponse->getSelectableTeams());
             $App->Session->set('auth_userid', $AuthResponse->getAuthUserid());
             $location = '/login.php';
 

--- a/web/login.php
+++ b/web/login.php
@@ -70,9 +70,10 @@ try {
     }
 
     if ($App->Request->query->get('switch_team') === '1') {
-        $App->Session->set('team_switch_required', true);
-        $App->Session->set('team_selection', $App->Users->userData['teams']);
-        $App->Session->set('auth_userid', $App->Users->userData['userid']);
+        $loggedInUser = new Users($App->Session->get('userid'));
+        $App->Session->set('team_selection_required', true);
+        $App->Session->set('team_selection', json_decode($loggedInUser->userData['teams'], true, 3));
+        $App->Session->set('auth_userid', $loggedInUser->userData['userid']);
         $App->Session->remove('is_auth');
     }
 


### PR DESCRIPTION
remove jsonDecode from twig template: data is array
decode json from switch team and make sure to fetch data first

Based on @MoustaphaCamara 's work in mouss-250822-switch-teams-decoded branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team selection on the login page now reliably displays the correct list of teams, reducing cases where no options appeared.
  * Switching teams during login uses the current user context for improved accuracy, reducing unexpected redirects or loops.
  * Session handling for team selection is more consistent (stored as native data), improving persistence of the chosen team across the login flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->