### PR TITLE
refactor: ui: reorder navigation items for improved accessibility

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -84,18 +84,18 @@
                 {% set isActive = scriptName == 'experiments.php' and App.Request.query.get('scope') == 3 %}
                 <a class='dropdown-item {{ isActive ? 'active' }}' href='experiments.php?scope=3' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-globe fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'All experiments'|trans }}</a>
                 <div class='dropdown-divider'></div>
-                {% for entity in App.experimentsCategoryArr|filter(c => c.is_current_team == 1) %}
-                  {% set isActive = scriptName == 'experiments.php' and App.Request.query.get('category') == entity.id %}
-                  <a class='dropdown-item {{ isActive ? 'active' }}' href='experiments.php?category={{ entity.id }}' {{ isActive ? 'aria-current="page"' }}><span class='round-spot mr-1' style='background-color: #{{ entity.color }}'></span>{{ entity.title }}</a>
-                {% endfor %}
-                <div class='dropdown-divider'></div>
                 {% set isActive = scriptName == 'templates.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }}' href='templates.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-copy fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Experiment templates'|trans }}</a>
                 {% set isActive = scriptName == 'experiments-categories.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }} {{ not App.Teams.teamArr.users_canwrite_experiments_categories and not App.Users.isAdmin ? 'disabled' }}' href='experiments-categories.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-rectangle-list fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Experiment categories'|trans }}</a>
                 {% set isActive = scriptName == 'experiments-status.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }} {{ not App.Teams.teamArr.users_canwrite_experiments_status and not App.Users.isAdmin ? 'disabled' }}' href='experiments-status.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-list-check fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Experiment status'|trans }}</a>
-              </div>
+                <div class='dropdown-divider'></div>
+                {% for entity in App.experimentsCategoryArr|filter(c => c.is_current_team == 1) %}
+                  {% set isActive = scriptName == 'experiments.php' and App.Request.query.get('category') == entity.id %}
+                  <a class='dropdown-item {{ isActive ? 'active' }}' href='experiments.php?category={{ entity.id }}' {{ isActive ? 'aria-current="page"' }}><span class='round-spot mr-1' style='background-color: #{{ entity.color }}'></span>{{ entity.title }}</a>
+                {% endfor %}
+                </div>
             </div>
             <div class='nav-item dropdown'>
               {% if App.devMode -%}
@@ -123,18 +123,18 @@
                 {% set isActive = scriptName == 'database.php' and App.Request.query.get('bookable') == 1 %}
                 <a class='dropdown-item {{ isActive ? 'active' }}' href='database.php?bookable=1' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-calendar-check fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Bookable resources'|trans }}</a>
                 <div class='dropdown-divider'></div>
-                {% for entity in App.itemsCategoryArr|filter(c => c.is_current_team == 1) %}
-                  {% set isActive = scriptName == 'database.php' and App.Request.query.get('category') == entity.id %}
-                  <a class='dropdown-item {{ isActive ? 'active' }}' href='database.php?category={{ entity.id }}' {{ isActive ? 'aria-current="page"' }}><span class='round-spot mr-1' style='background-color: #{{ entity.color }}'></span>{{ entity.title }}</a>
-                {% endfor %}
-                <div class='dropdown-divider'></div>
                 {% set isActive = scriptName == 'resources-templates.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }}' href='resources-templates.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-copy fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Resource templates'|trans }}</a>
                 {% set isActive = scriptName == 'resources-categories.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }} {{ not App.Teams.teamArr.users_canwrite_resources_categories and not App.Users.isAdmin ? 'disabled' }}' href='resources-categories.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-rectangle-list fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Resource categories'|trans }}</a>
                 {% set isActive = scriptName == 'resources-status.php' %}
                 <a class='dropdown-item {{ isActive ? 'active' }} {{ not App.Teams.teamArr.users_canwrite_resources_status and not App.Users.isAdmin ? 'disabled' }}' href='resources-status.php' {{ isActive ? 'aria-current="page"' }}><i class='fas fa-list-check fa-fw mr-1 {{ isActive ? 'color-white' }}'></i>{{ 'Resource status'|trans }}</a>
-              </div>
+                <div class='dropdown-divider'></div>
+                {% for entity in App.itemsCategoryArr|filter(c => c.is_current_team == 1) %}
+                  {% set isActive = scriptName == 'database.php' and App.Request.query.get('category') == entity.id %}
+                  <a class='dropdown-item {{ isActive ? 'active' }}' href='database.php?category={{ entity.id }}' {{ isActive ? 'aria-current="page"' }}><span class='round-spot mr-1' style='background-color: #{{ entity.color }}'></span>{{ entity.title }}</a>
+                {% endfor %}
+                </div>
             </div>
             {% set isActive = scriptName == 'scheduler.php' %}
             <a class='nav-item nav-link {{ isActive ? 'active' }}'


### PR DESCRIPTION
Reorder dropdown menu items in the main navigation to improve usability and accessibility.

- Move templates, categories, and status links above category lists in both Experiments and Resources menus.
- Prevent long category lists from pushing important actions out of view :)

This improves the overall user experience without altering functionality.

| Before | After |
| -------- | ------- |
| <img width="" height="300" alt="image" src="https://github.com/user-attachments/assets/b2030750-b277-4c52-a714-3d05cb5d9cde" /> | <img width="" height="300" alt="image" src="https://github.com/user-attachments/assets/be65d898-128a-4e88-bd57-23941e3171a8" /> |
