### PR TITLE
bug/minor: links: fix related links not showing in view mode

### DIFF
--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -144,7 +144,7 @@
 {% include 'steps-view.html' %}
 
 {# we only show this section in view mode if there are at least one link #}
-{% if Entity.entityData.experiments_links or Entity.entityData.items_links or Entity.entityData.compounds_links %}
+{% if Entity.entityData.experiments_links or Entity.entityData.items_links or Entity.entityData.compounds_links or Entity.entityData.related_experiments_links or Entity.entityData.related_items_links %}
   {% include 'links.html' %}
 {% endif %}
 


### PR DESCRIPTION
fix #6450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of related links in views. The links section now appears when related experiments or items are present, in addition to existing link types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->