### PR TITLE
a11y: use a for menu links in nav

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -63,10 +63,10 @@
               {% if App.devMode -%}
                 <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
               {%- endif %}
-              <a href='#' class='nav-link dropdown-toggle {{ scriptName in ['experiments.php', 'templates.php', 'experiments-categories.php', 'experiments-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              <a id='navExperimentsDropdown' href='#' class='nav-link dropdown-toggle {{ scriptName in ['experiments.php', 'templates.php', 'experiments-categories.php', 'experiments-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-haspopup='menu' aria-expanded='false'>
               {% trans %}Experiment{% plural 2 %}Experiments{% endtrans %}
               </a>
-              <div class='dropdown-menu'>
+              <div class='dropdown-menu' aria-labelledby='navExperimentsDropdown'>
                 <form class='dropdown-item form-inline' action='experiments.php' aria-label='{{ 'Quick search experiments'|trans }}'>
                   <label for='nav-search-experiments' class='sr-only'>{{ 'Search experiments'|trans }}</label>
                   <div class='input-group'>
@@ -97,10 +97,13 @@
               </div>
             </div>
             <div class='nav-item dropdown'>
-              <a href='#' class='nav-link dropdown-toggle {{ scriptName in ['database.php', 'resources-templates.php', 'resources-categories.php', 'resources-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              {% if App.devMode -%}
+                <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
+              {%- endif %}
+              <a id='navResourcesDropdown' href='#' class='nav-link dropdown-toggle {{ scriptName in ['database.php', 'resources-templates.php', 'resources-categories.php', 'resources-status.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-haspopup='menu' aria-expanded='false'>
               {% trans %}Resource{% plural 2 %}Resources{% endtrans %}
               </a>
-              <div class='dropdown-menu'>
+              <div class='dropdown-menu' aria-labelledby='navResourcesDropdown'>
                 <form class='dropdown-item form-inline' action='database.php' aria-label='{{ 'Quick search resources'|trans }}'>
                   <label for='nav-search-resources' class='sr-only'>{{ 'Search resources'|trans }}</label>
                   <div class='input-group'>
@@ -143,10 +146,13 @@
             {% endif %}
 
             <div class='nav-item dropdown'>
-              <a href='#' class='nav-link dropdown-toggle {{ scriptName in ['compounds.php', 'chem-editor.php', 'syc.php', 'inventory.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-expanded='false'>
+              {% if App.devMode -%}
+                <!-- [html-validate-disable-next prefer-native-element: using a button here will mess up the navbar] -->
+              {%- endif %}
+              <a id='navToolsDropdown' href='#' class='nav-link dropdown-toggle {{ scriptName in ['compounds.php', 'chem-editor.php', 'syc.php', 'inventory.php'] ? 'active' }}' role='button' data-toggle='dropdown' aria-haspopup='menu' aria-expanded='false'>
               {{ 'Tools'|trans }}
               </a>
-              <div class='dropdown-menu'>
+              <div class='dropdown-menu' aria-labelledby='navToolsDropdown'>
                 {% set isActive = scriptName == 'compounds.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }}' href='compounds.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-flask fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Compounds'|trans }}</a>
                 {% set isActive = scriptName == 'chem-editor.php' %}


### PR DESCRIPTION
so they are keyboard accessible instead of div

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the structure of the Experiment, Resource, and Tools dropdown triggers to use anchor elements while preserving existing behavior.
* **Accessibility**
  * Added ARIA attributes to improve menu semantics and screen-reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->