### PR TITLE
ui: permissions: show derived permissions for templates in view mode

### DIFF
--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -141,34 +141,7 @@
     <h5>{{ 'Permissions for the template'|trans }}</h5>
   {% endif %}
   {% include 'edit-permissions.html' %}
-  {# templates also have a read/write target #}
-  {% if Entity.entityData.canread_target %}
-   {# TARGET PERMISSIONS #}
-    <h5>{{ 'Permissions for the derived entry'|trans }}</h5>
-    <p class='smallgray'>{{ 'Entries created from this template will inherit these permissions. If they are locked down, the permissions will not be modifiable by Users, only Admins.'|trans }}</p>
-    <div class='d-flex mb-2 align-items-center'>
-      {# CANREAD #}
-      {% include 'view-permissions.html' with {rw: 'canread_target', can: Entity.entityData.canread_target|canToHuman, can_base: Entity.entityData.canread_target_base_human} %}
-    </div>
-    <div class='d-flex'>
-      <label for='canread_is_immutable' class='col-form-label mr-2'>{{ 'Lock down read permissions'|trans }}</label>
-      <label class='switch ucp-align'>
-        <input type='checkbox' autocomplete='off' data-trigger='change' data-model='{{ Entity.entityType.value ~ '/' ~ Entity.id }}' data-target='canread_is_immutable' {{ Entity.entityData.canread_is_immutable ? 'checked="checked"' }} id='canread_is_immutable'>
-        <span class='slider'></span>
-      </label>
-    </div>
-    <div class='d-flex mb-2 align-items-center'>
-      {# CANWRITE #}
-      {% include 'view-permissions.html' with {rw: 'canwrite_target', can: Entity.entityData.canwrite_target|canToHuman, can_base: Entity.entityData.canwrite_target_base_human} %}
-    </div>
-    <div class='d-flex'>
-      <label for='canwrite_is_immutable' class='col-form-label mr-2'>{{ 'Lock down write permissions'|trans }}</label>
-      <label class='switch ucp-align'>
-        <input type='checkbox' autocomplete='off' data-trigger='change' data-model='{{ Entity.entityType.value ~ '/' ~ Entity.id }}' data-target='canwrite_is_immutable' {{ Entity.entityData.canwrite_is_immutable ? 'checked="checked"' }} id='canwrite_is_immutable'>
-        <span class='slider'></span>
-      </label>
-    </div>
-  {% endif %}
+  {% include 'view-edit-target-permissions.html' %}
 </div>
 <hr>
 

--- a/src/templates/view-edit-target-permissions.html
+++ b/src/templates/view-edit-target-permissions.html
@@ -1,0 +1,28 @@
+{# templates also have a read/write target #}
+{% if Entity.entityData.canread_target %}
+ {# TARGET PERMISSIONS #}
+  <h5>{{ 'Permissions for the derived entry'|trans }}</h5>
+  <p class='smallgray'>{{ 'Entries created from this template will inherit these permissions. If they are locked down, the permissions will not be modifiable by Users, only Admins.'|trans }}</p>
+  <div class='d-flex mb-2 align-items-center'>
+    {# CANREAD #}
+    {% include 'view-permissions.html' with {rw: 'canread_target', can: Entity.entityData.canread_target|canToHuman, can_base: Entity.entityData.canread_target_base_human} %}
+  </div>
+  <div class='d-flex'>
+    <label for='canread_is_immutable' class='col-form-label mr-2'>{{ 'Lock down read permissions'|trans }}</label>
+    <label class='switch ucp-align'>
+      <input type='checkbox' autocomplete='off' data-trigger='change' data-model='{{ Entity.entityType.value ~ '/' ~ Entity.id }}' data-target='canread_is_immutable' {{ Entity.entityData.canread_is_immutable ? 'checked="checked"' }} id='canread_is_immutable'>
+      <span class='slider'></span>
+    </label>
+  </div>
+  <div class='d-flex mb-2 align-items-center'>
+    {# CANWRITE #}
+    {% include 'view-permissions.html' with {rw: 'canwrite_target', can: Entity.entityData.canwrite_target|canToHuman, can_base: Entity.entityData.canwrite_target_base_human} %}
+  </div>
+  <div class='d-flex'>
+    <label for='canwrite_is_immutable' class='col-form-label mr-2'>{{ 'Lock down write permissions'|trans }}</label>
+    <label class='switch ucp-align'>
+      <input type='checkbox' autocomplete='off' data-trigger='change' data-model='{{ Entity.entityType.value ~ '/' ~ Entity.id }}' data-target='canwrite_is_immutable' {{ Entity.entityData.canwrite_is_immutable ? 'checked="checked"' }} id='canwrite_is_immutable'>
+      <span class='slider'></span>
+    </label>
+  </div>
+{% endif %}

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -157,6 +157,7 @@
 <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='permissionsDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Permissions'|trans }}</h3>
 <div class='mt-2 ml-3' id='permissionsDiv' data-save-hidden='permissionsDiv'>
   {% include('edit-permissions.html') %}
+  {% include 'view-edit-target-permissions.html' %}
 </div>
 <hr>
 


### PR DESCRIPTION
it was only visible in edit mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored target permissions UI by extracting inline controls into a dedicated reusable template component. This improves code organization and ensures consistent rendering of derived entry permissions across view and edit pages, including read/write toggles and lock-down options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->