### PR TITLE
bug/minor: fix checkbox in the QRcode generation modal

### DIFF
--- a/src/templates/export-menu.html
+++ b/src/templates/export-menu.html
@@ -79,10 +79,10 @@
           <div>
             <label class='d-inline mr-1' for='qrpng_exportTitle'>{{ 'Include title'|trans }}</label>
           </div>
-          <label class='switch' title='{{ 'Include title'|trans }}'><span class='sr-only'>{{ 'Include title'|trans }}<span>
+          <label class='switch' title='{{ 'Include title'|trans }}'><span class='sr-only'>{{ 'Include title'|trans }}</span>
+            <input type='checkbox' checked='checked' id='qrpng_exportTitle'>
             <span class='slider'></span>
           </label>
-          <input type='checkbox' checked='checked' id='qrpng_exportTitle'>
         </div>
 
         {# MAX LINES #}


### PR DESCRIPTION
Problem:
In the QR code generation modal, the checkbox to include the resource title under the QR code was missing

Expected behavior:
The user should be able to see and use the checkbox to choose whether the title is displayed under the QRc ode

Fix:
THe <span> tag inside the switch label was not close properly 