### PR TITLE
ci: update cypress image and use sha pinning

### DIFF
--- a/containers/cypress/Dockerfile
+++ b/containers/cypress/Dockerfile
@@ -6,7 +6,6 @@ FROM cypress/included@sha256:848fb0d361178e695aa3ebd0f9632f2966232907c0fc02fbd64
 
 WORKDIR /home/node
 
-# copy everything because we can't bind mount in CI
 COPY tsconfig.json .
 COPY cypress.config.ts .
 COPY tests/cypress/ ./tests/cypress/
@@ -20,7 +19,7 @@ RUN chown -R node:node tests/cypress
 USER node
 
 # add html validation tools to cypress
-RUN npm install typescript html-validate@^8 cypress-html-validate@^7 cypress-terminal-report
+RUN npm install typescript@^5 html-validate@^8 cypress-html-validate@^7 cypress-terminal-report
 
 # overwrite default 'cypress run' entry point, will call it manually later
 # https://github.com/cypress-io/cypress-docker-images/tree/master/included#keep-the-container

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "NodeNext",
-    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "moduleResolution": "NodeNext",
     "strict": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the Cypress test image to a content-addressable digest for more reproducible test runs.
  * Added inline comments documenting the upstream image reference.
  * Added a build step to copy TypeScript configuration into the test image.
  * Pinned the TypeScript package spec to a caret-constrained major version to stabilize installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->