### PR TITLE
bug/minor: compounds: create resource from compound with no category doesnt link compound

### DIFF
--- a/src/templates/create-new-item-modal-body.html
+++ b/src/templates/create-new-item-modal-body.html
@@ -46,13 +46,13 @@
     {% set categoryPage = categoryPageOverride|default(Entity.entityType.toCategoryPage()|default(entityPage == 'database' ? 'resources-categories.php' : 'experiments-categories.php')) %}
     <a href='{{ categoryPage }}' class='btn btn-ghost btn-sm'><i class='fas fa-cogs mr-1'></i>{{ 'Manage categories'|trans }}</a>
   </div>
-  <a class='btn btn-ghost mt-1' href='#' data-action='create-entity-ask-title' data-type='{{ entityPage }}' data-catid='-1'>
+  {# if we're creating item from compounds page or chem-editor page, use 'create-resource-from-compound' action. #}
+  {% set action = (scriptName == 'compounds.php' or scriptName == 'chem-editor.php') ? actionName : 'create-entity-ask-title' %}
+  <a class='btn btn-ghost mt-1' href='#' data-action='{{ action }}' data-type='{{ entityPage }}' data-catid='-1'>
     <span class='round-spot round-spot-ghost mr-1'></span>{{ 'No category'|trans }}
   </a>
   {% set categoryArr = entityPage == 'experiments' ? App.experimentsCategoryArr : App.itemsCategoryArr %}
   {% for category in categoryArr %}
-    {# if we're creating item from compounds page or chem-editor page, use 'create-from-compounds' action. #}
-    {% set action = (scriptName == 'compounds.php' or scriptName == 'chem-editor.php') ? actionName : 'create-entity-ask-title' %}
     <a class='btn btn-ghost mt-1' href='#' data-action='{{ action }}' data-type='{{ entityPage }}' data-catid='{{ category.id }}'>
       <span class='round-spot mr-1' style='background-color: #{{ category.color }};'></span>{{ category.title }}
     </a>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -879,7 +879,7 @@ on('create-resource-from-compound', (el: HTMLElement) => {
   if (el.dataset.tplid) {
     payload = { template: el.dataset.tplid };
   } else if (el.dataset.catid) {
-    payload = { category: el.dataset.catid };
+    payload = { category: parseInt(el.dataset.catid, 10) };
   }
   ApiC.post2location('items', payload).then(id => {
     // now create a link with that compound


### PR DESCRIPTION
fix #6149
On compounds page, when creating a resource from compound:
- for the "**no category**" button, the action used was a 'create-entity' instead of 'create-entity-from-compound'.
- Also, the `create-resource-from-compound` action did not parse the category value so it was sent as a string (`-1`), not an integer. This caused a database error when the backend tried to insert it. The fix is to use parseInt to ensure the value is a proper number.
- There's no more asking a title for creating the resource from existing compound


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category data handling to ensure proper type processing when creating items from compounds.

* **Refactor**
  * Optimized action variable handling for category-related buttons to reduce redundant computations and improve code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->