### PR TITLE
feat: exclusive edit: add a bail out button

### DIFF
--- a/src/Models/ExclusiveEditMode.php
+++ b/src/Models/ExclusiveEditMode.php
@@ -83,6 +83,7 @@ final class ExclusiveEditMode
             // everyone can ...
             if ($action === Action::Pin
                 || $action === Action::AccessKey
+                || $action === Action::RemoveExclusiveEditMode
             ) {
                 return null;
             }

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -30,10 +30,11 @@
 {# Exclusive edit mode notification #}
 <div id='exclusiveEditModeInfo'>
   {% if Entity.entityData.exclusive_edit_mode.locked_by > 0 and Entity.entityData.exclusive_edit_mode.locked_by != App.Users.userid and not Entity.entityData.exclusive_edit_mode.is_stale %}
-  {% set writeLockNotice = 'This entry is being edited by %s.'|trans|format(
-      Entity.entityData.exclusive_edit_mode.locked_by_human,
-    )|msg('warning', false) %}
-  {{ writeLockNotice|raw }}
+  {% macro writeLockNotice(locked_by_human) %}
+  {{ 'This entry is being edited by %s.'|trans|format(locked_by_human) }}
+      <button type='button' class='btn btn-sm btn-secondary' data-action='override-exclusive-edit-lock'>{{ 'Override lock'|trans }}</button>
+  {% endmacro %}
+  {{ _self.writeLockNotice(Entity.entityData.exclusive_edit_mode.locked_by_human)|msg('warning', false) }}
 {% endif %}
 </div>
 

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -60,6 +60,11 @@ if (mode === 'view') {
       .then(() => window.location.href = `?mode=view&id=${entity.id}`);
   });
 
+  on('override-exclusive-edit-lock', () => {
+    ApiC.patch(`${entity.type}/${entity.id}`, { action: Action.RemoveExclusiveEditMode })
+      .then(() => window.location.href = `?mode=view&id=${entity.id}`);
+  });
+
   // add the title in the page name (see #324)
   document.title = document.getElementById('documentTitle').textContent + ' - eLabFTW';
 

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -49,6 +49,10 @@ describe('Exclusive edit mode', () => {
     }).as('redirect');
     cy.get('[aria-label="Edit"]').should('have.class', 'disabled');
     cy.get('[class="alert alert-warning"]').should('contain', 'This entry is being edited by Toto Le sysadmin');
+    // now test the button
+    cy.get('[data-action="override-exclusive-edit-lock"]').click();
+    cy.get('body').should('not.contain', 'This entry is being edited by Toto Le sysadmin');
+    cy.get('[aria-label="Edit"]').should('not.have.class', 'disabled');
   };
 
   it('Try to open entity with exclusive edit mode', () => {

--- a/tests/cypress/integration/exclusiveEditMode.cy.ts
+++ b/tests/cypress/integration/exclusiveEditMode.cy.ts
@@ -5,6 +5,13 @@ describe('Exclusive edit mode', () => {
   const title = 'Entity with exclusive edit mode';
   // prepare an experiment with exclusive edit mode
   const setupEntityWithExclusiveEditMode = () => {
+    // ignore window.onbeforeunload so we can keep the exclusive edit mode running
+    cy.on('window:before:load', (win) => {
+      Object.defineProperty(win, 'onbeforeunload', {
+        get: () => null,
+        set: () => {}, // swallow
+      });
+    });
     cy.visit('/experiments.php');
     cy.contains('Create').click();
     cy.get('#createModal_experiments').should('be.visible').should('contain', 'No category').contains('No category').click();
@@ -17,7 +24,6 @@ describe('Exclusive edit mode', () => {
     cy.wait('@apiPATCH');
     cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
     // edit mode is always exclusive as of 2025/03, without clicking on a specific button
-    cy.intercept('GET', '/experiments.php?mode=edit*').as('getPage');
     cy.get('#date_input').type('2024-04-20').blur();
     cy.wait('@apiPATCH');
     cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');


### PR DESCRIPTION
In some cases the removal of exclusive edit mode upon leaving the edit mode would not work and block edition of an entry for no good reason. This change adds a button to the warning message to remove the exclusive edit mode unconditonally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Override lock” control on locked items so you can remove the lock and regain editing access; the page refreshes to the item’s view after unlocking.

* **Refactor**
  * Consolidated the lock notice into a reusable template component for consistent messaging and localization.

* **Tests**
  * Improved test setup to reliably simulate and preserve exclusive edit locks and to validate the override flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->