### PR TITLE
perf: use fastq query for links

### DIFF
--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -401,7 +401,7 @@ export function addAutocompleteToLinkInputs(): void {
             response(res);
             return;
           }
-          ApiC.getJson(`${object.itemType}/?${object.filterFamily}=${filterEl.value}&q=${escapeExtendedQuery(request.term)}&scope=3`).then(json => {
+          ApiC.getJson(`${object.itemType}/?${object.filterFamily}=${filterEl.value}&fastq=${escapeExtendedQuery(request.term)}&scope=3`).then(json => {
             cache[object.selectElid][term] = json;
             const res = [];
             json.forEach(entity => {


### PR DESCRIPTION
this will make the result appear much faster, as we don't need to pull all associated tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated autocomplete link input logic to use an alternative API parameter for fetching autocomplete results, maintaining existing functionality and caching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->