### PR TITLE
tests: phpunit: add some coverage

### DIFF
--- a/src/Traits/ControllerUtilsTrait.php
+++ b/src/Traits/ControllerUtilsTrait.php
@@ -40,4 +40,11 @@ trait ControllerUtilsTrait
         $m->setAccessible(true);
         return $m->invoke($class);
     }
+
+    protected function injectInto(object $controller, object $entity, string $property): void
+    {
+        $rp = new ReflectionClass($controller)->getProperty($property);
+        $rp->setAccessible(true);
+        $rp->setValue($controller, $entity);
+    }
 }

--- a/src/Traits/ControllerUtilsTrait.php
+++ b/src/Traits/ControllerUtilsTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Traits;
+
+use ReflectionClass;
+
+trait ControllerUtilsTrait
+{
+    /**
+     * @template T of object
+     * @param class-string<T>|T $class
+     * @return T
+     */
+    protected function makeWithoutConstructor($class): object
+    {
+        $ref = new ReflectionClass($class); // accepts object or class-string
+        return $ref->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * @template T of object
+     * @param T $class
+     * @return mixed
+     */
+    protected function invokeProtected($class, string $method): mixed
+    {
+        $ref = new ReflectionClass($class);
+        $m = $ref->getMethod($method);
+        $m->setAccessible(true);
+        return $m->invoke($class);
+    }
+}

--- a/tests/unit/controllers/AbstractHtmlControllerTest.php
+++ b/tests/unit/controllers/AbstractHtmlControllerTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 /**
  * @author Nicolas CARPi <nico-git@deltablot.email>
- * @copyright 2024 Nicolas CARPi
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
  * @see https://www.elabftw.net Official website
  * @license AGPL-3.0
  * @package elabftw
@@ -27,6 +28,6 @@ class AbstractHtmlControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($ref->getMethod('getPageTitle')->isAbstract());
         $this->assertTrue($ref->getMethod('getTemplate')->isAbstract());
         $this->assertTrue($ref->getMethod('getData')->hasReturnType());
-        $this->assertSame('array', $ref->getMethod('getData')->getReturnType()->getName());
+        $this->assertSame('array', $ref->getMethod('getData')->getReturnType());
     }
 }

--- a/tests/unit/controllers/AbstractHtmlControllerTest.php
+++ b/tests/unit/controllers/AbstractHtmlControllerTest.php
@@ -28,6 +28,8 @@ class AbstractHtmlControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($ref->getMethod('getPageTitle')->isAbstract());
         $this->assertTrue($ref->getMethod('getTemplate')->isAbstract());
         $this->assertTrue($ref->getMethod('getData')->hasReturnType());
-        $this->assertSame('array', $ref->getMethod('getData')->getReturnType());
+        $type = $ref->getMethod('getData')->getReturnType();
+        $this->assertInstanceOf(\ReflectionNamedType::class, $type);
+        $this->assertSame('array', $type->getName());
     }
 }

--- a/tests/unit/controllers/AbstractHtmlControllerTest.php
+++ b/tests/unit/controllers/AbstractHtmlControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+use Elabftw\Traits\TestsUtilsTrait;
+use ReflectionClass;
+
+class AbstractHtmlControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+    use TestsUtilsTrait;
+
+    public function testGetResponse(): void
+    {
+        $ref = new ReflectionClass(AbstractHtmlController::class);
+        $this->assertTrue($ref->getMethod('getPageTitle')->isAbstract());
+        $this->assertTrue($ref->getMethod('getTemplate')->isAbstract());
+        $this->assertTrue($ref->getMethod('getData')->hasReturnType());
+        $this->assertSame('array', $ref->getMethod('getData')->getReturnType()->getName());
+    }
+}

--- a/tests/unit/controllers/ChemEditorControllerTest.php
+++ b/tests/unit/controllers/ChemEditorControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class ChemEditorControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'chem-editor.html',
+            $this->invokeProtected($this->makeWithoutConstructor(ChemEditorController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Chemical Structure Editor',
+            $this->invokeProtected($this->makeWithoutConstructor(ChemEditorController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/ChemEditorControllerTest.php
+++ b/tests/unit/controllers/ChemEditorControllerTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Elabftw\Controllers;
 
+use Elabftw\Elabftw\App;
+use Elabftw\Models\Users\Users;
 use Elabftw\Traits\ControllerUtilsTrait;
+use ReflectionClass;
 
 class ChemEditorControllerTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,5 +36,21 @@ class ChemEditorControllerTest extends \PHPUnit\Framework\TestCase
             'Chemical Structure Editor',
             $this->invokeProtected($this->makeWithoutConstructor(ChemEditorController::class), 'getPageTitle')
         );
+    }
+
+    public function testGetData(): void
+    {
+        $controller = $this->makeWithoutConstructor(ChemEditorController::class);
+        $app = new ReflectionClass(App::class)->newInstanceWithoutConstructor();
+        $users = new Users(1, 1);
+
+        $this->injectInto($app, $users, 'Users');
+        $this->injectInto($controller, $app, 'app');
+        $data = $this->invokeProtected($controller, 'getData');
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('pageTitle', $data);
+        $this->assertArrayHasKey('resourceCategoriesArr', $data);
+        $this->assertIsArray($data['resourceCategoriesArr']);
     }
 }

--- a/tests/unit/controllers/CompoundsControllerTest.php
+++ b/tests/unit/controllers/CompoundsControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class CompoundsControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'compounds.html',
+            $this->invokeProtected($this->makeWithoutConstructor(CompoundsController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Compounds',
+            $this->invokeProtected($this->makeWithoutConstructor(CompoundsController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/CompoundsControllerTest.php
+++ b/tests/unit/controllers/CompoundsControllerTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Elabftw\Controllers;
 
+use Elabftw\Elabftw\App;
+use Elabftw\Models\Users\Users;
 use Elabftw\Traits\ControllerUtilsTrait;
+use ReflectionClass;
 
 class CompoundsControllerTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,5 +36,21 @@ class CompoundsControllerTest extends \PHPUnit\Framework\TestCase
             'Compounds',
             $this->invokeProtected($this->makeWithoutConstructor(CompoundsController::class), 'getPageTitle')
         );
+    }
+
+    public function testGetData(): void
+    {
+        $controller = $this->makeWithoutConstructor(CompoundsController::class);
+        $app = new ReflectionClass(App::class)->newInstanceWithoutConstructor();
+        $users = new Users(1, 1);
+
+        $this->injectInto($app, $users, 'Users');
+        $this->injectInto($controller, $app, 'app');
+        $data = $this->invokeProtected($controller, 'getData');
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('pageTitle', $data);
+        $this->assertArrayHasKey('resourceCategoriesArr', $data);
+        $this->assertIsArray($data['resourceCategoriesArr']);
     }
 }

--- a/tests/unit/controllers/DashboardControllerTest.php
+++ b/tests/unit/controllers/DashboardControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class DashboardControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'dashboard.html',
+            $this->invokeProtected($this->makeWithoutConstructor(DashboardController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Dashboard',
+            $this->invokeProtected($this->makeWithoutConstructor(DashboardController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/DashboardControllerTest.php
+++ b/tests/unit/controllers/DashboardControllerTest.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Elabftw\Controllers;
 
+use Elabftw\Elabftw\App;
+use Elabftw\Models\Teams;
+use Elabftw\Models\Users\Users;
 use Elabftw\Traits\ControllerUtilsTrait;
+use ReflectionClass;
 
 class DashboardControllerTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,5 +37,29 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             'Dashboard',
             $this->invokeProtected($this->makeWithoutConstructor(DashboardController::class), 'getPageTitle')
         );
+    }
+
+    public function testGetData(): void
+    {
+        $controller = $this->makeWithoutConstructor(DashboardController::class);
+        $app = new ReflectionClass(App::class)->newInstanceWithoutConstructor();
+        $users = new Users(1, 1);
+        $teams = new Teams($users, 1);
+        $this->injectInto($app, $teams, 'Teams');
+        $this->injectInto($app, $users, 'Users');
+        $this->injectInto($controller, $app, 'app');
+        $data = $this->invokeProtected($controller, 'getData');
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('pageTitle', $data);
+        $this->assertArrayHasKey('bookingsArr', $data);
+        $this->assertArrayHasKey('itemsStatusArr', $data);
+        $this->assertArrayHasKey('experimentsStatusArr', $data);
+        $this->assertArrayHasKey('itemsArr', $data);
+        $this->assertArrayHasKey('templatesArr', $data);
+        $this->assertArrayHasKey('usersArr', $data);
+        $this->assertArrayHasKey('visibilityArr', $data);
+        $this->assertIsArray($data['bookingsArr']);
+        $this->assertIsArray($data['itemsTemplatesArr']);
     }
 }

--- a/tests/unit/controllers/DatabaseControllerTest.php
+++ b/tests/unit/controllers/DatabaseControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Models\AbstractEntity;
+use Elabftw\Traits\ControllerUtilsTrait;
+use Elabftw\Traits\TestsUtilsTrait;
+use ReflectionClass;
+
+class DatabaseControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+    use TestsUtilsTrait;
+
+    public function testGetPageTitleWhenEntityIsItems(): void
+    {
+        $controller = $this->makeWithoutConstructor(DatabaseController::class);
+        $Item = $this->getFreshItem();
+        $this->initEntity($controller, $Item, 'Entity');
+        $this->assertSame('Resources', $this->invokeProtected($controller, 'getPageTitle'));
+    }
+
+    public function testGetPageTitleWhenEntityIsResourcesTemplates(): void
+    {
+        $controller = $this->makeWithoutConstructor(DatabaseController::class);
+        $Template = $this->getFreshTemplate();
+        $this->initEntity($controller, $Template, 'Entity');
+        $this->assertSame('Resources templates', $this->invokeProtected($controller, 'getPageTitle'));
+    }
+
+    protected function initEntity(object $controller, AbstractEntity $entity, string $property): void
+    {
+        $rp = new ReflectionClass($controller)->getProperty($property);
+        $rp->setAccessible(true);
+        $rp->setValue($controller, $entity);
+    }
+}

--- a/tests/unit/controllers/ExperimentsCategoriesControllerTest.php
+++ b/tests/unit/controllers/ExperimentsCategoriesControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class ExperimentsCategoriesControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'experiments-categories.html',
+            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsCategoriesController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Experiments categories',
+            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsCategoriesController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/ExperimentsControllerTest.php
+++ b/tests/unit/controllers/ExperimentsControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Models\AbstractEntity;
+use Elabftw\Traits\ControllerUtilsTrait;
+use Elabftw\Traits\TestsUtilsTrait;
+use ReflectionClass;
+
+class ExperimentsControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+    use TestsUtilsTrait;
+
+    public function testGetPageTitleWhenEntityIsExperiments(): void
+    {
+        $controller = $this->makeWithoutConstructor(ExperimentsController::class);
+        $Experiment = $this->getFreshExperiment();
+        $this->initEntity($controller, $Experiment, 'Entity');
+        $this->assertSame('Experiments', $this->invokeProtected($controller, 'getPageTitle'));
+    }
+
+    public function testGetPageTitleWhenEntityIsExperimentsTemplates(): void
+    {
+        $controller = $this->makeWithoutConstructor(ExperimentsController::class);
+        $Template = $this->getFreshTemplate();
+        $this->initEntity($controller, $Template, 'Entity');
+        $this->assertSame('Experiment templates', $this->invokeProtected($controller, 'getPageTitle'));
+    }
+
+    protected function initEntity(object $controller, AbstractEntity $entity, string $property): void
+    {
+        $rp = new ReflectionClass($controller)->getProperty($property);
+        $rp->setAccessible(true);
+        $rp->setValue($controller, $entity);
+    }
+}

--- a/tests/unit/controllers/ExperimentsStatusControllerTest.php
+++ b/tests/unit/controllers/ExperimentsStatusControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Elabftw\App;
+use Elabftw\Models\AbstractEntity;
+use Elabftw\Models\ExperimentsStatus;
+use Elabftw\Models\Teams;
+use Elabftw\Models\Users\Users;
+use Elabftw\Traits\ControllerUtilsTrait;
+use Elabftw\Traits\TestsUtilsTrait;
+use ReflectionClass;
+
+class ExperimentsStatusControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+    use TestsUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'experiments-status.html',
+            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsStatusController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Experiments status',
+            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsStatusController::class), 'getPageTitle')
+        );
+    }
+
+    public function testGetModelReturnsExperimentsStatus(): void
+    {
+        $controller = $this->makeWithoutConstructor(ExperimentsStatusController::class);
+        // build a minimal $app with a Teams instance. Prevents $app must not be accessed before initialization
+        $app = new ReflectionClass(App::class)->newInstanceWithoutConstructor();
+        $teams = new Teams(new Users(1, 1), 1);
+        // inject Teams into $app
+        $this->injectInto($app, $teams, 'Teams');
+        // inject $app into controller
+        $this->injectInto($controller, $app, 'app');
+
+        $model = $this->invokeProtected($controller, 'getModel');
+        $this->assertInstanceOf(ExperimentsStatus::class, $model);
+    }
+
+    protected function injectInto(object $controller, object $entity, string $property): void
+    {
+        $rp = new ReflectionClass($controller)->getProperty($property);
+        $rp->setAccessible(true);
+        $rp->setValue($controller, $entity);
+    }
+}

--- a/tests/unit/controllers/ExperimentsStatusControllerTest.php
+++ b/tests/unit/controllers/ExperimentsStatusControllerTest.php
@@ -56,11 +56,4 @@ class ExperimentsStatusControllerTest extends \PHPUnit\Framework\TestCase
         $model = $this->invokeProtected($controller, 'getModel');
         $this->assertInstanceOf(ExperimentsStatus::class, $model);
     }
-
-    protected function injectInto(object $controller, object $entity, string $property): void
-    {
-        $rp = new ReflectionClass($controller)->getProperty($property);
-        $rp->setAccessible(true);
-        $rp->setValue($controller, $entity);
-    }
 }

--- a/tests/unit/controllers/InventoryControllerTest.php
+++ b/tests/unit/controllers/InventoryControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class InventoryControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'inventory.html',
+            $this->invokeProtected($this->makeWithoutConstructor(InventoryController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Inventory',
+            $this->invokeProtected($this->makeWithoutConstructor(InventoryController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/ItemsStatusControllerTest.php
+++ b/tests/unit/controllers/ItemsStatusControllerTest.php
@@ -56,11 +56,4 @@ class ItemsStatusControllerTest extends \PHPUnit\Framework\TestCase
         $model = $this->invokeProtected($controller, 'getModel');
         $this->assertInstanceOf(ItemsStatus::class, $model);
     }
-
-    protected function injectInto(object $controller, object $entity, string $property): void
-    {
-        $rp = new ReflectionClass($controller)->getProperty($property);
-        $rp->setAccessible(true);
-        $rp->setValue($controller, $entity);
-    }
 }

--- a/tests/unit/controllers/ItemsStatusControllerTest.php
+++ b/tests/unit/controllers/ItemsStatusControllerTest.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Elabftw\Controllers;
 
 use Elabftw\Elabftw\App;
-use Elabftw\Models\ExperimentsStatus;
+use Elabftw\Models\ItemsStatus;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\ControllerUtilsTrait;
 use Elabftw\Traits\TestsUtilsTrait;
 use ReflectionClass;
 
-class ExperimentsStatusControllerTest extends \PHPUnit\Framework\TestCase
+class ItemsStatusControllerTest extends \PHPUnit\Framework\TestCase
 {
     use ControllerUtilsTrait;
     use TestsUtilsTrait;
@@ -29,22 +29,22 @@ class ExperimentsStatusControllerTest extends \PHPUnit\Framework\TestCase
     public function testGetTemplate(): void
     {
         $this->assertSame(
-            'experiments-status.html',
-            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsStatusController::class), 'getTemplate')
+            'resources-status.html',
+            $this->invokeProtected($this->makeWithoutConstructor(ItemsStatusController::class), 'getTemplate')
         );
     }
 
     public function testGetPageTitle(): void
     {
         $this->assertSame(
-            'Experiments status',
-            $this->invokeProtected($this->makeWithoutConstructor(ExperimentsStatusController::class), 'getPageTitle')
+            'Resources status',
+            $this->invokeProtected($this->makeWithoutConstructor(ItemsStatusController::class), 'getPageTitle')
         );
     }
 
-    public function testGetModelReturnsExperimentsStatus(): void
+    public function testGetModelReturnsItemsStatus(): void
     {
-        $controller = $this->makeWithoutConstructor(ExperimentsStatusController::class);
+        $controller = $this->makeWithoutConstructor(ItemsStatusController::class);
         // build a minimal $app with a Teams instance. Prevents $app must not be accessed before initialization
         $app = new ReflectionClass(App::class)->newInstanceWithoutConstructor();
         $teams = new Teams(new Users(1, 1), 1);
@@ -54,7 +54,7 @@ class ExperimentsStatusControllerTest extends \PHPUnit\Framework\TestCase
         $this->injectInto($controller, $app, 'app');
 
         $model = $this->invokeProtected($controller, 'getModel');
-        $this->assertInstanceOf(ExperimentsStatus::class, $model);
+        $this->assertInstanceOf(ItemsStatus::class, $model);
     }
 
     protected function injectInto(object $controller, object $entity, string $property): void

--- a/tests/unit/controllers/ResourcesCategoriesControllerTest.php
+++ b/tests/unit/controllers/ResourcesCategoriesControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class ResourcesCategoriesControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'resources-categories.html',
+            $this->invokeProtected($this->makeWithoutConstructor(ResourcesCategoriesController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'Resources categories',
+            $this->invokeProtected($this->makeWithoutConstructor(ResourcesCategoriesController::class), 'getPageTitle')
+        );
+    }
+}

--- a/tests/unit/controllers/SycControllerTest.php
+++ b/tests/unit/controllers/SycControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Moustapha <Deltablot>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+use Elabftw\Traits\ControllerUtilsTrait;
+
+class SycControllerTest extends \PHPUnit\Framework\TestCase
+{
+    use ControllerUtilsTrait;
+
+    public function testGetTemplate(): void
+    {
+        $this->assertSame(
+            'syc.html',
+            $this->invokeProtected($this->makeWithoutConstructor(SycController::class), 'getTemplate')
+        );
+    }
+
+    public function testGetPageTitle(): void
+    {
+        $this->assertSame(
+            'OpenCloning',
+            $this->invokeProtected($this->makeWithoutConstructor(SycController::class), 'getPageTitle')
+        );
+    }
+}


### PR DESCRIPTION
Most are plain simple tests to cover for the 0% of `getTemplate()`, `getPageTitle()` and stuff.

Another PR could refactor these better, as the Utils can be improved greatly! Considering the amount of repetition.
The main idea here was just to get some better coverage on some 0% files, prevents our PR's being ❌ as well

<img width="2212" height="66" alt="Capture d’écran du 2025-10-03 15-10-55" src="https://github.com/user-attachments/assets/e351a27a-c363-4d83-8f97-eb40774d21e6" />

<img width="2181" height="67" alt="Capture d’écran du 2025-10-03 18-25-16" src="https://github.com/user-attachments/assets/3cb986d5-906d-4a41-9753-0002b14a69f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive unit tests across multiple controllers (Dashboard, Database, Experiments, Inventory, Resources/Experiments Categories, Status, Chem Editor, Compounds, Syc) verifying templates, page titles, data structures, and model types to improve coverage and reliability.

- Chores
  - Introduced internal testing utilities to facilitate instantiation and access of non-public members, streamlining controller test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->