### PR TITLE
feat: doc: update resource categories & templates, steps

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -4641,6 +4641,14 @@ paths:
                 action:
                   type: string
                   enum: ['finish', 'notif', 'update']
+                is_immutable:
+                  type: integer
+                  enum: [ 0, 1 ]
+                body:
+                  type: string
+                  description: The text content of the step.
+                finished:
+                  type: integer
             examples:
               first:
                 summary: Make a step "immutable"


### PR DESCRIPTION
- Add api spec related to resources templates; being more specific about items_types, add missing routes
- add resource categories as a separate entity from resources templates (5.3 changes): fix places where it's mentioned to homogenize and use `statuslike` schema (same then experiments_status, experiments_categories and items_status)
- Steps update
Steps related to PR https://github.com/elabftw/elabftw/pull/6091 and https://github.com/elabftw/elabdoc/pull/54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team-level resources categories endpoints for managing team-scoped resource categories.
  * Added is_immutable flag on steps to mark steps as read-only.
  * New duplication and improved handling for resource templates in API operations.

* **Refactor**
  * Public API references and labels standardized to use resource templates across endpoints and responses.

* **Bug Fixes**
  * Corrected entity description and labeling for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->