### PR TITLE
ci: build edge image only on pre-release

### DIFF
--- a/.github/workflows/build_edge.yaml
+++ b/.github/workflows/build_edge.yaml
@@ -1,9 +1,10 @@
-name: Build edge image on tag
+name: Build edge image on pre-release
 
+# triggered by publishing a release
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
+
 
 ## GITHUB_TOKEN authentication
 permissions:
@@ -14,6 +15,8 @@ jobs:
         #runs-on: ubuntu-latest
         # temporary revert for arm build
         runs-on: ubuntu-22.04
+        # only on pre-releases
+        if: github.event.release.prerelease == true
         steps:
             # https://github.com/CycodeLabs/cimon-action
             - name: Cimon supply chain attack protection


### PR DESCRIPTION
not on tags as this can lead to issues with stable tags mixed with newer tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to trigger on pre-release events instead of tag push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->