### PR TITLE
feat: notifications: add notifications:clear command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -68,6 +68,7 @@ $Application->add(new CacheClear());
 $Application->add(new CheckDatabase((int) $Config->configArr['schema']));
 $Application->add(new CheckTsBalance((int) $Config->configArr['ts_balance'], $Email));
 $Application->add(new CleanDatabase());
+$Application->add(new ClearNotifications());
 $Application->add(new FingerprintCompounds());
 $Application->add(new ExportCommand($exportsFs));
 $Application->add(new ExportEln($exportsFs));

--- a/src/Commands/ClearNotifications.php
+++ b/src/Commands/ClearNotifications.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Commands;
+
+use Elabftw\Elabftw\Db;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Override;
+
+/**
+ * Remove all notifications
+ */
+#[AsCommand(name: 'notifications:clear')]
+final class ClearNotifications extends Command
+{
+    #[Override]
+    protected function configure(): void
+    {
+        $this->setDescription('Clear all notifications, past and future.')
+            ->setHelp('Will remove all notifications from the notifications mysql table.');
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $Db = Db::getConnection();
+        $Db->q('DELETE FROM notifications');
+        $output->writeln('All notifications removed.');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Commands/ClearNotifications.php
+++ b/src/Commands/ClearNotifications.php
@@ -29,15 +29,15 @@ final class ClearNotifications extends Command
     protected function configure(): void
     {
         $this->setDescription('Clear all notifications, past and future.')
-            ->setHelp('Will remove all notifications from the notifications mysql table.');
+            ->setHelp('Will remove all notifications from the notifications database table. This operation is destructive.');
     }
 
     #[Override]
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $Db = Db::getConnection();
-        $Db->q('DELETE FROM notifications');
-        $output->writeln('All notifications removed.');
+        $req = $Db->q('DELETE FROM notifications');
+        $output->writeln(sprintf('Removed %d notifications.', $req->rowCount()));
         return Command::SUCCESS;
     }
 }

--- a/tests/unit/commands/CommandsTest.php
+++ b/tests/unit/commands/CommandsTest.php
@@ -248,4 +248,11 @@ class CommandsTest extends \PHPUnit\Framework\TestCase
         ));
         $commandTester->assertCommandIsSuccessful();
     }
+
+    public function testClearNotifications(): void
+    {
+        $commandTester = new CommandTester(new ClearNotifications());
+        $commandTester->execute(array());
+        $commandTester->assertCommandIsSuccessful();
+    }
 }

--- a/tests/unit/models/UserNotificationsTest.php
+++ b/tests/unit/models/UserNotificationsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Models\Notifications\SelfIsValidated;
 use Elabftw\Models\Notifications\StepDeadline;
 use Elabftw\Models\Notifications\UserNotifications;
 use Elabftw\Models\Users\Users;
@@ -45,11 +46,17 @@ class UserNotificationsTest extends \PHPUnit\Framework\TestCase
 
     public function testReadOne(): void
     {
+        $Notif = new SelfIsValidated();
+        $id = $Notif->create(1);
+        $this->UserNotifications->setId($id);
         $this->assertIsArray($this->UserNotifications->readOne());
     }
 
     public function testPatch(): void
     {
+        $Notif = new SelfIsValidated();
+        $id = $Notif->create(1);
+        $this->UserNotifications->setId($id);
         $this->assertIsArray($this->UserNotifications->patch(Action::Update, array()));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a CLI command (notifications:clear) to remove all notifications and report success.

- Tests
  - Added unit tests covering the new notifications clear command.
  - Updated notification tests to instantiate concrete notification objects before read and patch operations, improving test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->