### PR TITLE
bug/minor: view: tables readability in view mode

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -983,6 +983,11 @@ the form-control fails to do that so we do the border ourselves */
   @include breakable;
 }
 
+/* links in tables (view mode) often contain long-name files. See #6137 */
+#body_view a {
+  @include breakable;
+}
+
 /* TITLE */
 /* add several rules for the word-wrap, see https://stackoverflow.com/a/36555643 */
 .title {

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -124,7 +124,7 @@
       {# body in view mode is text-dark for more lisibility see github issue #52 #}
       <div {{ not displayMainText ? 'hidden' }}>
         <h3 data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='body_view'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Main text'|trans }}</h3>
-        <div id='body_view' class='pt-2 ml-3 text-dark' data-save-hidden='body_view'>{{ body|raw }}</div>
+        <div id='body_view' class='pt-2 ml-3 text-dark overflow-auto' data-save-hidden='body_view'>{{ body|raw }}</div>
         <hr>
       </div>
   {% endif %}


### PR DESCRIPTION
fix #6137
- make tables readable by allowing overflow navigation
- links are word-breakable as filenames are often long

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Long file name links now wrap properly for improved readability in view mode
  * Document view now supports scrolling when content exceeds the visible area

<!-- end of auto-generated comment: release notes by coderabbit.ai -->