### PR TITLE
bug/minor: users api: give full response to sysadmins too

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -354,9 +354,9 @@ class Users extends AbstractRest
             $Request->query->getBoolean('onlyAdmins'),
             $Request->query->getBoolean('onlyArchived'),
         );
-        // if the user is Admin somewhere, return a pretty complete response
+        // if the user is Admin somewhere (or Sysadmin), return a pretty complete response
         // Note: having something where you get different response depending if the user is part of your team or not seems too complex to implement and maintain
-        if ($this->requester->isAdminSomewhere()) {
+        if ($this->requester->isAdminSomewhere() || $this->requester->userData['is_sysadmin'] === 1) {
             return $users;
         }
         // otherwise, remove some more data, here we want only the super basic data for basic users


### PR DESCRIPTION
if a user was sysadmin but not admin of any team, they would have incomplete is_sysadmin response when looking at the users table from sysconfig panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - System administrators are now correctly recognized with full administrative privileges when viewing user lists, providing complete data visibility where appropriate.
  - Aligns admin access behavior for sysadmins with other admin roles to ensure consistent, expected permissions across the app.
  - Regular users’ access remains unchanged; only admin-level visibility is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->