### PR TITLE
feat: exports: add custom id to pdf exports

### DIFF
--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -209,8 +209,3 @@ blockquote {
   margin: 1.5em 10px;
   padding: 0.5em 10px;
 }
-
-.customid-badge {
-  background-color: variables.$superlight;
-  border: 1px solid variables.$firstlevel;
-}

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -23,7 +23,7 @@
   <div id='header'>
     <h1 class='entry-title'>
       {% if entityData.custom_id %}
-        <span class='customid-badge'>{{ entityData.custom_id }}</span>
+        <span style='color:#4d4c4c'>{{ entityData.custom_id }}</span>
       {% endif %}
       {{ entityData.title }}
     </h1>


### PR DESCRIPTION
feat #6047

add custom_id reference to pdf exports

<img width="1422" height="360" alt="image" src="https://github.com/user-attachments/assets/244e81b5-8e72-4378-9300-c918edf63f7e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF header now displays a custom ID badge before the entity title when a custom ID is available, improving at-a-glance identification.
  * When no custom ID is present, the title renders exactly as before, ensuring no change to existing documents.
  * The addition integrates seamlessly into the current header layout without altering spacing or title formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->