### PR TITLE
bug/minor: ux/search: preserve active filters when performing a new search

### DIFF
--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -201,10 +201,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Preserve filters from navbar dropdown (e.g., category, scope, bookable) when performing a search. #6284
-  const searchParams = new URLSearchParams(window.location.search);
   ['category', 'scope', 'bookable'].forEach(param => {
-    if (searchParams.has(param)) {
-      addHiddenInputToMainSearchForm(param, searchParams.get(param));
+    if (params.has(param)) {
+      addHiddenInputToMainSearchForm(param, params.get(param));
     }
   });
 


### PR DESCRIPTION
fix #6284

Previously, when selecting a filter from the dropdown (in navbar), performing a new search from the main search bar cleared contextual filters such as category, scope, or bookable, forcing users to reselect them.

This update preserves those filters by appending their current values as hidden inputs in the main search form when a search is performed. The result is a smoother and more intuitive search experience that maintains the selected context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter selections (category, scope, bookable) in the URL are now preserved and applied to the main search form on page load, ensuring consistent results when returning to or sharing a filtered view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->