### PR TITLE
feat: tags: clear input after selection on the show page

### DIFF
--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -609,6 +609,11 @@ document.addEventListener('DOMContentLoaded', () => {
       window.history.replaceState({}, '', url.toString());
       reloadEntitiesShow();
     },
+    onItemAdd() {
+      this.setTextboxValue('');
+      // refresh the dropdown so it shows suggestions for new input
+      this.refreshOptions();
+    },
     plugins: {
       clear_button: {},
       dropdown_input: {},


### PR DESCRIPTION
feat #6084
tomselect has a double input for typing the tag we want to select. Reset it once we have selected the desired tag so it's easier to write new input.

![tags clear input](https://github.com/user-attachments/assets/cb9e8502-a622-4b9d-b24a-629c4d346be1)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input field now automatically clears after selecting an item, and dropdown suggestions refresh to display relevant options for continued use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->