### PR TITLE
bug/minor: api: display correct error message in notifications

### DIFF
--- a/src/ts/Apiv2.class.ts
+++ b/src/ts/Apiv2.class.ts
@@ -93,7 +93,7 @@ export class Api {
     return fetch(`api/v2/${query}${urlParams}`, options).then(async response => {
       if (response.status !== this.getOkStatusFromMethod(method)) {
         // if there is an error we will get the message in the reply body
-        return response.json().then(json => { throw new Error(json.description); });
+        return response.json().then(json => { throw new Error(json.message || json.description); });
       }
       return response;
     }).then(response => {
@@ -103,7 +103,7 @@ export class Api {
       return response;
     }).catch(error => {
       if (this.notifOnError) {
-        notify.error(error);
+        notify.error(error.message);
       }
       return Promise.reject(new Error(error.message));
     });


### PR DESCRIPTION
Error notifications were displaying only the generic "Error" label instead of the actual API error message. The error handler now uses `error.message` instead of the full Error object to ensure the notification shows the proper text returned from the backend (`json.message` or `json.description`).

Improves clarity for users by exposing meaningful error details in alerts.

<img width="110" height="133" alt="image" src="https://github.com/user-attachments/assets/59699ba5-c230-4f96-9a43-0b8939dc5612" />

->

<img width="682" height="98" alt="Capture d’écran du 2026-01-23 13-52-08" src="https://github.com/user-attachments/assets/3d50acf8-0ea9-472f-9cb9-27fe12b9db6f" />

I initially did this change in #6343 but removing it from there, this change is useful for other branches and quick to review

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling for API responses, prioritizing more relevant error details when available to provide clearer feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->