### PR TITLE
bug/medium: eln: add archived files to .eln exports

### DIFF
--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -177,7 +177,10 @@ class MakeEln extends AbstractMakeEln
 
         // UPLOADS
         // ignore the uploads from entity and fetch a new list including archived uploads
-        $uploadedFilesArr = $entity->Uploads->readAll(new BaseQueryParams(states: array(State::Normal, State::Archived)));
+        $uploadedFilesArr = $entity->Uploads->readAll(new BaseQueryParams(
+            limit: PHP_INT_MAX,
+            states: array(State::Normal, State::Archived),
+        ));
         if (!empty($uploadedFilesArr)) {
             try {
                 // this gets modified by the function so we have the correct real_names


### PR DESCRIPTION
fix #6056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exports now include both active and archived uploads, yielding more complete file listings in hasPart and Files sections.
  * Improves consistency of linked files across records by sourcing uploads from the canonical storage, reducing missing or inconsistent file references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->