### PR TITLE
ux/minor: search: make placeholder text dynamic based on page title

### DIFF
--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -20,7 +20,7 @@
     {# SEARCH BAR #}
     {% set pageName = scriptName|replace({'.php': ''}) %}
     {% set searchTarget = pageName %}
-    {% set searchPlaceholder = ('Search in'|trans ~ ' ' ~ pageTitle)|lower %}
+    {% set searchPlaceholder = 'Search in %s'|trans|format(pageTitle|lower) %}
     {% if pageName == 'database' %}
       {% set searchTarget = 'resources'|trans %}
     {% endif %}


### PR DESCRIPTION
fix #6224
The main search bar placeholder was hardcoded to "Search in experiments", and "resources", which made it inaccurate on other pages (e.g., res/exp **template** views).
This update builds the placeholder dynamically using the translated page title, ensuring it correctly reflects the current section (e.g., "**search in resources templates**", "**search in experiments templates**"). However, it adds a need for translation for "**search in**" string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search placeholder now dynamically reflects the current page title (lowercased) using a translatable "Search in %s" format, removing previously inconsistent hardcoded cases so the prompt is consistent across pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->