### PR TITLE
bug/minor: fix inverted logic of verifying TLS for compounds service

### DIFF
--- a/src/Commands/FingerprintCompounds.php
+++ b/src/Commands/FingerprintCompounds.php
@@ -56,7 +56,7 @@ final class FingerprintCompounds extends Command
             return Command::SUCCESS;
         }
         $proxy = Env::asBool('FINGERPRINTER_USE_PROXY') ? Config::getConfig()->configArr['proxy'] : '';
-        $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, Env::asBool('DEV_MODE'));
+        $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, !Env::asBool('DEV_MODE'));
         $Fingerprinter = new Fingerprinter($fingerPrinterHttpGetter, Env::asUrl('FINGERPRINTER_URL'));
         foreach ($compounds as $compound) {
             if (empty($compound['smiles'])) {

--- a/src/Commands/ImportCompoundsCsv.php
+++ b/src/Commands/ImportCompoundsCsv.php
@@ -86,11 +86,11 @@ final class ImportCompoundsCsv extends Command
         $locationSplitter = $input->getOption('location-splitter');
         $Config = Config::getConfig();
         $Fingerprinter = new NullFingerprinter();
-        $httpGetter = new HttpGetter(new Client(), $Config->configArr['proxy'], Env::asBool('DEV_MODE'));
+        $httpGetter = new HttpGetter(new Client(), $Config->configArr['proxy'], !Env::asBool('DEV_MODE'));
         if (Env::asBool('USE_FINGERPRINTER')) {
             // we use a different httpGetter object so we can configure proxy usage
             $proxy = Env::asBool('FINGERPRINTER_USE_PROXY') ? $Config->configArr['proxy'] : '';
-            $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, Env::asBool('DEV_MODE'));
+            $fingerPrinterHttpGetter = new HttpGetter(new Client(), $proxy, !Env::asBool('DEV_MODE'));
             $Fingerprinter = new Fingerprinter($fingerPrinterHttpGetter, Env::asUrl('FINGERPRINTER_URL'));
         }
 

--- a/src/Commands/RefreshIdps.php
+++ b/src/Commands/RefreshIdps.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Commands;
 
 use DOMDocument;
+use Elabftw\Elabftw\Env;
 use Elabftw\Models\Idps;
 use Elabftw\Models\IdpsSources;
 use Elabftw\Models\Users\UltraAdmin;
@@ -50,7 +51,7 @@ final class RefreshIdps extends Command
         $requester = new UltraAdmin();
         $IdpsSources = new IdpsSources($requester);
         $Idps = new Idps($requester);
-        $getter = new HttpGetter(new Client(), $this->proxy);
+        $getter = new HttpGetter(new Client(), $this->proxy, !Env::asBool('DEV_MODE'));
         $sources = $IdpsSources->readAllAutoRefreshable();
         foreach ($sources as $source) {
             $IdpsSources->setId($source['id']);

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -295,7 +295,7 @@ final class Apiv2Controller extends AbstractApiController
                         $Fingerprinter = new Fingerprinter($httpGetter, Env::asUrl('FINGERPRINTER_URL'));
                     }
                     return new Compounds(
-                        new HttpGetter(new Client(), $Config->configArr['proxy'], Env::asBool('DEV_MODE')),
+                        new HttpGetter(new Client(), $Config->configArr['proxy'], !Env::asBool('DEV_MODE')),
                         $this->requester,
                         $Fingerprinter,
                         $Config->configArr['compounds_require_edit_rights'] === '1',

--- a/src/Make/ReportsHandler.php
+++ b/src/Make/ReportsHandler.php
@@ -14,6 +14,7 @@ namespace Elabftw\Make;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Elabftw\Elabftw\Env;
 use Elabftw\Enums\ReportScopes;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\AbstractRest;
@@ -36,7 +37,7 @@ final class ReportsHandler extends AbstractRest
 
     public function getResponse(ReportScopes $scope, ?InputBag $query = null): Response
     {
-        $httpGetter = new HttpGetter(new Client(), verifyTls: false);
+        $httpGetter = new HttpGetter(new Client(), verifyTls: !Env::asBool('DEV_MODE'));
         $Reporter = match ($scope) {
             ReportScopes::Compounds => new MakeCompoundsReport(new Compounds($httpGetter, $this->requester, new NullFingerprinter(), false)),
             ReportScopes::CompoundsHistory => (

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -973,7 +973,7 @@ abstract class AbstractEntity extends AbstractRest
     protected function bloxberg(): array
     {
         $configArr = Config::getConfig()->configArr;
-        $HttpGetter = new HttpGetter(new Client(), $configArr['proxy']);
+        $HttpGetter = new HttpGetter(new Client(), $configArr['proxy'], !Env::asBool('DEV_MODE'));
         $Maker = new MakeBloxberg(
             $this->Users,
             $this,

--- a/src/Models/IdpsSources.php
+++ b/src/Models/IdpsSources.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use DOMDocument;
+use Elabftw\Elabftw\Env;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BinaryValue;
 use Elabftw\Exceptions\ImproperActionException;
@@ -60,7 +61,7 @@ final class IdpsSources extends AbstractRest
                 function () {
                     $source = $this->readOne();
                     $Config = Config::getConfig();
-                    $getter = new HttpGetter(new Client(), $Config->configArr['proxy']);
+                    $getter = new HttpGetter(new Client(), $Config->configArr['proxy'], !Env::asBool('DEV_MODE'));
                     $Url2Xml = new Url2Xml($getter, $source['url'], new DOMDocument());
                     $dom = $Url2Xml->getXmlDocument();
                     $Xml2Idps = new Xml2Idps($dom);


### PR DESCRIPTION
it was: don't verify in prod instead of don't verify in dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP client behavior adjusted so network requests (including fingerprinting, imports, IDP refreshes, and report retrieval) now use proper verification and mode settings depending on development vs. production environments.
  * Improves reliability and security of external requests and makes fingerprinting/import flows more consistent across deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->