### PR TITLE
apidoc: remove default values for enums

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1148,7 +1148,6 @@ components:
               type: integer
               enum: [ 0, 1 ]
               description: Hide the main text of an entry. When applied to templates, this setting also applies to derived entries.
-              default: 0
             id:
               type: integer
             items_links:
@@ -1288,7 +1287,6 @@ components:
 
             If unset, it will use the user's preference value.
           example: 1
-          default: 1
           enum: [ 1, 2 ]
         custom_id:
           type: integer
@@ -1622,7 +1620,6 @@ components:
               - 40: Everyone with an account
               - 50: Everyone including anonymous users
           example: 20
-          default: 30
           enum: [10, 20, 30, 40, 50]
         canbook:
           type: string


### PR DESCRIPTION
see https://github.com/elabftw/elabapi-python/issues/45

It would generate incorrect default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed default values from select API schema field definitions. API clients may now need to explicitly specify values for these fields where defaults previously applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->