### PR TITLE
bug/minor: uploads: fix real_name filter being too stringent

### DIFF
--- a/src/Params/UploadParams.php
+++ b/src/Params/UploadParams.php
@@ -38,6 +38,6 @@ final class UploadParams extends ContentParams
         if ($ext === 'php') {
             throw new ImproperActionException('No php extension allowed!');
         }
-        return Filter::forFilesystem($this->asString());
+        return Filter::toPureString($this->asString());
     }
 }


### PR DESCRIPTION
fix #5950



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of uploaded file names to better preserve user-provided names while still blocking dangerous extensions (e.g., .php). Reduces unexpected character stripping and ensures more consistent filenames across platforms and browsers.
- Refactor
  - Streamlined filename sanitization logic for uploads using a more robust normalization approach, improving reliability and maintainability without changing validation rules for disallowed extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->