### PR TITLE
bug/minor: automatic scope switch: add scope=3 to manager links

### DIFF
--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -303,12 +303,12 @@
               <th data-label='{{ 'Tag'|trans }}' scope='row' class='border-right-0'><button type='button' class='btn tag editable hl-hover lh-normal border-0' data-id='{{ tag.id }}'>{{ tag.tag }}</button></th>
               <td data-label='{{ 'Occurence'|trans }}' class='align-middle'>{{ tag.item_count }}</td>
               <td data-label='{{ 'Show tagged experiments'|trans }}'>
-                <a title='{{ 'Show tagged experiments'|trans }}' aria-label='{{ 'Show tagged experiments'|trans }}' href='experiments.php?mode=show&amp;tags%5B%5D={{ tag.tag|url_encode }}&scope=3' class='btn hl-hover-gray lh-normal p-1 my-n1'>
+                <a title='{{ 'Show tagged experiments'|trans }}' aria-label='{{ 'Show tagged experiments'|trans }}' href='experiments.php?mode=show&amp;tags%5B%5D={{ tag.tag|url_encode }}&amp;scope=3' class='btn hl-hover-gray lh-normal p-1 my-n1'>
                   <i class='fas fa-external-link-square-alt'></i>
                 </a>
               </td>
               <td data-label='{{ 'Show tagged resources'|trans }}'>
-                <a title='{{ 'Show tagged resources'|trans }}' aria-label='{{ 'Show tagged resources'|trans }}' href='database.php?mode=show&amp;tags%5B%5D={{ tag.tag|url_encode }}&scope=3' class='btn hl-hover-gray lh-normal p-1 my-n1'>
+                <a title='{{ 'Show tagged resources'|trans }}' aria-label='{{ 'Show tagged resources'|trans }}' href='database.php?mode=show&amp;tags%5B%5D={{ tag.tag|url_encode }}&amp;scope=3' class='btn hl-hover-gray lh-normal p-1 my-n1'>
                   <i class='fas fa-external-link-square-alt'></i>
                 </a>
               </td>


### PR DESCRIPTION
fix #6348

Add` &scope=3` to "Show tagged experiments/resources" links to avoid empty results when admin scope defaults to self.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin tag manager: links that show tagged experiments and tagged resources now include an additional scope parameter so filtered views return correctly scoped results. No other visible behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->