### PR TITLE
doc: remove mentions of next and hypernext

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,6 @@ Please provide **clear context** for your proposed change:
 
 Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).
 
-**IMPORTANT**: Base your PR off the `hypernext` branch for a feature, and the `next` branch for a bugfix.
-
 **IMPORTANT**: All new features **MUST** have tests added.
 
 Please note that working on a PR doesn't automatically mean that your code will be merged.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     day: friday
     time: "02:00"
   open-pull-requests-limit: 10
-  target-branch: hypernext
+  target-branch: master
   ignore:
   - dependency-name: snyk
     versions:
@@ -19,4 +19,4 @@ updates:
     day: friday
     time: "02:00"
   open-pull-requests-limit: 10
-  target-branch: hypernext
+  target-branch: master

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - next
-      - hypernext
       - ird
 jobs:
   mirror:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "hypernext" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "hypernext" ]
+    branches: [ "master" ]
 
 jobs:
   analyze:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: Codespell
 
 on:
   push:
-    branches: [master,hypernext,next]
+    branches: [master]
   pull_request:
-    branches: [master,hypernext,next]
+    branches: [master]
 
 jobs:
   codespell:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # codespell github action does not yet allow for --config option
       # https://github.com/codespell-project/actions-codespell/issues/67
       # so we need to install and invoke "manually"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![CircleCI](https://circleci.com/gh/elabftw/elabftw/tree/master.svg?style=svg)](https://circleci.com/gh/elabftw/elabftw/tree/master)
 
-[![Code Coverage](https://codecov.io/gh/elabftw/elabftw/branch/hypernext/graph/badge.svg?token=SHSZuaxt17)](https://codecov.io/gh/elabftw/elabftw)
+[![Code Coverage](https://codecov.io/gh/elabftw/elabftw/branch/master/graph/badge.svg?token=SHSZuaxt17)](https://codecov.io/gh/elabftw/elabftw)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2766/badge)](https://bestpractices.coreinfrastructure.org/projects/2766)
 [![Join the chat at https://gitter.im/elabftw/elabftw](https://badges.gitter.im/elabftw/elabftw.svg)](https://gitter.im/elabftw/elabftw?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License](https://img.shields.io/badge/license-AGPL-blue.svg)](https://www.gnu.org/licenses/agpl-3.0.en.html)

--- a/tests/circleci.Dockerfile
+++ b/tests/circleci.Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for CircleCI
 FROM elabtmp
 
-# avoid carry-over from hypernext
+# avoid carry-over
 RUN rm -rf /elabftw/*
 
 # copy everything because we can't bind mount

--- a/tests/elabtmp.Dockerfile
+++ b/tests/elabtmp.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 # Dockerfile for CI image
 # we allow specifying a base image branch so the build will happen on the corresponding branch of elabimg
-ARG BASE_IMAGE_VERSION=hypernext
+ARG BASE_IMAGE_VERSION=master
 FROM elabftw/elabimg:$BASE_IMAGE_VERSION
 
 # Install xdebug for coverage


### PR DESCRIPTION
see: https://github.com/elabftw/elabftw/discussions/6549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to use the master branch as the primary trigger branch
  * Updated GitHub Actions checkout dependency to the latest version
  * Removed references to deprecated feature branches across build workflows
  * Updated container image configurations to use the master branch variant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->