### PR TITLE
ux: add a clear error when issuer cannot be found in IdP response

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -40,12 +40,12 @@ try {
         $IdpsHelper = new IdpsHelper($App->Config, new Idps($App->Users));
         $tmpSettings = $IdpsHelper->getSettings(); // get temporary settings to decode message
         $resp = new SamlResponse(new SamlSettings($tmpSettings), $App->Request->request->getString('SAMLResponse'));
-        $entId = $resp->getIssuers()[0]; // getIssuers returns always one or two entity ids
-        if (empty($entId)) {
+        $issuers = $resp->getIssuers(); // getIssuers returns one or two entity ids as an array
+        if (empty($issuers)) {
             throw new ImproperActionException('Could not find an Issuer in the response sent by the IdP!');
         }
-
-        $settings = $IdpsHelper->getSettingsByEntityId($entId);
+        // use the first issuer found in the response
+        $settings = $IdpsHelper->getSettingsByEntityId($issuers[0]);
         $idpId = $settings['idp_id'];
         $AuthService = new SamlAuth(new SamlAuthLib($settings), $App->Config->configArr, $settings);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SAML response validation to detect missing authentication identifiers and immediately halt processing, preventing downstream errors.
  * When multiple issuers are present, the system now consistently selects the first presented issuer to determine configuration, avoiding reliance on an incorrect identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->