### PR TITLE
feat: compounds: add command to recalculate fingerprints

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -68,6 +68,7 @@ $Application->add(new CacheClear());
 $Application->add(new CheckDatabase((int) $Config->configArr['schema']));
 $Application->add(new CheckTsBalance((int) $Config->configArr['ts_balance'], $Email));
 $Application->add(new CleanDatabase());
+$Application->add(new FingerprintCompounds());
 $Application->add(new ExportCommand($exportsFs));
 $Application->add(new ExportEln($exportsFs));
 $Application->add(new ImportEln($exportsFs));

--- a/src/Commands/FingerprintCompounds.php
+++ b/src/Commands/FingerprintCompounds.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @author Nicolas CARPi from Deltablot
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Commands;
+
+use Elabftw\Services\HttpGetter;
+use Elabftw\Elabftw\Env;
+use Elabftw\Models\Config;
+use Elabftw\Models\Fingerprints;
+use Elabftw\Services\Fingerprinter;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Override;
+
+/**
+ * (Re)calculate fingerprints for stored compounds
+ */
+#[AsCommand(name: 'compounds:fingerprint')]
+final class FingerprintCompounds extends Command
+{
+    #[Override]
+    protected function configure(): void
+    {
+        $this->setDescription('Calculate fingerprint of compounds missing one.')
+            ->setHelp('Calculate fingerprints of compounds in the database. Requires fingerprinting service obviously.')
+            ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not change anything in the database, just report number of compounds targeted.')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Recompute ALL compounds fingerprints, not just the ones missing.');
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $Fingerprints = new Fingerprints();
+        $compounds = $Fingerprints->getSmilesMissingFp((bool) $input->getOption('force'));
+        $output->writeln(sprintf('Found %d compounds to process...', count($compounds)));
+        if ($input->getOption('dry-run')) {
+            $output->writeln('Dry run mode: not processing anything.');
+            return Command::SUCCESS;
+        }
+        $proxy = Env::asBool('FINGERPRINTER_USE_PROXY') ? Config::getConfig()->configArr['proxy'] : '';
+        $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, Env::asBool('DEV_MODE'));
+        $Fingerprinter = new Fingerprinter($fingerPrinterHttpGetter, Env::asUrl('FINGERPRINTER_URL'));
+        foreach ($compounds as $compound) {
+            $output->writeln(sprintf('Processing compound with ID: %d', $compound['id']));
+            $fp = $Fingerprinter->calculate('smi', $compound['smiles']);
+            new Fingerprints($compound['id'])->upsert($fp['data']);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/FingerprintCompounds.php
+++ b/src/Commands/FingerprintCompounds.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
+use Throwable;
 
 /**
  * (Re)calculate fingerprints for stored compounds
@@ -41,11 +42,15 @@ final class FingerprintCompounds extends Command
     }
 
     #[Override]
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $Fingerprints = new Fingerprints();
         $compounds = $Fingerprints->getSmilesMissingFp((bool) $input->getOption('force'));
         $output->writeln(sprintf('Found %d compounds to process...', count($compounds)));
+        if (count($compounds) === 0) {
+            $output->writeln('All compounds have a fingerprint. Nothing to do! :)');
+            return Command::SUCCESS;
+        }
         if ($input->getOption('dry-run')) {
             $output->writeln('Dry run mode: not processing anything.');
             return Command::SUCCESS;
@@ -54,9 +59,22 @@ final class FingerprintCompounds extends Command
         $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, Env::asBool('DEV_MODE'));
         $Fingerprinter = new Fingerprinter($fingerPrinterHttpGetter, Env::asUrl('FINGERPRINTER_URL'));
         foreach ($compounds as $compound) {
+            if (empty($compound['smiles'])) {
+                $output->writeln(sprintf('Skipping compound with ID: %d (empty SMILES).', $compound['id']));
+                continue;
+            }
             $output->writeln(sprintf('Processing compound with ID: %d', $compound['id']));
-            $fp = $Fingerprinter->calculate('smi', $compound['smiles']);
-            new Fingerprints($compound['id'])->upsert($fp['data']);
+            try {
+                $fp = $Fingerprinter->calculate('smi', $compound['smiles']);
+                if (!is_array($fp['data'] ?? null) || count($fp['data']) !== 32) {
+                    $output->writeln(sprintf('Skipping compound with ID: %d (invalid fingerprint payload).', $compound['id']));
+                    continue;
+                }
+                new Fingerprints($compound['id'])->upsert($fp['data']);
+            } catch (Throwable $e) {
+                $output->writeln(sprintf('Error: %s', $e->getMessage()));
+                // continue with next compound
+            }
         }
 
         return Command::SUCCESS;

--- a/tests/unit/commands/CommandsTest.php
+++ b/tests/unit/commands/CommandsTest.php
@@ -239,4 +239,13 @@ class CommandsTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(array());
         $commandTester->assertCommandIsSuccessful();
     }
+
+    public function testFingerprintCompounds(): void
+    {
+        $commandTester = new CommandTester(new FingerprintCompounds());
+        $commandTester->execute(array(
+            '--dry-run' => true,
+        ));
+        $commandTester->assertCommandIsSuccessful();
+    }
 }


### PR DESCRIPTION
* add compounds:fingerprint command to calculate missing or all fingerprints

fix #5948



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compounds:fingerprint CLI command with --dry-run and --force; reports totals and processes missing fingerprints.
  - Honors proxy configuration for the external fingerprinting service; skips compounds with empty SMILES.

- **Data Integrity**
  - Stricter fingerprint validation and improved replace/upsert handling to ensure consistent stored fingerprints.

- **Tests**
  - Added unit test validating the command’s dry-run execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->