### PR TITLE
bug/medium: templates: fix incomplete uploads duplicate if body is null

### DIFF
--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -180,7 +180,7 @@ final class Uploads extends AbstractRest
             // replace links in body with the new long_name
             // don't bother if body is null
             if ($entity->entityData['body'] === null) {
-                return;
+                continue;
             }
             $newBody = str_replace($upload['long_name'], $fresh->uploadData['long_name'], $entity->entityData['body']);
             $entity->patch(Action::Update, array('body' => $newBody));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicating items with an empty/blank upload could stop the process prematurely. All remaining uploads are now processed correctly, ensuring complete duplication even when some uploads have no content.
  * Improves reliability of bulk duplication workflows that include mixed-content uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->