### PR TITLE
bug/minor: uploads: fix comment lost on replace

### DIFF
--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -299,7 +299,8 @@ final class Uploads extends AbstractRest
                 }
             )(),
             Action::Replace => $this->replace(new CreateUploadFromUploadedFile(
-                new UploadedFile($reqBody['filePath'], $reqBody['real_name'], $this->uploadData['comment'])
+                new UploadedFile($reqBody['filePath'], $reqBody['real_name']),
+                $this->uploadData['comment']
             )),
             default => throw new ImproperActionException('Invalid action for upload creation.'),
         };


### PR DESCRIPTION
wrong parenthesis placement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code consistency in upload handling to ensure consistent behavior across different upload actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->