### PR TITLE
fix: permissions: "lock derived experiments affect template itself

### DIFF
--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -784,7 +784,7 @@ abstract class AbstractEntity extends AbstractRest
         }
         // ensure no changes happen on entries with immutable permissions
         if ($params->getTarget() === 'canread' || $params->getTarget() === 'canwrite') {
-            if (($this->entityData[$params->getTarget() . '_is_immutable'] ?? 0) === 1) {
+            if (($this->entityData[$params->getTarget() . '_is_immutable'] ?? 0) === 1 && (!($this instanceof AbstractTemplateEntity))) {
                 throw new ImproperActionException(_('Cannot modify permissions on entry with immutable permissions.'));
             }
         }

--- a/tests/unit/models/TemplatesTest.php
+++ b/tests/unit/models/TemplatesTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\State;
 use Elabftw\Models\Users\Users;
@@ -59,6 +60,20 @@ class TemplatesTest extends \PHPUnit\Framework\TestCase
         $entityData = $this->Templates->patch(Action::Update, array('title' => 'Untitled', 'body' => '<p>Body</p>'));
         $this->assertEquals('Untitled', $entityData['title']);
         $this->assertEquals('<p>Body</p>', $entityData['body']);
+    }
+
+    public function testCanUpdatePermissionsOnImmutableTemplate(): void
+    {
+        $this->Templates->setId(1);
+        $this->Templates->patch(Action::Update, array('canread_is_immutable' => 1));
+        $this->assertEquals(1, $this->Templates->readOne()['canread_is_immutable']);
+        // patch read permissions for this template
+        $canread = BasePermissions::Organization->toJson();
+        $this->Templates->patch(Action::Update, array('canread' => $canread));
+        $this->assertEquals(
+            json_decode($canread),
+            json_decode($this->Templates->readOne()['canread'])
+        );
     }
 
     public function testDestroy(): void


### PR DESCRIPTION
fix #5799

The issue is that on editing a template's derived experiment permissions, it would also lock the current template's permissions
Adding tests to verify the behaviour is not inconsistent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Templates: You can now modify read/write permissions even when a template is marked immutable, enabling updates to access settings without unlocking the template.

- Tests
  - Added tests to ensure immutable templates correctly save permission changes.
  - Added tests confirming that items created from templates honor immutable permission settings and block permission changes accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->