### PR TITLE
bug/minor: metadata: editing an extra field creates duplicate entries

### DIFF
--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -436,6 +436,11 @@ if (document.getElementById('metadataDiv') && entity.id) {
             if (el?.checked) field[key] = true;
           }
 
+          // ensure the old extra field is replaced
+          if (!json['extra_fields']) json['extra_fields'] = {};
+          if (originalFieldKey && originalFieldKey !== newFieldKey) {
+            delete json['extra_fields'][originalFieldKey];
+          }
           json['extra_fields'][newFieldKey] = field;
 
           MetadataC.update(json as ValidMetadata).then(() => {


### PR DESCRIPTION
fix #6147
When renaming an extra field, the previous key was not deleted from `json['extra_fields']`, causing both the old and new keys to persist.
- Add a check to delete the old key when the field name changes, ensuring the metadata object stays consistent.
- also initializes `json['extra_fields']` if missing to avoid null reference issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where renaming extra fields would retain the original field name alongside the new one. Extra fields are now properly cleaned up when renamed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->