### PR TITLE
bug/minor: saml: don't refresh the friendly name of idp

### DIFF
--- a/src/Models/Idps.php
+++ b/src/Models/Idps.php
@@ -163,7 +163,7 @@ final class Idps extends AbstractRest
             }
             $this->setId($id);
             // when coming from XML, we do not overwrite these attributes
-            $immutableFields = array('email_attr', 'fname_attr', 'lname_attr', 'team_attr', 'orgid_attr');
+            $immutableFields = array('name', 'email_attr', 'fname_attr', 'lname_attr', 'team_attr', 'orgid_attr');
             foreach ($immutableFields as $key) {
                 unset($idp[$key]);
             }


### PR DESCRIPTION
for instance, microsoft Entra ID will have something like https://sts.windows.net/<uuid>. We want to keep the friendly name set by human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Identity provider names are now preserved during XML-based updates and will no longer be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->