### PR TITLE
bug/minor: templates: fix experiments templates tinymce template source

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -210,7 +210,9 @@ export function getTinymceBaseConfig(page: string): object {
   }
 
   const isDark = document.documentElement.classList.contains('dark-mode');
-  const templateEndpoint = entity.type === EntityType.Experiment ? EntityType.Template : EntityType.ItemType;
+  const templateEndpoint = (entity.type === EntityType.Experiment || entity.type === EntityType.Template)
+    ? EntityType.Template
+    : EntityType.ItemType;
 
   return {
     selector: '.mceditable',


### PR DESCRIPTION
was itemstypes instead of templates

followup of #6577.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template endpoint resolution to consistently handle both Experiment and Template entity types, ensuring templates are retrieved from the correct server endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->