### PR TITLE
bug/minor: populate: fix counting

### DIFF
--- a/src/Commands/PopulateDatabase.php
+++ b/src/Commands/PopulateDatabase.php
@@ -66,7 +66,7 @@ final class PopulateDatabase extends Command
         // ask confirmation before deleting all the database
         $helper = $this->getHelper('question');
         // the -y flag overrides the config value
-        if ($yaml['skip_confirm'] === false && !$input->getOption('yes')) {
+        if (($yaml['skip_confirm'] ?? false) === false && !$input->getOption('yes')) {
             $question = new ConfirmationQuestion("WARNING: this command will completely ERASE your current database!\nAre you sure you want to continue? (y/n)\n", false);
 
             /** @phpstan-ignore-next-line ask method is part of QuestionHelper which extends HelperInterface */
@@ -78,7 +78,8 @@ final class PopulateDatabase extends Command
 
         $fast = (bool) $input->getOption('fast');
         $iter = null;
-        if ($input->getOption('iterations')) {
+        // string 0 is falsy in php!
+        if ($input->getOption('iterations') || $input->getOption('iterations') === '0') {
             $iter = (int) $input->getOption('iterations');
         }
         new Populate($output, $yaml, $fast, $iter)->run();

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -124,7 +124,7 @@ final class Populate
             if ($this->fast) {
                 $iter = 2;
             }
-            for ($i = 0; $i <= $iter; $i++) {
+            for ($i = 0; $i < $iter; $i++) {
                 $this->createUser($teamid, array());
             }
 


### PR DESCRIPTION
* fix incorrect detection of -i 0 (because string 0 is falsy in php)
* fix incorrect loop number on users
* fix warning if skip_confirm is not present in yaml file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter handling for skip confirmation flag to correctly treat missing values as false.
  * Corrected iteration count when generating users to match the configured value precisely, preventing off-by-one generation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->