### PR TITLE
bug/major: team switch: fix cookie value taking over

### DIFF
--- a/web/login.php
+++ b/web/login.php
@@ -70,6 +70,15 @@ try {
     }
 
     if ($App->Request->query->get('switch_team') === '1') {
+        $cookieOptions = array(
+            'expires' => time() - 3600,
+            'path' => '/',
+            'domain' => '',
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        );
+        setcookie('token_team', '', $cookieOptions);
         $loggedInUser = new Users($App->Session->get('userid'));
         $App->Session->set('team_selection_required', true);
         $App->Session->set('team_selection', $loggedInUser->userData['teams']);


### PR DESCRIPTION
fix team switch by removing the token_team cookie that was taking over


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed team token handling during login when switching teams to ensure proper session cleanup and improve team selection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->