### PR TITLE
bug/minor: shortcuts: partial fix for "s" search shortcut

### DIFF
--- a/src/ts/KeyboardShortcuts.class.ts
+++ b/src/ts/KeyboardShortcuts.class.ts
@@ -67,10 +67,11 @@ export class KeyboardShortcuts {
     // SEARCH BAR FOCUS
     assignKey(this.search, (event: Event) => {
       // search input might not be visible on some pages
-      const qs = document.getElementById('quicksearchInput');
+      const qs = document.getElementById('extendedArea');
       if (qs) {
         // add this or the shortcut key gets written in the input
         event.preventDefault();
+        qs.scrollIntoView({ behavior: 'smooth' });
         qs.focus();
       }
     });


### PR DESCRIPTION
will work in show mode, but for view/edit modes we would need another logic, maybe have a modal window...

see #6011


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search keyboard shortcut behavior to reliably focus the search area.
  * Automatically scrolls the search area into view before focusing, preventing off-screen focus.
  * Smooth scrolling enhances usability and reduces disorientation when invoking the shortcut.
  * Better accessibility: ensures visible focus state and easier navigation for keyboard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->