### PR TITLE
bug/medium: sig keys: fix sql on readOne()

### DIFF
--- a/src/Models/SigKeys.php
+++ b/src/Models/SigKeys.php
@@ -93,9 +93,10 @@ final class SigKeys extends AbstractRest
     public function readOne(): array
     {
         $sql = 'SELECT id, pubkey, privkey, created_at, last_used_at, userid, state
-            FROM sig_keys WHERE id = :id';
+            FROM sig_keys WHERE id = :id AND userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
 
         return $this->Db->fetch($req);

--- a/tests/unit/models/SigKeysTest.php
+++ b/tests/unit/models/SigKeysTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 use Elabftw\Elabftw\MinisignKeys;
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Models\Users\Users;
 
 class SigKeysTest extends \PHPUnit\Framework\TestCase
@@ -49,6 +50,17 @@ class SigKeysTest extends \PHPUnit\Framework\TestCase
     public function testPatch(): void
     {
         $this->assertIsArray($this->SigKeys->patch(Action::Update, array('passphrase' => self::PASSPHRASE)));
+    }
+
+    public function testReadFromOtherUser(): void
+    {
+        $id = $this->SigKeys->postAction(
+            Action::Create,
+            array('passphrase' => self::PASSPHRASE)
+        );
+        $OtherUserSigKeys = new SigKeys(new Users(2, 1), $id);
+        $this->expectException(ResourceNotFoundException::class);
+        $OtherUserSigKeys->readOne();
     }
 
     public function testGetApiPath(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an authorization vulnerability where signature keys could be accessed by users other than their owner. The system now properly validates user ownership before retrieving keys, ensuring only authorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->