### PR TITLE
fix: extrafields: metadata value reset on using a switch Or editing field's name

### DIFF
--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -373,10 +373,10 @@ if (document.getElementById('metadataDiv') && entity.id) {
           if (metadata) {
             json = metadata;
           }
-          // If the key (name) is being changed, remove the old one to avoid creating two separate entries
-          if (originalFieldKey && originalFieldKey !== newFieldKey) {
-            delete json['extra_fields'][originalFieldKey];
-          }
+          // if the extra field's name (also acting as key) is updated, replace existing entry and keep the content
+          const prevField = json['extra_fields']?.[
+            originalFieldKey && originalFieldKey !== newFieldKey ? originalFieldKey : newFieldKey
+          ];
           const field = {};
           // handle field inputs : type, desc, and different type values
           field['type'] = (document.getElementById('newFieldTypeSelect') as HTMLSelectElement).value;
@@ -392,14 +392,14 @@ if (document.getElementById('metadataDiv') && entity.id) {
             field['value'] = textAreaField.value.trim();
           } else if (['date', 'datetime-local', 'email', 'time', 'url'].includes(field['type'])) {
             const val = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
-            field['value'] = val || json['extra_fields'][newFieldKey]?.value || '';
+            field['value'] = val || prevField?.value || '';
           } else if ([ExtraFieldInputType.Users, ExtraFieldInputType.Items, ExtraFieldInputType.Experiments].includes(field['type'])) {
             const elId = `newField${field['type']}Input`;
             const el = document.getElementById(elId) as HTMLInputElement | null;
             const val = (el?.value ?? '').trim();
-            field['value'] = val || json['extra_fields'][newFieldKey]?.value || '';
+            field['value'] = val || prevField?.value || '';
           } else if ([ExtraFieldInputType.Select, ExtraFieldInputType.Radio].includes(field['type'])) {
-            const prevVal = json['extra_fields'][newFieldKey]?.value || '';
+            const prevVal = prevField?.value || '';
             field['options'] = [];
             document.getElementById('choicesInputDiv').querySelectorAll('input').forEach(opt => {
               const val = (opt as HTMLInputElement).value.trim();
@@ -408,7 +408,7 @@ if (document.getElementById('metadataDiv') && entity.id) {
             // keep old value if no new option is provided
             field['value'] = field['options'].includes(prevVal) ? prevVal : (field['options'][0] || '');
           } else if (field['type'] === ExtraFieldInputType.Number) {
-            const prevVal = json['extra_fields'][newFieldKey]?.value || '';
+            const prevVal = prevField?.value || '';
             const val = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
             field['value'] = val || prevVal;
             field['units'] = [];
@@ -417,7 +417,7 @@ if (document.getElementById('metadataDiv') && entity.id) {
                 field['units'].push(opt.value.trim());
               }
             });
-            const prevUnit = json['extra_fields'][newFieldKey]?.unit || '';
+            const prevUnit = prevField?.unit || '';
             field['unit'] = field['units'].length === 0
               ? prevUnit
               : (field['units'].includes(prevUnit) ? prevUnit : field['units'][0]);

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -373,7 +373,7 @@ if (document.getElementById('metadataDiv') && entity.id) {
           if (metadata) {
             json = metadata;
           }
-          // If the key (name) is being changed, remove previous field else it will create two separate ones
+          // If the key (name) is being changed, remove the old one to avoid creating two separate entries
           if (originalFieldKey && originalFieldKey !== newFieldKey) {
             delete json['extra_fields'][originalFieldKey];
           }
@@ -418,26 +418,22 @@ if (document.getElementById('metadataDiv') && entity.id) {
               }
             });
             const prevUnit = json['extra_fields'][newFieldKey]?.unit || '';
-            field['unit'] = field['units'][0] || prevUnit;
+            field['unit'] = field['units'].length === 0
+              ? prevUnit
+              : (field['units'].includes(prevUnit) ? prevUnit : field['units'][0]);
           } else if (field['type'] === ExtraFieldInputType.Checkbox) {
             field['value'] = (document.getElementById('newFieldCheckboxDefaultSelect') as HTMLSelectElement).value === 'checked' ? 'on' : '';
           }
-
-          // deal with the blank_on_value
-          if ((document.getElementById('blankValueOnDuplicateSwitch') as HTMLInputElement).checked) {
-            field['blank_value_on_duplicate'] = true;
-          }
-          // deal with the required attribute
-          if ((document.getElementById('requiredSwitch') as HTMLInputElement).checked) {
-            field['required'] = true;
-          }
-          // deal with the readonly attribute
-          if ((document.getElementById('readonlySwitch') as HTMLInputElement).checked) {
-            field['readonly'] = true;
-          }
-          // deal with the multi select
-          if ((document.getElementById('newFieldAllowMultiSelect') as HTMLInputElement).checked) {
-            field['allow_multi_values'] = true;
+          // deal with modal SWITCHES (key: id, value: field's 'value')
+          const switches: Record<string, string> = {
+            blankValueOnDuplicateSwitch: 'blank_value_on_duplicate',
+            requiredSwitch: 'required',
+            readonlySwitch: 'readonly',
+            newFieldAllowMultiSelect: 'allow_multi_values',
+          };
+          for (const [id, key] of Object.entries(switches)) {
+            const el = document.getElementById(id) as HTMLInputElement | null;
+            if (el?.checked) field[key] = true;
           }
 
           json['extra_fields'][newFieldKey] = field;

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -398,24 +398,27 @@ if (document.getElementById('metadataDiv') && entity.id) {
             const el = document.getElementById(elId) as HTMLInputElement | null;
             const val = (el?.value ?? '').trim();
             field['value'] = val || json['extra_fields'][newFieldKey]?.value || '';
-          } else if (['select', 'radio'].includes(field['type'])) {
+          } else if ([ExtraFieldInputType.Select, ExtraFieldInputType.Radio].includes(field['type'])) {
+            const prevVal = json['extra_fields'][newFieldKey]?.value || '';
             field['options'] = [];
             document.getElementById('choicesInputDiv').querySelectorAll('input').forEach(opt => {
-              if (opt.value.trim()) {
-                field['options'].push(opt.value.trim());
-              }
+              const val = (opt as HTMLInputElement).value.trim();
+              if (val) field['options'].push(val);
             });
-            // make sure at least one value is set
-            field['value'] = field['options'][0] || '';
+            // keep old value if no new option is provided
+            field['value'] = field['options'].includes(prevVal) ? prevVal : (field['options'][0] || '');
           } else if (field['type'] === ExtraFieldInputType.Number) {
-            field['value'] = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
+            const prevVal = json['extra_fields'][newFieldKey]?.value || '';
+            const val = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
+            field['value'] = val || prevVal;
             field['units'] = [];
             document.getElementById('unitChoicesInputDiv').querySelectorAll('input').forEach(opt => {
               if (opt.value.trim()) {
                 field['units'].push(opt.value.trim());
               }
             });
-            field['unit'] = field['units'].length > 0 ? field['units'][0] : '';
+            const prevUnit = json['extra_fields'][newFieldKey]?.unit || '';
+            field['unit'] = field['units'][0] || prevUnit;
           } else if (field['type'] === ExtraFieldInputType.Checkbox) {
             field['value'] = (document.getElementById('newFieldCheckboxDefaultSelect') as HTMLSelectElement).value === 'checked' ? 'on' : '';
           }

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -391,7 +391,13 @@ if (document.getElementById('metadataDiv') && entity.id) {
           if (field['type'] === ExtraFieldInputType.Text) {
             field['value'] = textAreaField.value.trim();
           } else if (['date', 'datetime-local', 'email', 'time', 'url'].includes(field['type'])) {
-            field['value'] = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
+            const val = (document.getElementById('newFieldValueInput') as HTMLInputElement).value.trim();
+            field['value'] = val || json['extra_fields'][newFieldKey]?.value || '';
+          } else if ([ExtraFieldInputType.Users, ExtraFieldInputType.Items, ExtraFieldInputType.Experiments].includes(field['type'])) {
+            const elId = `newField${field['type']}Input`;
+            const el = document.getElementById(elId) as HTMLInputElement | null;
+            const val = (el?.value ?? '').trim();
+            field['value'] = val || json['extra_fields'][newFieldKey]?.value || '';
           } else if (['select', 'radio'].includes(field['type'])) {
             field['options'] = [];
             document.getElementById('choicesInputDiv').querySelectorAll('input').forEach(opt => {
@@ -436,7 +442,7 @@ if (document.getElementById('metadataDiv') && entity.id) {
           MetadataC.update(json as ValidMetadata).then(() => {
             $('#fieldBuilderModal').modal('toggle');
             // focus on the newly added element
-            document.querySelector(`[data-name="${newFieldKey}"`).scrollIntoView({behavior: 'smooth'});
+            document.querySelector(`[data-name="${newFieldKey}"]`).scrollIntoView({behavior: 'smooth'});
           });
         });
       // ADD OPTION FOR SELECT OR RADIO


### PR DESCRIPTION
fix #6013

Fix how the metadata update is handled:
On using a switch, the metadata's value (content) would be reset. Now it is handled correctly.
I noticed as well it happens on changing the name (also acting as key), it would delete the content before changing its value, having no field key to persist to.
For the number, it's the units that was set back to first option. Same for multiselect. fixed
A little bit of refactor and use of enums, update comments, fix a querySelector typo.