### PR TITLE
feat: resources: allow bulk update of booking permission

### DIFF
--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -436,6 +436,14 @@
               <option value='{{ key }}'>{{ value }}</option>
             {% endfor %}
           </select>
+            {% if pageName == 'database' %}
+            {# CANBOOK #}
+            <select aria-label='{{ 'Change book permissions'|trans }}' name='is_bookable' autocomplete='off' class='mr-1 mb-2 form-control'>
+                <option selected disabled value=''>{{ 'Change book permissions'|trans }}</option>
+                <option value='1'>{{ 'Allow booking this resource'|trans }}</option>
+                <option value='0'>{{ 'Do not allow booking this resource'|trans }}</option>
+            </select>
+            {% endif %}
           {# ADD A TAG #}
           <input type='text' aria-label='{{ 'Add a tag'|trans }}' id='createTagInputMultiple' name='tags' class='createTagInputMultiple mr-1 mb-2 form-control' data-autocomplete='tags' placeholder='{{ 'Add a tag'|trans }}' />
           {# ADD A RESOURCE LINK #}


### PR DESCRIPTION
fix #6222

Adds a bulk action option to change the booking permission (is_bookable) for selected resources from the show view.

Changes:
- Introduced a new "Change book permissions" select input in the bulk actions bar
- Allows toggling booking availability on multiple resources at once

On resuorces pages -> this improves resource management by enabling administrators and authorized users to quickly enable or disable booking without editing each resource individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a booking permissions selector for database resources, allowing you to control whether a resource can be booked or remain unavailable for booking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->