### PR TITLE
bug/minor: exports: disable DSpace export when not configured (#6511)

### DIFF
--- a/src/templates/export-menu.html
+++ b/src/templates/export-menu.html
@@ -127,6 +127,7 @@
     <div class='dropdown-item' data-action='toggle-modal' data-target='qrpngExportModal'><i class='fas fa-qrcode fa-fw'></i> {{ 'QR Code'|trans }}</div>
     <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}' target='_blank'><i class='fas fa-code fa-fw'></i>{{ 'JSON'|trans }}</a>
     <hr>
-    <div class='dropdown-item {{ Entity.isReadOnly ? 'disabled' }}' data-action='open-dspace-modal'><i class='fas fa-file-export fa-fw'></i> {{ 'Export to DSpace'|trans }}</div>
+      {% set isDisabled = App.Config.configArr.dspace_host == '' or Entity.isReadOnly %}
+    <div class='dropdown-item {{ isDisabled ? 'disabled' }}' data-action='open-dspace-modal'><i class='fas fa-file-export fa-fw {{ isDisabled ? 'color-weak' }}'></i> {{ 'Export to DSpace'|trans }}</div>
   </div>
 </div>


### PR DESCRIPTION
fix #6511

Prevents users from attempting to export to DSpace when it is not properly configured.

Changes:
- Disable "Export to DSpace" menu item if: 
• `dspace_host` is empty (not configured), or 
• the entity is read-only
- Visually indicate disabled state by applying `color-weak` to the icon too

This avoids confusing UX where the DSpace export option appears available but cannot function due to missing configuration.

<img width="185"  alt="Capture d’écran du 2026-02-24 16-19-00" src="https://github.com/user-attachments/assets/8a8ab512-5709-49c1-bbe2-5721da094dbd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The "Export to DSpace" dropdown option now displays as disabled with visual styling feedback, preventing users from attempting exports when the DSpace host configuration is not set or when the current entity is marked as read-only. This ensures a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->