### PR TITLE
tests: cypress: e2e delete of resource category

### DIFF
--- a/src/templates/categories-status-index.macro.html
+++ b/src/templates/categories-status-index.macro.html
@@ -31,7 +31,7 @@
 
           <li class='list-inline-item'>
             <label for='expcatName_{{ cat.id }}'>{{ 'Name'|trans }}</label>
-            <input class='form-control' required type='text' id='expcatName_{{ cat.id }}' data-trigger='blur' data-model='teams/current/{{ type }}/{{ cat.id }}' data-target='title' value='{{ cat.title|e('html_attr') }}' />
+            <input class='form-control' required type='text' id='expcatName_{{ cat.id }}' data-trigger='blur' data-model='teams/current/{{ type }}/{{ cat.id }}' data-target='title' data-cy='expcatName' value='{{ cat.title|e('html_attr') }}' />
           </li>
 
           <li class='list-inline-item align-top'>

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -123,6 +123,18 @@ describe('Experiments', () => {
     entityList('database.php');
   });
 
+  it('Delete a resource category', () => {
+    const catname = 'Justice';
+    cy.visit('/resources-categories.php');
+    cy.htmlvalidate();
+    cy.get(`[data-cy=expcatName][value="${catname}"]`)
+      .closest('li.list-group-item')
+      .find('[data-action="destroy-catstat"]')
+      .wait(500)
+      .click();
+    cy.get('input[data-cy=expcatName][value="Justice"]').should('not.exist');
+  });
+
   const entityRestore = (publicUrl: string) => {
     cy.visit(`/${publicUrl}`);
     cy.htmlvalidate();


### PR DESCRIPTION
Occasionally, when running the E2E tests, errors during execution can cause the process to crash and leave duplicate categories (e.g. multiple instances of "Justice") in the system.

This PR ensures that the test cleans up after itself by deleting the category it creates, preventing duplicate entries from being left behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that verifies deleting a resource category from the categories page, confirming the category is removed from the list.

* **Chores**
  * Introduced dedicated test selectors on category name inputs to improve end-to-end test reliability without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->