### PR TITLE
bug/medium: signature/timpstamp actions: fix require write access

### DIFF
--- a/src/Make/MakeBloxberg.php
+++ b/src/Make/MakeBloxberg.php
@@ -15,6 +15,7 @@ namespace Elabftw\Make;
 use Elabftw\Elabftw\CreateUploadFromLocalFile;
 use Elabftw\Elabftw\FsTools;
 use Elabftw\Enums\ExportFormat;
+use Elabftw\Enums\Messages;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\AbstractEntity;
@@ -62,6 +63,9 @@ final class MakeBloxberg extends AbstractMakeTimestamp
 
         // first request sends the hash to the certify endpoint
         $certifyResponse = json_decode($this->certify($dataHash), true);
+        if ($certifyResponse === null) {
+            throw new ImproperActionException(Messages::GenericError->toHuman());
+        }
         if (isset($certifyResponse['errors'])) {
             throw new ImproperActionException(implode(', ', $certifyResponse['errors']));
         }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -460,6 +460,8 @@ abstract class AbstractEntity extends AbstractRest
         $readAccessActions = array(Action::Pin, Action::Sign, Action::Timestamp, Action::Bloxberg);
         if (in_array($action, $readAccessActions, true)) {
             $requiredAccess = 'read';
+            // allow uploading a file to that entity too
+            $this->Uploads->Entity->bypassWritePermission = true;
         }
         $this->canOrExplode($requiredAccess);
         // if there is an active exclusive edit mode, entity cannot be modified
@@ -1011,8 +1013,6 @@ abstract class AbstractEntity extends AbstractRest
         $ZipArchive->addFromString('key.pub', $this->Users->userData['sig_pubkey']);
         $ZipArchive->addFromString('verify.sh', "#!/bin/sh\nminisign -H -V -p key.pub -m data.json\n");
         $ZipArchive->close();
-        // allow uploading a file to that entity because sign action only requires read access
-        $this->Uploads->Entity->bypassWritePermission = true;
         $comment = sprintf(_('Signature archive by %s (%s)'), $this->Users->userData['fullname'], $meaning->name);
         $this->Uploads->create(new CreateUploadFromLocalFile('signature archive.zip', $zipPath, $comment, immutable: 1, state: State::Archived));
         $RequestActions = new RequestActions($this->Users, $this);

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -210,14 +210,14 @@
   </button>
 
   {# TIMESTAMP #}
-  {% if not App.Session.has('is_anon') and not Entity.isReadOnly %}
+  {% if not App.Session.has('is_anon') %}
     <button type='button' title='{{ 'Timestamp'|trans }}' aria-label='{{ 'Timestamp'|trans }}' data-action='do-requestable-action' data-target='timestamp' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
       <i class='fas fa-calendar-check fa-fw'></i>
     </button>
   {% endif %}
 
   {# BLOXBERG TIMESTAMP #}
-  {% if not Entity.isReadOnly and App.Config.configArr.blox_enabled %}
+  {% if App.Config.configArr.blox_enabled %}
     <button type='button' title='{{ 'Add to blockchain'|trans }}' aria-label='{{ 'Add to blockchain'|trans }}' data-action='toggle-modal' data-target='blocktimestampModal' class='btn hl-hover-gray p-2 mr-2 lh-normal border-0'>
       <i class='fas fa-cubes fa-fw'></i>
     </button>


### PR DESCRIPTION
A regression introduced in 5.3 required a user to have write access to sign or timestamp an entry. Only read access is required for these actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted permission checks so certain patch actions (pin, sign, timestamp, blockchain timestamp) require read instead of write access, reducing unnecessary write-level restrictions.
  * Restored prior signing behavior to avoid bypassing write checks during archive creation.
  * Added a safety check for an external certify call and surface a clear error if no valid response is returned.

* **UI**
  * Timestamp controls now show for non-anonymous users regardless of item read-only state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->