### PR TITLE
feat: import: add timestamp when emitting log during import

### DIFF
--- a/src/Commands/ImportCompoundsCsv.php
+++ b/src/Commands/ImportCompoundsCsv.php
@@ -97,7 +97,7 @@ final class ImportCompoundsCsv extends Command
         $usePubchem = (bool) $input->getOption('use-pubchem');
         $pubChemImporter = null;
         if ($usePubchem) {
-            $output->writeln('[info] Using Pubchem to complete data: this might take a long time.');
+            $logger->info('Using Pubchem to complete data: this might take a long time.');
             $pubChemImporter = new PubChemImporter($httpGetter, Env::asUrl('PUBCHEM_PUG_URL'), Env::asUrl('PUBCHEM_PUG_VIEW_URL'));
         }
         $Items = new Items($user, bypassReadPermission: true, bypassWritePermission: true);
@@ -108,7 +108,7 @@ final class ImportCompoundsCsv extends Command
             $matchWith = $input->getOption('match-with');
         }
         $Importer = new CompoundsCsv(
-            $output,
+            $logger,
             $Items,
             $UploadedFile,
             $Compounds,
@@ -128,7 +128,7 @@ final class ImportCompoundsCsv extends Command
         $logger->info(sprintf('Done importing %d records', $count));
         $logger->info(sprintf('Import finished for Team with ID %d%s', $teamid, $infoTrailer));
         $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion('[*] Delete imported file? (y/N) ', false);
+        $question = new ConfirmationQuestion('[?] Delete imported file? (y/N) ', false);
         /** @phpstan-ignore-next-line ask method is part of QuestionHelper which extends HelperInterface */
         if ($helper->ask($input, $output, $question)) {
             $this->Fs->getFs()->delete((string) $input->getArgument('file'));

--- a/src/Commands/ImportCompoundsCsv.php
+++ b/src/Commands/ImportCompoundsCsv.php
@@ -36,6 +36,7 @@ use Elabftw\Services\NullFingerprinter;
 use Elabftw\Services\PubChemImporter;
 use GuzzleHttp\Client;
 use Override;
+use Symfony\Component\Console\Input\ArgvInput;
 
 use function sprintf;
 
@@ -106,6 +107,10 @@ final class ImportCompoundsCsv extends Command
         $matchWith = null;
         if ($input->getOption('match-with')) {
             $matchWith = $input->getOption('match-with');
+        }
+        $commandLine = $input instanceof ArgvInput ? (string) $input : null;
+        if ($commandLine) {
+            $logger->info(sprintf('Command arguments used: %s', $commandLine));
         }
         $Importer = new CompoundsCsv(
             $logger,

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -17,6 +17,7 @@ use League\Csv\Reader;
 use League\Csv\Info as CsvInfo;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Override;
+use Psr\Log\LoggerInterface;
 
 use function arsort;
 use function array_diff_key;
@@ -45,8 +46,9 @@ abstract class AbstractCsv extends AbstractImport
     public function __construct(
         protected Users $requester,
         protected UploadedFile $UploadedFile,
+        protected LoggerInterface $logger,
     ) {
-        parent::__construct($requester, $UploadedFile);
+        parent::__construct($requester, $UploadedFile, $logger);
         $this->reader = $this->preProcess();
     }
 

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Import;
 
+use DateTimeImmutable;
 use Elabftw\Elabftw\Db;
 use Elabftw\Enums\EntityType;
 use Elabftw\Exceptions\ImproperActionException;
@@ -24,6 +25,8 @@ use Elabftw\Models\Teams;
 use Elabftw\Models\Users\Users;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Override;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Import data from a file
@@ -44,6 +47,7 @@ abstract class AbstractImport implements ImportInterface
     public function __construct(
         protected Users $requester,
         protected UploadedFile $UploadedFile,
+        protected LoggerInterface $logger,
     ) {
         $this->Db = Db::getConnection();
         // yes, the bypassWritePermission opens it up to normal users that normally cannot create status and category,
@@ -59,6 +63,13 @@ abstract class AbstractImport implements ImportInterface
     public function getInserted(): int
     {
         return $this->inserted;
+    }
+
+    protected function emitLog(string $message, string $level = LogLevel::INFO): void
+    {
+        $timestamp = new DateTimeImmutable()->format('c');
+        $log = sprintf('%s %s', $timestamp, $message);
+        $this->logger->log($level, $log);
     }
 
     protected function getStatusId(EntityType $type, string $status): int

--- a/src/Import/AbstractZip.php
+++ b/src/Import/AbstractZip.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use League\Flysystem\ZipArchive\FilesystemZipArchiveProvider;
 use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use RuntimeException;
 
 /**
@@ -49,10 +50,10 @@ abstract class AbstractZip extends AbstractImport
         protected FilesystemOperator $fs,
         protected LoggerInterface $logger,
     ) {
-        parent::__construct($requester, $UploadedFile);
+        parent::__construct($requester, $UploadedFile, $logger);
         // we extract everything into a temporary directory
         $this->tmpDir = Tools::getUuidv4();
-        $this->logger->debug(sprintf('temporary directory: %s', $this->tmpDir));
+        $this->emitLog(sprintf('temporary directory: %s', $this->tmpDir), LogLevel::DEBUG);
         // we use the Exports storage to store decompressed data
         $this->tmpFs = Storage::EXPORTS->getStorage()->getFs();
 
@@ -109,13 +110,13 @@ abstract class AbstractZip extends AbstractImport
         foreach ($zipFs->listContents('', true) as $item) {
 
             $rawPath = $item->path();
-            $this->logger->debug(sprintf('ZIP: extracting: %s', $rawPath));
+            $this->emitLog(sprintf('ZIP: extracting: %s', $rawPath), LogLevel::DEBUG);
 
             // fix eln v < 106 with duplicated / in path for uploaded files
             $targetPath = $this->tmpDir . '/' . str_replace('//', '/', $rawPath);
 
             if ($item->isDir()) {
-                $this->logger->debug(sprintf('ZIP: creating directory %s', $targetPath));
+                $this->emitLog(sprintf('ZIP: creating directory %s', $targetPath), LogLevel::DEBUG);
                 $this->tmpFs->createDirectory($targetPath);
                 continue;
             }

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -23,8 +23,9 @@ use Elabftw\Params\EntityParams;
 use Elabftw\Services\PubChemImporter;
 use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Console\Output\OutputInterface;
 use Override;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function sprintf;
@@ -37,7 +38,7 @@ use function trim;
 final class CompoundsCsv extends AbstractCsv
 {
     public function __construct(
-        private OutputInterface $output,
+        protected LoggerInterface $logger,
         protected Items $Items,
         protected UploadedFile $UploadedFile,
         protected Compounds $Compounds,
@@ -46,7 +47,7 @@ final class CompoundsCsv extends AbstractCsv
         protected string $locationSplitter = '/',
         protected ?string $matchWith = null,
     ) {
-        parent::__construct($Items->Users, $UploadedFile);
+        parent::__construct($Items->Users, $UploadedFile, $logger);
     }
 
     #[Override]
@@ -54,7 +55,7 @@ final class CompoundsCsv extends AbstractCsv
     {
         // number of rows is stored in a var so we can decrement it when a compound is not imported
         $count = $countAll = $this->getCount();
-        $this->output->writeln(sprintf('[info] Found %d rows to import', $count));
+        $this->emitLog(sprintf('Found %d rows to import', $count));
 
         $loopIndex = 0;
 
@@ -88,7 +89,7 @@ final class CompoundsCsv extends AbstractCsv
                     }
 
                     foreach ($cids as $cid) {
-                        $this->output->writeln(sprintf('[info] Importing compound with CID %d', $cid));
+                        $this->emitLog(sprintf('Importing compound with CID %d', $cid));
                         $compound = $this->PubChemImporter->fromPugView($cid);
                         $ids[] = $this->Compounds->createFromCompound($compound);
                     }
@@ -176,7 +177,7 @@ final class CompoundsCsv extends AbstractCsv
                         try {
                             $this->Items->update(new EntityParams('custom_id', (int) $row['custom_id']));
                         } catch (ImproperActionException $e) {
-                            $this->output->writeln(sprintf('[error] Custom id %s: %s', $row['custom_id'], $e->getMessage()));
+                            $this->emitLog(sprintf('Custom id %s: %s', $row['custom_id'], $e->getMessage()), LogLevel::ERROR);
                         }
                     }
                 }
@@ -193,12 +194,12 @@ final class CompoundsCsv extends AbstractCsv
                     }
                 }
             } catch (ImproperActionException | RequestException $e) {
-                $this->output->writeln($e->getMessage());
+                $this->emitLog($e->getMessage(), LogLevel::ERROR);
                 // decrement the count so we can give a correct number
                 --$count;
             }
             ++$loopIndex;
-            $this->output->writeln(sprintf('[info] Imported %d/%d', $loopIndex, $countAll));
+            $this->emitLog(sprintf('Imported %d/%d', $loopIndex, $countAll));
         }
         return $count;
     }
@@ -213,7 +214,7 @@ final class CompoundsCsv extends AbstractCsv
         $DisplayParams = new DisplayParams($this->Items->Users, $this->Items->entityType, $query);
         $results = $this->Items->readShow($DisplayParams);
         if (count($results) > 1) {
-            $this->output->writeln(sprintf('[warning] Found %d matches for %s. Linking with first one found.', count($results), $value));
+            $this->emitLog(sprintf('Found %d matches for %s. Linking with first one found.', count($results), $value), LogLevel::WARNING);
         }
         return $results[0] ?? null;
     }

--- a/src/Import/Csv.php
+++ b/src/Import/Csv.php
@@ -42,6 +42,7 @@ final class Csv extends AbstractCsv
         parent::__construct(
             $requester,
             $UploadedFile,
+            $logger,
         );
         // we might have been forced to cast to int a null value, so bring it back to null
         if ($this->category === 0) {

--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -22,7 +22,6 @@ use Elabftw\Enums\FileFromString;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Hash\FileHash;
-use Elabftw\Hash\LocalFileHash;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Uploads;
 use Elabftw\Models\Users\Users;

--- a/tests/unit/Import/CompoundsCsvTest.php
+++ b/tests/unit/Import/CompoundsCsvTest.php
@@ -23,7 +23,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use Symfony\Component\Console\Output\NullOutput;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use const UPLOAD_ERR_OK;
@@ -53,7 +53,7 @@ class CompoundsCsvTest extends \PHPUnit\Framework\TestCase
         $cid = 3345;
         $compoundId = $Compounds->postAction(Action::Duplicate, array('cid' => $cid));
         $Compounds->setId($compoundId);
-        $Import = new CompoundsCsv(new NullOutput(), $Items, $uploadedFile, $Compounds, 1);
+        $Import = new CompoundsCsv(new NullLogger(), $Items, $uploadedFile, $Compounds, 1);
         $this->assertTrue($Import->import() > 1);
     }
 }


### PR DESCRIPTION
adding timestamp for importing stuff from console, also add the full command line for traceability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Import system now uses structured logging instead of direct console output; progress, warnings, errors and the full runtime command (when available) are logged for clearer, timestamped records.
* **Bug Fixes**
  * Confirmation prompt prefix changed to a standard query marker for clearer prompts.
* **Tests**
  * Unit tests updated to reflect the new logging mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->