### PR TITLE
feat: ui/ux: highlight tools menu as active when any subelement is open

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -63,7 +63,7 @@
               {% if App.devMode -%}
                 <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
               {%- endif %}
-              <div class='nav-link dropdown-toggle {{ scriptName == 'experiments.php' or scriptName == 'templates.php' or scriptName == 'experiments-categories.php' or scriptName == 'experiments-status.php' ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              <div class='nav-link dropdown-toggle {{ scriptName in ['experiments.php', 'templates.php', 'experiments-categories.php', 'experiments-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
               {% trans %}Experiment{% plural 2 %}Experiments{% endtrans %}
               </div>
               <div class='dropdown-menu'>
@@ -100,7 +100,7 @@
               {% if App.devMode -%}
                 <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
               {%- endif %}
-              <div class='nav-link dropdown-toggle {{ scriptName == 'database.php' or scriptName == 'resources-templates.php' or scriptName == 'resources-categories.php' or scriptName == 'resources-status.php' ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              <div class='nav-link dropdown-toggle {{ scriptName in ['database.php', 'resources-templates.php', 'resources-categories.php', 'resources-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
                 {{ 'Resources'|trans }}
               </div>
               <div class='dropdown-menu'>
@@ -149,7 +149,7 @@
               {% if App.devMode -%}
                 <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
               {%- endif %}
-              <div class='nav-link dropdown-toggle {{ scriptName == 'compounds.php' or scriptName == 'chem-editor.php' or scriptName == 'syc.php' or scriptName == 'inventory.php' ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              <div class='nav-link dropdown-toggle {{ scriptName in ['compounds.php', 'chem-editor.php', 'syc.php', 'inventory.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
               {{ 'Tools'|trans }}
               </div>
               <div class='dropdown-menu'>


### PR DESCRIPTION
When navigating through the pages, for example Experiments templates, the Experiments nav link is displayed as active. It's not the case for any of the sub elements on Tools, that should make Tools page active.
<img width="93" height="52" alt="image" src="https://github.com/user-attachments/assets/efab70a5-c60b-4a0e-a122-47df9abdaed0" />
<img width="316" height="184" alt="image" src="https://github.com/user-attachments/assets/87a5b4bd-bfdf-4163-a987-13b6e878f05f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Experiments dropdown now reliably shows the active state when viewing Experiments pages, improving navigation clarity.
  * Resources dropdown now correctly highlights the active section on Resources pages for clearer context.
  * Tools dropdown now consistently displays an active state when on Tools pages, enhancing menu feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->