### PR TITLE
ui: showpage: custom id no wrap on text

### DIFF
--- a/src/templates/show-item.html
+++ b/src/templates/show-item.html
@@ -74,7 +74,7 @@
     {# second line: title #}
     <div class='d-flex title flex-nowrap'>
       {% if item.custom_id %}
-        <span class='color-medium mr-1' title='{{ 'Custom ID'|trans }}'>{{ item.custom_id }}</span>
+        <span class='color-medium mr-1 text-nowrap' title='{{ 'Custom ID'|trans }}'>{{ item.custom_id }}</span>
       {% endif %}
       <a href='{{ Entity.entityType.toPage }}?mode=view&amp;id={{ item.id }}'>{{ item.title }}</a>
     </div>


### PR DESCRIPTION
Pervent text wrapping on custom ids

<img width="908" height="135" alt="image" src="https://github.com/user-attachments/assets/1e670dc2-dfd4-4e94-ab8e-28fb1fbbb84e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated item details header so the secondary ID no longer wraps, keeping it on a single line across screen sizes. This improves readability and prevents awkward line breaks, providing a cleaner, more consistent presentation without changing any content or behavior. Applies to the second-line title on the item page across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->