### PR TITLE
bug/minor: notifications: correct scheduler link for deleted events and extend tests

### DIFF
--- a/src/Models/Notifications/EventDeleted.php
+++ b/src/Models/Notifications/EventDeleted.php
@@ -89,7 +89,7 @@ final class EventDeleted extends AbstractNotifications implements MailableInterf
     public function getEmail(): array
     {
         $info = _('A booked slot was deleted from the scheduler.');
-        $url = Env::asUrl('SITE_URL') . '/team.php?item=' . $this->event['item'];
+        $url = Env::asUrl('SITE_URL') . '/scheduler.php?item=' . $this->event['item'];
         $body = sprintf(_('Hi. %s (%s). See item: %s. It was booked from %s to %s.'), $info, $this->actor, $url, $this->event['start'], $this->event['end']);
         if (!empty($this->msg)) {
             $body .= "\n\n" . _('Message:') . "\n" . $this->msg;

--- a/src/Services/Transform.php
+++ b/src/Services/Transform.php
@@ -48,7 +48,7 @@ final class Transform
                 ),
             Notifications::EventDeleted =>
                 sprintf(
-                    '<span data-action="ack-notif" data-id="%d" data-href="team.php?item=%d">%s (%s)</span>' . $relativeMoment,
+                    '<span data-action="ack-notif" data-id="%d" data-href="scheduler.php?item=%d">%s (%s)</span>' . $relativeMoment,
                     (int) $notif['id'],
                     (int) $notif['body']['event']['item'],
                     _('A booked slot was deleted from the scheduler.'),

--- a/tests/unit/services/TransformTest.php
+++ b/tests/unit/services/TransformTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 
 namespace Elabftw\Services;
 
+use Elabftw\Elabftw\App;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Notifications;
+use ValueError;
 
 class TransformTest extends \PHPUnit\Framework\TestCase
 {
@@ -23,51 +25,115 @@ class TransformTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("<input type='hidden' name='csrf' value='$token' />", $input);
     }
 
-    public function testNotifPdfGenericError(): void
+    /**
+     * @dataProvider notifProvider
+     */
+    public function testNotif(array $input, string $expected): void
     {
-        $expected = '<span data-action="ack-notif" data-id="1">';
-        $expected .= 'There was a problem during PDF creation.';
-        $expected .= '</span><br><span class="relative-moment" title="test"></span>';
-        $actual = Transform::notif(array(
-            'category' => Notifications::PdfGenericError->value,
-            'id' => 1,
-            'created_at' => 'test',
-        ));
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, Transform::notif($input));
     }
 
-    public function testNotifMathJaxFailed(): void
+    public static function notifProvider(): array
     {
-        $expected = '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2">';
-        $expected .= 'Tex rendering failed during PDF generation. The raw tex commands are retained but you might want to carefully check the generated PDF.';
-        $expected .= '</span><br><span class="relative-moment" title="test"></span>';
-        $actual = Transform::notif(array(
-            'category' => Notifications::MathjaxFailed->value,
-            'id' => 1,
-            'created_at' => 'test',
-            'body' => array(
-                'entity_page' => EntityType::Experiments->toPage(),
-                'entity_id' => 2,
+        return array(
+            'CommentCreated' => array(
+                array(
+                    'category' => Notifications::CommentCreated->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('page' => 'experiments.php', 'entity_id' => 42),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=42">'
+                . 'New comment on your entry.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
             ),
-        ));
-        $this->assertEquals($expected, $actual);
+            'EventDeleted' => array(
+                array(
+                    'category' => Notifications::EventDeleted->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('event' => array('item' => 42), 'actor' => 'John'),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="scheduler.php?item=42">'
+                . 'A booked slot was deleted from the scheduler. (John)'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'UserCreated' => array(
+                array('category' => Notifications::UserCreated->value, 'id' => 1, 'created_at' => 'DATE'),
+                '<span data-action="ack-notif" data-id="1">'
+                . 'New user added to your team'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'UserNeedValidation' => array(
+                array('category' => Notifications::UserNeedValidation->value, 'id' => 1, 'created_at' => 'DATE'),
+                '<span data-action="ack-notif" data-id="1" data-href="admin.php">'
+                . 'A user needs account validation.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'PdfGenericError' => array(
+                array('category' => Notifications::PdfGenericError->value, 'id' => 1, 'created_at' => 'DATE'),
+                '<span data-action="ack-notif" data-id="1">'
+                . 'There was a problem during PDF creation.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'MathjaxFailed' => array(
+                array(
+                    'category' => Notifications::MathjaxFailed->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('entity_page' => EntityType::Experiments->toPage(), 'entity_id' => 2),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2">'
+                . 'Tex rendering failed during PDF generation. The raw tex commands are retained but you might want to carefully check the generated PDF.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'PdfAppendmentFailed' => array(
+                array(
+                    'category' => Notifications::PdfAppendmentFailed->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('entity_page' => EntityType::Experiments->toPage(), 'entity_id' => 2, 'file_names' => 'file1.pdf'),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2">'
+                . 'Some attached PDFs could not be appended. (file1.pdf)'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'StepDeadline' => array(
+                array(
+                    'category' => Notifications::StepDeadline->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('entity_page' => 'experiments.php', 'entity_id' => 2, 'step_id' => 5),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2&amp;highlightstep=5#step_view_5">'
+                . 'A step deadline is approaching.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'NewVersionInstalled' => array(
+                array('category' => Notifications::NewVersionInstalled->value, 'created_at' => 'DATE'),
+                '<a class="color-white" href="'
+                . App::getWhatsnewLink(App::INSTALLED_VERSION_INT)
+                . '" target="_blank">'
+                . sprintf('A new eLabFTW version has been installed since your last visit.%sRead the release notes by clicking this message.', '<br>')
+                . '</a><br><span class="relative-moment" title="DATE"></span>',
+            ),
+            'ActionRequested' => array(
+                array(
+                    'category' => Notifications::ActionRequested->value,
+                    'id' => 1,
+                    'created_at' => 'DATE',
+                    'body' => array('entity_page' => 'experiments.php', 'entity_id' => 2, 'requester_fullname' => 'Alice', 'action' => 'approval'),
+                ),
+                '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2">'
+                . 'Alice has requested approval from you.'
+                . '</span><br><span class="relative-moment" title="DATE"></span>',
+            ),
+        );
     }
 
-    public function testNotifPdfAppendmentFailed(): void
+    public function testNotifInvalidTypeThrows(): void
     {
-        $expected = '<span data-action="ack-notif" data-id="1" data-href="experiments.php?mode=view&amp;id=2">';
-        $expected .= 'Some attached PDFs could not be appended. (file1.pdf, file2.pdf)';
-        $expected .= '</span><br><span class="relative-moment" title="TIMESTAMP"></span>';
-        $actual = Transform::notif(array(
-            'category' => Notifications::PdfAppendmentFailed->value,
-            'id' => 1,
-            'created_at' => 'TIMESTAMP',
-            'body' => array(
-                'entity_page' => EntityType::Experiments->toPage(),
-                'entity_id' => 2,
-                'file_names' => 'file1.pdf, file2.pdf',
-            ),
-        ));
-        $this->assertEquals($expected, $actual);
+        $this->expectException(ValueError::class);
+        Transform::notif(array('category' => 999999, 'id' => 1, 'created_at' => 'DATE'));
     }
 }


### PR DESCRIPTION
100% coverage for TransformTest :100: :rocket: 

When a booked slot was deleted from the scheduler, the notification link incorrectly pointed to team.php instead of scheduler.php. This lead me to following changes:
- Updated EventDeleted email notification to link to scheduler.php
- Updated Transform service to generate correct scheduler link
- Refactored TransformTest using a data provider to improve coverage
- Added test for invalid notification type (throws ValueError)
<img width="699" height="297" alt="image" src="https://github.com/user-attachments/assets/7707fefd-5cbb-4a6b-bd12-19ff42813a84" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event deletion notification links to direct users to the scheduler page instead of the team page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->