### PR TITLE
bug/minor: admin panel: fix grayed out screen after delete user

### DIFF
--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -161,9 +161,10 @@ if (document.getElementById('users-table')) {
       if (confirm('Are you sure you want to remove permanently this user and all associated data?')) {
         ApiC.delete(`users/${userid}`)
           .then(() => {
-            reloadElements(['editUsersBox', 'unvalidatedUsersBox']);
-            $('#editUserModal').modal('toggle');
-            document.dispatchEvent(new CustomEvent('dataReload'));
+            reloadElements(['unvalidatedUsersBox']).then(() => {
+              $('#editUserModal').modal('hide');
+              document.dispatchEvent(new CustomEvent('dataReload'));
+            });
           });
       }
     // ADD USER TO TEAM


### PR DESCRIPTION
when deleting an unvalidated user from admin panel in header box, the modal was toggled and this caused the screen to be grayed out because it was not opened


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the user deletion workflow to properly sequence UI updates and modal state changes, ensuring the interface updates consistently after user removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->