### PR TITLE
bug/minor: create-new: fix entity type when creating from template

### DIFF
--- a/src/ts/create-new.ts
+++ b/src/ts/create-new.ts
@@ -45,7 +45,7 @@ function setTypeRadio(type: EntityType, scope: string = '') {
   } else {
     const templatesEndpoint = type === EntityType.Experiment ? EntityType.Template : EntityType.ItemType;
     ApiC.getJson(`${templatesEndpoint}/?fastq&scope=${scope}`).then(templates => {
-      renderTemplates(templates, type);
+      renderTemplates(templates);
       toggleCategoryList(type);
     });
   }
@@ -169,9 +169,11 @@ const templateCols: (keyof Templates)[] = [
   'id',
 ];
 
-function renderTemplates(templates: Templates[], type?: string | null): void {
+function renderTemplates(templates: Templates[]): void {
   const tbody = document.getElementById('tplCreateNewTable') as HTMLTableSectionElement;
   const templateRow = document.getElementById('templateRow') as HTMLTemplateElement;
+  // pass the type of the selected entity (either experiments, or items)
+  const type = document.querySelector('input[name="type"]:checked') as HTMLSelectElement;
 
   tbody.replaceChildren(
     ...templates.map(template => {
@@ -183,9 +185,7 @@ function renderTemplates(templates: Templates[], type?: string | null): void {
         // ACTIONS
         if (key === 'id') {
           const createBtn = cells[i].querySelector('button[data-action="create-entity"]') as HTMLButtonElement;
-          // using `template.type` makes the "create" action always create a Template from a Template.
-          // we pass the target entity type so we can create an Experiment/Item from a template instead.
-          createBtn.dataset.type = type;
+          createBtn.dataset.type = type.value;
           createBtn.dataset.tplid = String(template[key]);
           const viewLink = cells[i].querySelector('a') as HTMLAnchorElement;
           viewLink.href = `${template.page}?mode=view&id=${template.id}`;


### PR DESCRIPTION
Creating a new entity from a template was incorrectly reusing the template's own type, causing the system to always create templates instead of the intended entity type (e.g. experiment, item).

The fix passes the selected entity type explicitly to `renderTemplates()` and assigns it to the create button's dataset instead of using `template.type`.

This ensures that "Create from template" now correctly creates an entity of the chosen type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the creation workflow so the chosen entity type is correctly used when creating items, ensuring created items reflect the currently selected type rather than a default template type.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->