### PR TITLE
fix: Correct storage unit IDs and parent IDs on query

### DIFF
--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -54,8 +54,10 @@ final class StorageUnits extends AbstractRest
                 -- Base case: Start with the given id
                 SELECT
                     id,
+                    id AS original_id,
                     name,
                     parent_id,
+                    parent_id AS original_parent_id,
                     CAST(name AS CHAR(1000)) AS full_path,
                     0 AS level_depth
                 FROM
@@ -68,8 +70,10 @@ final class StorageUnits extends AbstractRest
                 -- Recursive case: Trace the path upwards by finding parent units
                 SELECT
                     parent.id,
+                    child.original_id,
                     child.name,
                     parent.parent_id,
+                    child.original_parent_id,
                     CAST(CONCAT(parent.name, ' > ', child.full_path) AS CHAR(1000)) AS full_path,
                     child.level_depth + 1
                 FROM
@@ -80,10 +84,10 @@ final class StorageUnits extends AbstractRest
 
             -- Get the full path from the root to the given id
             SELECT
-                id,
+                original_id AS id,
                 name,
                 full_path,
-                parent_id,
+                original_parent_id AS parent_id,
                 level_depth
             FROM
                 storage_hierarchy

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -55,6 +55,16 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->StorageUnits->readOne());
         // directly test destroy function too
         $this->assertTrue($this->StorageUnits->destroy());
+
+        // Verify correct id and parent_id are returned for a child unit
+        $parentId = $this->StorageUnits->create('Test freezer');
+        $childId = $this->StorageUnits->create('Test box', $parentId);
+        $this->StorageUnits->setId($childId);
+        $result = $this->StorageUnits->readOne();
+        $this->assertEquals($childId, $result['id']);
+        $this->assertEquals($parentId, $result['parent_id']);
+        $this->assertStringContainsString('Test freezer', $result['full_path']);
+        $this->assertStringContainsString('Test box', $result['full_path']);
     }
 
     public function testReadAll(): void


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [x] I have mentioned the related **issue** (if applicable).
- [x] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation).
---

### Pull Request Description

**What issue does this PR address?**

`GET /api/v2/storage_units/{id}` returned the wrong `id` and `parent_id` when called on any non-root storage unit (i.e. any unit with a parent). Instead of the requested unit's own values, it returned the values from its root ancestor. The `name` and `full_path` fields were unaffected.

Issue #6540 

**How did you approach the solution?**

`readOne()` uses a recursive CTE that walks upward from the requested unit to the root in order to build the `full_path` string. The columns `id` and `parent_id` were carried as ordinary CTE columns and got overwritten on each recursive step with the parent row's values. By the time the recursion terminated they held the root unit's values.

The fix captures the originally requested `id` and `parent_id` as `original_id` and `original_parent_id` in the base case of the CTE, carries them unchanged through every recursive step, and aliases them back as `id` and `parent_id` in the final `SELECT`.

A regression test has been added to `testReadOne()` that creates a parent and child unit, calls `readOne()` on the child, and asserts that `id`, `parent_id`, and `full_path` are all correct.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: Base your PR off the `hypernext` branch for a feature, and the `next` branch for a bugfix.

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage unit hierarchy improvements ensure original identifiers are correctly preserved and propagated for nested items, maintaining accurate parent-child relationships and full path information.

* **Tests**
  * Added tests verifying nested storage unit structures return correct identifiers and hierarchical relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->