### PR TITLE
feat: spreadsheet: add documentation link below editor

### DIFF
--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -69,6 +69,7 @@ final class i18n4Js
             'editing-metadata' => _('You are currently editing the metadata attached to this entry.'),
             'email-sent-to-x' => _('Email sent to {{num, number}} users.'),
             'current-edit' => _('Currently editing'),
+            'documentation' => _('Documentation'),
             'email' => _('Email'),
             'enable-permission' => _('You must allow at least one permission setting.'),
             'encryption' => _('Encryption'),

--- a/src/templates/spreadsheet-editor.html
+++ b/src/templates/spreadsheet-editor.html
@@ -12,9 +12,5 @@
       {# allow-modals is needed for prompts asking the filename #}
       <iframe id='spreadsheetIframe' title='{{ 'Spreadsheet Editor'|trans }}' src='/spreadsheet.html' sandbox='allow-scripts allow-same-origin allow-forms allow-downloads allow-modals'></iframe>
   </div>
-    <span>
-        <i class='fas fa-exclamation-circle' aria-hidden='true'></i>
-        {{ 'See more about calculations in the %s.'|trans|format("<a href='https://doc.elabftw.net/docs/usage/user-guide/experiments#spreadsheet-editor' class='external-link' target='_blank' rel='noopener'>Spreadsheet Editor documentation</a>")|raw }}
-    </span>
 </section>
 <hr>

--- a/src/ts/langs/ca_ES.ts
+++ b/src/ts/langs/ca_ES.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Actualment esteu editant les metadades adjuntes a aquesta entrada.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Editant actualment",
+    "documentation": "Documentació",
     "email": "Correu electrònic",
     "enable-permission": "Has de permetre almenys un permís de configuració.",
     "encryption": "Encriptació",

--- a/src/ts/langs/cs_CZ.ts
+++ b/src/ts/langs/cs_CZ.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Právě upravujete metadata připojená k tomuto záznamu.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Dokumentace",
     "email": "Email",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/de_DE.ts
+++ b/src/ts/langs/de_DE.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Sie bearbeiten gerade die Metadaten zu diesem Eintrag.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Wird gerade bearbeitet",
+    "documentation": "Dokumentation",
     "email": "E-Mail",
     "enable-permission": "Sie müssen mindestens eine Berechtigung vergeben.",
     "encryption": "Verschlüsselung",

--- a/src/ts/langs/el_GR.ts
+++ b/src/ts/langs/el_GR.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Αυτήν τη στιγμή επεξεργάζεστε τα μεταδεδομένα που επισυνάπτονται σε αυτήν την καταχώριση.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Τεκμηρίωση",
     "email": "Ηλεκτρονικό ταχυδρομείο",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/en_GB.ts
+++ b/src/ts/langs/en_GB.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "You are currently editing the metadata attached to this entry.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Documentation",
     "email": "Email",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/en_US.ts
+++ b/src/ts/langs/en_US.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "You are currently editing the metadata attached to this entry.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Documentation",
     "email": "Email",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/es_ES.ts
+++ b/src/ts/langs/es_ES.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Actualmente estás editando los metadatos adjuntos a esta entrada.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Editando en este momento",
+    "documentation": "Documentación",
     "email": "Correo electrónico",
     "enable-permission": "Debes permitir por lo menos una configuración de permiso.",
     "encryption": "Encriptación",

--- a/src/ts/langs/et_EE.ts
+++ b/src/ts/langs/et_EE.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Sa muudad praegu sellele kirjele lisatud metaandmeid.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Praegu toimetab",
+    "documentation": "Dokumentatsioon",
     "email": "E-post",
     "enable-permission": "Peate lubama vähemalt ühe loa seadistuse.",
     "encryption": "Encryption",

--- a/src/ts/langs/fi_FI.ts
+++ b/src/ts/langs/fi_FI.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Muokkaat tällä hetkellä tähän merkintään liitettyjä metatietoja.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Dokumentaatio",
     "email": "Sähköposti",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/fr_FR.ts
+++ b/src/ts/langs/fr_FR.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Vous êtes en train de modifier les métadonnées jointes à cette entrée.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Actuellement en cours d'édition",
+    "documentation": "Documentation",
     "email": "Email",
     "enable-permission": "Vous devez autoriser au moins un paramètre de permission.",
     "encryption": "Chiffrement",

--- a/src/ts/langs/id_ID.ts
+++ b/src/ts/langs/id_ID.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Anda sedang menyunting metadata yang dilampirkan ke entri ini.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Sedang mengedit",
+    "documentation": "Dokumentasi",
     "email": "Surel",
     "enable-permission": "Anda harus mengizinkan setidaknya satu pengaturan izin.",
     "encryption": "Encryption",

--- a/src/ts/langs/it_IT.ts
+++ b/src/ts/langs/it_IT.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Si stanno modificando i metadati allegati a questa voce.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Attualmente in fase di editing",
+    "documentation": "Documentazione",
     "email": "Indirizzo email",
     "enable-permission": "È necessario consentire almeno un'impostazione di autorizzazione.",
     "encryption": "Criptazione",

--- a/src/ts/langs/ja_JP.ts
+++ b/src/ts/langs/ja_JP.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "現在、このエントリーに添付されているメタデータを編集中です。",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "現在編集中",
+    "documentation": "公式ドキュメント",
     "email": "Eメールアドレス",
     "enable-permission": "少なくとも1つのパーミッション設定を許可する必要があります。",
     "encryption": "Encryption",

--- a/src/ts/langs/ko_KR.ts
+++ b/src/ts/langs/ko_KR.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "현재 이 항목에 첨부된 메타데이터를 편집하고 있습니다.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "문서",
     "email": "이메일",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/nl_BE.ts
+++ b/src/ts/langs/nl_BE.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "U bewerkt momenteel de metadata die aan dit item gekoppeld zijn.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Documentatie",
     "email": "E-mail",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/pl_PL.ts
+++ b/src/ts/langs/pl_PL.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Aktualnie edytujesz metadane dołączone do tego wpisu.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Obecnie edytowany",
+    "documentation": "Dokumentacja",
     "email": "Email",
     "enable-permission": "Musisz zezwolić na co najmniej jedno ustawienie uprawnień.",
     "encryption": "Kodowanie",

--- a/src/ts/langs/pt_BR.ts
+++ b/src/ts/langs/pt_BR.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "No momento, você está editando os metadados anexados a este registro.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Documentação",
     "email": "E-mail",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/pt_PT.ts
+++ b/src/ts/langs/pt_PT.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Está atualmente a editar os metadados associados a esta entrada.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Documentação",
     "email": "E-mail",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/ru_RU.ts
+++ b/src/ts/langs/ru_RU.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "В настоящее время вы редактируете метаданные, прикрепленные к этой записи.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Документация",
     "email": "Email",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/sk_SK.ts
+++ b/src/ts/langs/sk_SK.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Editujete metadáta pripojené k tejto položke.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Dokumentácia",
     "email": "Email",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/sl_SI.ts
+++ b/src/ts/langs/sl_SI.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Trenutno urejate metapodatke, priložene temu vnosu.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Dokumentacija",
     "email": "Elektronska pošta",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/uz_UZ.ts
+++ b/src/ts/langs/uz_UZ.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "Siz hozirda ushbu yozuvga biriktirilgan metamaʼlumotlarni tahrir qilyapsiz.",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "Currently editing",
+    "documentation": "Hujjatlar",
     "email": "Elektron pochta",
     "enable-permission": "You must allow at least one permission setting.",
     "encryption": "Encryption",

--- a/src/ts/langs/zh_CN.ts
+++ b/src/ts/langs/zh_CN.ts
@@ -35,6 +35,7 @@ const t = {
     "editing-metadata": "当前正在编辑附加到此项的元数据。",
     "email-sent-to-x": "Email sent to {{num, number}} users.",
     "current-edit": "目前正在编辑",
+    "documentation": "文档",
     "email": "Email",
     "enable-permission": "您必须允许至少一个权限设置。",
     "encryption": "加密",

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -146,8 +146,10 @@ function SpreadsheetEditor() {
     };
     // we render the spreadsheet in an iframe, so we'll also use a custom fullscreen button
     const fullscreenBtn = { type: 'icon', class: 'mx-2 fas fa-expand', tooltip: i18next.t('fullscreen'), onclick: () => toggleFullscreen()};
-    const clearBtn = { type: 'icon', class: 'ml-2 fas fa-trash', tooltip: i18next.t('clear'), onclick: clearSpreadsheet };
+    const clearBtn = { type: 'icon', class: 'mx-2 fas fa-trash', tooltip: i18next.t('clear'), onclick: clearSpreadsheet };
     const importBtn = { type: 'icon', class: 'fas fa-upload', tooltip: i18next.t('import'), onclick: () => document.getElementById('importFileInput').click() };
+    const docUrl = 'https://doc.elabftw.net/docs/usage/user-guide/experiments#spreadsheet-editor';
+    const docBtn = { type: 'icon', class: 'ml-2 fa-solid fa-book-atlas', tooltip: i18next.t('documentation'), onclick: () => window.top.open(docUrl, '_blank')};
     // replace original save & fullscreen buttons with our custom functions
     Object.assign(saveBtn, {
       content: '',
@@ -157,7 +159,7 @@ function SpreadsheetEditor() {
       onclick: isSaving ? undefined : onSaveOrReplace,
     });
 
-    tb.items.push(fullscreenBtn, importBtn, exportBtn, clearBtn );
+    tb.items.push(fullscreenBtn, importBtn, exportBtn, clearBtn, {type: 'divisor'}, docBtn );
     return tb;
   };
   // pass a dynamic key to force SpreadsheetInner to remount when data shape changes


### PR DESCRIPTION
implements #6258

Adds a contextual help link below the spreadsheet editor iframe, pointing users to the Spreadsheet Editor documentation.

This provides quick access to guidance about calculations and usage, improving discoverability and user experience without modifying editor functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a documentation button to the spreadsheet toolbar for quick access to documentation resources.

* **Localization**
  * Extended translation support for the new documentation feature across 25 languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->