### PR TITLE
bug/minor: 404: fix js error

### DIFF
--- a/src/ts/view.ts
+++ b/src/ts/view.ts
@@ -61,7 +61,8 @@ if (mode === 'view') {
   });
 
   // add the title in the page name (see #324)
-  document.title = document.getElementById('documentTitle')?.textContent + ' - eLabFTW';
+  const titleElement = document.getElementById('documentTitle');
+  document.title = titleElement?.textContent ? `${titleElement.textContent} - eLabFTW` : 'eLabFTW';
 
   if (!core.isAnon) {
     // listen on existing comments


### PR DESCRIPTION
When you access a non existing entry (e.g.
database.php?mode=view&id=3939399393), you get an error "Nothing to show ith this id". But you also get a JS error because it cannot update the document title because no element with id documentTitle exists.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents runtime errors when the page title element is missing, improving stability.
  * Ensures the app preserves the existing title suffix when present and falls back to "eLabFTW" if no title element is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->