### PR TITLE
bug: minor: inventory search query limited

### DIFF
--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -38,6 +38,7 @@ final class InventoryController extends AbstractHtmlController
         $StorageUnits = new StorageUnits($this->app->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1');
         $containersArr = array();
         // only make a query if we do a search
+        // set the 'limit' parameter for both readAll and readAllFromStorage. see #6116
         $this->app->Request->query->set('limit', 9999);
         if ($this->app->Request->query->has('q')) {
             $containersArr = $StorageUnits->readAll($StorageUnits->getQueryParams($this->app->Request->query));


### PR DESCRIPTION
fix #6116

Search query has limited results to 15. Allow higher cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inventory data retrieval to handle larger result sets more effectively, ensuring comprehensive data access across all inventory queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->