### PR TITLE
bug/minor: purifier: fix warning with cache folder

### DIFF
--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -53,6 +53,9 @@ final class Filter
     public static function toPureString(string $input): string
     {
         $config = HTMLPurifier_HTML5Config::createDefault();
+        // configure the cache for htmlpurifier
+        $tmpDir = FsTools::getCacheFolder('purifier');
+        $config->set('Cache.SerializerPath', $tmpDir);
         $config->set('HTML.Allowed', '');
         $config->set('AutoFormat.RemoveEmpty', true);
         return new HTMLPurifier($config)->purify(trim($input));


### PR DESCRIPTION
in the function Filter::toPureString the HTML Purifier was not configured explicitely to use a cache folder and emitted a warning:

PHP Warning:  Directory /elabftw/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer not writable, please alter file permissions in /elabftw/vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer.php on line 302

So configure cache like for body function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized content processing performance through caching improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->