### PR TITLE
bug/minor: links: add autocomplete back on page load

### DIFF
--- a/src/ts/steps-links.ts
+++ b/src/ts/steps-links.ts
@@ -24,6 +24,8 @@ import { ApiC } from './api';
 import { entity } from './getEntity';
 import { on } from './handlers';
 
+addAutocompleteToLinkInputs();
+
 // FINISH: outside if stepsDiv because can be from Todolist panel
 $(document).on('click', 'input[type=checkbox].stepbox', function(e) {
   // ask for confirmation before un-finishing a step
@@ -176,6 +178,5 @@ if (document.getElementById('stepsDiv')) {
     }
   });
   // AUTOCOMPLETE
-  addAutocompleteToLinkInputs();
   addAutocompleteToCompoundsInputs();
 }


### PR DESCRIPTION
The function to bind autocomplete on link inputs was not triggered on page load. This change makes it happen.

fix #6375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized link input autocomplete initialization to occur only once during page load, eliminating redundant processing calls and improving startup efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->