### PR TITLE
bug/minor: inventory: don't list deleted entries

### DIFF
--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -520,7 +520,7 @@ final class StorageUnits extends AbstractRest
                     users AS u ON (u.userid = entity.userid)
                 WHERE
                     -- can sql AND query or storage_id
-                    1=1 AND %s %s
+                    1=1 AND entity.state IN (1,2) AND %s %s
 
             UNION
                 SELECT
@@ -585,7 +585,7 @@ final class StorageUnits extends AbstractRest
                     users AS u ON (u.userid = entity.userid)
                 WHERE
                     -- can sql AND query or storage_id
-                    1=1 AND %s %s",
+                    1=1 AND entity.state IN (1,2) AND %s %s",
             $userid,
             $team,
             $discriminator,

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -78,6 +78,10 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $res = $this->StorageUnits->readAllFromStorage($storageId);
         $this->assertCount(3, $res);
         $this->assertNotEmpty($res[0]['container2item_id']);
+        // now delete the resource and verify nothing shows up in results
+        $Item->destroy();
+        $res = $this->StorageUnits->readAllFromStorage($storageId);
+        $this->assertCount(0, $res);
     }
 
     public function testGetApiPath(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage unit listings now correctly filter to display only active items
  * Deleted items are properly removed from storage unit queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->