### PR TITLE
bug/major: auth: prevent cookies from messing up auth

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -32,6 +32,7 @@ use Elabftw\Enums\AuthType;
 use Elabftw\Enums\EnforceMfa;
 use Elabftw\Enums\Entrypoint;
 use Elabftw\Enums\Language;
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\InvalidDeviceTokenException;
 use Elabftw\Exceptions\QuantumException;
@@ -90,7 +91,7 @@ final class LoginController implements ControllerInterface
                     $this->Request->cookies->getInt('token_team'),
                 )->tryAuth();
             }
-        } catch (UnauthorizedException) {
+        } catch (UnauthorizedException | IllegalActionException) {
         }
 
         return $this->getAuthService()->tryAuth();


### PR DESCRIPTION
In some cases, the cookies could prevent user from login in, and user
    had to clear cookies. fix #6139
    Now we catch the exception and let the auth continue.
    Also fix a bug where config.open_science = 1 would prevent other forms
    of auth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie-based auto-login handling with safer exception management so failed cookie attempts gracefully fall back to other authentication paths.
  * Removed an explicit error throw in an auto-login path to avoid premature failures.

* **Refactor**
  * Reworked internal authentication flow to centralize and simplify auto-login behavior for increased reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->