### PR TITLE
bug/minor: email: prevent footer from being added twice in ungrouped mass emails (#6253)

### DIFF
--- a/src/Services/Email.php
+++ b/src/Services/Email.php
@@ -146,7 +146,7 @@ class Email
         ->subject($subject)
         ->from($this->from)
         ->to($to)
-        ->text($body . $this->footer);
+        ->text($body);
 
         if (!empty($cc)) {
             $message->cc(...$cc);
@@ -157,7 +157,7 @@ class Email
         }
 
         if (!empty($htmlBody)) {
-            $message->html($htmlBody . $this->footer);
+            $message->html($htmlBody);
 
             if (empty($body)) {
                 $textWithLinks = (new Transformer())
@@ -168,7 +168,7 @@ class Email
                 // <a href="url">link text</a> => link text (url)
                 $plainText = preg_replace('/<a href="([^"]*)">([^<]*)<\/a>/iu', '$2 ($1)', $textWithLinks);
 
-                $message->text($plainText . $this->footer);
+                $message->text($plainText);
             }
         }
 


### PR DESCRIPTION
fix #6253

When the "Send mass emails grouped" sysadmin setting was disabled, the email footer was appended twice: once in the massEmail() method (where the full message content is built) and again in the Email service before sending.
This fix removes redundant footer concatenations from the Email class, ensuring that the footer is only added once regardless of grouping configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where email footers were being automatically appended to message content in plain text and HTML formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->