### PR TITLE
doc: contributing: add triage guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ How to best label new issues:
 
 Then answer:
 
-- For bugs: write a brief message explaining wether it's reproducible or not.
+- For bugs: write a brief message explaining whether it's reproducible or not.
 - For feature requests, simply acknowledge the request with a generic message: "Thank you for your request, we will look into it".


### PR DESCRIPTION
Add triage guidelines to make it clear what should be done when triaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Issue triage" section to contributing guidelines explaining how to label incoming issues (bug vs feature), mark reproducibility, and apply optional priority and module tags.
  * Added standard response templates for bug reports and feature requests to ensure consistent triage, required reproducibility info, and clearer communication with contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->