### PR TITLE
feat: spreadsheet: add documentation link next to editor

### DIFF
--- a/src/templates/spreadsheet-editor.html
+++ b/src/templates/spreadsheet-editor.html
@@ -12,8 +12,8 @@
     {% if App.devMode -%}
       <!-- [html-validate-disable-block unique-landmark, no-deprecated-attr, prefer-native-element: suppress errors from spreadsheet editor] -->
     {%- endif %}
-      {# allow-modals is needed for prompts asking the filename #}
-      <iframe id='spreadsheetIframe' title='{{ 'Spreadsheet Editor'|trans }}' src='/spreadsheet.html' sandbox='allow-scripts allow-same-origin allow-forms allow-downloads allow-modals'></iframe>
+    {# allow-modals is needed for prompts asking the filename #}
+    <iframe id='spreadsheetIframe' title='{{ 'Spreadsheet Editor'|trans }}' src='/spreadsheet.html' sandbox='allow-scripts allow-same-origin allow-forms allow-downloads allow-modals'></iframe>
   </div>
 </section>
 <hr>


### PR DESCRIPTION
implements #6258

Adds a contextual help button next the spreadsheet editor iframe, pointing users to the Spreadsheet Editor documentation.

This provides quick access to guidance about calculations and usage, improving discoverability and user experience without modifying editor functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Documentation link inside the spreadsheet editor panel, placed at the top and right-aligned for quick access to external documentation.
  * UI and editor behavior remain unchanged; the link provides convenient access without affecting the embedded editor or existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->