### PR TITLE
feat/ux: create modal: add focus on title input

### DIFF
--- a/src/ts/create-new.ts
+++ b/src/ts/create-new.ts
@@ -140,7 +140,11 @@ on('toggle-create-modal', async (el: HTMLElement) => {
     $('#editCompoundModal').modal('hide');
   }
 
-  $('#createModal').modal('toggle');
+  $('#createModal')
+    .one('shown.bs.modal', () => {
+      document.getElementById('createNewFormTitle')?.focus();
+    })
+    .modal('show');
 });
 
 on('toggle-templates', (el: HTMLElement) => {


### PR DESCRIPTION
This allows typing directly after clicking the button, and pressing enter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved the create form modal to automatically focus the title input field when opened, enhancing user experience and streamlining the creation workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->