### PR TITLE
feat: exports: simplify team association in scheduler exports

### DIFF
--- a/src/Make/MakeSchedulerReport.php
+++ b/src/Make/MakeSchedulerReport.php
@@ -16,11 +16,9 @@ use Elabftw\Elabftw\Db;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\Scheduler;
-use Elabftw\Services\UsersHelper;
 use Override;
 
 use function date;
-use function implode;
 
 /**
  * Create a report of scheduler bookings
@@ -50,28 +48,11 @@ final class MakeSchedulerReport extends AbstractMakeCsv
     }
 
     /**
-     * Columns of the CSV
-     */
-    #[Override]
-    protected function getHeader(): array
-    {
-        $header = parent::getHeader();
-        $header[] = 'team(s)';
-        return $header;
-    }
-
-    /**
      * Get the rows for each users
      */
     #[Override]
     protected function getRows(): array
     {
-        foreach ($this->rows as $key => $entry) {
-            // append the team(s) of user
-            $UsersHelper = new UsersHelper($entry['userid']);
-            $teams = implode(',', $UsersHelper->getTeamsNameFromUserid());
-            $this->rows[$key]['team(s)'] = $teams;
-        }
         return $this->rows;
     }
 }

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -185,6 +185,7 @@ final class Scheduler extends AbstractRest
             "SELECT
                 team_events.id,
                 team_events.team,
+                teams.name AS team_name,
                 team_events.title AS title_only,
                 team_events.start,
                 team_events.end,
@@ -205,6 +206,7 @@ final class Scheduler extends AbstractRest
                 items_linkt.title AS item_link_title,
                 CASE WHEN %s THEN 1 ELSE 0 END AS canbook
             FROM team_events
+            LEFT JOIN teams ON (team_events.team = teams.id)
             LEFT JOIN experiments ON (team_events.experiment = experiments.id)
             LEFT JOIN items ON (team_events.item = items.id)
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)


### PR DESCRIPTION
feat #6124
The scheduler report previously used `UsersHelper` to append team names for each user when generating CSV rows. 
- This approach has been removed in favor of retrieving team names (for the **event's origin** and not the user's) directly through an SQL join on the teams table.
- The new query in Scheduler now joins `teams` and selects `teams.name`, removing the need for UsersHelper and the additional processing step in MakeSchedulerReport. This reduces redundant queries and simplifies report generation logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed team column from scheduler CSV export reports.

* **Refactor**
  * Enhanced scheduler data queries to include team name information in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->