### PR TITLE
bug/major: pdf: fix embedded images not displayed

### DIFF
--- a/src/Make/MakePdf.php
+++ b/src/Make/MakePdf.php
@@ -284,7 +284,15 @@ class MakePdf extends AbstractMakePdf
         // the slash (/) in the f parameter might be url encoded (%2F), see https://github.com/elabftw/elabftw/issues/4961
         // a generic regex that asserts that the f parameter is present and well formatted but ignores the order of parameters
         $matches = array();
-        preg_match_all('/app\/download\.php\?(?=.*?f=[[:alnum:]]{2}(?:\/|%2F)[[:alnum:]]{128}\.(?:jpe?g|gif|png|svg|webp|wmf|bmp))[^"]+/i', $body, $matches);
+        preg_match_all(
+            '/app\/download\.php\?(?=.*?f=(?:' .
+            '[[:alnum:]]{2}(?:\/|%2F)[[:alnum:]]{128}\.(?:jpe?g|gif|png|svg|webp|wmf|bmp)' .
+            '|' .
+            '[[:alnum:]]{2}(?:\/|%2F)[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.(?:jpe?g|gif|png|svg|webp|wmf|bmp)' .
+          '))[^"]+/i',
+            $body,
+            $matches
+        );
         foreach ($matches[0] as $src) {
             // src will look similar to: app/download.php?f=c2/c2741a{...}016a3.png&amp;storage=1
             // ampersand (&) in html attributes should be encoded (&amp;) so we decode first


### PR DESCRIPTION
The change to storing files with UUIDv4 was not taken into account in a regexp to match files in pdf generation. This patch adapts the regex. Thanks LamininA1!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded PDF generation to recognize additional formats for embedded image references, improving compatibility with diverse file types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->