### PR TITLE
bug/ui: navbar: fix dashboard overlap on tablet viewports

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1559,7 +1559,7 @@ input[type='color'] {
 #main-nav {
   background-color: inherit;
 
-  @media (min-width: 768px) {
+  @media (min-width: 992px) {
     height: 43px;
   }
 


### PR DESCRIPTION
fix #6437

On tablet-sized screens, the dashboard section was rendered above the main navigation bar, making some menu items (notifications, user menu) unclickable.

Adjusted the responsive breakpoint for the #main-nav height rule from `min-width: 768px` to `min-width: 992px`, ensuring proper stacking and interaction behavior between tablet and desktop layouts.

This restores correct navigation visibility and interactivity on tablet devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the responsive breakpoint for navigation height styling. The navigation styling now applies on larger viewports (992px and above) instead of smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->