### PR TITLE
bug/medium: eln import: fix issue when " is present in title

### DIFF
--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -516,6 +516,7 @@ class Eln extends AbstractZip
         $filepath = strtr($filepath, ':', '_');
         // quick patch to fix issue with | in the title, but we will need a proper fix to avoid the need for such patches...
         $filepath = strtr($filepath, '|', '_');
+        $filepath = strtr($filepath, '"', '_');
 
         $hasher = new LocalFileHash($filepath);
         $hash = $hasher->getHash();


### PR DESCRIPTION
To reproduce: have an experiment with `"` in title + attached files.

Export as eln. Try and import. File cannot be found because the `"` is a `_` in the filename.

Note to self: let's use uuidv4 for all filenames in the .eln. No need to be bothered with all this complexity in the first place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file import handling for filenames containing double-quote characters. Special characters in filenames are now properly normalized before storage, preventing import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->