### PR TITLE
bug/minor: resources categories: gatekeep on resources categories page, when edition is disabled by admin

### DIFF
--- a/web/resources-categories.php
+++ b/web/resources-categories.php
@@ -14,6 +14,7 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Controllers\ResourcesCategoriesController;
 use Elabftw\Exceptions\AppException;
+use Elabftw\Exceptions\ImproperActionException;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,6 +26,9 @@ require_once 'app/init.inc.php';
 $Response = new Response();
 
 try {
+    if ($App->Teams->teamArr['users_canwrite_resources_categories'] === 0 && !$App->Users->isAdmin) {
+        throw new ImproperActionException(_('Sorry, edition of resources categories has been disabled for users by your team Admin.'));
+    }
     $Response = new ResourcesCategoriesController($App)->getResponse();
 } catch (AppException $e) {
     $Response = $e->getResponseFromException($App);


### PR DESCRIPTION
Adds a permission check in resources-categories.php to prevent users from editing resource categories when the team setting `users_canwrite_resources_categories` is disabled.

Non-admin users now receive an ImproperActionException with a clear error message, ensuring proper enforcement of team-level restrictions.

For experiment categories, for example, we have this alert:
<img width="938" height="347" alt="Capture d’écran du 2026-01-07 14-07-50" src="https://github.com/user-attachments/assets/84779f05-1af2-4f79-853d-fee3f92dac96" />

(The menu is greyed out and we can only access it via url) However it was not the case for resources categories.