### PR TITLE
bug/minor: tags: fix display of Korean tags

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -516,7 +516,6 @@ tr:first-child td {
   .tags {
     max-width: 20ch;
     overflow-wrap: normal;  // don't force per-character wrapping
-    white-space: normal;
     word-break: keep-all;
   }
 


### PR DESCRIPTION
fix #6319. Tags in Korean appeared vertically, this change makes the tags stay on one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tag rendering in the item-table view: tags now avoid awkward mid-word breaks and wrap more predictably, preserving layout and readability across different content lengths and screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->