### PR TITLE
Don't show Password Reset note, if federated accounts are enabled

### DIFF
--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -26,7 +26,7 @@
 <h3 class='my-3 p-2 pl-3 section-title'>{{ 'Add account'|trans }}</h3>
 <div class='pl-3'>
   {% if App.Config.configArr.saml_toggle == '0' and App.Config.configArr.ldap_toggle == '0' %}
-    <p class='smallgray'>{{ 'Note: new user will need to use the "Forgot password" button on the login page to set a password.'|trans }}</p>
+    <p class='smallgray'>{{ 'Note: new users will need to use the "Forgot password" button on the login page to set a password.'|trans }}</p>
   {% endif %}
   <form class='form-group' id='createUserForm'>
     <div class='row mb-2'>


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

[ ] I have added **tests** for any new features.
Uncertain if this push requires tests, please clarify.

- [x] I have mentioned the related **issue** (if applicable) 
#6238 

- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/elabdoc).
---

### Pull Request Description

Please provide **clear context** for your proposed change:

> What issue or need does this PR address?

Showing the `Password reset` note for newly created accounts is applicable only with local accounts but not if an instance is set to use federated accounts. For those showing the text may be confusing for team admins.

> How did you approach the solution?

Condition added based on system config.

- If applicable, include **screenshots or examples** (especially for UI changes).

> ⚠️ We’re committed to reviewing your contributions, so in return, we ask that you take the time to present your work clearly.
> Pull requests without any description are frowned upon and will likely be closed immediately.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/contributing.html).

**IMPORTANT**: Base your PR off the `hypernext` branch for a feature, and the `next` branch for a bugfix.

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Add account" guidance in the user management form now shows only under the appropriate system configuration, ensuring the note appears conditionally and consistently across both the Add account and admin-create-users sections so users see relevant guidance at the right time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->