### PR TITLE
fix/minor: extrafields: alignment in list mode

### DIFF
--- a/src/templates/show-item-table.html
+++ b/src/templates/show-item-table.html
@@ -91,7 +91,7 @@
 {# a random id is used because with the favorites the item can appear two times on the page so the old blah_123 doesn't work well #}
 <tr hidden id='{{ randomId }}' style='border-left: 4px solid #{{ item.category_color }}'>
   <td colspan='8'>
-    <div style='overflow:auto;margin: 10px 0 0 20px'></div>
+    <div class='d-flex flex-column align-items-start'></div>
   </td>
 </tr>
 


### PR DESCRIPTION
fix #5538

* Reduce spacing between extrafield titles and values in list mode to improve readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling markup for improved consistency in the item table display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->