### PR TITLE
feat: spreadsheet: misc adjustments

### DIFF
--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -39,7 +39,6 @@ final class i18n4Js
             '2FA' => _('2FA'),
             'add-compound' => _('Add compound'),
             'add-column' => _('Add column'),
-            'add-row' => _('Add row'),
             'add-team' => _('Add team'),
             'archive-user' => _('Archive user'),
             'archive-user-description' => _('Archiving a user means their account will be disabled. This action is reversible.'),

--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -110,7 +110,7 @@ final class i18n4Js
             'only-a-sysadmin' => _('Only a Sysadmin can modify this.'),
             'please-wait' => _('Please wait…'),
             'remove' => _('Remove'),
-            'rename-column' => _('New title for the column'),
+            'edit-column' => _('Edit column name'),
             'replace-edited-file' => _('Do you want to replace the file on the server with this edit?'),
             'replace-existing' => _('Overwrite original file'),
             'request-filename' => _('Enter name of the file'),

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -144,6 +144,8 @@
 
 {% include 'steps-view.html' %}
 
+{% include 'spreadsheet-editor.html' %}
+
 {% include 'links.html' %}
 
 {% include 'storage-view-edit.html' %}

--- a/src/ts/KeyboardShortcuts.class.ts
+++ b/src/ts/KeyboardShortcuts.class.ts
@@ -53,6 +53,9 @@ export class KeyboardShortcuts {
       if (isNaN(id)) {
         return;
       }
+      // if already in edit mode, do nothing
+      if ((urlParams.get('mode') || '').toLowerCase() === 'edit') return;
+
       window.location.href = `?mode=edit&id=${id}`;
     });
 

--- a/src/ts/SpreadsheetEditorHelper.class.ts
+++ b/src/ts/SpreadsheetEditorHelper.class.ts
@@ -181,8 +181,9 @@ export class SpreadsheetEditorHelper {
   }
 
   private static createWorkbookFromGrid(columnDefs: GridColumn[], rowData: GridRow[]): WorkBook {
-    const headers = columnDefs.map(col => col.field);
-    const aoa = [headers, ...rowData.map(row => headers.map(h => row[h] ?? ''))];
+    const headerLabels = columnDefs.map(c => (c.headerName && String(c.headerName).trim()) || c.field);
+    const fields = columnDefs.map(c => c.field);
+    const aoa = [headerLabels, ...rowData.map(row => fields.map(f => row[f] ?? ''))];
     const ws = utils.aoa_to_sheet(aoa);
     const wb = utils.book_new();
     utils.book_append_sheet(wb, ws, 'Sheet1');

--- a/src/ts/SpreadsheetEditorHelper.class.ts
+++ b/src/ts/SpreadsheetEditorHelper.class.ts
@@ -156,7 +156,7 @@ export class SpreadsheetEditorHelper {
   }
 
   private static parseFileToAOA(buffer: ArrayBuffer): Cell[][] {
-    const wb = read(buffer, { type: 'array' });
+    const wb = read(buffer, { type: 'array', codepage: 65001 }); // UTF-8
     const ws = wb.Sheets[wb.SheetNames[0]];
     // keep empty cells, drop truly empty rows
     const aoa = utils.sheet_to_json(ws, {

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -190,6 +190,9 @@ interface Entity {
 interface GridColumn {
   field: string;
   editable: boolean;
+  headerName?: string;
+  colId?: string;
+  sortable?: boolean;
 }
 
 interface GridRow {

--- a/src/ts/keymaster.ts
+++ b/src/ts/keymaster.ts
@@ -156,9 +156,12 @@ function resetModifiers() {
 };
 
 function filter(event){
-  const tagName = (event.target || event.srcElement).tagName;
+  const el = event.target as HTMLElement;
+  const tagName = el.tagName;
   // ignore keypressed in any elements that support keyboard data input
-  return !(tagName == 'INPUT' || tagName == 'SELECT' || tagName == 'TEXTAREA' || (event.target || event.srcElement).hasAttribute('contenteditable'));
+  const isTyping = tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA' || el.hasAttribute('contenteditable');
+  const inSpreadsheet = !!el.closest('#spreadsheetGrid');
+  return !(isTyping || inSpreadsheet);
 }
 
 // initialize key.<modifier> to false

--- a/src/ts/langs/ca_ES.ts
+++ b/src/ts/langs/ca_ES.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Afegir compost",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Afegir equip",
     "archive-user": "Usuari actiu",
     "archive-user-description": "Arxivar un usuari significa que el seu compte es desactivarà. Aquesta acció és reversible.",

--- a/src/ts/langs/ca_ES.ts
+++ b/src/ts/langs/ca_ES.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Espereu...",
     "remove": "Eliminar",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Vol reemplaçar el fitxer al servidor amb aquesta edicio",
     "replace-existing": "Overwrite original file",
     "request-filename": "Introduïu el nom del fitxer",

--- a/src/ts/langs/cs_CZ.ts
+++ b/src/ts/langs/cs_CZ.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Přidat sloučeninu",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Přidat tým",
     "archive-user": "Archivovat uživatele",
     "archive-user-description": "Archivace uživatele znamená, že jeho účet bude deaktivován. Tato akce je vratná.",

--- a/src/ts/langs/cs_CZ.ts
+++ b/src/ts/langs/cs_CZ.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Počkejte prosím…",
     "remove": "Odstranit",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Chcete nahradit soubor na serveru touto úpravou?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Zadejte název souboru",

--- a/src/ts/langs/de_DE.ts
+++ b/src/ts/langs/de_DE.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Bitte warten …",
     "remove": "Entfernen",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Möchten Sie die Datei auf dem Server durch diese Bearbeitung ersetzen?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Geben Sie den Namen der Datei ein",

--- a/src/ts/langs/de_DE.ts
+++ b/src/ts/langs/de_DE.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Verbindung hinzufügen",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Team hinzufügen",
     "archive-user": "Nutzer archivieren",
     "archive-user-description": "Die Archivierung eines Nutzers deaktiviert seinen Zugang. Diese Aktion ist umkehrbar.",

--- a/src/ts/langs/el_GR.ts
+++ b/src/ts/langs/el_GR.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Παρακαλώ περιμένετε",
     "remove": "Αφαίρεση",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Θέλετε να αντικαταστήσετε το αρχείο στον διακομιστή με αυτήν την επεξεργασία;",
     "replace-existing": "Overwrite original file",
     "request-filename": "Εισαγάγετε το όνομα του αρχείου",

--- a/src/ts/langs/el_GR.ts
+++ b/src/ts/langs/el_GR.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Προσθήκη ένωσης",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Προσθήκη Ομάδας",
     "archive-user": "Αρχειοθέτηση χρήστη",
     "archive-user-description": "Η αρχειοθέτηση ενός χρήστη σημαίνει ότι ο λογαριασμός του θα απενεργοποιηθεί. Αυτή η ενέργεια είναι αναστρέψιμη.",

--- a/src/ts/langs/en_GB.ts
+++ b/src/ts/langs/en_GB.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Add compound",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Add team",
     "archive-user": "Archive user",
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",

--- a/src/ts/langs/en_GB.ts
+++ b/src/ts/langs/en_GB.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Please wait…",
     "remove": "Remove",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Do you want to replace the file on the server with this edit?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Enter name of the file",

--- a/src/ts/langs/en_US.ts
+++ b/src/ts/langs/en_US.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Add compound",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Add team",
     "archive-user": "Archive user",
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",

--- a/src/ts/langs/en_US.ts
+++ b/src/ts/langs/en_US.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Please wait…",
     "remove": "Remove",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Do you want to replace the file on the server with this edit?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Enter name of the file",

--- a/src/ts/langs/es_ES.ts
+++ b/src/ts/langs/es_ES.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Por favor espera…",
     "remove": "Eliminar",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "¿Quiere reemplazar el archivo en el servidor por esta edición?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Ingrese el nombre del archivo",

--- a/src/ts/langs/es_ES.ts
+++ b/src/ts/langs/es_ES.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Añadir compuesto",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Agregar equipo",
     "archive-user": "Usuario activo",
     "archive-user-description": "Archivar a un usuario significa que su cuenta se desactivará. Esta acción es reversible.",

--- a/src/ts/langs/et_EE.ts
+++ b/src/ts/langs/et_EE.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Lisa ühend",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Lisa meeskond",
     "archive-user": "Arhiivi kasutaja",
     "archive-user-description": "Kasutaja arhiveerimine tähendab tema konto sulgemist. See toiming on tagasipööratav.",

--- a/src/ts/langs/et_EE.ts
+++ b/src/ts/langs/et_EE.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Ainult süsteemiadministraator saab seda muuta.",
     "please-wait": "Palun oodake…",
     "remove": "Eemalda",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Kas soovite serveris oleva faili selle muudatusega asendada?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Sisesta faili nimi",

--- a/src/ts/langs/fi_FI.ts
+++ b/src/ts/langs/fi_FI.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Lisää yhdiste",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Lisää tiimi",
     "archive-user": "Arkistoi käyttäjä",
     "archive-user-description": "Käyttäjän arkistointi tarkoittaa, että hänen tilinsä poistetaan käytöstä. Tämä toiminto on peruutettava.",

--- a/src/ts/langs/fi_FI.ts
+++ b/src/ts/langs/fi_FI.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Odota…",
     "remove": "Poistaa",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Haluatko korvata palvelimella olevan tiedoston tällä muokkauksella?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Anna tiedoston nimi",

--- a/src/ts/langs/fr_FR.ts
+++ b/src/ts/langs/fr_FR.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Ajouter un composé",
     "add-column": "Ajouter une colonne",
-    "add-row": "Ajouter une rangée",
     "add-team": "Ajouter une équipe",
     "archive-user": "Archiver utilisateur",
     "archive-user-description": "L'archivage d'un utilisateur signifie que son compte sera désactivé. Cette action est réversible.",

--- a/src/ts/langs/fr_FR.ts
+++ b/src/ts/langs/fr_FR.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Seul un administrateur système peut le modifier.",
     "please-wait": "Patientez…",
     "remove": "Supprimer",
-    "rename-column": "Nouveau titre pour la colonne",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Souhaitez-vous remplacer le fichier sur le serveur avec ce changement ?",
     "replace-existing": "Écraser le fichier original",
     "request-filename": "Nom du fichier",

--- a/src/ts/langs/id_ID.ts
+++ b/src/ts/langs/id_ID.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Mohon tunggu…",
     "remove": "Menghapus",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Apakah Anda ingin mengganti file di server dengan hasil edit ini?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Masukkan nama file",

--- a/src/ts/langs/id_ID.ts
+++ b/src/ts/langs/id_ID.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Tambahkan senyawa",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Tambahkan tim",
     "archive-user": "Arsipkan pengguna",
     "archive-user-description": "Mengarsipkan pengguna berarti akun mereka akan dinonaktifkan. Tindakan ini dapat dibatalkan.",

--- a/src/ts/langs/it_IT.ts
+++ b/src/ts/langs/it_IT.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Aggiungi composto",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Aggiungi team",
     "archive-user": "Archivia utente",
     "archive-user-description": "Archiviare un utente significa che il suo account verrà disabilitato. Questa azione è reversibile.",

--- a/src/ts/langs/it_IT.ts
+++ b/src/ts/langs/it_IT.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Attendere, prego…",
     "remove": "Rimuovere",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Si vuole rimpiazzare il file sul server con questo?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Inserire il nome del file",

--- a/src/ts/langs/ja_JP.ts
+++ b/src/ts/langs/ja_JP.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "お待ちください…",
     "remove": "取り除く",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "この編集したものでサーバー上のファイルを置き換えますか？",
     "replace-existing": "Overwrite original file",
     "request-filename": "ファイルの名前を入力してください",

--- a/src/ts/langs/ja_JP.ts
+++ b/src/ts/langs/ja_JP.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "化合物を追加する",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "チームを追加",
     "archive-user": "アーカイブユーザー",
     "archive-user-description": "ユーザーをアーカイブすると、そのユーザーのアカウントは無効になります。この操作は元に戻すことができます。",

--- a/src/ts/langs/ko_KR.ts
+++ b/src/ts/langs/ko_KR.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "잠시만 기다려주세요…",
     "remove": "제거하다",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "서버에 저장된 파일을 현재 수정본으로 교체할까요?",
     "replace-existing": "Overwrite original file",
     "request-filename": "파일 이름 입력",

--- a/src/ts/langs/ko_KR.ts
+++ b/src/ts/langs/ko_KR.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "화합물 추가",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "팀 추가",
     "archive-user": "사용자 차단",
     "archive-user-description": "사용자를 보관처리하면 해당 사용자의 계정이 비활성화됩니다. 이 작업은 되돌릴 수 있습니다.",

--- a/src/ts/langs/nl_BE.ts
+++ b/src/ts/langs/nl_BE.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Gelieve te wachten…",
     "remove": "Verwijderen",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Wilt u het bestand op de server vervangen met deze wijziging?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Voer de naam van het bestand in",

--- a/src/ts/langs/nl_BE.ts
+++ b/src/ts/langs/nl_BE.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Voeg samenstelling toe",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Team toevoegen",
     "archive-user": "Archiveer gebruiker",
     "archive-user-description": "Het archiveren van een gebruiker betekent dat zijn/haar account wordt uitgeschakeld. Deze actie is omkeerbaar.",

--- a/src/ts/langs/pl_PL.ts
+++ b/src/ts/langs/pl_PL.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Proszę czekać…",
     "remove": "Usuń",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Czy chcesz zastąpić plik na serwerze tą edycją?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Wpisz nazwę pliku",

--- a/src/ts/langs/pl_PL.ts
+++ b/src/ts/langs/pl_PL.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Dodaj związek",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Dodaj zespół",
     "archive-user": "Archiwizuj użytkownika",
     "archive-user-description": "Archiwizacja użytkownika oznacza dezaktywację jego konta. To działanie jest odwracalne.",

--- a/src/ts/langs/pt_BR.ts
+++ b/src/ts/langs/pt_BR.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Adicionar composto",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Adicionar equipe",
     "archive-user": "Arquivar usuário",
     "archive-user-description": "O arquivamento de um usuário significa que sua conta será desativada. Essa ação É reversível.",

--- a/src/ts/langs/pt_BR.ts
+++ b/src/ts/langs/pt_BR.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Por favor, aguarde...",
     "remove": "Remoção",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Você gostaria de substituir o arquivo no servidor por esta versão editada?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Digite o nome do arquivo",

--- a/src/ts/langs/pt_PT.ts
+++ b/src/ts/langs/pt_PT.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Por favor aguarde…",
     "remove": "Remover",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Gostaria de substituir o ficheiro no servidor por esta edição?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Inserir nome do ficheiro",

--- a/src/ts/langs/pt_PT.ts
+++ b/src/ts/langs/pt_PT.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Adicionar composto",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Adicionar equipa",
     "archive-user": "Arquivar utilizador",
     "archive-user-description": "Arquivar um utilizador significa que a sua conta será desactivada. Esta ação é reversível.",

--- a/src/ts/langs/ru_RU.ts
+++ b/src/ts/langs/ru_RU.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Добавить соединение",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Добавить команду",
     "archive-user": "Пользователь в архиве",
     "archive-user-description": "Архивирование пользователя означает, что его учетная запись будет отключена. Это действие обратимо.",

--- a/src/ts/langs/ru_RU.ts
+++ b/src/ts/langs/ru_RU.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Пожалуйста, подождите…",
     "remove": "Удалять",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Вы хотите заменить файл на сервере этим редактированием?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Введите имя файла",

--- a/src/ts/langs/sk_SK.ts
+++ b/src/ts/langs/sk_SK.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Prosím počkajte…",
     "remove": "Odstrániť",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Chcete touto úpravou nahradiť súbor na servery?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Zadajte názov súboru",

--- a/src/ts/langs/sk_SK.ts
+++ b/src/ts/langs/sk_SK.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Pridajte zlúčeninu",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Pridať tím",
     "archive-user": "Zálohuj užívateľa",
     "archive-user-description": "Archivácia používateľa znamená, že jeho účet bude deaktivovaný. Táto akcia je reverzibilná.",

--- a/src/ts/langs/sl_SI.ts
+++ b/src/ts/langs/sl_SI.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Prosim počakaj…",
     "remove": "Odstrani",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Ali želite zamenjati datoteko na strežniku s tem urejanjem?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Vnesite ime datoteke",

--- a/src/ts/langs/sl_SI.ts
+++ b/src/ts/langs/sl_SI.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Dodaj spojino",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Dodaj ekipo",
     "archive-user": "Arhiviraj uporabnika",
     "archive-user-description": "Arhiviranje uporabnika pomeni, da bo njegov račun onemogočen. To dejanje je reverzibilno.",

--- a/src/ts/langs/uz_UZ.ts
+++ b/src/ts/langs/uz_UZ.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Murakkab qo'shing",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "Jamoa qo'shing",
     "archive-user": "Arxiv foydalanuvchisi",
     "archive-user-description": "Foydalanuvchini arxivlash uning hisobi o'chirilishini anglatadi. Bu harakat qaytarilishi mumkin.",

--- a/src/ts/langs/uz_UZ.ts
+++ b/src/ts/langs/uz_UZ.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "Iltimos kuting…",
     "remove": "O'chirish",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "Serverdagi faylni ushbu tahrir bilan almashtirmoqchimisiz?",
     "replace-existing": "Overwrite original file",
     "request-filename": "Fayl nomini kiriting",

--- a/src/ts/langs/zh_CN.ts
+++ b/src/ts/langs/zh_CN.ts
@@ -74,7 +74,7 @@ const t = {
     "only-a-sysadmin": "Only a Sysadmin can modify this.",
     "please-wait": "请稍候…",
     "remove": "移除",
-    "rename-column": "New title for the column",
+    "edit-column": "Edit column name",
     "replace-edited-file": "您要用此编辑替换服务器上的文件吗？",
     "replace-existing": "Overwrite original file",
     "request-filename": "输入文件名",

--- a/src/ts/langs/zh_CN.ts
+++ b/src/ts/langs/zh_CN.ts
@@ -5,7 +5,6 @@ const t = {
     "2FA": "2FA",
     "add-compound": "添加化合物",
     "add-column": "Add column",
-    "add-row": "Add row",
     "add-team": "添加团队",
     "archive-user": "归档用户",
     "archive-user-description": "归档用户意味着他们的账户将被禁用。此操作是可逆的。",

--- a/src/ts/spreadsheet-editor-column-header.jsx
+++ b/src/ts/spreadsheet-editor-column-header.jsx
@@ -54,7 +54,7 @@ export function ColumnHeader(props) {
 
   // rename column header
   const rename = () => {
-    const newName = prompt(i18next.t('rename-column'), displayName);
+    const newName = prompt(i18next.t('edit-column'), displayName);
     if (!newName || newName === displayName) return;
     const newCols = columnDefs.map(column => column.field === field ? { ...column, field: newName } : column);
     const newRows = rowData.map(row => {
@@ -84,7 +84,7 @@ export function ColumnHeader(props) {
 
       {/* Row 2: toolbar with actions */}
       <div>
-        <button onClick={rename} title={i18next.t('rename-column')} className='border-0 bg-transparent mr-2'>
+        <button onClick={rename} title={i18next.t('edit-column')} className='border-0 bg-transparent mr-2'>
           <i className='fas fa-edit fa-sm' />
         </button>
         <button onClick={remove} title={i18next.t('delete')} className='border-0 bg-transparent mr-2'>

--- a/src/ts/spreadsheet-editor-column-header.jsx
+++ b/src/ts/spreadsheet-editor-column-header.jsx
@@ -79,13 +79,13 @@ export function ColumnHeader(props) {
 
       {/* Row 2: toolbar with actions */}
       <div>
-        <button onClick={rename} title={i18next.t('edit-column')} className='border-0 bg-transparent mr-2'>
+        <button type='button' onClick={rename} title={i18next.t('edit-column')} className='border-0 bg-transparent mr-2'>
           <i className='fas fa-edit fa-sm' />
         </button>
-        <button onClick={remove} title={i18next.t('delete')} className='border-0 bg-transparent mr-2'>
+        <button type='button' onClick={remove} title={i18next.t('delete')} className='border-0 bg-transparent mr-2'>
           <i className='fas fa-trash-alt fa-sm' />
         </button>
-        <button onClick={insertColumn} title={i18next.t('add-column')} className='border-0 bg-transparent'>
+        <button type='button' onClick={insertColumn} title={i18next.t('add-column')} className='border-0 bg-transparent'>
           <i className='fas fa-plus fa-sm' />
         </button>
       </div>

--- a/src/ts/spreadsheet-editor-column-header.jsx
+++ b/src/ts/spreadsheet-editor-column-header.jsx
@@ -18,6 +18,7 @@ import i18next from './i18n';
 
 export function ColumnHeader(props) {
   const { displayName, column, progressSort, api, columnDefs, rowData, setColumnDefs, setRowData } = props;
+  const liveLabel = (column.getColDef().headerName ?? column.getColDef().field) || displayName;
   const field = column.getColDef().field;
 
   // keep icon in sync with external sort changes
@@ -40,7 +41,7 @@ export function ColumnHeader(props) {
   const insertColumn = () => {
     const idx = columnDefs.findIndex(column => column.field === field);
     const newField = `Column${columnDefs.length}`;
-    const newCol = { field: newField, editable: true, sortable: true };
+    const newCol = { field: newField, colId: newField, headerName: `Column${columnDefs.length}`, editable: true, sortable: true };
 
     const newCols = [
       ...columnDefs.slice(0, idx + 1),
@@ -55,17 +56,11 @@ export function ColumnHeader(props) {
   // rename column header
   const rename = () => {
     const newName = prompt(i18next.t('edit-column'), displayName);
-    if (!newName || newName === displayName) return;
-    const newCols = columnDefs.map(column => column.field === field ? { ...column, field: newName } : column);
-    const newRows = rowData.map(row => {
-      const value = row[field];
-      const nr = { ...row };
-      delete nr[field];
-      nr[newName] = value;
-      return nr;
-    });
+    if (!newName) return;
+    const label = newName.trim();
+    if (!label || label === displayName) return;
+    const newCols = columnDefs.map(column => column.field === field ? { ...column, headerName: label, colId: column.colId ?? column.field } : column);
     setColumnDefs(newCols);
-    setRowData(newRows);
   };
 
   // remove a column
@@ -77,8 +72,8 @@ export function ColumnHeader(props) {
   return (
     <div className='ag-header-cell-label d-flex justify-content-between'>
       {/* row 1: title + default sort behavior */}
-      <span className='d-flex' onClick={(e) => progressSort?.(e.shiftKey)} title={displayName} aria-label={displayName}>
-        <span>{displayName}</span>
+      <span className='d-flex' onClick={(e) => progressSort?.(e.shiftKey)} title={liveLabel} aria-label={liveLabel}>
+        <span>{liveLabel}</span>
         <span className={`ag-icon ${sortIconClass}`} aria-hidden='true' />
       </span>
 

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -290,7 +290,7 @@ if (document.getElementById('spreadsheetEditor')) {
             </button>
             <div className='dropdown-menu'>
               {FILE_EXPORT_OPTIONS.map(({ type, icon, labelKey }) => (
-                <button key={type} className='dropdown-item' onClick={() => handleExport(type)}>
+                <button key={type} className='dropdown-item' type='button' onClick={() => handleExport(type)}>
                   <i className={`fas ${icon} fa-fw`}></i>{i18next.t(labelKey)}
                 </button>
               ))}

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -234,16 +234,16 @@ if (document.getElementById('spreadsheetEditor')) {
         <>
         {currentUploadId ? (
             // REPLACE EXISTING FILE WITH CURRENT EDITIONS
-            <button disabled={!currentUploadId} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2' id='replaceExisting' onClick={() => SpreadsheetHelperC.replaceExisting(columnDefs, rowData, entity.type, entity.id, currentUploadName, currentUploadId).then((res) => {
+            <button type='button' disabled={!currentUploadId} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2' id='replaceExisting' onClick={() => SpreadsheetHelperC.replaceExisting(columnDefs, rowData, entity.type, entity.id, currentUploadName, currentUploadId).then((res) => {
               if (res?.id) setCurrentUploadId(res.id); // track the latest subid and prevent duplicating
               setDirty(false);
-            })} title={i18next.t('replace-existing')} aria-label={i18next.t('replace-existing')} type='button'>
+            })} title={i18next.t('replace-existing')} aria-label={i18next.t('replace-existing')}>
               <i className='fas fa-save fa-fw'></i>
             </button>
           ) : (
             <>
               {/*SAVE AS ATTACHMENT (Opens modal to save the new Upload*/}
-              <button id='saveAsAttachment' disabled={isDisabled} className='btn hl-hover-gray d-inline p-2 mr-2' title={i18next.t('save-attachment')} aria-label={i18next.t('save-attachment')} type='button' onClick={() => $('#saveNewSpreadsheetModal').modal?.('show')}>
+              <button type='button' id='saveAsAttachment' disabled={isDisabled} className='btn hl-hover-gray d-inline p-2 mr-2' title={i18next.t('save-attachment')} aria-label={i18next.t('save-attachment')} onClick={() => $('#saveNewSpreadsheetModal').modal?.('show')}>
                 <i className='fas fa-save fa-fw' />
               </button>
               {/* The modal itself */}
@@ -314,9 +314,6 @@ if (document.getElementById('spreadsheetEditor')) {
             <div className='ag-theme-alpine' style={{ width: "100%", height: "100%" }}>
               <AgGridReact
                 ref={gridRef}
-                // rowData={rowData}
-                // columnDefs={columnDefs}
-                // onCellValueChanged={() => setDirty(true)}
                 rowData={displayRowData}
                 columnDefs={displayColumnDefs}
                 defaultColDef={defaultColDef}

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -226,7 +226,7 @@ if (document.getElementById('spreadsheetEditor')) {
       editable: true,
       headerComponent: ColumnHeader,
       headerComponentParams: headerParams,
-      cellStyle: { borderRight: '1px solid lightgray'}
+      cellStyle: { borderRight: '1px solid var(--border-color, lightgray)'}
     }), [headerParams]);
 
     function SaveButton() {
@@ -310,7 +310,7 @@ if (document.getElementById('spreadsheetEditor')) {
         {columnDefs.length > 0 && rowData.length > 0 && (
           <>
           {/* parent div to make it resizeable, as it's not built-in in ag-grid */}
-          <div style={{ resize: "both", overflow: "auto", height: 600 }} className='mb-2' id='spreadsheetGrid'>
+          <div style={{ resize: "both", overflow: "auto", height: 600, minHeight: 300, minWidth: 300 }} className='mb-2' id='spreadsheetGrid'>
             <div className='ag-theme-alpine' style={{ width: "100%", height: "100%" }}>
               <AgGridReact
                 ref={gridRef}

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -121,28 +121,6 @@ if (document.getElementById('spreadsheetEditor')) {
       SpreadsheetHelperC.handleExport(format, columnDefs, rowData).then(() => setDirty(false));
     }, [SpreadsheetHelperC, columnDefs, rowData]);
 
-    // add a row next to the selected line. When no row is selected, it's added at the bottom line.
-    const addRow = useCallback(() => {
-      const api = gridRef.current.api;
-      // https://www.ag-grid.com/react-data-grid/data-update-transactions/#transaction-update-api
-      const selectedNodes = api.getSelectedNodes();
-      // figure out the insertion index
-      const insertIndex = selectedNodes.length > 0
-        ? selectedNodes[0].rowIndex + 1
-        : rowData.length;
-      // build your new empty row
-      const newRow = {};
-      columnDefs.forEach(col => { newRow[col.field] = '' });
-      // update React state, adding a new column takes into account existing rows.
-      const updated = [
-        ...rowData.slice(0, insertIndex),
-        newRow,
-        ...rowData.slice(insertIndex),
-      ];
-      setRowData(updated);
-      setDirty(true);
-    }, [columnDefs, rowData]);
-
     const removeSelectedRows = () => {
       const api = gridRef.current.api;
       const selected = api.getSelectedRows();
@@ -311,10 +289,6 @@ if (document.getElementById('spreadsheetEditor')) {
 
           <span hidden id='spreadsheetUnsavedChangesWarningDiv'>{i18next.t('You have unsaved changes')}</span>
           <div className='vertical-separator'></div>
-          {/* ADD NEW ROW */}
-          <button disabled={isDisabled} onClick={addRow} className='btn hl-hover-gray d-inline p-2' title={i18next.t('add-row')} type='button'>
-            <i className='fas fa-plus-minus fa-fw'></i>
-          </button>
           {/* CLEAR */}
           <button disabled={isDisabled} title={i18next.t('clear')} aria-label={i18next.t('clear')} type='button' onClick={clear} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2 ml-auto'>
             <i className='fas fa-trash-alt fa-fw'></i>

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -179,14 +179,6 @@ if (document.getElementById('spreadsheetEditor')) {
       headerComponentParams: headerParams,
     }), [headerParams]);
 
-    // little issue on create new sheet, it takes the whole space
-    // // make grid resizeable
-    // const fitCols = useCallback(() => {
-    //   if (!gridRef.current) return;
-    //   const api = gridRef.current.api;
-    //   if (api?.sizeColumnsToFit) api.sizeColumnsToFit();
-    // }, []);
-
     function SaveButton() {
       return (
         <>
@@ -273,7 +265,7 @@ if (document.getElementById('spreadsheetEditor')) {
         {columnDefs.length > 0 && rowData.length > 0 && (
           <>
           {/* parent div to make it resizeable, as it's not built-in in ag-grid */}
-          <div style={{ resize: "both", overflow: "auto", height: 600 }} className='mb-2'>
+          <div style={{ resize: "both", overflow: "auto", height: 600 }} className='mb-2' id='spreadsheetGrid'>
             <div className='ag-theme-alpine' style={{ width: "100%", height: "100%" }}>
               <AgGridReact
                 ref={gridRef}
@@ -282,8 +274,6 @@ if (document.getElementById('spreadsheetEditor')) {
                 defaultColDef={defaultColDef}
                 rowSelection='multiple'
                 onCellValueChanged={() => setDirty(true)}
-                // onGridSizeChanged={fitCols}
-                // onFirstDataRendered={fitCols}
               />
             </div>
           </div>

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -288,7 +288,6 @@ if (document.getElementById('spreadsheetEditor')) {
           <SaveButton />
 
           <span hidden id='spreadsheetUnsavedChangesWarningDiv'>{i18next.t('You have unsaved changes')}</span>
-          <div className='vertical-separator'></div>
           {/* CLEAR */}
           <button disabled={isDisabled} title={i18next.t('clear')} aria-label={i18next.t('clear')} type='button' onClick={clear} className='btn hl-hover-gray p-2 lh-normal border-0 mr-2 ml-auto'>
             <i className='fas fa-trash-alt fa-fw'></i>


### PR DESCRIPTION
Misc improvements for smoother editing

- enabled on view page
- On creating new spreadsheet, empty cells are always available and editable.
- **BEFORE** <img width="2342" height="1060" alt="image" src="https://github.com/user-attachments/assets/f3a88126-06fd-4b1c-b325-b5617adc607e" />
- **NOW** <img width="2342" height="1060" alt="image" src="https://github.com/user-attachments/assets/35a1c5fa-17c8-4e0a-ad3c-318ff57beff1" />
- All cells are editable, and cells are automatically created when the last cell (or one in the last ten) is filled
- <img width="946" height="558" alt="image" src="https://github.com/user-attachments/assets/7dedcdb5-fb12-4add-90c4-3e7662261d7d" />
- remove "add row" button unnecessary now
- disable keyboard shortcuts in spreadsheet editor allows fluent editions right on focus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Spreadsheet editor integrated into the record view (two sections).
  - Virtual padding: typing in empty edge cells creates real rows/columns automatically.
  - Column headers prefer custom names and show “Edit column name” for header actions.

- Bug Fixes
  - Keyboard shortcuts no-oped when already in edit mode or focused inside the spreadsheet.

- Chores
  - Translations updated: “Rename column” → “Edit column name”; removed “Add row.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->