### PR TITLE
bug/medium: eln import: fix issue with incorrect url for images

### DIFF
--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -35,6 +35,7 @@ use Override;
 use function array_find;
 use function basename;
 use function json_decode;
+use function rawurlencode;
 use function sprintf;
 use function strtr;
 
@@ -535,7 +536,7 @@ class Eln extends AbstractZip
             $Uploads = new Uploads($this->Entity, $newUploadId);
             $currentBody = $this->Entity->readOne()['body'];
             // also search for url encoded filename
-            $newBody = str_replace(array(urlencode($file['alternateName']), $file['alternateName']), $Uploads->uploadData['long_name'], $currentBody);
+            $newBody = str_replace(array(rawurlencode($file['alternateName']), $file['alternateName']), $Uploads->uploadData['long_name'], $currentBody);
             $this->Entity->patch(Action::Update, array('body' => $newBody));
         }
     }

--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -534,7 +534,8 @@ class Eln extends AbstractZip
             // read the newly created upload so we can get the new long_name to replace the old in the body
             $Uploads = new Uploads($this->Entity, $newUploadId);
             $currentBody = $this->Entity->readOne()['body'];
-            $newBody = str_replace($file['alternateName'], $Uploads->uploadData['long_name'], $currentBody);
+            // also search for url encoded filename
+            $newBody = str_replace(array(urlencode($file['alternateName']), $file['alternateName']), $Uploads->uploadData['long_name'], $currentBody);
             $this->Entity->patch(Action::Update, array('body' => $newBody));
         }
     }


### PR DESCRIPTION
in some cases the url in body for included images are percent-encoded (url-encoded), so we need to look for that too when doing a search and replace with the new filename.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * During import, entries that reference uploaded files via alternate names are now fully updated: both plain and URL-encoded filename mentions in the body are replaced with the new name. This prevents stale encoded filenames, reduces broken links, and ensures consistent references across content after imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->