### PR TITLE
ui: don't auto select team on switch team action

### DIFF
--- a/src/ts/localStorage.ts
+++ b/src/ts/localStorage.ts
@@ -44,6 +44,10 @@ export function rememberLastSelected(elementId: string) {
 // get back the value of last selected option from localStorage
 export function selectLastSelected(elementId: string) {
   return function() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('switch_team') === '1') {
+      return;
+    }
     const last = localStorage.getItem(`persistent_${elementId}_last`);
     if (last) {
       this.setValue(last);


### PR DESCRIPTION
fix #6123



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where previously selected settings were incorrectly restored when switching teams via URL. The application now properly respects explicit team switches without applying cached preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->