### PR TITLE
feat: permissions: allow admin to edit a derived entity's permissions

### DIFF
--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -631,7 +631,7 @@ abstract class AbstractEntity extends AbstractRest
     public function canOrExplode(string $rw): void
     {
         if ($this->id === null) {
-            throw new ImproperActionException('Cannot check permissions without an id!');
+            throw new IllegalActionException('Cannot check permissions without an id!');
         }
         if ($this->bypassWritePermission && $rw === 'write') {
             return;

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -778,14 +778,18 @@ abstract class AbstractEntity extends AbstractRest
             $content = $this->readOne()['body'] . $content;
         }
         // ensure no changes happen on entries with immutable permissions
+        // admins can override the immutability of an entity's permissions. See #5800
         if ($params->getTarget() === 'canread' || $params->getTarget() === 'canwrite') {
-            if (($this->entityData[$params->getTarget() . '_is_immutable'] ?? 0) === 1 && (!($this instanceof AbstractTemplateEntity))) {
-                throw new ImproperActionException(_('Cannot modify permissions on entry with immutable permissions.'));
+            if (($this->entityData[$params->getTarget() . '_is_immutable'] ?? 0) === 1
+                && !($this instanceof AbstractTemplateEntity)
+                && !($this->Users->isAdmin)
+            ) {
+                throw new UnprocessableContentException(_('Cannot modify permissions on entry with immutable permissions.'));
             }
         }
         // also prevent modifying immutability of permissions on concrete entities
         if (str_ends_with($params->getTarget(), '_is_immutable') && $this instanceof AbstractConcreteEntity) {
-            throw new ImproperActionException(_('Cannot modify permissions immutability settings.'));
+            throw new UnprocessableContentException(_('Cannot modify permissions immutability settings.'));
         }
 
         // save a revision for body target

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -133,7 +133,7 @@
   {% if Entity.entityData.canread_target %}
    {# TARGET PERMISSIONS #}
     <h5>{{ 'Permissions for the derived entry'|trans }}</h5>
-    <p class='smallgray col-md-8'>{{ 'All entries created from this experiment will inherit these permissions, which cannot be modified. Only an Admin can override and change them on the derived entry.'|trans }}</p>
+    <p class='smallgray col-md-8'>{{ 'Entries created from this template will inherit these permissions and cannot be modified by Users. Only an Admin can override them on the derived entry.'|trans }}</p>
     <div class='d-flex mb-2 align-items-center'>
       {# CANREAD #}
       {% set rw = 'canread_target' %}

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -133,7 +133,7 @@
   {% if Entity.entityData.canread_target %}
    {# TARGET PERMISSIONS #}
     <h5>{{ 'Permissions for the derived entry'|trans }}</h5>
-    <p class='smallgray col-md-8'>{{ 'Entries created from this template will inherit these permissions and cannot be modified by Users. Only an Admin can override them on the derived entry.'|trans }}</p>
+    <p class='smallgray'>{{ 'Entries created from this template will inherit these permissions. If they are locked down, the permissions will not be modifiable by Users, only Admins.'|trans }}</p>
     <div class='d-flex mb-2 align-items-center'>
       {# CANREAD #}
       {% set rw = 'canread_target' %}

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -133,6 +133,7 @@
   {% if Entity.entityData.canread_target %}
    {# TARGET PERMISSIONS #}
     <h5>{{ 'Permissions for the derived entry'|trans }}</h5>
+    <p class='smallgray col-md-8'>{{ 'All entries created from this experiment will inherit these permissions, which cannot be modified. Only an Admin can override and change them on the derived entry.'|trans }}</p>
     <div class='d-flex mb-2 align-items-center'>
       {# CANREAD #}
       {% set rw = 'canread_target' %}

--- a/src/templates/view-permissions.html
+++ b/src/templates/view-permissions.html
@@ -20,7 +20,7 @@
 <label class='col-form-label mr-3 edit-mode-label'><i class='fas fa-fw fa-{{ icon }} mr-1' title='{{ label }}'></i>{{ label }}</label>
 {% if not Entity.isReadOnly %}
   {% set permissionsIsDisabled = false %}
-  {% if Entity.entityData[immutableVar] and Entity.entityType.value != 'experiments_templates' and Entity.entityType.value != 'items_types' and not App.Users.isAdmin%}
+  {% if Entity.entityData[immutableVar] and Entity.entityType.value != 'experiments_templates' and Entity.entityType.value != 'items_types' and not App.Users.isAdmin %}
     {% set permissionsIsDisabled = true %}
   {% endif %}
   {# show the button as disabled and without any action related #}

--- a/src/templates/view-permissions.html
+++ b/src/templates/view-permissions.html
@@ -20,7 +20,7 @@
 <label class='col-form-label mr-3 edit-mode-label'><i class='fas fa-fw fa-{{ icon }} mr-1' title='{{ label }}'></i>{{ label }}</label>
 {% if not Entity.isReadOnly %}
   {% set permissionsIsDisabled = false %}
-  {% if Entity.entityData[immutableVar] and Entity.entityType.value != 'experiments_templates' and Entity.entityType.value != 'items_types' %}
+  {% if Entity.entityData[immutableVar] and Entity.entityType.value != 'experiments_templates' and Entity.entityType.value != 'items_types' and not App.Users.isAdmin%}
     {% set permissionsIsDisabled = true %}
   {% endif %}
   {# show the button as disabled and without any action related #}

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -90,6 +90,7 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $Items = $this->makeItemFromImmutableTemplateFor($admin);
         $Items->patch(Action::Update, array('canread' => BasePermissions::UserOnly->toJson()));
         $canRead = json_decode($Items->readOne()['canread'], true);
+        $this->assertSame(1, $Items->readOne()['canread_is_immutable']);
         $this->assertEquals(BasePermissions::UserOnly->value, $canRead['base']);
     }
 

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\FileFromString;
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnprocessableContentException;
 use Elabftw\Models\Users\AuthenticatedUser;
@@ -127,11 +128,18 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $this->Items->patch(Action::NotifDestroy, array('unavailable' => 'action'));
     }
 
-    public function testReadOneWithoutId(): void
+    public function testCannotReadOneWithoutId(): void
     {
         $this->Items->setId(null);
-        $this->expectException(ImproperActionException::class);
+        $this->expectException(IllegalActionException::class);
         $this->Items->readOne();
+    }
+
+    public function testCannotCheckPermissionsWithoutId(): void
+    {
+        $this->Items->setId(null);
+        $this->expectException(IllegalActionException::class);
+        $this->Items->canOrExplode('read');
     }
 
     public function testReadBookable(): void


### PR DESCRIPTION
### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Once an entity is created from a template, the permissions were forever locked. Now, it is possible for admins to update these settings for a selected entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can override immutable permissions on entries derived from templates; admins see active permission controls.

* **Bug Fixes**
  * More precise error handling for permission operations (new error responses for missing-ID and immutability cases) and prevention of modifying immutability flags on concrete entries.

* **Documentation**
  * UI copy added clarifying permission inheritance and admin-only overrides for template-derived entries.

* **Tests**
  * Added/expanded tests for immutable-permissions, admin bypass, and related error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->