### PR TITLE
feat: events: mail users who have booked the entry in surrounding periods

### DIFF
--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -419,7 +419,6 @@ final class EntitySqlBuilder implements SqlBuilderInterface
                 SEPARATOR '|'
             ) AS events_start_itemid";
 
-
         // only select events from the future
         $this->joinsSql[] = "LEFT JOIN team_events
             ON ((team_events.$eventsColumn = entity.id)

--- a/src/Services/Email.php
+++ b/src/Services/Email.php
@@ -176,7 +176,7 @@ class Email
     }
 
     // get users who booked current item in the 4 surrounding months
-    public function getSurroundingBookersWithCount(int $itemId): array
+    public function getSurroundingBookers(int $itemId): array
     {
         $Db = Db::getConnection();
         $sql = 'SELECT DISTINCT email, CONCAT(firstname, " ", lastname) AS fullname
@@ -190,9 +190,9 @@ class Email
         $Db->execute($req);
         $rows = $req->fetchAll();
         $addresses = array_map(fn($row) => new Address($row['email'], $row['fullname']), $rows);
-        // for API purposes, we keep the raw data
-        $rawEmails = array_map(fn($row) => array('email' => $row['email'], 'fullname' => $row['fullname']), $rows);
-        return array('count' => count($rows), 'emailsRaw' => $rawEmails, 'addressesRaw' => $addresses);
+        // for listing recipients, keep only count & fullname
+        $fullNames = array_column($rows, 'fullname');
+        return array('fullnames' => $fullNames, 'emailAddresses' => $addresses);
     }
 
     public function notifySysadminsTsBalance(int $tsBalance): bool

--- a/src/Services/Email.php
+++ b/src/Services/Email.php
@@ -188,13 +188,11 @@ class Email
         $req = $Db->prepare($sql);
         $req->bindValue(':itemid', $itemId, PDO::PARAM_INT);
         $Db->execute($req);
-
         $rows = $req->fetchAll();
-        $addresses = array_map(
-            fn($row) => new Address($row['email'], $row['fullname']),
-            $rows
-        );
-        return array('count' => count($addresses), 'emails' => $addresses);
+        $addresses = array_map(fn($row) => new Address($row['email'], $row['fullname']), $rows);
+        // for API purposes, we keep the raw data
+        $rawEmails = array_map(fn($row) => array('email' => $row['email'], 'fullname' => $row['fullname']), $rows);
+        return array('count' => count($rows), 'emailsRaw' => $rawEmails, 'addressesRaw' => $addresses);
     }
 
     public function notifySysadminsTsBalance(int $tsBalance): bool

--- a/src/templates/bookings-email-modal.html
+++ b/src/templates/bookings-email-modal.html
@@ -8,12 +8,12 @@
         </button>
       </div>
       <div class='modal-body'>
-        <span id='listEmailRecipients' class='mb-2'></span>
+        <span id='listEmailRecipients' class='mb-2'></span><br>
         {# SUBJECT #}
-        <label for='bookingsEmailSubject' class='col-form-label'>{{ 'Email Subject'|trans }}</label>
+        <label for='bookingsEmailSubject' class='col-form-label font-weight-bold'>{{ 'Subject'|trans }}</label>
         <input class='form-control col-md-12' type='text' id='bookingsEmailSubject' size='45' />
         {# BODY #}
-        <label for='bookingsEmailBody' class='col-form-label mt-2'>{{ 'Email Body'|trans }}</label>
+        <label for='bookingsEmailBody' class='col-form-label mt-2 font-weight-bold'>{{ 'Message'|trans }}</label>
         <textarea class='form-control col-md-12' id='bookingsEmailBody'></textarea>
       </div>
       <div class='modal-footer'>

--- a/src/templates/bookings-email-modal.html
+++ b/src/templates/bookings-email-modal.html
@@ -14,6 +14,9 @@
         {# BODY #}
         <label for='bookingsEmailBody' class='col-form-label mt-2'>{{ 'Email Body'|trans }}</label>
         <textarea class='form-control col-md-12' id='bookingsEmailBody'></textarea>
+        {# list of recipients filled by ts #}
+        <button type='button' data-action='get-surrounding-bookers' data-itemid='{{ Entity.entityData.id }}'>{{ 'List recipients' }}</button>
+        <span id='listEmailRecipients'></span>
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/templates/bookings-email-modal.html
+++ b/src/templates/bookings-email-modal.html
@@ -1,5 +1,5 @@
 <div class='modal fade' id='sendBookingsEmailModal' tabindex='-1' role='dialog' aria-labelledby='sendBookingsEmailModalLabel'>
-  <div class='modal-dialog' role='document'>
+  <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>
         <h5 class='modal-title' id='sendBookingsEmailModalLabel'><i class='fas fa-fw fa-envelope'></i> {{ 'Send an email to users who booked this resource'|trans }}</h5>
@@ -8,15 +8,13 @@
         </button>
       </div>
       <div class='modal-body'>
+        <span id='listEmailRecipients' class='mb-2'></span>
         {# SUBJECT #}
         <label for='bookingsEmailSubject' class='col-form-label'>{{ 'Email Subject'|trans }}</label>
         <input class='form-control col-md-12' type='text' id='bookingsEmailSubject' size='45' />
         {# BODY #}
         <label for='bookingsEmailBody' class='col-form-label mt-2'>{{ 'Email Body'|trans }}</label>
         <textarea class='form-control col-md-12' id='bookingsEmailBody'></textarea>
-        {# list of recipients filled by ts #}
-        <button type='button' data-action='get-surrounding-bookers' data-itemid='{{ Entity.entityData.id }}'>{{ 'List recipients' }}</button>
-        <span id='listEmailRecipients'></span>
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/templates/bookings-email-modal.html
+++ b/src/templates/bookings-email-modal.html
@@ -1,0 +1,24 @@
+<div class='modal fade' id='sendBookingsEmailModal' tabindex='-1' role='dialog' aria-labelledby='sendBookingsEmailModalLabel'>
+  <div class='modal-dialog' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='sendBookingsEmailModalLabel'><i class='fas fa-fw fa-envelope'></i> {{ 'Send an email to users who booked this resource'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body'>
+        {# SUBJECT #}
+        <label for='bookingsEmailSubject' class='col-form-label'>{{ 'Email Subject'|trans }}</label>
+        <input class='form-control col-md-12' type='text' id='bookingsEmailSubject' size='45' />
+        {# BODY #}
+        <label for='bookingsEmailBody' class='col-form-label mt-2'>{{ 'Email Body'|trans }}</label>
+        <textarea class='form-control col-md-12' id='bookingsEmailBody'></textarea>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
+        <button type='button' class='btn btn-primary' data-dismiss='modal' data-action='notify-surrounding-bookers' title='{{ 'Send'|trans }}' data-itemid='{{ Entity.entityData.id }}'>{{ 'Send'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -192,7 +192,7 @@
         <a class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' title='{{ 'Book item'|trans }}' aria-label='{{ 'Book item'|trans }}' href='scheduler.php?items[]={{ Entity.id }}'>
           <i class='fas fa-calendar-plus fa-fw'></i>
         </a>
-        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray p-2 mr-2' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
+        <button type='button' aria-label='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' class='btn border-0 lh-normal hl-hover-gray p-2 mr-2' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
       {% else %}
         <button type='button' class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' aria-label='{{ 'Modify booking parameters'|trans }}' title='{{ 'Modify booking parameters'|trans }}' data-action='toggle-modal' data-target='bookingParamsModal'>
           <i class='fas fa-calendar-plus color-disabled fa-fw'></i>

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -192,12 +192,14 @@
         <a class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' title='{{ 'Book item'|trans }}' aria-label='{{ 'Book item'|trans }}' href='scheduler.php?items[]={{ Entity.id }}'>
           <i class='fas fa-calendar-plus fa-fw'></i>
         </a>
-        <button type='button' aria-label='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' class='btn border-0 lh-normal hl-hover-gray p-2 mr-2' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
+        <button type='button' class='btn border-0 lh-normal hl-hover-gray p-2 mr-2' aria-label='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'>
+          <i class='fas fa-fw fa-envelope'></i>
+        </button>
       {% else %}
         <button type='button' class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' aria-label='{{ 'Modify booking parameters'|trans }}' title='{{ 'Modify booking parameters'|trans }}' data-action='toggle-modal' data-target='bookingParamsModal'>
           <i class='fas fa-calendar-plus color-disabled fa-fw'></i>
         </button>
-        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn hl-hover-gray d-inline p-2 mr-2' disabled><i class='fas fa-fw fa-envelope'></i></button>
+        <button type='button' class='btn hl-hover-gray d-inline p-2 mr-2' title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' aria-label='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' disabled><i class='fas fa-fw fa-envelope'></i></button>
       {% endif %}
     {% endif %}
 

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -192,10 +192,12 @@
         <a class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' title='{{ 'Book item'|trans }}' aria-label='{{ 'Book item'|trans }}' href='scheduler.php?items[]={{ Entity.id }}'>
           <i class='fas fa-calendar-plus fa-fw'></i>
         </a>
+        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray p-2 mr-2' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
       {% else %}
         <button type='button' class='btn mr-2 hl-hover-gray p-2 lh-normal border-0' aria-label='{{ 'Modify booking parameters'|trans }}' title='{{ 'Modify booking parameters'|trans }}' data-action='toggle-modal' data-target='bookingParamsModal'>
           <i class='fas fa-calendar-plus color-disabled fa-fw'></i>
         </button>
+        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn hl-hover-gray d-inline p-2 mr-2' disabled><i class='fas fa-fw fa-envelope'></i></button>
       {% endif %}
     {% endif %}
 

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -93,14 +93,12 @@
 
   {# SHOW EVENTS #}
   <div class='mb-2'>
+    {% if Entity.entityData.type == 'items' and Entity.entityData.is_bookable == '1' %}
+      <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='toggle-modal' data-target='sendBookingsEmailModal'><i class='fas fa-fw fa-envelope'></i></button>
+    {% endif %}
   {% if Entity.entityData.events_start %}
     <div class='mb-2'>
       <i class='far fa-fw fa-calendar-alt'></i>
-      {% if Entity.entityData.type == 'items' %}
-        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='notify-past-bookers' data-itemid='{{ Entity.entityData.id }}'>
-          <i class='fas fa-fw fa-envelope'></i>
-        </button>
-      {% endif %}
       {% set splitItemids = Entity.entityData.events_start_itemid|split('|') %}
       {% for event in Entity.entityData.events_start|split('|') %}
         <a href='scheduler.php?items[]={{ splitItemids[loop.index - 1] }}&amp;start={{ event|url_encode }}' class='mx-1 btn btn-neutral relative-moment'  title='{{ event|date('Y-m-d H:i:s') }}' aria-label='{{ event|date('Y-m-d H:i:s') }}'></a>
@@ -109,6 +107,7 @@
     <hr>
   {% endif %}
   </div>
+  {% include 'bookings-email-modal.html' %}
 
   {# SHOW NEXT STEP #}
   {% set next_step = Entity.entityData.next_step %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -93,10 +93,8 @@
 
   {# SHOW EVENTS #}
   {% if Entity.entityData.type == 'items' and Entity.entityData.is_bookable == '1' %}
-    <div class='d-flex align-content-center'>
-      <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
-      <div class='vertical-separator'></div>
-      {% if Entity.entityData.events_start %}
+    {% if Entity.entityData.events_start %}
+      <div class='d-flex align-content-center'>
         <div>
           <i class='far fa-fw fa-calendar-alt'></i>
           {% set splitItemids = Entity.entityData.events_start_itemid|split('|') %}
@@ -104,10 +102,10 @@
             <a href='scheduler.php?items[]={{ splitItemids[loop.index - 1] }}&amp;start={{ event|url_encode }}' class='mx-1 btn btn-neutral relative-moment'  title='{{ event|date('Y-m-d H:i:s') }}' aria-label='{{ event|date('Y-m-d H:i:s') }}'></a>
           {% endfor %}
         </div>
-      {% endif %}
-    </div>
+      </div>
+      <hr>
+    {% endif %}
     {% include 'bookings-email-modal.html' %}
-    <hr>
   {% endif %}
 
   {# SHOW NEXT STEP #}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -92,22 +92,23 @@
   <hr>
 
   {# SHOW EVENTS #}
-  <div class='mb-2'>
-    {% if Entity.entityData.type == 'items' and Entity.entityData.is_bookable == '1' %}
+  {% if Entity.entityData.type == 'items' and Entity.entityData.is_bookable == '1' %}
+    <div class='d-flex align-content-center'>
       <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='toggle-modal' data-target='sendBookingsEmailModal'><i class='fas fa-fw fa-envelope'></i></button>
-    {% endif %}
-  {% if Entity.entityData.events_start %}
-    <div class='mb-2'>
-      <i class='far fa-fw fa-calendar-alt'></i>
-      {% set splitItemids = Entity.entityData.events_start_itemid|split('|') %}
-      {% for event in Entity.entityData.events_start|split('|') %}
-        <a href='scheduler.php?items[]={{ splitItemids[loop.index - 1] }}&amp;start={{ event|url_encode }}' class='mx-1 btn btn-neutral relative-moment'  title='{{ event|date('Y-m-d H:i:s') }}' aria-label='{{ event|date('Y-m-d H:i:s') }}'></a>
-      {% endfor %}
+      <div class='vertical-separator'></div>
+      {% if Entity.entityData.events_start %}
+        <div>
+          <i class='far fa-fw fa-calendar-alt'></i>
+          {% set splitItemids = Entity.entityData.events_start_itemid|split('|') %}
+          {% for event in Entity.entityData.events_start|split('|') %}
+            <a href='scheduler.php?items[]={{ splitItemids[loop.index - 1] }}&amp;start={{ event|url_encode }}' class='mx-1 btn btn-neutral relative-moment'  title='{{ event|date('Y-m-d H:i:s') }}' aria-label='{{ event|date('Y-m-d H:i:s') }}'></a>
+          {% endfor %}
+        </div>
+      {% endif %}
     </div>
+    {% include 'bookings-email-modal.html' %}
     <hr>
   {% endif %}
-  </div>
-  {% include 'bookings-email-modal.html' %}
 
   {# SHOW NEXT STEP #}
   {% set next_step = Entity.entityData.next_step %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -94,7 +94,7 @@
   {# SHOW EVENTS #}
   {% if Entity.entityData.type == 'items' and Entity.entityData.is_bookable == '1' %}
     <div class='d-flex align-content-center'>
-      <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='toggle-modal' data-target='sendBookingsEmailModal'><i class='fas fa-fw fa-envelope'></i></button>
+      <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='open-bookings-email-modal' data-itemid='{{ Entity.entityData.id }}'><i class='fas fa-fw fa-envelope'></i></button>
       <div class='vertical-separator'></div>
       {% if Entity.entityData.events_start %}
         <div>

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -92,9 +92,15 @@
   <hr>
 
   {# SHOW EVENTS #}
+  <div class='mb-2'>
   {% if Entity.entityData.events_start %}
     <div class='mb-2'>
       <i class='far fa-fw fa-calendar-alt'></i>
+      {% if Entity.entityData.type == 'items' %}
+        <button title='{{ 'Send an email to users who have booked this resource within the 4 last & upcoming months.'|trans }}' type='button' class='btn border-0 lh-normal hl-hover-gray' data-action='notify-past-bookers' data-itemid='{{ Entity.entityData.id }}'>
+          <i class='fas fa-fw fa-envelope'></i>
+        </button>
+      {% endif %}
       {% set splitItemids = Entity.entityData.events_start_itemid|split('|') %}
       {% for event in Entity.entityData.events_start|split('|') %}
         <a href='scheduler.php?items[]={{ splitItemids[loop.index - 1] }}&amp;start={{ event|url_encode }}' class='mx-1 btn btn-neutral relative-moment'  title='{{ event|date('Y-m-d H:i:s') }}' aria-label='{{ event|date('Y-m-d H:i:s') }}'></a>
@@ -102,7 +108,7 @@
     </div>
     <hr>
   {% endif %}
-
+  </div>
 
   {# SHOW NEXT STEP #}
   {% set next_step = Entity.entityData.next_step %}

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -32,7 +32,7 @@ function updateTsFieldsVisibility(select: HTMLSelectElement) {
   }
 }
 
-function handleEmailResponse(resp: Response, button: HTMLButtonElement): void {
+export function handleEmailResponse(resp: Response, button: HTMLButtonElement): void {
   resp.json().then(json => {
     notify.response(json);
     if (json.res) {
@@ -45,7 +45,7 @@ function handleEmailResponse(resp: Response, button: HTMLButtonElement): void {
   });
 }
 
-function postForm(controller: string, params: Record<string, string|Blob>): Promise<Response> {
+export function postForm(controller: string, params: Record<string, string|Blob>): Promise<Response> {
   const formData = new FormData();
   formData.append('csrf', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
   for (const [key, value] of Object.entries(params)) {

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -13,6 +13,7 @@ import { Action, Model } from './interfaces';
 import { entity } from './getEntity';
 import { on } from './handlers';
 import { core } from './core';
+import { handleEmailResponse, postForm } from './sysconfig';
 
 const mode = new URLSearchParams(window.location.search).get('mode');
 if (mode === 'view') {
@@ -53,6 +54,21 @@ if (mode === 'view') {
     if (confirm(i18next.t('generic-delete-warning'))) {
       ApiC.delete(`${entity.type}/${entity.id}/${Model.Comment}/${el.dataset.id}`).then(() => el.parentElement.parentElement.remove());
     }
+  });
+
+  on('notify-past-bookers', (el: HTMLElement) => {
+    const itemId = el.dataset.itemid;
+    const subject = 'Update about an item you booked';
+    const body = 'Hello! You previously booked this item. Here\'s something important.';
+    const button = (el as HTMLButtonElement);
+    button.disabled = true;
+    button.innerText = 'Sending…';
+    postForm('app/controllers/SysconfigAjaxController.php', {
+      notifyPastBookers: '1',
+      itemId: itemId.toString(),
+      subject: subject,
+      body: body,
+    }).then(resp => handleEmailResponse(resp, button));
   });
 
   on('override-exclusive-edit-lock', () => {

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -56,6 +56,18 @@ if (mode === 'view') {
     }
   });
 
+  on('get-surrounding-bookers', (el: HTMLElement) => {
+    postForm('app/controllers/SysconfigAjaxController.php', { listBookers: '1', itemId: el.dataset.itemid })
+      .then(resp => resp.json())
+      .then(json => {
+        // msg is already an object with { count, emails }
+        const count = json.count;
+        const emails = json.emails;
+        const recipientsList = document.getElementById('listEmailRecipients');
+        recipientsList.textContent = `This email will be sent to ${count} users. Emails: ${emails.join(', ')}`;
+      });
+  })
+
   on('notify-surrounding-bookers', (el: HTMLElement) => {
     const itemId = el.dataset.itemid;
     const subject = (document.getElementById('bookingsEmailSubject') as HTMLInputElement).value;

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -14,6 +14,7 @@ import { entity } from './getEntity';
 import { on } from './handlers';
 import { core } from './core';
 import { handleEmailResponse, postForm } from './sysconfig';
+import $ from 'jquery';
 
 const mode = new URLSearchParams(window.location.search).get('mode');
 if (mode === 'view') {
@@ -56,17 +57,17 @@ if (mode === 'view') {
     }
   });
 
-  on('get-surrounding-bookers', (el: HTMLElement) => {
+  on('open-bookings-email-modal', (el: HTMLElement) => {
     postForm('app/controllers/SysconfigAjaxController.php', { listBookers: '1', itemId: el.dataset.itemid })
       .then(resp => resp.json())
       .then(json => {
-        // msg is already an object with { count, fullnames }
         const fullnames = json.fullnames;
         const recipientsList = document.getElementById('listEmailRecipients');
         const count = fullnames.length;
-        recipientsList.textContent = `This email will be sent to ${count} user${count > 1 ? 's' : ''}: ${fullnames.join(', ')}`;
-      });
-  });
+        recipientsList.textContent = `This email will be sent to ${count} user${count > 1 ? 's' : ''}: ${fullnames.join(', ')}.`;
+      })
+      .then(() => $('#sendBookingsEmailModal').modal('toggle'));
+  })
 
   on('notify-surrounding-bookers', (el: HTMLElement) => {
     const itemId = el.dataset.itemid;

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -60,13 +60,13 @@ if (mode === 'view') {
     postForm('app/controllers/SysconfigAjaxController.php', { listBookers: '1', itemId: el.dataset.itemid })
       .then(resp => resp.json())
       .then(json => {
-        // msg is already an object with { count, emails }
-        const count = json.count;
-        const emails = json.emails;
+        // msg is already an object with { count, fullnames }
+        const fullnames = json.fullnames;
         const recipientsList = document.getElementById('listEmailRecipients');
-        recipientsList.textContent = `This email will be sent to ${count} users. Emails: ${emails.join(', ')}`;
+        const count = fullnames.length;
+        recipientsList.textContent = `This email will be sent to ${count} user${count > 1 ? 's' : ''}: ${fullnames.join(', ')}`;
       });
-  })
+  });
 
   on('notify-surrounding-bookers', (el: HTMLElement) => {
     const itemId = el.dataset.itemid;

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -56,10 +56,10 @@ if (mode === 'view') {
     }
   });
 
-  on('notify-past-bookers', (el: HTMLElement) => {
+  on('notify-surrounding-bookers', (el: HTMLElement) => {
     const itemId = el.dataset.itemid;
-    const subject = 'Update about an item you booked';
-    const body = 'Hello! You previously booked this item. Here\'s something important.';
+    const subject = (document.getElementById('bookingsEmailSubject') as HTMLInputElement).value;
+    const body = (document.getElementById('bookingsEmailBody') as HTMLInputElement).value;
     const button = (el as HTMLButtonElement);
     button.disabled = true;
     button.innerText = 'Sending…';

--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -5,16 +5,16 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import i18next from './i18n';
 import { InputType, Malle } from '@deltablot/malle';
+import $ from 'jquery';
 import { ApiC } from './api';
-import { relativeMoment, reloadElements } from './misc';
-import { Action, Model } from './interfaces';
+import { core } from './core';
 import { entity } from './getEntity';
 import { on } from './handlers';
-import { core } from './core';
+import i18next from './i18n';
+import { Action, Model } from './interfaces';
+import { relativeMoment, reloadElements } from './misc';
 import { handleEmailResponse, postForm } from './sysconfig';
-import $ from 'jquery';
 
 const mode = new URLSearchParams(window.location.search).get('mode');
 if (mode === 'view') {
@@ -63,11 +63,18 @@ if (mode === 'view') {
       .then(json => {
         const fullnames = json.fullnames;
         const recipientsList = document.getElementById('listEmailRecipients');
+        const sendBtn = document.querySelector<HTMLButtonElement>('[data-action="notify-surrounding-bookers"]');
         const count = fullnames.length;
-        recipientsList.textContent = `This email will be sent to ${count} user${count > 1 ? 's' : ''}: ${fullnames.join(', ')}.`;
+        if (count === 0 && sendBtn) {
+          recipientsList.textContent = 'There are no users to email to.';
+          sendBtn.disabled = true;
+        } else {
+          recipientsList.textContent = `This email will be sent to ${count} user${count > 1 ? 's' : ''}: ${fullnames.join(', ')}`;
+          sendBtn.disabled = false;
+        }
       })
       .then(() => $('#sendBookingsEmailModal').modal('toggle'));
-  })
+  });
 
   on('notify-surrounding-bookers', (el: HTMLElement) => {
     const itemId = el.dataset.itemid;

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -56,6 +56,16 @@ try {
 
     $subject = $App->Request->request->getString('subject');
     $body = $App->Request->request->getString('body');
+    // get list of recipient
+    if ($App->Request->request->has('listBookers')) {
+        $result = $Email->getSurroundingBookersWithCount($App->Request->request->getInt('itemId'));
+        $emails = $result['emailsRaw'];
+        $emailList = array();
+        foreach ($emails as $email) {
+            $emailList[] = $email['email'];
+        }
+        $Response->setData(array('res' => true, 'emails' => $emailList, 'count' => $result['count']));
+    }
     // SEND MULTIPLE EMAILS (accepts a list of emails)
     if ($App->Request->request->has('notifyPastBookers')) {
         $replyTo = new Address($App->Users->userData['email'], $App->Users->userData['fullname']);

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -65,8 +65,10 @@ try {
     if ($App->Request->request->has('notifyPastBookers')) {
         $replyTo = new Address($App->Users->userData['email'], $App->Users->userData['fullname']);
         $result = $Email->getSurroundingBookers($App->Request->request->getInt('itemId'));
-        $emails = $result['emailAddresses'];
-
+        $emails = $result['emailAddresses'] ?? array();
+        if (!$emails) {
+            throw new ImproperActionException(_('No users/emails found for this resource\'s events.'));
+        }
         foreach ($emails as $address) {
             try {
                 $Email->sendEmail($address, $subject, $body, replyTo: $replyTo);

--- a/web/app/controllers/SysconfigAjaxController.php
+++ b/web/app/controllers/SysconfigAjaxController.php
@@ -56,22 +56,16 @@ try {
 
     $subject = $App->Request->request->getString('subject');
     $body = $App->Request->request->getString('body');
-    // get list of recipient
+    // GET LIST OF RECIPIENTS' FULL NAMES
     if ($App->Request->request->has('listBookers')) {
-        $result = $Email->getSurroundingBookersWithCount($App->Request->request->getInt('itemId'));
-        $emails = $result['emailsRaw'];
-        $emailList = array();
-        foreach ($emails as $email) {
-            $emailList[] = $email['email'];
-        }
-        $Response->setData(array('res' => true, 'emails' => $emailList, 'count' => $result['count']));
+        $result = $Email->getSurroundingBookers($App->Request->request->getInt('itemId'));
+        $Response->setData(array('res' => true, 'fullnames' => $result['fullnames']));
     }
     // SEND MULTIPLE EMAILS (accepts a list of emails)
     if ($App->Request->request->has('notifyPastBookers')) {
         $replyTo = new Address($App->Users->userData['email'], $App->Users->userData['fullname']);
-        $result = $Email->getSurroundingBookersWithCount($App->Request->request->getInt('itemId'));
-        $emails = $result['emails'];
-        $count = $result['count'];
+        $result = $Email->getSurroundingBookers($App->Request->request->getInt('itemId'));
+        $emails = $result['emailAddresses'];
 
         foreach ($emails as $address) {
             try {
@@ -82,7 +76,11 @@ try {
         }
         $Response->setData(array(
             'res' => true,
-            'msg' => sprintf('Email has been sent to %d users who booked this item within ±4 months.', $count),
+            'msg' => sprintf(
+                _('Email has been sent to %d %s who booked this item within ±4 months.'),
+                count($emails),
+                (count($emails) > 1 ? _('users') : _('user'))
+            ),
         ));
     }
     // SEND MASS EMAIL (accepts a predefined list of users, admins, etc.)


### PR DESCRIPTION
Per custom request, allow sending a message to previous users of a bookable resource directly from the
resource itself
- Add a button "Message users" that will target all users that booked this resource within the last & upcoming 4
months so an email can be sent to them, for instance to inform about maintenance
<img width="817" height="238" alt="Capture d’écran du 2025-09-04 15-16-18" src="https://github.com/user-attachments/assets/2ff5846a-cc8b-4d7b-bc42-f953dd75fb51" />
<img width="817" height="238" alt="Capture d’écran du 2025-09-04 15-16-28" src="https://github.com/user-attachments/assets/3920af97-7779-4e4a-aba0-25d80ffeded9" />
<img width="1210" height="698" alt="Capture d’écran du 2025-09-04 15-19-51" src="https://github.com/user-attachments/assets/7cf44b7b-510b-4301-8c25-2e89dabba5bd" />
