### PR TITLE
fix: dashboard: create button does not display resources templates

### DIFF
--- a/src/templates/create-new-item-modal-body.html
+++ b/src/templates/create-new-item-modal-body.html
@@ -15,7 +15,6 @@
       </thead>
       <tbody id='tplCreateNewTable_{{ entityPage }}'>
       {% set label = entityPage == 'database' ? 'Create resource from template'|trans : 'Create experiment from template'|trans %}
-      {% set templatesArr = entityPage == 'experiments' ? templatesArr : itemsTemplatesArr %}
       {% for template in templatesArr %}
         <tr>
           <td data-label='{{ 'Title'|trans }}'>

--- a/src/templates/create-new-item-modal.html
+++ b/src/templates/create-new-item-modal.html
@@ -25,6 +25,7 @@
             <a href='{{ templatesPage }}' class='btn btn-ghost btn-sm'><i class='fas fa-cogs mr-1'></i>{{ 'Manage templates'|trans }}</a>
           </div>
 
+          {% set templatesArr = entityPage == 'experiments' ? templatesArr : itemsTemplatesArr %}
           {% include 'create-new-item-modal-body.html' %}
         {% endif %}
       </div>


### PR DESCRIPTION
fix #6156
On fresh instance, if there are resources templates but no resources templates, it would display "No template found" for both. This fix makes the dashboard assign the templates Arr correctly, so that resources templates are displayed if they exist and vice versa.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed template selection logic when creating new items to ensure the correct templates display based on context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->