### PR TITLE
Replace direct execute() calls with Db::execute() for consistent error handling

### DIFF
--- a/src/Commands/ExperimentsTimestamp.php
+++ b/src/Commands/ExperimentsTimestamp.php
@@ -66,7 +66,7 @@ final class ExperimentsTimestamp extends Command
 
         $req = $Db->prepare($sql);
         $req->bindValue(':m', $dateTimeImmutable->format('Y-m-d H:i:s'));
-        $req->execute();
+        $Db->execute($req);
         $expArr = $req->fetchAll();
         if ($output->isVerbose()) {
             $output->writeln(sprintf('Found %d experiments to timestamp.', count($expArr)));

--- a/src/Commands/TagsTeamsSync.php
+++ b/src/Commands/TagsTeamsSync.php
@@ -67,7 +67,7 @@ final class TagsTeamsSync extends Command
         $Db = Db::getConnection();
         $sql = 'SELECT DISTINCT tag FROM tags WHERE team IN ( ' . implode(',', $teams) . ' )';
         $req = $Db->prepare($sql);
-        $req->execute();
+        $Db->execute($req);
         return $req->fetchAll(PDO::FETCH_COLUMN);
     }
 }

--- a/src/Elabftw/Update.php
+++ b/src/Elabftw/Update.php
@@ -100,7 +100,7 @@ final class Update
     {
         $sql = 'SELECT id, date FROM items';
         $req = $this->Db->prepare($sql);
-        $req->execute();
+        $this->Db->execute($req);
         $items = $req->fetchAll();
         if (empty($items)) {
             return;
@@ -112,7 +112,7 @@ final class Update
             $elabid = $item['date'] . '-' . sha1(bin2hex(random_bytes(16)));
             $req->bindParam(':id', $item['id'], PDO::PARAM_INT);
             $req->bindParam(':elabid', $elabid);
-            $req->execute();
+            $this->Db->execute($req);
         }
     }
 
@@ -126,7 +126,7 @@ final class Update
         $req = $this->Db->prepare($sql);
         $req->bindValue(':name1', 'fk_experiments_revisions_experiments_id');
         $req->bindValue(':name2', 'fk_experiments_revisions_users_userid');
-        $req->execute();
+        $this->Db->execute($req);
 
         if ($req->rowCount() === 0) {
             // Now, add the constraints

--- a/src/Elabftw/UserStats.php
+++ b/src/Elabftw/UserStats.php
@@ -101,7 +101,7 @@ final class UserStats
         $req = $this->Db->prepare($this->getSQL(true));
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         $countExpWithoutStatus = $req->fetchColumn();
 
         // prepare sql query for experiments with status
@@ -122,7 +122,7 @@ final class UserStats
             } else {
                 // now get the count
                 $req->bindParam(':status', $status['id'], PDO::PARAM_INT);
-                $req->execute();
+                $this->Db->execute($req);
                 $this->pieData[$lastKey]['count'] = $req->fetchColumn();
             }
 

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -780,7 +780,7 @@ abstract class AbstractEntity extends AbstractRest
         $req->bindValue(':statenormal', State::Normal->value, PDO::PARAM_INT);
         $req->bindValue(':statearchived', State::Archived->value, PDO::PARAM_INT);
         $req->bindParam(':category', $category);
-        $req->execute();
+        $this->Db->execute($req);
 
         return array_column($req->fetchAll(), 'id');
     }
@@ -792,7 +792,7 @@ abstract class AbstractEntity extends AbstractRest
         $req->bindValue(':statenormal', State::Normal->value, PDO::PARAM_INT);
         $req->bindValue(':statearchived', State::Archived->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
 
         return array_column($req->fetchAll(), 'id');
     }

--- a/src/Models/AuthFail.php
+++ b/src/Models/AuthFail.php
@@ -51,7 +51,7 @@ final class AuthFail
     {
         $sql = 'SELECT COUNT(id) FROM lockout_devices WHERE locked_at > (NOW() - INTERVAL 1 HOUR)';
         $req = $this->Db->prepare($sql);
-        $req->execute();
+        $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }
 
@@ -82,7 +82,7 @@ final class AuthFail
         $sql = 'INSERT INTO lockout_devices (device_token) VALUES (:device_token)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':device_token', $this->deviceToken);
-        return $req->execute();
+        return $this->Db->execute($req);
     }
 
     /**
@@ -94,7 +94,7 @@ final class AuthFail
         $req = $this->Db->prepare($sql);
         $req->bindParam(':users_id', $this->userid, PDO::PARAM_INT);
         $req->bindParam(':device_token', $this->deviceToken);
-        return $req->execute();
+        return $this->Db->execute($req);
     }
 
     /**
@@ -105,7 +105,7 @@ final class AuthFail
         $sql = 'SELECT COUNT(id) FROM authfail WHERE device_token = :device_token AND attempt_time > (NOW() - INTERVAL 1 HOUR)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':device_token', $this->deviceToken);
-        $req->execute();
+        $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }
 
@@ -117,7 +117,7 @@ final class AuthFail
         $sql = 'SELECT COUNT(id) FROM authfail WHERE users_id = :users_id AND attempt_time > (NOW() - INTERVAL 1 HOUR)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':users_id', $this->userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }
 

--- a/src/Models/Compounds.php
+++ b/src/Models/Compounds.php
@@ -585,7 +585,7 @@ final class Compounds extends AbstractRest
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
         $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll();
     }
 

--- a/src/Models/Fingerprints.php
+++ b/src/Models/Fingerprints.php
@@ -89,7 +89,7 @@ final class Fingerprints
             $sql .= sprintf(' AND fp%d & %d = %d', $key, $value, $value);
         }
         $req = $this->Db->prepare($sql . ' LIMIT 2');
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll();
     }
 
@@ -101,7 +101,7 @@ final class Fingerprints
             $sql .= ' WHERE compounds_fingerprints.id IS NULL';
         }
         $req = $this->Db->prepare($sql);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll();
     }
 

--- a/src/Models/SigKeys.php
+++ b/src/Models/SigKeys.php
@@ -50,7 +50,7 @@ final class SigKeys extends AbstractRest
         $req->bindValue(':pubkey', $key->serializePk());
         $req->bindValue(':privkey', $key->serializeSk());
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
-        $res = $req->execute();
+        $res = $this->Db->execute($req);
         $keyId = $this->Db->lastInsertId();
         if ($res) {
             AuditLogs::create(new SignatureKeysCreated($key->getIdHex(), $this->userid, $this->userid));

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -93,7 +93,7 @@ final class StorageUnits extends AbstractRest
 
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
 
         return $this->Db->fetch($req);
     }
@@ -123,7 +123,7 @@ final class StorageUnits extends AbstractRest
         $req = $this->Db->prepare($sql);
         $req->bindParam(':storage_id', $storageId, PDO::PARAM_INT);
         $req->bindValue(':userid', $this->requester->userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll();
     }
 

--- a/src/Models/Tags2Entity.php
+++ b/src/Models/Tags2Entity.php
@@ -47,7 +47,7 @@ final class Tags2Entity
         }
         $req->bindValue(':type', $this->entityType->value);
         $req->bindValue(':count', count($tags), PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll(PDO::FETCH_COLUMN);
     }
 

--- a/src/Models/Templates.php
+++ b/src/Models/Templates.php
@@ -81,7 +81,7 @@ final class Templates extends AbstractTemplateEntity
         $req->bindValue(':content_type', $contentType->value, PDO::PARAM_INT);
         $req->bindParam(':rating', $rating, PDO::PARAM_INT);
         $req->bindValue(':hide_main_text', $hideMainText->value, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         $id = $this->Db->lastInsertId();
         $this->insertTags($tags, $id);
 

--- a/src/Models/UserRequestActions.php
+++ b/src/Models/UserRequestActions.php
@@ -62,7 +62,7 @@ final class UserRequestActions extends AbstractRest
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->requester->userData['userid'], PDO::PARAM_INT);
         $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->fetchAll();
     }
 

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -518,7 +518,7 @@ class Users extends AbstractRest
         $sql = 'SELECT allow_untrusted, auth_lock_time > (NOW() - INTERVAL 1 HOUR) AS currently_locked FROM users WHERE userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         $res = $req->fetch();
 
         if ($res['allow_untrusted'] === 1) {
@@ -572,7 +572,7 @@ class Users extends AbstractRest
         $req = $this->Db->prepare($sql);
         $req->bindParam(':admin_userid', $this->userid, PDO::PARAM_INT);
         $req->bindParam(':user_userid', $userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         return $req->rowCount() >= 1;
     }
 

--- a/src/Services/DatabaseCleaner.php
+++ b/src/Services/DatabaseCleaner.php
@@ -78,7 +78,7 @@ final class DatabaseCleaner implements CleanerInterface
             LEFT JOIN ' . $foreignTable . ' ON (' . $table . '.' . $foreignKey . ' = ' . $foreignTable . '.' . $foreignId . ')
             WHERE ' . $foreignTable . '.' . $foreignId . ' IS NULL';
         $req = $this->Db->prepare($sql);
-        $req->execute();
+        $this->Db->execute($req);
         $res = $req->fetchAll();
         if (!empty($res)) {
             echo sprintf("Found %d rows to delete in %s\n", count($res), $table);
@@ -98,7 +98,7 @@ final class DatabaseCleaner implements CleanerInterface
         $req = $this->Db->prepare($sql);
         foreach ($results as $orphan) {
             $req->bindParam(':id', $orphan['id']);
-            $req->execute();
+            $this->Db->execute($req);
         }
     }
 }

--- a/src/Services/DeviceTokenValidator.php
+++ b/src/Services/DeviceTokenValidator.php
@@ -38,7 +38,7 @@ final class DeviceTokenValidator
             $sql = 'SELECT COUNT(id) FROM lockout_devices WHERE device_token = :device_token AND locked_at > (NOW() - INTERVAL 1 HOUR)';
             $req = $Db->prepare($sql);
             $req->bindParam(':device_token', $this->deviceToken);
-            $req->execute();
+            $Db->execute($req);
             if ($req->fetchColumn() > 0) {
                 return false;
             }

--- a/src/Services/RevisionsCleaner.php
+++ b/src/Services/RevisionsCleaner.php
@@ -59,6 +59,6 @@ final class RevisionsCleaner implements CleanerInterface
                     ) rev
                 WHERE `rownum` % 2 = 0)';
         $req = $this->Db->prepare($sql);
-        $req->execute();
+        $this->Db->execute($req);
     }
 }

--- a/tests/unit/Auth/CookieTest.php
+++ b/tests/unit/Auth/CookieTest.php
@@ -41,7 +41,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         $req = $this->Db->prepare('UPDATE users SET token = :token, token_created_at = DATE_SUB(NOW(), INTERVAL 4 MINUTE) WHERE userid = :userid');
         $req->bindValue(':token', $this->CookieToken->getToken());
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         // now try login but our cookie isn't valid anymore
         $this->expectException(UnauthorizedException::class);
         $CookieAuth->tryAuth();
@@ -70,7 +70,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         $req = $this->Db->prepare('UPDATE users SET token = :token WHERE userid = :userid');
         $req->bindValue(':token', $this->CookieToken->getToken());
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
-        $req->execute();
+        $this->Db->execute($req);
         $this->expectException(UnauthorizedException::class);
         $CookieAuth->tryAuth();
     }

--- a/tests/unit/models/LinksTest.php
+++ b/tests/unit/models/LinksTest.php
@@ -296,7 +296,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $req->bindValue(':canbook', AbstractEntity::EMPTY_CAN_JSON);
         $req->bindValue(':canread_target', AbstractEntity::EMPTY_CAN_JSON);
         $req->bindValue(':canwrite_target', AbstractEntity::EMPTY_CAN_JSON);
-        $req->execute();
+        $this->Db->execute($req);
 
         $ItemsTypes = new ItemsTypes($User, $ItemB->id);
         $this->assertSame($ItemsTypes->id, $ItemB->id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated database query execution paths across the application to use a centralized execution handler. This improves code organization and consistency throughout the codebase without affecting end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->