### PR TITLE
bug/major: saml: fix error with permission check

### DIFF
--- a/src/Elabftw/IdpsHelper.php
+++ b/src/Elabftw/IdpsHelper.php
@@ -57,7 +57,7 @@ final class IdpsHelper
     private function getSettingsByIdp(int $idpId): array
     {
         $this->Idps->setId($idpId);
-        $idp = $this->Idps->readOne();
+        $idp = $this->Idps->selectOne();
         $idpSigningCerts = array();
         $idpEncryptionCerts = array();
         foreach ($idp['certs'] as $cert) {

--- a/src/Models/Idps.php
+++ b/src/Models/Idps.php
@@ -70,6 +70,11 @@ final class Idps extends AbstractRest
     public function readOne(): array
     {
         $this->requester->isSysadminOrExplode();
+        return $this->selectOne();
+    }
+
+    public function selectOne(): array
+    {
         $sql = sprintf($this->getReadSql(), 'WHERE idps.id = :id');
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);


### PR DESCRIPTION
the code was calling readOne instead of an internal function without the check that must be used for external (api) calls. So trying to login would throw 403 error because user is not sysadmin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of Identity Provider data retrieval logic with no end-user visible changes. Improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->