### PR TITLE
bug/medium: users-table: improve filtering for badges and translated values

### DIFF
--- a/src/ts/users-table.jsx
+++ b/src/ts/users-table.jsx
@@ -31,23 +31,11 @@ const validUntilText = v => v === null ? i18next.t('forever') : v;
 const teamsText = teams => teams?.map(t => `${t.name} ${t.is_admin ? i18next.t('admin') : i18next.t('user')}`).join(' ') ?? '';
 
 async function toggleUserModal(user) {
-  const textParams = [
-    'userid',
-    'firstname',
-    'lastname',
-    'email',
-    'valid_until',
-    'orgid',
-  ];
+  const textParams = ['userid', 'firstname', 'lastname', 'email', 'valid_until', 'orgid'];
   textParams.forEach(param => {
     (document.getElementById(`userInput-${param}`)).value = user[param];
   });
-  const binaryParams = [
-    'is_sysadmin',
-    'can_manage_users2teams',
-    'can_manage_compounds',
-    'can_manage_inventory_locations',
-  ];
+  const binaryParams = ['is_sysadmin', 'can_manage_users2teams', 'can_manage_compounds', 'can_manage_inventory_locations'];
   binaryParams.forEach(param => {
     const input = (document.getElementById(`userInput-${param}`));
     input.checked = user[param] === 1;
@@ -61,8 +49,8 @@ if (document.getElementById('users-table')) {
   ModuleRegistry.registerModules([ClientSideRowModelModule]);
 
   const rowSelection = {
-      mode: 'multiRow',
-      headerCheckbox: false,
+    mode: 'multiRow',
+    headerCheckbox: false,
   };
 
   const GridExample = () => {
@@ -110,26 +98,26 @@ if (document.getElementById('users-table')) {
     };
 
     const [columnDefs] = useState([
-        { field: 'userid', headerName: i18next.t('userid'), pinned: 'left' },
-        { field: 'teams', headerName: i18next.t('teams'), cellRenderer: TeamsRenderer, filterValueGetter: p => teamsText(p.data.teams) },
-        { field: 'firstname', headerName: i18next.t('firstname') },
-        { field: 'lastname', headerName: i18next.t('lastname') },
-        { field: 'email', headerName: i18next.t('email') },
-        { field: 'last_login', headerName: i18next.t('last-login'), valueGetter: p => lastLoginText(p.data.last_login), filterValueGetter: p => lastLoginText(p.data.last_login), cellRenderer: LastLoginRenderer },
-        { field: 'is_sysadmin', headerName: i18next.t('is-sysadmin'), valueGetter: p => yesNo(p.data.is_sysadmin), filterValueGetter: p => yesNo(p.data.is_sysadmin), cellRenderer: BinaryRenderer },
-        { field: 'has_mfa_enabled', headerName: i18next.t('2FA'), valueGetter: p => enabledDisabled(p.data.has_mfa_enabled), filterValueGetter: p => enabledDisabled(p.data.has_mfa_enabled), cellRenderer: HasMfaEnabledRenderer },
-        { field: 'valid_until', headerName: i18next.t('Valid until'), valueGetter: p => validUntilText(p.data.valid_until), filterValueGetter: p => validUntilText(p.data.valid_until), cellRenderer: ValidUntilRenderer },
-        { field: 'validated', headerName: i18next.t('Validated'), valueGetter: p => yesNo(p.data.validated), filterValueGetter: p => yesNo(p.data.validated), cellRenderer: BinaryRenderer },
-        { field: 'orgid', headerName: i18next.t('Internal id') },
-        { field: 'orcid', headerName: 'ORCID' },
-        { field: 'can_manage_users2teams', headerName: i18next.t('can-manage-users2teams'), valueGetter: p => yesNo(p.data.can_manage_users2teams), filterValueGetter: p => yesNo(p.data.can_manage_users2teams), cellRenderer: BinaryRenderer },
-        { field: 'can_manage_compounds', headerName: i18next.t('can-manage-compounds'), valueGetter: p => yesNo(p.data.can_manage_compounds), filterValueGetter: p => yesNo(p.data.can_manage_compounds), cellRenderer: BinaryRenderer },
-        { field: 'can_manage_inventory_locations', headerName: i18next.t('can-manage-inventory-locations'), valueGetter: p => yesNo(p.data.can_manage_inventory_locations), filterValueGetter: p => yesNo(p.data.can_manage_inventory_locations), cellRenderer: BinaryRenderer },
+      { field: 'userid', headerName: i18next.t('userid'), pinned: 'left' },
+      { field: 'teams', headerName: i18next.t('teams'), cellRenderer: TeamsRenderer, filterValueGetter: p => teamsText(p.data.teams) },
+      { field: 'firstname', headerName: i18next.t('firstname') },
+      { field: 'lastname', headerName: i18next.t('lastname') },
+      { field: 'email', headerName: i18next.t('email') },
+      { field: 'last_login', headerName: i18next.t('last-login'), valueGetter: p => lastLoginText(p.data.last_login), filterValueGetter: p => lastLoginText(p.data.last_login), cellRenderer: LastLoginRenderer },
+      { field: 'is_sysadmin', headerName: i18next.t('is-sysadmin'), valueGetter: p => yesNo(p.data.is_sysadmin), filterValueGetter: p => yesNo(p.data.is_sysadmin), cellRenderer: BinaryRenderer },
+      { field: 'has_mfa_enabled', headerName: i18next.t('2FA'), valueGetter: p => enabledDisabled(p.data.has_mfa_enabled), filterValueGetter: p => enabledDisabled(p.data.has_mfa_enabled), cellRenderer: HasMfaEnabledRenderer },
+      { field: 'valid_until', headerName: i18next.t('Valid until'), valueGetter: p => validUntilText(p.data.valid_until), filterValueGetter: p => validUntilText(p.data.valid_until), cellRenderer: ValidUntilRenderer },
+      { field: 'validated', headerName: i18next.t('Validated'), valueGetter: p => yesNo(p.data.validated), filterValueGetter: p => yesNo(p.data.validated), cellRenderer: BinaryRenderer },
+      { field: 'orgid', headerName: i18next.t('Internal id') },
+      { field: 'orcid', headerName: 'ORCID' },
+      { field: 'can_manage_users2teams', headerName: i18next.t('can-manage-users2teams'), valueGetter: p => yesNo(p.data.can_manage_users2teams), filterValueGetter: p => yesNo(p.data.can_manage_users2teams), cellRenderer: BinaryRenderer },
+      { field: 'can_manage_compounds', headerName: i18next.t('can-manage-compounds'), valueGetter: p => yesNo(p.data.can_manage_compounds), filterValueGetter: p => yesNo(p.data.can_manage_compounds), cellRenderer: BinaryRenderer },
+      { field: 'can_manage_inventory_locations', headerName: i18next.t('can-manage-inventory-locations'), valueGetter: p => yesNo(p.data.can_manage_inventory_locations), filterValueGetter: p => yesNo(p.data.can_manage_inventory_locations), cellRenderer: BinaryRenderer },
     ]);
 
     // Load data on component mount
     useEffect(() => {
-        fetchData();
+      fetchData();
     }, []);
 
     // all the users are loaded in the table, which does client side pagination
@@ -156,15 +144,15 @@ if (document.getElementById('users-table')) {
     };
 
     const defaultColDef = useMemo(() => {
-        return {
-            filter: 'agTextColumnFilter',
-            floatingFilter: true,
-            onCellValueChanged: (event) => {
-              const params = {};
-              params[event.column.colId] = event.newValue;
-              ApiC.patch(`users/${event.data.id}`, params);
-            }
-        };
+      return {
+        filter: 'agTextColumnFilter',
+        floatingFilter: true,
+        onCellValueChanged: (event) => {
+          const params = {};
+          params[event.column.colId] = event.newValue;
+          ApiC.patch(`users/${event.data.id}`, params);
+        }
+      };
     }, []);
 
     // when a row is selected with the checkbox
@@ -190,39 +178,39 @@ if (document.getElementById('users-table')) {
     return (
       <>
         <input
-          type="text"
+          type='text'
           placeholder={i18next.t('search')}
           onChange={onQuickFilterChange}
           className={'form-control mb-2'}
           aria-label={i18next.t('search')}
         />
-      <div
-        className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'} style={{ height: 650 }}>
-        <AgGridReact
-          rowData={rowData}
-          columnDefs={columnDefs}
-          defaultColDef={defaultColDef}
-          onGridReady={onGridReady}
-          rowSelection={rowSelection}
-          onCellDoubleClicked={cellDoubleClicked}
-          onSelectionChanged={selectionChanged}
-          pagination={true}
-          paginationPageSize={15}
-          paginationPageSizeSelector={[15, 50, 100, 500]}
-        />
-      </div>
-      <div className='d-flex justify-content-start my-2'>
-        <button
-          data-action='import-users-in-team'
-          id='importUsersBtn'
-          type='button'
-          disabled='disabled'
-          className={'btn btn-sm btn-secondary'}
-        >
-        {i18next.t('add-to-team')}
-        </button>
-      </div>
-    </>
+        <div
+          className={isDark ? 'ag-theme-alpine-dark' : 'ag-theme-alpine'} style={{ height: 650 }}>
+          <AgGridReact
+            rowData={rowData}
+            columnDefs={columnDefs}
+            defaultColDef={defaultColDef}
+            onGridReady={onGridReady}
+            rowSelection={rowSelection}
+            onCellDoubleClicked={cellDoubleClicked}
+            onSelectionChanged={selectionChanged}
+            pagination={true}
+            paginationPageSize={15}
+            paginationPageSizeSelector={[15, 50, 100, 500]}
+          />
+        </div>
+        <div className='d-flex justify-content-start my-2'>
+          <button
+            data-action='import-users-in-team'
+            id='importUsersBtn'
+            type='button'
+            disabled='disabled'
+            className={'btn btn-sm btn-secondary'}
+          >
+            {i18next.t('add-to-team')}
+          </button>
+        </div>
+      </>
     );
   };
 
@@ -232,11 +220,11 @@ if (document.getElementById('users-table')) {
     const [reloadKey, setReloadKey] = useState(0);
     // trigger this with document.dispatchEvent(new CustomEvent('dataReload'))
     document.addEventListener('dataReload', () => setReloadKey(prevKey => prevKey + 1));
-    return <GridExample key={reloadKey} />;
+    return <GridExample key={reloadKey}/>;
   };
 
   const root = createRoot(document.getElementById('users-table'));
   root.render(
-    <App />
+    <App/>
   );
 }


### PR DESCRIPTION
fix #6538

Turns out, not only team filter was broken but most of them (I guess we mainly use 'text-only' ones like usernames and emails.

Before:
![userstable-before](https://github.com/user-attachments/assets/aa1859f4-931b-4f48-96e4-5bcf6c297223)

After :heavy_check_mark: 
![userstable-after](https://github.com/user-attachments/assets/76248f60-598b-4696-97e9-ed933f8cc09f)

This fix improves filtering behavior in the users table by aligning filter
values with rendered (translated) display values.

- Add helper mappers (yes/no, enabled/disabled, never/forever).
- Use valueGetter and filterValueGetter so filters operate on
  translated text instead of raw numeric/null values.
- Enable filtering by team name and role (admin/user) in teams column.
- Adjust renderers to work with translated values.
- Add defensive check for empty teams list.
- some linting!

This makes table filtering consistent with what users actually see
in the UI, especially for badges, icons, and null-based fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Teams column now displays individual team badges with role indicators (admin/user)
  * Enhanced filtering capabilities across multiple table columns

* **Improvements**
  * Binary fields and MFA status now display localized yes/no and enabled/disabled text
  * Last login and valid-until fields show clearer placeholders for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->