### PR TITLE
fix: spreadsheet: replace existing returns id to prevent duplicates on spamm

### DIFF
--- a/src/ts/SpreadsheetEditorHelper.class.ts
+++ b/src/ts/SpreadsheetEditorHelper.class.ts
@@ -111,7 +111,7 @@ export class SpreadsheetEditorHelper {
     return { id, name: chosenName };
   }
 
-  async replaceExisting(columnDefs: GridColumn[], rowData: GridRow[], entityType: string, entityId: number, currentUploadName: string, currentUploadId: number):  Promise<void> {
+  async replaceExisting(columnDefs: GridColumn[], rowData: GridRow[], entityType: string, entityId: number, currentUploadName: string, currentUploadId: number): Promise<{ id: number; name: string } | void> {
     if (!columnDefs.length || !rowData.length || !currentUploadName || !currentUploadId) {
       return;
     }
@@ -120,7 +120,9 @@ export class SpreadsheetEditorHelper {
     const file = new File([wbBinary], currentUploadName, {
       type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     });
-    await SpreadsheetEditorHelper.uploadWorkbook(file, SpreadsheetEditorHelper.uploadUrl(entityType, entityId, currentUploadId));
+    const url  = SpreadsheetEditorHelper.uploadUrl(entityType, entityId, currentUploadId);
+    const newId = await SpreadsheetEditorHelper.uploadWorkbookAndReturnId(file, url);
+    return { id: newId, name: currentUploadName };
   }
 
   private static workbookToFile(wb: WorkBook, name: string, format: FileType): File {

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -192,7 +192,10 @@ if (document.getElementById('spreadsheetEditor')) {
         <>
         {currentUploadId ? (
             // REPLACE EXISTING FILE WITH CURRENT EDITIONS
-            <button disabled={!currentUploadId} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2' id='replaceExisting' onClick={() => SpreadsheetHelperC.replaceExisting(columnDefs, rowData, entity.type, entity.id, currentUploadName, currentUploadId).then(() => setDirty(false))} title={i18next.t('replace-existing')} aria-label={i18next.t('replace-existing')} type='button'>
+            <button disabled={!currentUploadId} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2' id='replaceExisting' onClick={() => SpreadsheetHelperC.replaceExisting(columnDefs, rowData, entity.type, entity.id, currentUploadName, currentUploadId).then((res) => {
+              if (res?.id) setCurrentUploadId(res.id); // track the latest subid and prevent duplicating
+              setDirty(false);
+            })} title={i18next.t('replace-existing')} aria-label={i18next.t('replace-existing')} type='button'>
               <i className='fas fa-save fa-fw'></i>
             </button>
           ) : (


### PR DESCRIPTION
- Ensure the “Replace existing” action now returns the new upload id from the backend response. This id is tracked in state so that further "replaces" action target the latest file instead of the archived original. (See Uploads.php, `Attached files are immutable (change history is kept), so the current file gets its state changed to "archived" and a new one is added`)
- Fixes the issue where repeated clicks created duplicate uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replacing an existing spreadsheet now automatically links to the newly created version, updating the current upload reference without extra steps.

* **Bug Fixes**
  * Prevents accidental duplicate uploads when using “Replace Existing” by correctly updating to the latest uploaded version.
  * Ensures the editor’s dirty state is cleared consistently after a successful replace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->