### PR TITLE
bug/minor: extra fields: fix reload after DSpace export for empty entries

### DIFF
--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -127,6 +127,7 @@
 
 </section>
 
+<section id='extraFieldsSection'>
 {# METADATA view #}
 {% if Entity.entityData.metadata %}
   <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='extraFieldsDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Extra fields'|trans }}</h3>
@@ -135,6 +136,7 @@
   </div>
   <hr>
 {% endif %}
+</section>
 
 {% if Entity.entityData.uploads %}
   {% include 'uploads.html' %}

--- a/src/ts/dspace.ts
+++ b/src/ts/dspace.ts
@@ -39,7 +39,7 @@ async function saveDspaceIdAsExtraField(itemUuid: string): Promise<void> {
   const mode = new URLSearchParams(window.location.search).get('mode');
   await MetadataC.save(metadata).then(() => mode === 'edit'
     ? MetadataC.display('edit')
-    : reloadElements(['extraFieldsDiv']));
+    : reloadElements(['extraFieldsSection']));
 }
 
 interface DspaceCollection {


### PR DESCRIPTION
fix #6419

When exporting an experiment to DSpace from view mode, the extra fields section did not reload if no extra fields previously existed. This caused the DSpace export field to remain hidden until a full page reload.

Changes:
- Wrapped extra fields markup in a dedicated `<section id='extraFieldsSection'>`
- Updated DSpace export logic to call reloadElements(['extraFieldsSection']) instead of ['extraFieldsDiv']

This ensures the extra fields area is correctly refreshed after export, even when initially empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the DOM structure for metadata and extra fields display, improving the underlying organization of page elements without visible user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->