### PR TITLE
bug/minor: sysadmin: checkboxes for canmanage permissions not collected after first modal submit

### DIFF
--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -192,8 +192,8 @@ export function collectForm(form: HTMLElement): object {
     if (el.type === 'checkbox') {
       value = el.checked ? 'on' : 'off';
     }
-    if (el.dataset.ignore !== '1' && el.disabled === false && (el.value !== '' || el.dataset.allowEmpty === '1')) {
-      params = Object.assign(params, {[input.name]: value});
+    if (el.dataset.ignore !== '1' && el.disabled === false && (value !== '' || el.dataset.allowEmpty === '1')) {
+      params = Object.assign(params, {[el.name]: value});
     }
   });
 


### PR DESCRIPTION
fix #6146

In collectForm(), the condition that determines whether an input should be included used `el.value` instead of the computed `value` variable. for checkboxes, `el.value` is often empty string (unless an explicit value attribute is set), so those fields were skipped after reopening the modal.

By switching the condition to use `value !== ''` instead of `el.value !== ''`, checkboxes with dynamically computed values ("on"/"off") are now correctly included in the params object!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form data collection to correctly handle empty values and checkbox inputs, ensuring forms submit accurate data in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->