### PR TITLE
ui: compounds: add molecular weight in linked section and table

### DIFF
--- a/src/templates/compounds-view-edit.html
+++ b/src/templates/compounds-view-edit.html
@@ -64,13 +64,13 @@
             <h5 class='d-inline togglable-section-title'>{{ fp.name|default('Name unset'|trans) }} {{ _self.compoundPicto(fp) }}</h5>
           </summary>
           <ul class='mt-2 list-group'>
-          {{ _self.fpList('cas' ~ fp.id, 'CAS', fp.cas_number) }}
+          {{ _self.fpList('cas_' ~ fp.id, 'CAS', fp.cas_number) }}
           {{ _self.fpList('iupac_name_' ~ fp.id, 'IUPAC Name', fp.iupac_name) }}
-          {{ _self.fpList('molecular_weight_' ~ fp.id, 'Molecular weight', fp.molecular_weight) }}
-          {{ _self.fpList('molecular_formula' ~ fp.id, 'Molecular formula'|trans, fp.molecular_formula) }}
+          {{ _self.fpList('molecular_weight_' ~ fp.id, 'Molecular weight|trans', fp.molecular_weight) }}
+          {{ _self.fpList('molecular_formula_' ~ fp.id, 'Molecular formula'|trans, fp.molecular_formula) }}
           {{ _self.fpList('inchi_' ~ fp.id, 'InChI', fp.inchi) }}
-          {{ _self.fpList('inchi_key' ~ fp.id, 'InChIKey', fp.inchi_key) }}
-          {{ _self.fpList('smiles' ~ fp.id, 'SMILES', fp.smiles) }}
+          {{ _self.fpList('inchi_key_' ~ fp.id, 'InChIKey', fp.inchi_key) }}
+          {{ _self.fpList('smiles_' ~ fp.id, 'SMILES', fp.smiles) }}
           <li class='list-group-item'>
             <div class='d-flex justify-content-between'>
               {% if fp.smiles %}

--- a/src/ts/compounds-table.jsx
+++ b/src/ts/compounds-table.jsx
@@ -40,7 +40,7 @@ if (document.getElementById('compounds-table')) {
           { field: 'smiles', headerName: 'SMILES' },
           { field: 'inchi', headerName: 'InChI' },
           { field: 'inchi_key', headerName: 'InChI Key' },
-          { field: 'molecular_weight', headerName: 'Molecular weight' },
+          { field: 'molecular_weight', headerName: 'Molecular weight (g/mol)' },
           { field: 'molecular_formula', headerName: 'Molecular formula' },
           { field: 'ec_number', headerName: 'EC Number' },
           { field: 'pubchem_cid', headerName: 'PubChem CID' },


### PR DESCRIPTION
Molecular weight is pretty useful. Display it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Molecular weight and Molecular formula fields to the compound detail view.
  * Reordered detail fields: CAS, IUPAC Name, Molecular weight, Molecular formula, InChI, InChIKey, SMILES.
  * Added a Molecular weight column to the compounds table for easier browsing and comparison.
  * Molecular weight and molecular formula labels are localized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->