### PR TITLE
bug/minor: tinymce: fix internal links escaping on paste

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -386,9 +386,11 @@ export function getTinymceBaseConfig(page: string): object {
           }, 50);
         }
       });
-      // prevent tables width from being set to "auto" and cause pdf export issues (see #5601)
       editor.on('GetContent', (e) => {
+        // prevent tables width from being set to "auto" and cause pdf export issues (see #5601)
         e.content = e.content.replace(/(<table[^>]*?)\sstyle="[^"]*?width\s*:\s*auto;?[^"]*?"([^>]*?>)/gi, '$1$2');
+        // fix internal links on pasting with shortcut (&amp; → &). see #6291
+        e.content = e.content.replace(/href="([^"]*\.php\?mode=(?:view|edit)[^"]*?)&amp;([^"]*?)"/g, 'href="$1&$2"');
       });
 
       // floppy disk icon from COLLECTION: Zest Interface Icons LICENSE: MIT License AUTHOR: zest


### PR DESCRIPTION
fix #6291
When pasting internal links into the editor using keyboard shortcuts, the `&` characters in query parameters were escaped as `&amp;`, breaking links to internal pages.

This patch sanitizes pasted content in the GetContent event, converting escaped `&amp;` back to `&` in href attributes, ensuring internal links work correctly after pasting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table width preservation during content editing to prevent auto-resizing
  * Fixed internal links containing query parameters to display and function correctly after content paste operations
  * Enhanced content transformation processes for better formatting consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->