### PR TITLE
bug/minor: ui/layout: prevent category name truncation in tabular view

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1071,12 +1071,12 @@ the form-control fails to do that so we do the border ourselves */
   line-height: normal;
   padding: 0.25rem;
   text-transform: uppercase;
+  white-space: normal;
 
   /* Only Category */
   &.category-btn {
     background-color: var(--bg);
     color: $white;
-    white-space: normal;
 
     &:hover {
       background-color: $secondlevel;


### PR DESCRIPTION
fix #6189
In tabular layouts for experiments and resources, long category names were truncated or hidden when their text exceeded the column width. Adding `white-space: normal;` to the category cell allows text wrapping, ensuring the full category name remains visible even for long titles. This improves readability without affecting overall layout alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated category/status button styling to allow text wrapping, improving layout and readability for longer labels and on smaller screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->