### PR TITLE
rework the onboarding code, add option to import users back

### DIFF
--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -39,6 +39,7 @@ final class i18n4Js
             '2FA' => _('2FA'),
             'add-compound' => _('Add compound'),
             'add-team' => _('Add team'),
+            'add-to-team' => _('Add selected users to team'),
             'archive-user' => _('Archive user'),
             'archive-user-description' => _('Archiving a user means their account will be disabled. This action is reversible.'),
             'add-user-error' => _('Use the autocompletion menu to add users.'),

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -8,7 +8,7 @@
         <div class='d-flex justify-content-between'>
           <label for='showAllUsers' class='col-form-label'>{{ 'Show users from all teams'|trans }}</label>
           <label class='switch ucp-align'>
-            <input type='checkbox' autocomplete='off' data-trigger='change' data-custom-action='show-all-users' {{ scriptName == 'sysconfig.php' ? 'checked="checked"' }} id='showAllUsers'>
+            <input type='checkbox' autocomplete='off' data-trigger='change' data-custom-action='show-all-users' id='showAllUsers'>
             <span class='slider'></span>
           </label>
         </div>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -2,7 +2,18 @@
 <div>
   <h3 class='mb-3 p-2 pl-3 section-title'>{{ 'Users list'|trans }}</h3>
   <div class='pl-3'>
-    <p class='smallgray'>{{ 'Double-click a row in the table below to edit user.'|trans }}</p>
+    <div class='d-flex justify-content-between align-items-baseline'>
+      <p>{{ 'Double-click a row in the table below to edit user.'|trans }}</p>
+      {% if scriptName == 'admin.php' and (App.Users.userData.can_manage_users2teams or App.Config.configArr.admins_import_users) %}
+        <div class='d-flex justify-content-between'>
+          <label for='showAllUsers' class='col-form-label'>{{ 'Show users from all teams'|trans }}</label>
+          <label class='switch ucp-align'>
+            <input type='checkbox' autocomplete='off' data-trigger='change' data-custom-action='show-all-users' {{ scriptName == 'sysconfig.php' ? 'checked="checked"' }} id='showAllUsers'>
+            <span class='slider'></span>
+          </label>
+        </div>
+      {% endif %}
+    </div>
     {% if App.devMode -%}
     <!-- [html-validate-disable-block prefer-native-element, element-permitted-content, {{ App.Request.getScriptName|split('/')|last == 'admin.php' ? 'no-missing-references' }}: ag-grid] -->
     {%- endif %}

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -89,6 +89,7 @@
 <script type='application/json' id='core'>
   {
     "isAnon": {{ App.Session.has('is_anon') ? 'true' : 'false' }},
-    "isAuth": {{ App.Session.has('is_auth') ? 'true' : 'false' }}
+    "isAuth": {{ App.Session.has('is_auth') ? 'true' : 'false' }},
+    "currentTeam": {{ App.Users.userData.team|default(-1) }}
   }
 </script>

--- a/src/ts/core.ts
+++ b/src/ts/core.ts
@@ -13,6 +13,7 @@
 type Core = {
   isAnon: boolean;
   isAuth: boolean;
+  currentTeam: number;
 };
 
 const el = document.getElementById('core') as HTMLScriptElement | null;

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -11,6 +11,7 @@ import { ApiC } from './api';
 import { Action, Model } from './interfaces';
 import $ from 'jquery';
 import { notify } from './notify';
+import { core } from './core';
 
 if (document.getElementById('users-table')) {
 
@@ -171,6 +172,13 @@ if (document.getElementById('users-table')) {
       const team = parseInt(selectEl.options[selectEl.selectedIndex].value, 10);
       ApiC.patch(`${Model.User}/${userid}`, {action: Action.Add, team: team})
         .then(response => response.json()).then(user => populateUserModal(user));
+    } else if (el.matches('[data-action="import-users-in-team"]')) {
+      const idList = el.dataset.target.split(',');
+      if (!confirm(`Add ${idList.length} user(s) to your team?`)) {
+        return;
+      }
+      idList.forEach(userid => ApiC.patch(`${Model.User}/${userid}`, {action: Action.Add, team: core.currentTeam}));
+      document.dispatchEvent(new CustomEvent('dataReload'));
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {
       if (confirm(i18next.t('generic-delete-warning'))) {

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -177,7 +177,8 @@ if (document.getElementById('users-table')) {
       if (!confirm(`Add ${idList.length} user(s) to your team?`)) {
         return;
       }
-      idList.forEach(userid => ApiC.patch(`${Model.User}/${userid}`, {action: Action.Add, team: core.currentTeam}));
+      const requests = idList.map(userid => ApiC.patch(`${Model.User}/${userid}`, {action: Action.Add, team: core.currentTeam}));
+      await Promise.all(requests);
       document.dispatchEvent(new CustomEvent('dataReload'));
     // REMOVE USER FROM TEAM
     } else if (el.matches('[data-action="destroy-user2team"]')) {

--- a/src/ts/langs/ca_ES.ts
+++ b/src/ts/langs/ca_ES.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Afegir compost",
     "add-team": "Afegir equip",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Usuari actiu",
     "archive-user-description": "Arxivar un usuari significa que el seu compte es desactivarà. Aquesta acció és reversible.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/cs_CZ.ts
+++ b/src/ts/langs/cs_CZ.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Přidat sloučeninu",
     "add-team": "Přidat tým",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archivovat uživatele",
     "archive-user-description": "Archivace uživatele znamená, že jeho účet bude deaktivován. Tato akce je vratná.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/de_DE.ts
+++ b/src/ts/langs/de_DE.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Verbindung hinzufügen",
     "add-team": "Team hinzufügen",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Nutzer archivieren",
     "archive-user-description": "Die Archivierung eines Nutzers deaktiviert seinen Zugang. Diese Aktion ist umkehrbar.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/el_GR.ts
+++ b/src/ts/langs/el_GR.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Προσθήκη ένωσης",
     "add-team": "Προσθήκη Ομάδας",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Αρχειοθέτηση χρήστη",
     "archive-user-description": "Η αρχειοθέτηση ενός χρήστη σημαίνει ότι ο λογαριασμός του θα απενεργοποιηθεί. Αυτή η ενέργεια είναι αναστρέψιμη.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/en_GB.ts
+++ b/src/ts/langs/en_GB.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Add compound",
     "add-team": "Add team",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archive user",
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/en_US.ts
+++ b/src/ts/langs/en_US.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Add compound",
     "add-team": "Add team",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archive user",
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/es_ES.ts
+++ b/src/ts/langs/es_ES.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Añadir compuesto",
     "add-team": "Agregar equipo",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Usuario activo",
     "archive-user-description": "Archivar a un usuario significa que su cuenta se desactivará. Esta acción es reversible.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/et_EE.ts
+++ b/src/ts/langs/et_EE.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Lisa ühend",
     "add-team": "Lisa meeskond",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arhiivi kasutaja",
     "archive-user-description": "Kasutaja arhiveerimine tähendab tema konto sulgemist. See toiming on tagasipööratav.",
     "add-user-error": "Kasutajate lisamiseks kasutage automaatse täitmise menüüd.",

--- a/src/ts/langs/fi_FI.ts
+++ b/src/ts/langs/fi_FI.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Lisää yhdiste",
     "add-team": "Lisää tiimi",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arkistoi käyttäjä",
     "archive-user-description": "Käyttäjän arkistointi tarkoittaa, että hänen tilinsä poistetaan käytöstä. Tämä toiminto on peruutettava.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/fr_FR.ts
+++ b/src/ts/langs/fr_FR.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Ajouter un composé",
     "add-team": "Ajouter une équipe",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archiver utilisateur",
     "archive-user-description": "L'archivage d'un utilisateur signifie que son compte sera désactivé. Cette action est réversible.",
     "add-user-error": "Utilisez le menu d'autocomplétion pour ajouter des utilisateurs.",

--- a/src/ts/langs/id_ID.ts
+++ b/src/ts/langs/id_ID.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Tambahkan senyawa",
     "add-team": "Tambahkan tim",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arsipkan pengguna",
     "archive-user-description": "Mengarsipkan pengguna berarti akun mereka akan dinonaktifkan. Tindakan ini dapat dibatalkan.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/it_IT.ts
+++ b/src/ts/langs/it_IT.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Aggiungi composto",
     "add-team": "Aggiungi team",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archivia utente",
     "archive-user-description": "Archiviare un utente significa che il suo account verrà disabilitato. Questa azione è reversibile.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/ja_JP.ts
+++ b/src/ts/langs/ja_JP.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "化合物を追加する",
     "add-team": "チームを追加",
+    "add-to-team": "Add selected users to team",
     "archive-user": "アーカイブユーザー",
     "archive-user-description": "ユーザーをアーカイブすると、そのユーザーのアカウントは無効になります。この操作は元に戻すことができます。",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/ko_KR.ts
+++ b/src/ts/langs/ko_KR.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "화합물 추가",
     "add-team": "팀 추가",
+    "add-to-team": "Add selected users to team",
     "archive-user": "사용자 차단",
     "archive-user-description": "사용자를 보관처리하면 해당 사용자의 계정이 비활성화됩니다. 이 작업은 되돌릴 수 있습니다.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/nl_BE.ts
+++ b/src/ts/langs/nl_BE.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Voeg samenstelling toe",
     "add-team": "Team toevoegen",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archiveer gebruiker",
     "archive-user-description": "Het archiveren van een gebruiker betekent dat zijn/haar account wordt uitgeschakeld. Deze actie is omkeerbaar.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/pl_PL.ts
+++ b/src/ts/langs/pl_PL.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Dodaj związek",
     "add-team": "Dodaj zespół",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Archiwizuj użytkownika",
     "archive-user-description": "Archiwizacja użytkownika oznacza dezaktywację jego konta. To działanie jest odwracalne.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/pt_BR.ts
+++ b/src/ts/langs/pt_BR.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Adicionar composto",
     "add-team": "Adicionar equipe",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arquivar usuário",
     "archive-user-description": "O arquivamento de um usuário significa que sua conta será desativada. Essa ação É reversível.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/pt_PT.ts
+++ b/src/ts/langs/pt_PT.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Adicionar composto",
     "add-team": "Adicionar equipa",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arquivar utilizador",
     "archive-user-description": "Arquivar um utilizador significa que a sua conta será desactivada. Esta ação é reversível.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/ru_RU.ts
+++ b/src/ts/langs/ru_RU.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Добавить соединение",
     "add-team": "Добавить команду",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Пользователь в архиве",
     "archive-user-description": "Архивирование пользователя означает, что его учетная запись будет отключена. Это действие обратимо.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/sk_SK.ts
+++ b/src/ts/langs/sk_SK.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Pridajte zlúčeninu",
     "add-team": "Pridať tím",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Zálohuj užívateľa",
     "archive-user-description": "Archivácia používateľa znamená, že jeho účet bude deaktivovaný. Táto akcia je reverzibilná.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/sl_SI.ts
+++ b/src/ts/langs/sl_SI.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Dodaj spojino",
     "add-team": "Dodaj ekipo",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arhiviraj uporabnika",
     "archive-user-description": "Arhiviranje uporabnika pomeni, da bo njegov račun onemogočen. To dejanje je reverzibilno.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/uz_UZ.ts
+++ b/src/ts/langs/uz_UZ.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "Murakkab qo'shing",
     "add-team": "Jamoa qo'shing",
+    "add-to-team": "Add selected users to team",
     "archive-user": "Arxiv foydalanuvchisi",
     "archive-user-description": "Foydalanuvchini arxivlash uning hisobi o'chirilishini anglatadi. Bu harakat qaytarilishi mumkin.",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/langs/zh_CN.ts
+++ b/src/ts/langs/zh_CN.ts
@@ -5,6 +5,7 @@ const t = {
     "2FA": "2FA",
     "add-compound": "添加化合物",
     "add-team": "添加团队",
+    "add-to-team": "Add selected users to team",
     "archive-user": "归档用户",
     "archive-user-description": "归档用户意味着他们的账户将被禁用。此操作是可逆的。",
     "add-user-error": "Use the autocompletion menu to add users.",

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -81,6 +81,11 @@ function triggerHandler(event: Event, el: HTMLInputElement): void {
       .then(() => document.dispatchEvent(new CustomEvent('dataReload')));
     return;
   }
+  // Idea: maybe have a data-dispatch with the custom event name in data-target
+  if (el.dataset.customAction === 'show-all-users') {
+    document.dispatchEvent(new CustomEvent('dataReload'));
+    return;
+  }
   // END CUSTOM ACTIONS
 
   if (el.dataset.transform === 'permissionsToJson') {

--- a/src/ts/users-table.jsx
+++ b/src/ts/users-table.jsx
@@ -135,13 +135,13 @@ if (document.getElementById('users-table')) {
     // all the users are loaded in the table, which does client side pagination
     const fetchData = async () => {
       const params = new URLSearchParams(document.location.search);
-      let teamParam = params.get('team');
+      let teamParam = params.get('team') ?? '';
       let currentTeam = 0;
       const showAllUsersInput = document.getElementById('showAllUsers');
-      if (!teamParam && document.location.pathname === '/admin.php') {
+      if (!teamParam && document.location.pathname.endsWith('/admin.php')) {
         currentTeam = 1;
       }
-      if (showAllUsersInput && showAllUsersInput.checked) {
+      if (showAllUsersInput?.checked) {
         teamParam = 0;
         currentTeam = 0;
       }

--- a/src/ts/users-table.jsx
+++ b/src/ts/users-table.jsx
@@ -137,8 +137,13 @@ if (document.getElementById('users-table')) {
       const params = new URLSearchParams(document.location.search);
       let teamParam = params.get('team');
       let currentTeam = 0;
+      const showAllUsersInput = document.getElementById('showAllUsers');
       if (!teamParam && document.location.pathname === '/admin.php') {
         currentTeam = 1;
+      }
+      if (showAllUsersInput && showAllUsersInput.checked) {
+        teamParam = 0;
+        currentTeam = 0;
       }
       const queryParams = `&onlyArchived=${params.get('onlyArchived')}&team=${teamParam}&currentTeam=${currentTeam}`;
       try {
@@ -163,11 +168,18 @@ if (document.getElementById('users-table')) {
     }, []);
 
     // when a row is selected with the checkbox
-    //const selectionChanged = (event) => {
+    const selectionChanged = (event) => {
       // we store the selected rows as data-target string on the delete and restore buttons
-      //const selectedRows = event.api.getSelectedRows();
-      //const selectedIds = selectedRows.map(c => c.id).join(',');
-    //};
+      const selectedRows = event.api.getSelectedRows();
+      const selectedIds = selectedRows.map(c => c.userid).join(',');
+      const importBtn = document.getElementById('importUsersBtn');
+
+      // buttons are disabled if no rows are selected.
+      if (importBtn) {
+        importBtn.disabled = selectedRows.length === 0;
+        importBtn.dataset.target = selectedIds;
+      }
+    };
 
     const cellDoubleClicked = (event) => {
       ApiC.getJson(`users/${event.data.userid}`).then(json => {
@@ -194,11 +206,22 @@ if (document.getElementById('users-table')) {
           onGridReady={onGridReady}
           rowSelection={rowSelection}
           onCellDoubleClicked={cellDoubleClicked}
-          //onSelectionChanged={selectionChanged}
+          onSelectionChanged={selectionChanged}
           pagination={true}
           paginationPageSize={15}
           paginationPageSizeSelector={[15, 50, 100, 500]}
         />
+      </div>
+      <div className='d-flex justify-content-start my-2'>
+        <button
+          data-action='import-users-in-team'
+          id='importUsersBtn'
+          type='button'
+          disabled='disabled'
+          className={'btn btn-sm btn-secondary'}
+        >
+        {i18next.t('add-to-team')}
+        </button>
       </div>
     </>
     );


### PR DESCRIPTION
* allow admins to list users from other teams if they are allowed to manage users2teams or import users in their team
* rework the onboarding code a bit
* allow admins to import existing users in their team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - User management: toggle to show users from all teams.
  - Users table: bulk action to add selected users to the current team (import selected users).
  - Onboarding: onboarding emails now dispatched after validation, both instance-wide and per‑team when enabled.

- Chores
  - Added translation for “Add selected users to team” across all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->