### PR TITLE
dev: mkbuildinfo: allow any version (master/prod/whatever)

### DIFF
--- a/src/tools/mkbuildinfo.php
+++ b/src/tools/mkbuildinfo.php
@@ -22,7 +22,7 @@ $version = getenv('ELABFTW_VERSION') ?: 'dev';
 // major is untouched, and minor and patch are padded with one 0 each
 // we should be pretty safe from ever reaching 100 as a minor or patch version!
 
-$versionInt = 99999;
+$versionInt = 0;
 if (preg_match('/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\d*)?$/', $version, $m)) {
     $versionInt = ((int) $m[1]) * 10000 + ((int) $m[2]) * 100 + (int) $m[3];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made build/version parsing more tolerant: version integer now defaults to zero and only updates when the version string matches a numeric pattern; invalid or non-matching version strings no longer emit an error or terminate the build process, allowing builds to proceed instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->