### PR TITLE
ux: make emails lowercase

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -51,8 +51,6 @@ use PDO;
 use Symfony\Component\HttpFoundation\Request;
 use Override;
 
-use function strtolower;
-
 /**
  * Users
  */
@@ -192,7 +190,7 @@ class Users extends AbstractRest
         }
         if ($isValidated) {
             // send the instance level onboarding email
-            if (Config::getConfig()->configArr['onboarding_email_active'] === '1') {
+            if ($Config->configArr['onboarding_email_active'] === '1') {
                 new OnboardingEmail(-1)->create($userid);
             }
         } else {
@@ -667,7 +665,10 @@ class Users extends AbstractRest
             if (!$this->isSelf() && !$this->requester->isSysadmin()) {
                 throw new IllegalActionException('User tried to edit email of another user but is not sysadmin.');
             }
-            Filter::email($params->getStringContent());
+            // run email validator
+            $Config = Config::getConfig();
+            $EmailValidator = new EmailValidator($params->getStringContent(), (bool) $Config->configArr['admins_import_users'], $Config->configArr['email_domain']);
+            $EmailValidator->validate();
         }
 
         // columns that can only be modified by Sysadmin requester

--- a/src/Params/UserParams.php
+++ b/src/Params/UserParams.php
@@ -27,7 +27,6 @@ use Elabftw\Services\Filter;
 use Elabftw\Services\PasswordValidator;
 use Override;
 
-use function trim;
 use function mb_substr;
 
 final class UserParams extends ContentParams
@@ -37,7 +36,7 @@ final class UserParams extends ContentParams
     {
         return match ($this->target) {
             // checked in update
-            'email' => trim($this->asString()),
+            'email' => Filter::sanitizeEmail($this->asString()),
             'firstname', 'lastname', 'orgid' => $this->content,
             'valid_until' => (
                 function () {

--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -23,6 +23,7 @@ use function filter_var;
 use function grapheme_substr;
 use function grapheme_strlen;
 use function strlen;
+use function strtolower;
 use function trim;
 
 /**
@@ -107,15 +108,8 @@ final class Filter
         if ($output === false) {
             return '';
         }
-        return $output;
-    }
-
-    public static function email(string $input): string
-    {
-        // if the sent email is different from the existing one, check it's valid (not duplicate and respects domain constraint)
-        $Config = Config::getConfig();
-        $EmailValidator = new EmailValidator($input, (bool) $Config->configArr['admins_import_users'], $Config->configArr['email_domain']);
-        return $EmailValidator->validate();
+        // make it lowercase every time
+        return trim(strtolower($output));
     }
 
     /**


### PR DESCRIPTION
prevents issues with mail validator and uppercase emails also, emails should be lowercase everytime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email inputs are now consistently sanitized and normalized to lowercase to avoid case-related login or account matching issues.
  * User create/update flows include improved email validation and respect account-import and domain validation settings for more reliable onboarding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->