### PR TITLE
feat: uploads: add full BMP support for insertion and preview

### DIFF
--- a/src/Controllers/DownloadController.php
+++ b/src/Controllers/DownloadController.php
@@ -100,6 +100,8 @@ final class DownloadController implements ControllerInterface
             'image/gif',
             'image/jpeg',
             'image/png',
+            'image/bmp',
+            'image/x-bmp',
             'video/mp4',
             'text/plain',
         );

--- a/src/Elabftw/Extensions.php
+++ b/src/Elabftw/Extensions.php
@@ -57,6 +57,7 @@ final class Extensions
         'gif',
         'heic',
         'jpeg',
+        'bmp',
         'jpg',
         'png',
         'tif',

--- a/src/Factories/MakeThumbnailFactory.php
+++ b/src/Factories/MakeThumbnailFactory.php
@@ -41,6 +41,8 @@ final class MakeThumbnailFactory
             'image/tiff',
             'image/x-eps' => new MakeThumbnailFromFirstFrame($mime, $filePath, $longName, $storageFs),
             'image/jpeg',
+            'image/bmp',
+            'image/x-bmp',
             'image/png',
             'image/svg+xml' => new MakeThumbnail($mime, $filePath, $longName, $storageFs),
             default => new MakeNullThumbnail($mime, $filePath, $longName, $storageFs),

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -8,7 +8,7 @@
 
   {% if mode == 'edit' %}
     {# INSERT IN TEXT in edit mode for images #}
-    {% if ext matches '/(jpg|jpeg|png|gif|svg)$/i' %}
+    {% if ext matches '/(jpg|jpeg|png|gif|svg|bmp)$/i' %}
       <button type='button' class='dropdown-item' data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
         <i class='fas fa-fw fa-image mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
       </button>
@@ -46,7 +46,7 @@
   {% if mode == 'edit' %}
 
     {# Annotate image #}
-    {% if ext matches '/(jpg|jpeg|png|gif)$/i' %}
+    {% if ext matches '/(jpg|jpeg|png|gif|bmp)$/i' %}
       <button type='button' class='dropdown-item' data-action='annotate-image' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'>
         <i class='fas fa-fw fa-paint-brush mr-1'></i>{{ 'Annotate this image'|trans }}
       </button>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -143,25 +143,25 @@
             {% endif %}
 
             {# IMAGES #}
-            {% if ext matches '/(jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg|heic)$/i' %}
+            {% if ext matches '/(bmp|jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg|heic)$/i' %}
               {# don't make the thumbnail clickable if it's a tif #}
-              {% if ext matches '/(jpg|jpeg|png|gif|pdf|eps|svg|heic)$/i' %}
+              {% if ext matches '/(bmp|jpg|jpeg|png|gif|pdf|eps|svg|heic)$/i' %}
                 <div class='text-center'>
                   <a class='text-break' target='_blank' href='app/download.php?f={{ upload.long_name|e('url') }}&amp;storage={{ upload.storage }}&amp;name={{ upload.real_name|e('url') }}'
-                    {% if upload.real_name matches '/(jpg|jpeg|png|gif)$/i' %}data-fancybox='group' data-caption='{{ upload.real_name|e('html_attr') }}'{% endif %}
+                    {% if upload.real_name matches '/(bmp|jpg|jpeg|png|gif)$/i' %}data-fancybox='group' data-caption='{{ upload.real_name|e('html_attr') }}'{% endif %}
                     {% if upload.comment %}title='{{ upload.comment|e('html_attr') }}' data-caption='{{ upload.comment|e('html_attr') }}'{% endif %}
                   >
               {% endif %}
               {% set thumb_name = upload.long_name ~ '_th.jpg' %}
               {# old timestamp pdf don't have a thumbnail, so don't try to display one for them #}
-              {% if ext matches '/(jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg|heic)$/i' %}
+              {% if ext matches '/(bmp|jpg|jpeg|png|gif|tif|tiff|pdf|eps|svg|heic)$/i' %}
                 <div class='text-center'>
                   <img class='thumb img-thumbnail rounded' class='text-break' src='app/download.php?f={{ thumb_name|e('url') }}&amp;storage={{ upload.storage }}&amp;name={{ upload.real_name|e('url') }}' alt='thumbnail' />
                 </div>
               {% else %}
                 <i class='fas {{ ext2icon(ext) }} thumb rounded mx-auto d-block text-center'></i>
               {% endif %}
-              {% if upload.real_name matches '/.(jpg|jpeg|png|gif|pdf|eps|svg|heic)$/i' %}
+              {% if upload.real_name matches '/.(bmp|jpg|jpeg|png|gif|pdf|eps|svg|heic)$/i' %}
                   </a>
                 </div>
               {% endif %}


### PR DESCRIPTION
fix #6409

Extends consistent image handling to include BMP files across all upload and preview workflows.

Changes:
- Added BMP and X-BMP MIME types to DownloadController and MakeThumbnailFactory
- Added `.bmp` to the allowed extensions list
- Updated upload templates to recognize BMP in: • insert-image-in-body action • annotate-image option • preview thumbnails and lightbox (fancybox) display

This aligns BMP behavior with other supported bitmap formats (PNG, JPEG, GIF), ensuring drag-and-drop, inline insertion, and preview all function uniformly.
<img width="1090" height="421" alt="image" src="https://github.com/user-attachments/assets/a23e438d-b143-4c64-b70c-ebf0fdf4a8b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BMP image format, enabling users to upload, display, and generate thumbnails for BMP files alongside existing image formats. BMP files are now treated as inline images rather than forced downloads, with full support for insertion, annotation, and thumbnail previews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->