### PR TITLE
bug/minor: metadata: revisions page only needs body content

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1126,14 +1126,17 @@ on('toggle-body', (el: HTMLElement) => {
     queryUrl += `/revisions/${el.dataset.revid}`;
   }
   ApiC.getJson(queryUrl).then(json => {
-    // add extra fields elements from metadata json
-    const entity = {type: el.dataset.type as EntityType, id: entityId};
-    const MetadataC = new Metadata(entity, new JsonEditorHelper(entity));
-    MetadataC.metadataDiv = contentDiv;
-    MetadataC.display('view').then(() => {
-      // go over all the type: url elements and create a link dynamically
-      generateMetadataLink();
-    });
+    // skip extra fields on the revisions page (focus remains on body). See #6053
+    if (window.location.pathname !== '/revisions.php') {
+      // add extra fields elements from metadata json
+      const entity = {type: el.dataset.type as EntityType, id: entityId};
+      const MetadataC = new Metadata(entity, new JsonEditorHelper(entity));
+      MetadataC.metadataDiv = contentDiv;
+      MetadataC.display('view').then(() => {
+        // go over all the type: url elements and create a link dynamically
+        generateMetadataLink();
+      });
+    }
     // add html content
     contentDiv.innerHTML = json.body_html;
 


### PR DESCRIPTION
fix #6053

The revisions page should not contain extra fields, focus remains on body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized the revisions page by preventing unnecessary loading and rendering of extra metadata fields, improving performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->