### PR TITLE
feat: scheduler: add links to selected resource badges

### DIFF
--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -209,12 +209,14 @@ if (window.location.pathname === '/scheduler.php') {
       const opt = selectInput.querySelector(`option[value="${id}"]`) as HTMLOptionElement;
       if (!opt) return;
 
-      const badge = document.createElement('a');
-      badge.textContent = opt.textContent;
-      badge.href = `/database.php?mode=view&id=${id}`;
-      badge.target='_blank';
-      badge.textContent = opt.textContent;
+      const badge = document.createElement('span');
       badge.className = 'selected-item-badge';
+      const link = document.createElement('a');
+      link.textContent = opt.textContent;
+      link.className = 'always-white';
+      link.href = `database.php?mode=view&id=${encodeURIComponent(id)}`;
+      link.target = '_blank';
+      link.rel = 'noopener';
       const rawColor = opt.dataset.color;
       badge.style.setProperty('--badge-color', rawColor?.startsWith('#') ? rawColor : `#${rawColor || '888'}`);
 
@@ -226,7 +228,7 @@ if (window.location.pathname === '/scheduler.php') {
       removeBtnIcon.classList.add('fas', 'fa-xmark', 'fa-fw', 'color-white');
       removeBtn.appendChild(removeBtnIcon);
 
-      badge.appendChild(removeBtn);
+      badge.append(link, removeBtn);
       wrapper.appendChild(badge);
 
       // also handle keydown (enter)


### PR DESCRIPTION
Enhance usability of the scheduler by making selected resource badges clickable.

We had this previously but was removed due to (?) some decision on https://github.com/elabftw/elabftw/commit/375ba0a5c9d912a4a0183023d73f37e6749c5268
- Convert selected item badges from <span> to <a> elements.
- Link badges to the corresponding resource view page in the database.
- Open links in a new tab to preserve the current scheduler context.
- Retain existing styling via the selected-item-badge class.

This improvement allows users to quickly access resource details directly from the scheduler interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected-item badges are now clickable links that open item details in a new tab, using the badge label as the link text. The existing remove control remains on the badge so users can still dismiss items while having quick access to item details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->