### PR TITLE
feat: dashboard: use readAllSimple

### DIFF
--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -56,8 +56,8 @@ final class DashboardController extends AbstractHtmlController
         $DisplayParamsExp = new DisplayParams(
             $this->app->Users,
             EntityType::Experiments,
-            limit: self::SHOWN_NUMBER,
             orderby: Orderby::Lastchange,
+            limit: self::SHOWN_NUMBER,
         );
         $Experiments = new Experiments($this->app->Users);
         $Items = new Items($this->app->Users);
@@ -69,8 +69,8 @@ final class DashboardController extends AbstractHtmlController
         $DisplayParamsItems = new DisplayParams(
             $this->app->Users,
             EntityType::Items,
-            limit: self::SHOWN_NUMBER,
             orderby: Orderby::Lastchange,
+            limit: self::SHOWN_NUMBER,
         );
         $PermissionsHelper = new PermissionsHelper();
         $ExperimentsStatus = new ExperimentsStatus($this->app->Teams);
@@ -86,7 +86,7 @@ final class DashboardController extends AbstractHtmlController
 
         $DisplayParamsItemsTypes = new DisplayParams(
             $this->app->Users,
-            EntityType::Templates,
+            EntityType::ItemsTypes,
             limit: 9999,
             states: array(State::Normal)
         );

--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -84,6 +84,13 @@ final class DashboardController extends AbstractHtmlController
             states: array(State::Normal)
         );
 
+        $DisplayParamsItemsTypes = new DisplayParams(
+            $this->app->Users,
+            EntityType::Templates,
+            limit: 9999,
+            states: array(State::Normal)
+        );
+
         return array_merge(
             parent::getData(),
             array(
@@ -92,7 +99,7 @@ final class DashboardController extends AbstractHtmlController
                 'experimentsArr' => $Experiments->readShow($DisplayParamsExp),
                 'experimentsStatusArr' => $ExperimentsStatus->readAll($ExperimentsStatus->getQueryParams(new InputBag(array('limit' => 9999)))),
                 'itemsArr' => $Items->readShow($DisplayParamsItems),
-                'itemsTemplatesArr' => $ItemsTypes->readAll(),
+                'itemsTemplatesArr' => $ItemsTypes->readAllSimple($DisplayParamsItemsTypes),
                 'requestActionsArr' => $UserRequestActions->readAllFull(),
                 'templatesArr' => $Templates->readAllSimple($DisplayParamsTemplates),
                 'usersArr' => $this->app->Users->readAllActiveFromTeam(),

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -583,7 +583,9 @@ abstract class AbstractEntity extends AbstractRest
 
     public function readAllSimple(QueryParamsInterface $displayParams): array
     {
-        $categoryTable = $this instanceof Items ? 'items_categories' : 'experiments_categories';
+        $categoryTable = in_array($this->entityType->value, ['items', 'items_types'], true)
+            ? 'items_categories'
+            : 'experiments_categories';
         $CanSqlBuilder = new CanSqlBuilder($this->Users->requester, AccessType::Read);
         $canFilter = $CanSqlBuilder->getCanFilter();
         $displayParams->setSkipOrderPinned(true);

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -583,7 +583,7 @@ abstract class AbstractEntity extends AbstractRest
 
     public function readAllSimple(QueryParamsInterface $displayParams): array
     {
-        $categoryTable = in_array($this->entityType->value, ['items', 'items_types'], true)
+        $categoryTable = in_array($this->entityType->value, array('items', 'items_types'), true)
             ? 'items_categories'
             : 'experiments_categories';
         $CanSqlBuilder = new CanSqlBuilder($this->Users->requester, AccessType::Read);

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -48,7 +48,7 @@
                       <a href='{{ templatesPage }}.php?mode=view&id={{ template.id }}' class='p-2 rounded mr-2 hl-hover-gray' title='{{ 'View template'|trans }}' aria-label='{{ 'View template'|trans }}'>
                         <i class='fas fa-eye fa-fw'></i>
                       </a>
-                      {% if template.category or template.category_title %}
+                      {% if template.category_title %}
                         <span class='catstat-btn category-btn mr-2' style='--bg: #{{ template.category_color|default('bdbdbd') }}'>{{ template.category_title }}</span>
                       {% endif %}
                       {% if template.status %}

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -48,7 +48,7 @@
                       <a href='{{ templatesPage }}.php?mode=view&id={{ template.id }}' class='p-2 rounded mr-2 hl-hover-gray' title='{{ 'View template'|trans }}' aria-label='{{ 'View template'|trans }}'>
                         <i class='fas fa-eye fa-fw'></i>
                       </a>
-                      {% if template.category %}
+                      {% if template.category or template.category_title %}
                         <span class='catstat-btn category-btn mr-2' style='--bg: #{{ template.category_color|default('bdbdbd') }}'>{{ template.category_title }}</span>
                       {% endif %}
                       {% if template.status %}


### PR DESCRIPTION
References https://github.com/elabftw/elabftw/discussions/5853#discussioncomment-14137754

The readAll on dashboard would load all data from itemsTypes instead of a readAllSimple that fetches only necessary data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category badges in the "Create New Item" modal now render reliably when a category title is present and use consistent colors.
  * Dashboard lists for items and item types now load more completely and consistently, with correct category associations shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->