### PR TITLE
feat: expose flat StorageUnits structure to API

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2298,207 +2298,252 @@ paths:
 
   # STORAGE UNITS
   /storage_units:
-    summary: List containers.
+    summary: List containers or storage unit hierarchy.
     get:
       tags: ['Storage units']
-      summary: Read all containers. Yes, the name of this endpoint should be `containers`, but it's not, deal with it.
-      description: Get the full list of containers from entries you have access to.
+      summary: Read all containers, or the storage unit hierarchy when `?hierarchy=true`.
+      description: |
+        Without parameters, returns the full list of containers (assignments of experiments or resources to storage locations) that you have access to.
+
+        With `?hierarchy=true`, returns a flat list of all storage units (freezers, boxes, positions, etc.) with their hierarchy metadata (`id`, `name`, `parent_id`, `full_path`, `level_depth`, `children_count`). This allows clients to discover, traverse, or display the storage unit tree.
       operationId: read-storage-units
+      parameters:
+        - name: hierarchy
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: |
+            When true, returns a flat list of all storage units in the hierarchy
+            (id, name, parent_id, full_path, level_depth, children_count)
+            instead of the default container assignment list.
       responses:
         '200':
-          description: A list of containers attached to experiments or resources.
+          description: |
+            Without `hierarchy`: a list of containers attached to experiments or resources.
+            With `hierarchy=true`: a flat list of storage units with hierarchy metadata.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    entity_id:
-                      type: integer
-                      example: 211
-                    entity_title:
-                      type: string
-                      example: Some title
-                    entity_custom_id:
-                      nullable: true
-                      type: integer
-                      example: null
-                    page:
-                      type: string
-                      example: experiments
-                    container2item_id:
-                      type: integer
-                      example: 1
-                    qty_stored:
-                      type: string
-                      description: Quantity stored, formatted as a string (often decimal).
-                      example: "1.00"
-                    qty_unit:
-                      type: string
-                      description: Quantity unit (may contain special characters).
-                      example: "•"
-                    created_at:
-                      type: string
-                      description: Timestamp in `YYYY-MM-DD HH:MM:SS` format.
-                      example: "2026-01-23 16:10:41"
-                    modified_at:
-                      type: string
-                      description: Timestamp in `YYYY-MM-DD HH:MM:SS` format.
-                      example: "2026-01-23 16:10:41"
-                    firstname:
-                      type: string
-                      example: Ada
-                    lastname:
-                      type: string
-                      example: Lovelace
-                    fullname:
-                      type: string
-                      example: Ada Lovelace
-                    team_name:
-                      type: string
-                      example: BIOMEKA
-                    team_id:
-                      type: integer
-                      example: 1
-                    storage_id:
-                      type: integer
-                      example: 12
-                    storage_name:
-                      type: string
-                      example: 4th floor
-                    full_path:
-                      type: string
-                      description: Full storage path, formatted with separators.
-                      example: "Hospital > 4th floor"
-                    cas_number:
-                      type: string
-                      nullable: true
-                      example: null
-                    pubchem_cid:
-                      type: integer
-                      nullable: true
-                      example: null
-                    is_corrosive:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_serious_health_hazard:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_explosive:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_flammable:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_gas_under_pressure:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_hazardous2env:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_hazardous2health:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_oxidising:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_toxic:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_radioactive:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_antibiotic:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_antibiotic_precursor:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_drug:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_drug_precursor:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_explosive_precursor:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_cmr:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_nano:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_controlled:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_ed2health:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_ed2env:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_pbt:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_pmt:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_vpvb:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
-                    is_vpvm:
-                      type: integer
-                      nullable: true
-                      enum: [0, 1]
-                      example: null
+                oneOf:
+                  - description: Default mode — container assignments.
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        entity_id:
+                          type: integer
+                          example: 211
+                        entity_title:
+                          type: string
+                          example: Some title
+                        entity_custom_id:
+                          nullable: true
+                          type: integer
+                          example: null
+                        page:
+                          type: string
+                          example: experiments
+                        container2item_id:
+                          type: integer
+                          example: 1
+                        qty_stored:
+                          type: string
+                          description: Quantity stored, formatted as a string (often decimal).
+                          example: "1.00"
+                        qty_unit:
+                          type: string
+                          description: Quantity unit (may contain special characters).
+                          example: "•"
+                        created_at:
+                          type: string
+                          description: Timestamp in `YYYY-MM-DD HH:MM:SS` format.
+                          example: "2026-01-23 16:10:41"
+                        modified_at:
+                          type: string
+                          description: Timestamp in `YYYY-MM-DD HH:MM:SS` format.
+                          example: "2026-01-23 16:10:41"
+                        firstname:
+                          type: string
+                          example: Ada
+                        lastname:
+                          type: string
+                          example: Lovelace
+                        fullname:
+                          type: string
+                          example: Ada Lovelace
+                        team_name:
+                          type: string
+                          example: BIOMEKA
+                        team_id:
+                          type: integer
+                          example: 1
+                        storage_id:
+                          type: integer
+                          example: 12
+                        storage_name:
+                          type: string
+                          example: 4th floor
+                        full_path:
+                          type: string
+                          description: Full storage path, formatted with separators.
+                          example: "Hospital > 4th floor"
+                        cas_number:
+                          type: string
+                          nullable: true
+                          example: null
+                        pubchem_cid:
+                          type: integer
+                          nullable: true
+                          example: null
+                        is_corrosive:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_serious_health_hazard:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_explosive:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_flammable:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_gas_under_pressure:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_hazardous2env:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_hazardous2health:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_oxidising:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_toxic:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_radioactive:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_antibiotic:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_antibiotic_precursor:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_drug:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_drug_precursor:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_explosive_precursor:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_cmr:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_nano:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_controlled:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_ed2health:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_ed2env:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_pbt:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_pmt:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_vpvb:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                        is_vpvm:
+                          type: integer
+                          nullable: true
+                          enum: [0, 1]
+                          example: null
+                  - description: Hierarchy mode (`?hierarchy=true`) — flat list of storage units.
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 5
+                        name:
+                          type: string
+                          example: Freezer A
+                        parent_id:
+                          type: integer
+                          nullable: true
+                          description: ID of parent storage unit, or null for root units.
+                          example: null
+                        full_path:
+                          type: string
+                          description: Full path from root to this unit, separated by " > ".
+                          example: "Hospital > 4th floor > Freezer A"
+                        level_depth:
+                          type: integer
+                          description: Depth in hierarchy (0 for root units).
+                          example: 2
+                        children_count:
+                          type: integer
+                          description: Number of direct children of this storage unit.
+                          example: 3
 
         '401':
            $ref: '#/components/responses/Unauthorized'

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -131,6 +131,9 @@ final class StorageUnits extends AbstractRest
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
         $queryParams ??= $this->getQueryParams();
+        if ($queryParams->getQuery()->getBoolean('hierarchy')) {
+            return $this->readHierarchyRows();
+        }
         $sql = $this->getRecursiveSql(
             (int) $this->requester->userData['userid'],
             (int) $this->requester->userData['team'],
@@ -247,54 +250,7 @@ final class StorageUnits extends AbstractRest
 
     public function readAllRecursive(): array
     {
-        $sql = "WITH RECURSIVE storage_hierarchy AS (
-            -- Base case: Select all top-level units (those with no parent)
-            SELECT
-                id,
-                name,
-                parent_id,
-                name AS full_path,
-                0 AS level_depth,
-                (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = storage_units.id) AS children_count
-            FROM
-                storage_units
-            WHERE
-                parent_id IS NULL
-
-            UNION
-
-            -- Recursive case: Select child units and append them to the parent's path
-            SELECT
-                child.id,
-                child.name,
-                child.parent_id,
-                CONCAT(parent.full_path, ' > ', child.name) AS full_path,
-                parent.level_depth + 1,
-                (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = child.id) AS children_count
-            FROM
-                storage_units AS child
-            INNER JOIN
-                storage_hierarchy AS parent
-            ON
-                child.parent_id = parent.id
-        )
-
-        -- Query to view the full hierarchy
-        SELECT
-            id,
-            name,
-            full_path,
-            parent_id,
-            level_depth,
-            children_count
-        FROM
-            storage_hierarchy
-        ORDER BY
-            storage_hierarchy.name, parent_id";
-        $req = $this->Db->prepare($sql);
-        $this->Db->execute($req);
-
-        $all = $req->fetchAll();
+        $all = $this->readHierarchyRows();
         $groupedItems = array();
         foreach ($all as $item) {
             $groupedItems[$item['parent_id']][] = $item;
@@ -390,6 +346,57 @@ final class StorageUnits extends AbstractRest
         if (!$this->canWrite()) {
             throw new IllegalActionException();
         }
+    }
+
+    private function readHierarchyRows(): array
+    {
+        $sql = "WITH RECURSIVE storage_hierarchy AS (
+            -- Base case: Select all top-level units (those with no parent)
+            SELECT
+                id,
+                name,
+                parent_id,
+                name AS full_path,
+                0 AS level_depth,
+                (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = storage_units.id) AS children_count
+            FROM
+                storage_units
+            WHERE
+                parent_id IS NULL
+
+            UNION
+
+            -- Recursive case: Select child units and append them to the parent's path
+            SELECT
+                child.id,
+                child.name,
+                child.parent_id,
+                CONCAT(parent.full_path, ' > ', child.name) AS full_path,
+                parent.level_depth + 1,
+                (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = child.id) AS children_count
+            FROM
+                storage_units AS child
+            INNER JOIN
+                storage_hierarchy AS parent
+            ON
+                child.parent_id = parent.id
+        )
+
+        -- Query to view the full hierarchy
+        SELECT
+            id,
+            name,
+            full_path,
+            parent_id,
+            level_depth,
+            children_count
+        FROM
+            storage_hierarchy
+        ORDER BY
+            storage_hierarchy.name, parent_id";
+        $req = $this->Db->prepare($sql);
+        $this->Db->execute($req);
+        return $req->fetchAll();
     }
 
     private function hasContainers(): bool

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -63,6 +63,21 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->StorageUnits->readAllRecursive());
         $this->assertIsArray($this->StorageUnits->readAllFromStorage(1));
         $this->assertIsArray($this->StorageUnits->readCount());
+
+        // Test hierarchy mode returns storage units, not container assignments
+        $parentId = $this->StorageUnits->create('Hierarchy test freezer');
+        $childId = $this->StorageUnits->create('Hierarchy test box', $parentId);
+
+        $queryParams = $this->StorageUnits->getQueryParams(new \Symfony\Component\HttpFoundation\InputBag(array('hierarchy' => 'true')));
+        $result = $this->StorageUnits->readAll($queryParams);
+
+        $this->assertIsArray($result);
+        $ids = array_column($result, 'id');
+        $this->assertContains($parentId, $ids);
+        $this->assertContains($childId, $ids);
+        $this->assertArrayHasKey('parent_id', $result[0]);
+        $this->assertArrayHasKey('children_count', $result[0]);
+        $this->assertArrayNotHasKey('entity_id', $result[0]);
     }
 
     public function testReadAllFromStorage(): void


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:


### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [x] I have mentioned the related **issue** (if applicable).
- [x] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation) — the OpenAPI spec (`apidoc/v2/openapi.yaml`) has been updated with the new parameter and response schema. No change needed to the external documentation site.

---

### Pull Request Description

**What issue does this PR address?**

`GET /api/v2/storage_units` returns container assignments — rows linking experiments or resources to storage locations. There was no API way to list the storage units themselves (freezers, shelves, boxes, etc.) or discover their hierarchy. This blocked any API client that needs to display or navigate the storage tree.

Issue #6541 

**How did you approach the solution?**

Added a `?hierarchy=true` query parameter to `GET /api/v2/storage_units`. When set, the endpoint returns a flat array of all storage units with `id`, `name`, `parent_id`, `full_path`, `level_depth`, and `children_count`. All existing behaviour is preserved when the parameter is absent.

Implementation details:

- The CTE SQL that was embedded in `readAllRecursive()` has been extracted into a new private `readHierarchyRows()` method returning a flat array. `readAllRecursive()` now calls this method and groups by `parent_id` as before, preserving the existing web UI behaviour.
- `readAll()` checks for `?hierarchy=true` at the top and returns `readHierarchyRows()` directly if set, otherwise falls through to the existing container-assignment query unchanged.
- A flat array is used rather than the grouped format from `readAllRecursive()` because the `""` key used internally for root nodes is confusing for API consumers. A flat array lets clients filter with `parent_id === null` for roots or `parent_id === 5` for children of a specific unit.
- `apidoc/v2/openapi.yaml` documents the new `hierarchy` parameter and updates the `200` response schema to `oneOf` covering both modes.
- `testReadAll()` has been extended to verify that hierarchy mode returns storage unit rows (with `parent_id` and `children_count`) and not container assignment rows (no `entity_id`).

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: Base your PR off the `hypernext` branch for a feature, and the `next` branch for a bugfix.

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `hierarchy` parameter to the storage units endpoint, enabling retrieval of storage unit hierarchy metadata (parent relationships, depth level, children count) alongside standard container assignments.

* **Tests**
  * Added test coverage for storage unit hierarchy retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->