### PR TITLE
ux: booking params: preserve field values when disabling dependent inputs

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -563,10 +563,6 @@ on('toggle-dependent', (el: HTMLInputElement) => {
     .querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('input, select, textarea')
     .forEach(input => {
       input.disabled = disabled;
-      // reset numeric fields when disabling
-      if (disabled && input.type === 'number') {
-        input.value = '0';
-      }
     });
 });
 


### PR DESCRIPTION
fix #6670
Previously, numeric inputs were reset to "0" when a toggle-dependent checkbox disabled the form fields. This change removes that behavior so values are retained, preventing accidental data loss when toggling settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where numeric input values were unexpectedly reset to zero when dependent inputs were disabled. Values now persist as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->