### PR TITLE
feat: eln: use uuids for filenames and ids

### DIFF
--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -294,7 +294,9 @@ class Eln extends AbstractZip
         }
 
         // CREATE ENTITY
-        $this->Entity->setId($this->Entity->create());
+        $entityId = $this->Entity->create();
+        $this->Entity->setId($entityId);
+        $this->logger->debug(sprintf('Created %s with id: %d', $this->Entity->entityType->value, $entityId));
 
         // DATE
         $date = date('Y-m-d');

--- a/src/Make/AbstractMakeEln.php
+++ b/src/Make/AbstractMakeEln.php
@@ -24,7 +24,7 @@ abstract class AbstractMakeEln extends AbstractMakeZip
 {
     protected const string HASH_ALGO = 'sha256';
 
-    protected const int INTERNAL_ELN_VERSION = 104;
+    protected const int INTERNAL_ELN_VERSION = 105;
 
     protected string $extension = '.eln';
 

--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -18,20 +18,19 @@ use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Metadata;
 use Elabftw\Enums\State;
+use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Items;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\BaseQueryParams;
-use Elabftw\Services\Filter;
 use Elabftw\Traits\TwigTrait;
 use League\Flysystem\UnableToReadFile;
 use ZipStream\ZipStream;
 use Override;
 
 use function array_push;
-use function mb_substr;
 use function ksort;
 
 /**
@@ -124,19 +123,14 @@ class MakeEln extends AbstractMakeEln
         return sprintf('%s:%d', $entity->entityType->value, $entity->id ?? 0);
     }
 
-    protected static function getDatasetFolderName(array $entityData): string
+    protected static function getDatasetFolderName(): string
     {
-        $prefix = '';
-        if (!empty($entityData['category_title'])) {
-            $prefix = Filter::forFilesystem($entityData['category_title']) . ' - ';
-        }
-        // prevent a zip name with too many characters, see #3966
-        $prefixedTitle = mb_substr($prefix . Filter::forFilesystem($entityData['title']), 0, 103);
         // SHOULD end with /
-        return sprintf('%s - %s/', $prefixedTitle, Tools::getShortElabid($entityData['elabid'] ?? ''));
+        return sprintf('%s/', Tools::getUuidv4());
     }
 
-    protected function processEntity(AbstractEntity $entity): bool
+    // returns the datasetFolder
+    protected function processEntity(AbstractEntity $entity): string | false
     {
         // experiments:123 or items:123
         $slug = self::toSlug($entity);
@@ -146,7 +140,7 @@ class MakeEln extends AbstractMakeEln
         }
         $e = $entity->entityData;
         $hasPart = array();
-        $currentDatasetFolder = self::getDatasetFolderName($e);
+        $currentDatasetFolder = self::getDatasetFolderName();
         $this->processedEntities[] = $slug;
         $this->folder = $this->root . '/' . $currentDatasetFolder;
         $this->rootParts[] = array('@id' => './' . $currentDatasetFolder);
@@ -188,7 +182,7 @@ class MakeEln extends AbstractMakeEln
             } catch (UnableToReadFile) {
             }
             foreach ($uploadedFilesArr as $file) {
-                $uploadAtId = './' . $currentDatasetFolder . $file['real_name'];
+                $uploadAtId = './' . $currentDatasetFolder . $file['uuid'];
                 $hasPart[] = array('@id' => $uploadAtId);
                 $fileNode = array(
                     '@id' => $uploadAtId,
@@ -219,9 +213,11 @@ class MakeEln extends AbstractMakeEln
                     } else {
                         $link = new Experiments($this->requester, $link['entityid'], $this->bypassReadPermission);
                     }
-                    $mentions[] = array('@id' => './' . self::getDatasetFolderName($link->entityData));
                     // WARNING: recursion!
-                    $this->processEntity($link);
+                    $linkAtId = $this->processEntity($link);
+                    if ($linkAtId !== false) {
+                        $mentions[] = array('@id' => './' . $linkAtId);
+                    }
                 } catch (IllegalActionException) {
                     continue;
                 }
@@ -288,7 +284,25 @@ class MakeEln extends AbstractMakeEln
         }
 
         $this->dataEntities[] = $datasetNode;
-        return true;
+        return $currentDatasetFolder;
+    }
+
+    #[Override]
+    protected function addAttachedFiles($filesArr): array
+    {
+        foreach ($filesArr as &$file) {
+            $storageFs = Storage::from($file['storage'])->getStorage()->getFs();
+
+            // make sure we have a hash
+            if (empty($file['hash'])) {
+                $file['hash'] = hash($this->hashAlgorithm, $storageFs->read($file['long_name']));
+            }
+
+            // add files to archive
+            $file['uuid'] = Tools::getUuidv4();
+            $this->addAttachedFileInZip($this->folder . '/' . $file['uuid'], $storageFs->readStream($file['long_name']));
+        }
+        return $filesArr;
     }
 
     protected static function addIfNotEmpty(array $datasetNode, array ...$nameValueArr): array


### PR DESCRIPTION
this is to prevent having to deal with weird filenames issues, we don't need them to be human readable in the first place


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ELN format version to 105.

* **Refactor**
  * Improved internal file and folder storage organization to use unique identifiers for better consistency and tracking.
  * Enhanced entity processing and linked entity handling for more reliable data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->