### PR TITLE
ci: pin GitHub Actions to SHA-pinned commit versions

### DIFF
--- a/.github/workflows/build_edge.yaml
+++ b/.github/workflows/build_edge.yaml
@@ -20,7 +20,7 @@ jobs:
         steps:
             # https://github.com/CycodeLabs/cimon-action
             - name: Cimon supply chain attack protection
-              uses: cycodelabs/cimon-action@v0
+              uses: cycodelabs/cimon-action@f99ad5557cb80964bc2b2e76a47bf4b5ba6e323b # v0.10
               with:
                 prevent: true
                 allowed-hosts: >
@@ -42,21 +42,21 @@ jobs:
                   hooks.deltablot.dev
 
             - name: Checkout elabimg repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                 ref: ${{ github.ref_name }}
 
             # https://github.com/marketplace/actions/docker-setup-buildx
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
             # https://github.com/docker/setup-qemu-action#usage
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
             # https://github.com/docker/login-action#docker-hub
             - name: Login to Docker Hub
-              uses: docker/login-action@v3
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
               with:
                 username: ${{ secrets.DOCKER_HUB_USERNAME }}
                 password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
             # https://github.com/docker/build-push-action#multi-platform-image
             # https://docs.docker.com/build/ci/github-actions/cache/
             - name: Build release for all platforms and push to Docker Hub
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
               with:
                 context: .
                 file: containers/elabimg/Dockerfile

--- a/.github/workflows/build_nigthly.yaml
+++ b/.github/workflows/build_nigthly.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # https://github.com/CycodeLabs/cimon-action
       - name: Cimon supply chain attack protection
-        uses: cycodelabs/cimon-action@v0
+        uses: cycodelabs/cimon-action@f99ad5557cb80964bc2b2e76a47bf4b5ba6e323b # v0.10
         with:
           prevent: true
           allowed-hosts: >
@@ -43,22 +43,22 @@ jobs:
             hooks.deltablot.dev
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       # https://github.com/docker/login-action#docker-hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       # https://github.com/docker/build-push-action#multi-platform-image
       - name: Build nightly and push to docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         id: push
         with:
           context: .
@@ -101,7 +101,7 @@ jobs:
 
       # ATTESTATION
       - name: Create build provenance attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: index.docker.io/elabftw/elabimg
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -19,7 +19,7 @@ jobs:
         steps:
             # https://github.com/CycodeLabs/cimon-action
             - name: Cimon supply chain attack protection
-              uses: cycodelabs/cimon-action@v0
+              uses: cycodelabs/cimon-action@f99ad5557cb80964bc2b2e76a47bf4b5ba6e323b # v0.10
               with:
                 prevent: true
                 allowed-hosts: >
@@ -41,21 +41,21 @@ jobs:
                   hooks.deltablot.dev
 
             - name: Checkout elabimg repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                 ref: ${{ github.ref_name }}
 
             # https://github.com/marketplace/actions/docker-setup-buildx
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
             # https://github.com/docker/setup-qemu-action#usage
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
             # https://github.com/docker/login-action#docker-hub
             - name: Login to Docker Hub
-              uses: docker/login-action@v3
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
               with:
                 username: ${{ secrets.DOCKER_HUB_USERNAME }}
                 password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
             # https://github.com/docker/build-push-action#multi-platform-image
             # https://docs.docker.com/build/ci/github-actions/cache/
             - name: Build latest release for all platforms and push to Docker Hub
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
               with:
                 context: .
                 file: containers/elabimg/Dockerfile


### PR DESCRIPTION
Pin GitHub Actions to SHA-pinned commit versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment pipeline dependencies to newer versions with enhanced reproducibility and security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->