### PR TITLE
bug/minor: clearForm: prevent radio inputs value from being cleared

### DIFF
--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -205,7 +205,7 @@ export function collectForm(form: HTMLElement): object {
 export function clearForm(form: HTMLElement): void {
   ['input', 'select', 'textarea'].forEach(inp => {
     form.querySelectorAll(inp).forEach((input: HTMLInputElement) => {
-      if (input.dataset.noBlank !== '1') {
+      if (input.dataset.noBlank !== '1' && input.type !== 'radio') {
         input.value = '';
         if (input.type === 'checkbox') {
           input.checked = false;


### PR DESCRIPTION
The clearForm function clears input. But radio buttons' input value must not be cleared because they are static. This fixes #6600.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio button selections are now preserved when clearing form fields, correcting previous behavior where they were unintentionally reset with other form elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->