### PR TITLE
feat: compounds/inventory: add global flag to required edit rights

### DIFF
--- a/src/Commands/ImportCompoundsCsv.php
+++ b/src/Commands/ImportCompoundsCsv.php
@@ -101,7 +101,7 @@ final class ImportCompoundsCsv extends Command
             $pubChemImporter = new PubChemImporter($httpGetter, Env::asUrl('PUBCHEM_PUG_URL'), Env::asUrl('PUBCHEM_PUG_VIEW_URL'));
         }
         $Items = new Items($user, bypassReadPermission: true, bypassWritePermission: true);
-        $Compounds = new Compounds($httpGetter, $user, $Fingerprinter);
+        $Compounds = new Compounds($httpGetter, $user, $Fingerprinter, requireEditRights: false);
 
         $matchWith = null;
         if ($input->getOption('match-with')) {

--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -25,6 +25,7 @@ use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Changelog;
+use Elabftw\Models\Config;
 use Elabftw\Models\ExperimentsStatus;
 use Elabftw\Models\ExtraFieldsKeys;
 use Elabftw\Models\FavTags;
@@ -201,7 +202,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'lockerFullname' => $this->Entity->getLockerFullname(),
             'meaningArr' => $this->meaningArr,
             'requestableActionArr' => $this->requestableActionArr,
-            'storageUnitsArr' => (new StorageUnits($this->App->Users))->readAllRecursive(),
+            'storageUnitsArr' => new StorageUnits($this->App->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1')->readAllRecursive(),
             'surroundingBookers' => $this->Entity->getSurroundingBookers(),
             'usersArr' => $this->App->Users->readAllActiveFromTeam(),
             'visibilityArr' => $this->visibilityArr,
@@ -260,7 +261,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             'meaningArr' => $this->meaningArr,
             'requestableActionArr' => $this->requestableActionArr,
-            'storageUnitsArr' => (new StorageUnits($this->App->Users))->readAllRecursive(),
+            'storageUnitsArr' => new StorageUnits($this->App->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1')->readAllRecursive(),
             'surroundingBookers' => $this->Entity->getSurroundingBookers(),
             'templatesArr' => $this->templatesArr,
             'usersArr' => $this->App->Users->readAllActiveFromTeam(),

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -295,6 +295,7 @@ final class Apiv2Controller extends AbstractApiController
                         new HttpGetter(new Client(), $Config->configArr['proxy'], Env::asBool('DEV_MODE')),
                         $this->requester,
                         $Fingerprinter,
+                        $Config->configArr['compounds_require_edit_rights'] === '1',
                         $this->id,
                     );
                 }
@@ -326,7 +327,7 @@ final class Apiv2Controller extends AbstractApiController
             ),
             ApiEndpoint::FavTags => new FavTags($this->requester, $this->id),
             ApiEndpoint::Reports => new ReportsHandler($this->requester),
-            ApiEndpoint::StorageUnits => new StorageUnits($this->requester, $this->id),
+            ApiEndpoint::StorageUnits => new StorageUnits($this->requester, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1', $this->id),
             // Temporary informational endpoint, can be removed in 5.2
             ApiEndpoint::TeamTags => throw new ImproperActionException('Use api/v2/teams/current/tags endpoint instead.'),
             ApiEndpoint::Teams => new Teams($this->requester, $this->id),

--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Controllers;
 
+use Elabftw\Models\Config;
 use Elabftw\Models\StorageUnits;
 use Override;
 
@@ -34,7 +35,7 @@ final class InventoryController extends AbstractHtmlController
     #[Override]
     protected function getData(): array
     {
-        $StorageUnits = new StorageUnits($this->app->Users);
+        $StorageUnits = new StorageUnits($this->app->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1');
         $containersArr = array();
         // only make a query if we do a search
         if ($this->app->Request->query->has('q')) {

--- a/src/Elabftw/Update.php
+++ b/src/Elabftw/Update.php
@@ -37,7 +37,7 @@ use function mb_substr;
 final class Update
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 184;
+    public const int REQUIRED_SCHEMA = 185;
 
     private Db $Db;
 

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -151,7 +151,7 @@ final class CompoundsCsv extends AbstractCsv
                     // process localisation
                     if (isset($row['location']) && !empty($row['location']) && !empty($this->locationSplitter)) {
                         $locationSplit = explode($this->locationSplitter, $row['location']);
-                        $StorageUnits = new StorageUnits($this->requester);
+                        $StorageUnits = new StorageUnits($this->requester, requireEditRights: false);
                         $id = $StorageUnits->createImmutable($locationSplit);
                         $Containers2ItemsLinks = new Containers2ItemsLinks($this->Items, $id);
                         $Containers2ItemsLinks->createWithQuantity((float) ($row['quantity'] ?? 1.0), $row['unit'] ?? '•');

--- a/src/Make/ReportsHandler.php
+++ b/src/Make/ReportsHandler.php
@@ -35,11 +35,11 @@ final class ReportsHandler extends AbstractRest
     {
         $httpGetter = new HttpGetter(new Client(), verifyTls: false);
         $Reporter = match ($scope) {
-            ReportScopes::Compounds => (new MakeCompoundsReport(new Compounds($httpGetter, $this->requester, new NullFingerprinter()))),
+            ReportScopes::Compounds => (new MakeCompoundsReport(new Compounds($httpGetter, $this->requester, new NullFingerprinter(), false))),
             ReportScopes::Instance => (new MakeReport($this->requester)),
-            ReportScopes::Inventory => (new MakeInventoryReport(new StorageUnits($this->requester))),
+            ReportScopes::Inventory => (new MakeInventoryReport(new StorageUnits($this->requester, false))),
             ReportScopes::Team => (new MakeTeamReport($this->requester)),
-            ReportScopes::StoredCompounds => (new MakeStoredCompoundsReport(new StorageUnits($this->requester))),
+            ReportScopes::StoredCompounds => (new MakeStoredCompoundsReport(new StorageUnits($this->requester, false))),
         };
         return $Reporter->getResponse();
 

--- a/src/Models/Compounds.php
+++ b/src/Models/Compounds.php
@@ -64,7 +64,7 @@ final class Compounds extends AbstractRest
         'wikipedia',
     );
 
-    public function __construct(protected HttpGetter $httpGetter, private Users $requester, protected FingerprinterInterface $fingerprinter, ?int $id = null)
+    public function __construct(protected HttpGetter $httpGetter, private Users $requester, protected FingerprinterInterface $fingerprinter, private bool $requireEditRights, ?int $id = null)
     {
         parent::__construct();
         $this->setId($id);
@@ -506,7 +506,7 @@ final class Compounds extends AbstractRest
 
     protected function canWrite(): bool
     {
-        return $this->requester->userData['can_manage_compounds'] === 1;
+        return $this->requester->userData['can_manage_compounds'] === 1 || $this->requireEditRights === false;
     }
 
     protected function canWriteOrExplode(): void

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -211,7 +211,9 @@ final class Config extends AbstractRest
             ('onboarding_email_different_for_admins', '0'),
             ('onboarding_email_admins_subject', NULL),
             ('onboarding_email_admins_body', NULL),
-            ('allow_users_change_identity', '0')";
+            ('allow_users_change_identity', '0'),
+            ('compounds_require_edit_rights', '0'),
+            ('inventory_require_edit_rights', '0')";
 
         $req = $this->Db->prepare($sql);
         $req->bindValue(':schema', Update::REQUIRED_SCHEMA);

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -72,7 +72,7 @@ abstract class AbstractContainersLinks extends AbstractLinks
 
         $results = $req->fetchAll();
         // Note: currently it's easier to loop on the storage and do a readOne() rather than include the full_path here
-        $StorageUnits = new StorageUnits($this->Entity->Users);
+        $StorageUnits = new StorageUnits($this->Entity->Users, false);
         foreach ($results as &$result) {
             $StorageUnits->setId($result['storage_id']);
             $result['full_path'] = $StorageUnits->readOne()['full_path'];

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -33,7 +33,7 @@ final class StorageUnits extends AbstractRest
 {
     use SetIdTrait;
 
-    public function __construct(private Users $requester, ?int $id = null)
+    public function __construct(private Users $requester, private bool $requireEditRights, ?int $id = null)
     {
         parent::__construct();
         $this->setId($id);
@@ -378,7 +378,7 @@ final class StorageUnits extends AbstractRest
 
     protected function canWrite(): bool
     {
-        return $this->requester->userData['can_manage_inventory_locations'] === 1;
+        return $this->requester->userData['can_manage_inventory_locations'] === 1 || $this->requireEditRights === false;
     }
 
     protected function canWriteOrExplode(): void

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -296,7 +296,7 @@ final class Populate
 
         // INVENTORY
         if (isset($this->yaml['inventory'])) {
-            $StorageUnits = new StorageUnits($this->getRandomUserInTeam(1));
+            $StorageUnits = new StorageUnits($this->getRandomUserInTeam(1), false);
             foreach ($this->yaml['inventory'] as $entry) {
                 $zones = explode('|', $entry);
                 $StorageUnits->createImmutable($zones);
@@ -310,7 +310,7 @@ final class Populate
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $httpGetter = new HttpGetter($client);
-        $Compounds = new Compounds($httpGetter, $Users, new NullFingerprinter());
+        $Compounds = new Compounds($httpGetter, $Users, new NullFingerprinter(), false);
         foreach ($this->yaml['compounds'] ?? array() as $compound) {
             $id = $Compounds->create(
                 name: $compound['name'],

--- a/src/sql/schema185-down.sql
+++ b/src/sql/schema185-down.sql
@@ -1,0 +1,4 @@
+-- revert schema 185
+DELETE FROM `config` WHERE `conf_name` = 'compounds_require_edit_rights';
+DELETE FROM `config` WHERE `conf_name` = 'inventory_require_edit_rights';
+UPDATE config SET conf_value = 184 WHERE conf_name = 'schema';

--- a/src/sql/schema185.sql
+++ b/src/sql/schema185.sql
@@ -1,0 +1,3 @@
+-- schema 185
+INSERT INTO config (conf_name, conf_value) VALUES ('compounds_require_edit_rights', '0');
+INSERT INTO config (conf_name, conf_value) VALUES ('inventory_require_edit_rights', '0');

--- a/src/templates/compounds.html
+++ b/src/templates/compounds.html
@@ -17,14 +17,18 @@
 {% include('create-resource-from-compound-modal.html') %}
 {% include('edit-compound-modal.html') %}
 <p>{{ 'Compounds are chemical entities associated with properties such as a CAS number, a molecular formula, SMILES or InChI representations, hazardous properties, etc... This page allows you to manage your compounds database, which is shared to everyone on the instance. Once created, a compound can be associated with a Resource (or Experiment).'|trans }}</p>
-<p>{{ 'Note: only users who were given permission to edit the common compounds table can modify the compounds (add/edit/remove).'|trans }}</p>
+{% if App.Config.configArr.compounds_require_edit_rights == 1 %}
+  <p>{{ 'Note: only users who were given permission to edit the common compounds table can modify the compounds (add/edit/remove).'|trans }}</p>
+{% endif %}
+
   <div class='my-3'>
-    <button type='button' {{ App.Users.userData.can_manage_compounds == 0 ? 'disabled' }} data-action='toggle-modal' data-target='importFromPubChemModal' class='btn btn-primary'>{{ 'Import from PubChem'|trans }}</button>
-    <button type='button' {{ App.Users.userData.can_manage_compounds == 0 ? 'disabled' }} data-action='toggle-modal' data-target='createCompoundModal' class='btn btn-secondary'>{{ 'Add compound'|trans }}</button>
+    {% set compoundsDisabled = App.Users.userData.can_manage_compounds == 0 and App.Config.configArr.compounds_require_edit_rights == 1 %}
+    <button type='button' {{ compoundsDisabled ? 'disabled' }} data-action='toggle-modal' data-target='importFromPubChemModal' class='btn btn-primary'>{{ 'Import from PubChem'|trans }}</button>
+    <button type='button' {{ compoundsDisabled ? 'disabled' }} data-action='toggle-modal' data-target='createCompoundModal' class='btn btn-secondary'>{{ 'Add compound'|trans }}</button>
   </div>
   <p class='smallgray'>{{ 'Double-click a row in the table below to view complete information about a compound.'|trans }}</p>
   <div id='compounds-table'></div>
-  {% if App.Users.userData.can_manage_compounds %}
+  {% if not compoundsDisabled %}
     <div class='my-2'>
       <button type='button' id='deleteCompoundsBtn' disabled data-action='delete-compounds' class='btn btn-danger btn-sm'>{{ 'Delete selected compounds'|trans }}</button>
       <button type='button' id='restoreCompoundsBtn' disabled data-action='restore-compounds' class='btn btn-primary btn-sm'>{{ 'Restore selected compounds'|trans }}</button>

--- a/src/templates/edit-compound-modal.html
+++ b/src/templates/edit-compound-modal.html
@@ -29,7 +29,7 @@
   </div>
 {% endmacro %}
 
-{% set disabled = App.Users.userData.can_manage_compounds == 0 %}
+{% set compoundsDisabled = App.Users.userData.can_manage_compounds == 0 and App.Config.configArr.compounds_require_edit_rights == 1 %}
 
 {# Modal for manual creation/edition of a compound #}
 <div class='modal fade' id='editCompoundModal' tabindex='-1' role='dialog' aria-labelledby='editCompoundModalTitle'>
@@ -50,55 +50,55 @@
             <button type='button' class='btn btn-primary btn-sm ml-auto' data-action='toggle-modal' data-dismiss='modal' data-target='createResourceFromCompoundModal'>{{ 'Create resource from compound'|trans }}</button>
           </div>
           <div class='my-2' id='editCompoundInputs'>
-            {{ _self.textParam('name', 'Name'|trans, disabled, 'required') }}
-            {{ _self.textParam('iupac_name', 'IUPAC Name'|trans, disabled) }}
+            {{ _self.textParam('name', 'Name'|trans, compoundsDisabled, 'required') }}
+            {{ _self.textParam('iupac_name', 'IUPAC Name'|trans, compoundsDisabled) }}
             {# special case for CAS and EC numbers, too many specifics to use the macro #}
             <label for='compoundInput-cas_number'>{{ 'CAS number'|trans }}</label>
             <div class='input-group mb-2'>
               <div class='input-group-prepend'>
                 <button title='{{ 'Copy to clipboard'|trans }}' class='btn btn-outline-secondary' type='button' data-action='copy-to-clipboard' data-target='compoundInput-cas_number'><i class='fas fa-clone'></i></button>
               </div>
-              <input name='cas_number' {{ disabled ? 'readonly' }} pattern='^\d{2,7}-\d{2}-\d$' inputmode='numeric' title='{{ 'Please enter a valid CAS number (e.g., 58-08-2)'|trans }}' placeholder='58-08-2' class='form-control' id='compoundInput-cas_number' />
+              <input name='cas_number' {{ compoundsDisabled ? 'readonly' }} pattern='^\d{2,7}-\d{2}-\d$' inputmode='numeric' title='{{ 'Please enter a valid CAS number (e.g., 58-08-2)'|trans }}' placeholder='58-08-2' class='form-control' id='compoundInput-cas_number' />
             </div>
             <label for='compoundInput-ec_number'>{{ 'EC number'|trans }}</label>
             <div class='input-group mb-2'>
               <div class='input-group-prepend'>
                 <button title='{{ 'Copy to clipboard'|trans }}' class='btn btn-outline-secondary' type='button' data-action='copy-to-clipboard' data-target='compoundInput-ec_number'><i class='fas fa-clone'></i></button>
               </div>
-              <input name='ec_number' {{ disabled ? 'readonly' }} pattern='^\d{3}-\d{3}-\d$' inputmode='numeric' title='{{ 'Please enter a valid EC number (e.g., 200-362-1)'|trans }}' placeholder='200-362-1' class='form-control' id='compoundInput-ec_number' />
+              <input name='ec_number' {{ compoundsDisabled ? 'readonly' }} pattern='^\d{3}-\d{3}-\d$' inputmode='numeric' title='{{ 'Please enter a valid EC number (e.g., 200-362-1)'|trans }}' placeholder='200-362-1' class='form-control' id='compoundInput-ec_number' />
             </div>
-            {{ _self.textParam('molecular_formula', 'Molecular formula'|trans, disabled, '', '', 'C8H10N4O2') }}
-            {{ _self.textParam('molecular_weight', 'Molecular weight'|trans, disabled, '', 'number', '194.19') }}
-            {{ _self.textParam('smiles', 'SMILES', disabled, '', '', 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C') }}
-            {{ _self.textParam('inchi', 'InChI', disabled, '', '', 'InChI=1S/C8H10N4O2/c1-10-4-9-6-5(10)7(13)12(3)8(14)11(6)2/h4H,1-3H3') }}
-            {{ _self.textParam('inchi_key', 'InChI Key', disabled, '', '', 'RYYVLZVUVIJVGH-UHFFFAOYSA-N') }}
+            {{ _self.textParam('molecular_formula', 'Molecular formula'|trans, compoundsDisabled, '', '', 'C8H10N4O2') }}
+            {{ _self.textParam('molecular_weight', 'Molecular weight'|trans, compoundsDisabled, '', 'number', '194.19') }}
+            {{ _self.textParam('smiles', 'SMILES', compoundsDisabled, '', '', 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C') }}
+            {{ _self.textParam('inchi', 'InChI', compoundsDisabled, '', '', 'InChI=1S/C8H10N4O2/c1-10-4-9-6-5(10)7(13)12(3)8(14)11(6)2/h4H,1-3H3') }}
+            {{ _self.textParam('inchi_key', 'InChI Key', compoundsDisabled, '', '', 'RYYVLZVUVIJVGH-UHFFFAOYSA-N') }}
             <hr>
             <details>
               <summary><h5 class='d-inline'>{{ 'Safety information'|trans }}</h5></summary>
-              {{ _self.binaryParam('is_hazardous2health', 'Hazardous to health', '07', '', disabled) }}
-              {{ _self.binaryParam('is_corrosive', 'Corrosive', '05', '', disabled) }}
-              {{ _self.binaryParam('is_explosive', 'Explosive', '01', '', disabled) }}
-              {{ _self.binaryParam('is_flammable', 'Flammable', '02', '', disabled) }}
-              {{ _self.binaryParam('is_gas_under_pressure', 'Gas under pressure', '04', '', disabled) }}
-              {{ _self.binaryParam('is_hazardous2env', 'Hazardous to environment', '09', '', disabled) }}
-              {{ _self.binaryParam('is_serious_health_hazard', 'Serious health hazard', '08', '', disabled) }}
-              {{ _self.binaryParam('is_oxidising', 'Oxidising', '03', '', disabled) }}
-              {{ _self.binaryParam('is_toxic', 'Toxic', '06', '', disabled) }}
-              {{ _self.binaryParam('is_radioactive', 'Radioactive', '', 'radiation', disabled) }}
-              {{ _self.binaryParam('is_controlled', 'Controlled substance', '', 'shield', disabled) }}
-              {{ _self.binaryParam('is_antibiotic', 'Antibiotic', '', 'bacterium', disabled) }}
-              {{ _self.binaryParam('is_antibiotic_precursor', 'Antibiotic precursor', '', 'bacterium', disabled) }}
-              {{ _self.binaryParam('is_explosive_precursor', 'Explosive precursor', '', 'explosion', disabled) }}
-              {{ _self.binaryParam('is_drug', 'Drug', '', 'pills', disabled) }}
-              {{ _self.binaryParam('is_drug_precursor', 'Drug precursor', '', 'pills', disabled) }}
-              {{ _self.binaryParam('is_cmr', 'Carcinogenic, mutagenic and reprotoxic (CMR)', '', 'skull-crossbones', disabled) }}
-              {{ _self.binaryParam('is_nano', 'Nanomaterial', '', 'atom', disabled) }}
-              {{ _self.binaryParam('is_ed2health', 'Endocrine disruptor for human health', '', 'skull', disabled) }}
-              {{ _self.binaryParam('is_ed2env', 'Endocrine disruptor for the environment', '', 'skull', disabled) }}
-              {{ _self.binaryParam('is_pbt', 'Persistent, bioaccumulative and toxic', '', 'skull', disabled) }}
-              {{ _self.binaryParam('is_pmt', 'Persistent, mobile and toxic', '', 'skull', disabled) }}
-              {{ _self.binaryParam('is_vpvb', 'Very persistent and very bioaccumulative', '', 'skull', disabled) }}
-              {{ _self.binaryParam('is_vpvm', 'Very persistent and very mobile', '', 'skull', disabled) }}
+              {{ _self.binaryParam('is_hazardous2health', 'Hazardous to health', '07', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_corrosive', 'Corrosive', '05', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_explosive', 'Explosive', '01', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_flammable', 'Flammable', '02', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_gas_under_pressure', 'Gas under pressure', '04', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_hazardous2env', 'Hazardous to environment', '09', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_serious_health_hazard', 'Serious health hazard', '08', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_oxidising', 'Oxidising', '03', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_toxic', 'Toxic', '06', '', compoundsDisabled) }}
+              {{ _self.binaryParam('is_radioactive', 'Radioactive', '', 'radiation', compoundsDisabled) }}
+              {{ _self.binaryParam('is_controlled', 'Controlled substance', '', 'shield', compoundsDisabled) }}
+              {{ _self.binaryParam('is_antibiotic', 'Antibiotic', '', 'bacterium', compoundsDisabled) }}
+              {{ _self.binaryParam('is_antibiotic_precursor', 'Antibiotic precursor', '', 'bacterium', compoundsDisabled) }}
+              {{ _self.binaryParam('is_explosive_precursor', 'Explosive precursor', '', 'explosion', compoundsDisabled) }}
+              {{ _self.binaryParam('is_drug', 'Drug', '', 'pills', compoundsDisabled) }}
+              {{ _self.binaryParam('is_drug_precursor', 'Drug precursor', '', 'pills', compoundsDisabled) }}
+              {{ _self.binaryParam('is_cmr', 'Carcinogenic, mutagenic and reprotoxic (CMR)', '', 'skull-crossbones', compoundsDisabled) }}
+              {{ _self.binaryParam('is_nano', 'Nanomaterial', '', 'atom', compoundsDisabled) }}
+              {{ _self.binaryParam('is_ed2health', 'Endocrine disruptor for human health', '', 'skull', compoundsDisabled) }}
+              {{ _self.binaryParam('is_ed2env', 'Endocrine disruptor for the environment', '', 'skull', compoundsDisabled) }}
+              {{ _self.binaryParam('is_pbt', 'Persistent, bioaccumulative and toxic', '', 'skull', compoundsDisabled) }}
+              {{ _self.binaryParam('is_pmt', 'Persistent, mobile and toxic', '', 'skull', compoundsDisabled) }}
+              {{ _self.binaryParam('is_vpvb', 'Very persistent and very bioaccumulative', '', 'skull', compoundsDisabled) }}
+              {{ _self.binaryParam('is_vpvm', 'Very persistent and very mobile', '', 'skull', compoundsDisabled) }}
             </details>
 
             <hr>
@@ -119,7 +119,7 @@
 
         <div class='modal-footer'>
           <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
-          <button type='submit' {{ disabled ? 'disabled' }} class='btn btn-primary' id='editCompoundModalSaveBtn' data-action='save-compound'>{{ 'Save'|trans }}</button>
+          <button type='submit' {{ compoundsDisabled ? 'disabled' }} class='btn btn-primary' id='editCompoundModalSaveBtn' data-action='save-compound'>{{ 'Save'|trans }}</button>
         </div>
       </form>
     </div>

--- a/src/templates/edit-user-modal.html
+++ b/src/templates/edit-user-modal.html
@@ -52,7 +52,7 @@
               <span class='slider'></span>
             </label>
           </div>
-          <p class='smallgray'>{{ 'Enable this to allow user to manage compounds.'|trans }}</p>
+          <p class='smallgray'>{{ 'Enable this to allow user to manage compounds. This has no effect if compounds edition is not restricted globally.'|trans }}</p>
 
           {# Toggle can_manage_inventory-locations slider #}
           <div class='d-flex justify-content-between'>
@@ -62,7 +62,7 @@
               <span class='slider'></span>
             </label>
           </div>
-          <p class='smallgray'>{{ 'Enable this to allow user to manage inventory locations.'|trans }}</p>
+          <p class='smallgray'>{{ 'Enable this to allow user to manage inventory locations. This has no effect if inventory locations edition is not restricted globally.'|trans }}</p>
         </div>
 
         {% if App.Users.userData.is_sysadmin == 1 or App.Users.userData.can_manage_users2teams %}

--- a/src/templates/inventory.html
+++ b/src/templates/inventory.html
@@ -35,13 +35,16 @@
   </div>
 
   <div class='pl-3 mb-5'>
-    <p>{{ 'Note: only users who were given permission to edit the inventory locations can modify the locations (add/edit/remove).'|trans }}</p>
+    {% if App.Config.configArr.inventory_require_edit_rights == 1 %}
+      <p>{{ 'Note: only users who were given permission to edit the inventory locations can modify the locations (add/edit/remove).'|trans }}</p>
+    {% endif %}
+    {% set inventoryDisabled = App.Users.userData.can_manage_inventory_locations == 0 and App.Config.configArr.inventory_require_edit_rights == 1 %}
     <div class='d-flex'>
       <h4>{{ 'Browse inventory locations'|trans }}</h4>
       <div class='ml-auto'>
-        <button type='button' {{ App.Users.userData.can_manage_inventory_locations == 0 ? 'disabled' }} class='btn btn-secondary btn-sm' data-parent-id='' data-action='add-storage-children'><i class='fas fa-plus-circle mr-1 color-white'></i>{{ 'Add root element'|trans }}</button>
+        <button type='button' {{ inventoryDisabled ? 'disabled' }} class='btn btn-secondary btn-sm' data-parent-id='' data-action='add-storage-children'><i class='fas fa-plus-circle mr-1 color-white'></i>{{ 'Add root element'|trans }}</button>
       </div>
     </div>
-    {% include 'storage-list.html' with {'storage_editable': App.Users.userData.can_manage_inventory_locations == 1, 'is_entity': false} %}
+    {% include 'storage-list.html' with {'storage_editable': not inventoryDisabled, 'is_entity': false} %}
   </div>
 {% endblock body %}

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -109,7 +109,11 @@
     </div>
     <hr>
 
-    {% include 'binary-setting.html' with {'label': 'Allow users to change their first name, last name, internal id or email address'|trans, 'slug': 'allow_users_change_identity', 'help': 'When disabled, only a Sysadmin will be allowed to modify these parameters.'} %}
+    {% include 'binary-setting.html' with {'label': 'Allow users to change their first name, last name, internal id or email address'|trans, 'slug': 'allow_users_change_identity', 'help': 'When disabled, only a Sysadmin will be allowed to modify these parameters.'|trans} %}
+
+    {% include 'binary-setting.html' with {'label': 'Prevent modification of global compounds database unless user is given explicit rights.'|trans, 'slug': 'compounds_require_edit_rights', 'help': 'When enabled, a Sysadmin will need to give edit rights to all users that should be able to edit the common compounds database. All other users will access it in read-only.'|trans} %}
+
+    {% include 'binary-setting.html' with {'label': 'Prevent modification of inventory locations unless user is given explicit rights.'|trans, 'slug': 'inventory_require_edit_rights', 'help': 'When enabled, a Sysadmin will need to give edit rights to all users that should be able to edit the inventory locations. All other users will access it in read-only.'|trans} %}
 
   </div>
 

--- a/src/tools/mkfp.php
+++ b/src/tools/mkfp.php
@@ -106,7 +106,7 @@ $startTime = microtime(true);
 $requester = new Users(1, 1);
 $httpGetter = new HttpGetter(new Client(), verifyTls: false);
 $Fingerprinter = new Fingerprinter($httpGetter, Env::asUrl('FINGERPRINTER_URL'));
-$Compounds = new Compounds($httpGetter, $requester, fingerprinter: $Fingerprinter);
+$Compounds = new Compounds($httpGetter, $requester, fingerprinter: $Fingerprinter, requireEditRights: false);
 foreach ($smiles as $mol) {
     $Compounds->create(smiles: $mol['smiles'], name: $mol['name']);
 }

--- a/src/tools/mkstorage.php
+++ b/src/tools/mkstorage.php
@@ -17,7 +17,7 @@ use Elabftw\Models\Users\Users;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
-$StorageUnits = new StorageUnits(new Users(1, 1));
+$StorageUnits = new StorageUnits(new Users(1, 1), false);
 $paris = $StorageUnits->create('Paris');
 $StorageUnits->create('Pavillon des Sources', $paris);
 $StorageUnits->create('Musée', $paris);

--- a/tests/unit/Import/CompoundsCsvTest.php
+++ b/tests/unit/Import/CompoundsCsvTest.php
@@ -49,7 +49,7 @@ class CompoundsCsvTest extends \PHPUnit\Framework\TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $httpGetter = new HttpGetter($client, '', false);
-        $Compounds = new Compounds($httpGetter, $requester, new NullFingerprinter());
+        $Compounds = new Compounds($httpGetter, $requester, new NullFingerprinter(), false);
         $cid = 3345;
         $compoundId = $Compounds->postAction(Action::Duplicate, array('cid' => $cid));
         $Compounds->setId($compoundId);

--- a/tests/unit/Make/MakeCsvTest.php
+++ b/tests/unit/Make/MakeCsvTest.php
@@ -60,13 +60,13 @@ class MakeCsvTest extends \PHPUnit\Framework\TestCase
 
     public function testMakeInventoryReport(): void
     {
-        $Maker = new MakeInventoryReport(new StorageUnits(new Users(1, 1)));
+        $Maker = new MakeInventoryReport(new StorageUnits(new Users(1, 1), false));
         $this->assertIsString($Maker->getFileContent());
     }
 
     public function testMakeStoredCompoundsReport(): void
     {
-        $Maker = new MakeStoredCompoundsReport(new StorageUnits(new Users(1, 1)));
+        $Maker = new MakeStoredCompoundsReport(new StorageUnits(new Users(1, 1), false));
         $this->assertIsString($Maker->getFileContent());
     }
 

--- a/tests/unit/models/CompoundsLinksTest.php
+++ b/tests/unit/models/CompoundsLinksTest.php
@@ -38,7 +38,7 @@ class CompoundsLinksTest extends \PHPUnit\Framework\TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $httpGetter = new HttpGetter($client);
-        $Compounds = new Compounds($httpGetter, $user, new NullFingerprinter());
+        $Compounds = new Compounds($httpGetter, $user, new NullFingerprinter(), false);
         $compoundId = $Compounds->create(name: 'test compound');
         $Links->setId($compoundId);
         $expected = sprintf('api/v2/experiments/%d/compounds2experiments/', $Entity->id);

--- a/tests/unit/models/CompoundsTest.php
+++ b/tests/unit/models/CompoundsTest.php
@@ -59,7 +59,7 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
         $this->httpGetter = new HttpGetter($client);
         // this user has can_manage_compounds
         $user = new Users(1, 1);
-        $this->Compounds = new Compounds($this->httpGetter, $user, new NullFingerprinter());
+        $this->Compounds = new Compounds($this->httpGetter, $user, new NullFingerprinter(), false);
     }
 
     public function testCreateSearchAndDestroy(): void
@@ -95,7 +95,7 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $httpGetter = new HttpGetter($client);
-        $Compounds = new Compounds($httpGetter, new Users(1, 1), new NullFingerprinter());
+        $Compounds = new Compounds($httpGetter, new Users(1, 1), new NullFingerprinter(), false);
         // https://pubchem.ncbi.nlm.nih.gov/compound/3345
         $cid = 3345;
         $compoundId = $Compounds->postAction(Action::Duplicate, array('cid' => $cid));
@@ -109,7 +109,11 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(self::FENTANYL_CAS, $compound['cas_number']);
         // test with a user without can_manage_compounds
         $user = $this->getRandomUserInTeam(2);
-        $Compounds = new Compounds($this->httpGetter, $user, new NullFingerprinter());
+        $Compounds = new Compounds($this->httpGetter, $user, new NullFingerprinter(), false);
+        // okay because we did not require rights yet
+        $Compounds->postAction(Action::Create, array());
+        // now lock down edition
+        $Compounds = new Compounds($this->httpGetter, $user, new NullFingerprinter(), true);
         $this->expectException(IllegalActionException::class);
         $Compounds->postAction(Action::Create, array());
     }
@@ -117,7 +121,7 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
     public function testRestoreCompound(): void
     {
         // create a compound
-        $Compound = new Compounds($this->httpGetter, new Users(1, 1), new NullFingerprinter());
+        $Compound = new Compounds($this->httpGetter, new Users(1, 1), new NullFingerprinter(), false);
         $compoundId = $this->Compounds->create(casNumber: self::CAFFEINE_CAS, pubchemCid: 2519, smiles: $this->smilesCaf);
         $Compound->setId($compoundId);
         $compound = $Compound->readOne();
@@ -166,7 +170,7 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(array('handler' => $handlerStack));
         $httpGetter = new HttpGetter($client);
-        $Compounds = new Compounds($httpGetter, new Users(1, 1), new NullFingerprinter());
+        $Compounds = new Compounds($httpGetter, new Users(1, 1), new NullFingerprinter(), false);
 
         $queryParams = array('search_fp_smi' => $this->smiles);
         $req = new Request($queryParams);

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -26,7 +26,7 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->StorageUnits = new StorageUnits(new Users(1, 1));
+        $this->StorageUnits = new StorageUnits(new Users(1, 1), true);
     }
 
     public function testCreate(): void

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -107,7 +107,7 @@ try {
         }
     });
     $passwordComplexity = PasswordComplexity::from((int) $App->Config->configArr['password_complexity_requirement']);
-    $StorageUnits = new StorageUnits($App->Users);
+    $StorageUnits = new StorageUnits($App->Users, false);
     $template = 'sysconfig.html';
     $renderArr = array(
         'Request' => $App->Request,


### PR DESCRIPTION
this makes the upgrade smoother as we find the same behavior as before: all users can edit compounds and inventory locations. But the Sysadmin can lock it down and allow per-user rights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added admin settings to require edit rights for Compounds and Inventory locations.
  * UI now respects these restrictions: actions (add/import/delete/restore) and fields are disabled when editing is restricted; contextual notes display only when applicable.

* Documentation
  * Clarified Edit User modal texts to explain when per-user permissions apply.
  * Added translated labels and help for the new settings in System Configuration.

* Chores
  * Updated database schema to include default values for the new configuration flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->