### PR TITLE
bug/minor: ux: revert checkbox value for users2teams patch too

### DIFF
--- a/src/Services/UserArchiver.php
+++ b/src/Services/UserArchiver.php
@@ -19,6 +19,7 @@ use Elabftw\Enums\State;
 use Elabftw\Enums\Users2TeamsTargets;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Exceptions\UnprocessableContentException;
 use Elabftw\Models\AuditLogs;
 use Elabftw\Models\Config;
 use Elabftw\Models\Users\Users;
@@ -60,7 +61,7 @@ final class UserArchiver
             throw new ImproperActionException(_('You are trying to archive an unvalidated user. Maybe you want to delete the account?'));
         }
         if ($this->target->userData['is_sysadmin'] === 1) {
-            throw new ImproperActionException(_('A sysadmin account cannot be archived.'));
+            throw new UnprocessableContentException(_('A sysadmin account cannot be archived.'));
         }
         $this->target->invalidateToken();
         // if we are archiving a user, also lock all experiments (if asked)


### PR DESCRIPTION
previously the patch-user2team-is request would not be catched by the error handler reverting the position of the toggle button. Now it does because we merged it into one function.

# to test

go to sysconfig panel
try and archive a sysadmin user in a team
before: get an error but switch is active
after: get an error and switch is reverted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when attempting to archive restricted accounts; users now receive more appropriate error messages.
  * Enhanced checkbox state recovery—checkboxes now revert to their previous state if a form submission fails.
  * Refined form validation and data reload behavior for better consistency across user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->