### PR TITLE
bug/medium: import: fix import category/type toggle js code

### DIFF
--- a/src/ts/profile.ts
+++ b/src/ts/profile.ts
@@ -80,6 +80,9 @@ if (window.location.pathname === '/profile.php') {
     if (el.value === 'experiments_templates') {
       entityType = 'experiments';
     }
+    if (el.value === 'items') {
+      entityType = 'resources';
+    }
     ApiC.getJson(`teams/current/${entityType}_categories`).then(categories => {
       // Append new options
       categories.forEach(category => {


### PR DESCRIPTION
the query to fetch categories had a wrong endpoint

(to cherry pick in next for next patch release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed category loading when selecting “Items” during import; categories now populate reliably.
  * Resolved incorrect endpoint selection that could cause empty or failed category lists.
  * Improved accuracy of category suggestions, preventing mismatches and errors in the import flow.
  * Enhanced stability and consistency of category fetching across environments, reducing confusion and interruptions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->