### PR TITLE
dev: cleanup: remove kdate function

### DIFF
--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -19,12 +19,9 @@ use Elabftw\Models\Config;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
 
-use function checkdate;
 use function filter_var;
 use function grapheme_substr;
 use function grapheme_strlen;
-use function mb_strlen;
-use function mb_substr;
 use function strlen;
 use function trim;
 
@@ -76,21 +73,6 @@ final class Filter
             return $key;
         }
         throw new ImproperActionException('Incorrect value: must be a letter.');
-    }
-
-    /**
-     * Make sure the date is correct (YYYY-MM-DD)
-     */
-    public static function kdate(string $input): string
-    {
-        // Check if day/month/year are good
-        $year = (int) mb_substr($input, 0, 4);
-        $month = (int) mb_substr($input, 5, 2);
-        $day = (int) mb_substr($input, 8, 2);
-        if (mb_strlen($input) !== 10 || !checkdate($month, $day, $year)) {
-            return date('Y-m-d');
-        }
-        return $input;
     }
 
     /**

--- a/tests/unit/services/FilterTest.php
+++ b/tests/unit/services/FilterTest.php
@@ -18,14 +18,6 @@ use function str_repeat;
 
 class FilterTest extends \PHPUnit\Framework\TestCase
 {
-    public function testKdate(): void
-    {
-        $this->assertEquals('1969-07-21', Filter::kdate('1969-07-21'));
-        $this->assertEquals(date('Y-m-d'), Filter::kdate('3902348923'));
-        $this->assertEquals(date('Y-m-d'), Filter::kdate('Sun is shining'));
-        $this->assertEquals(date('Y-m-d'), Filter::kdate("\n"));
-    }
-
     public function testFormatLocalDate(): void
     {
         $input = '2024-10-16 17:12:47';


### PR DESCRIPTION
it's not in use anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the date parsing and validation method from the Filter service, which previously parsed and validated date input in YYYY-MM-DD format. Applications relying on this functionality will need alternative date handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->