### PR TITLE
feat: scheduler: remember last selected view across sessions

### DIFF
--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -103,7 +103,7 @@ if (window.location.pathname === '/scheduler.php') {
       : 'timeGridDay,timeGridWeek,listWeek,dayGridMonth'; // classic grid calendar
 
     // persist selected view type (day, week, month, and the layout)
-    const saved = localStorage.getItem('schedulerRange') as SavedView | null;
+    const saved = localStorage.getItem('persistent_schedulerRange') as SavedView | null;
     const range: Range = saved && saved !== LIST_WEEK_VIEW ? saved : 'week';
     const viewMap = layoutCheckbox.checked ? TIMELINE_VIEWS : GRID_VIEWS;
     const initialView =
@@ -225,7 +225,7 @@ if (window.location.pathname === '/scheduler.php') {
             info.view.type.includes('Day') ? 'day' :
               info.view.type.includes('Month') ? 'month' :
                 'week';
-        localStorage.setItem('schedulerRange', range);
+        localStorage.setItem('persistent_schedulerRange', range);
       },
       themeSystem: 'bootstrap',
       // i18n


### PR DESCRIPTION
implements #6369

Adds persistent scheduler view selection so users can keep their preferred view (day, week, month, or list) across page reloads and sessions.

Changes:
- Range and SavedView types for consistent view management
- Stored selected range in localStorage as `schedulerRange`
- Restored the saved view (grid or timeline) on page load
- Added `datesSet` listener to update localStorage whenever the view changes

This allows setups such as wall-mounted tablets to automatically reload the scheduler in the last selected view (e.g. month view), improving usability in shared and unattended display contexts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler now remembers your preferred view (day, week, month, or list week) across sessions.
  * The app restores the most relevant view based on your current layout (timeline or grid) and last-used range.
  * Calendar restores and maintains the last-selected view when you navigate away and return, ensuring a consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->