### PR TITLE
licensing: be more clear about provenance of files

### DIFF
--- a/containers/chem-plugin/indigo/NOTICE
+++ b/containers/chem-plugin/indigo/NOTICE
@@ -1,1 +1,10 @@
-Files in this folder are from epam/indigo and are licensed under Apache 2.0. We modified it to remove things we don't need and use uv.
+Indigo Chemistry Toolkit
+Copyright 2024 EPAM Systems
+Licensed under the Apache License, Version 2.0
+
+This software contains modified portions of the Indigo Toolkit from:
+https://github.com/epam/indigo
+
+Modifications made by eLabFTW:
+- Removed unnecessary components for eLabFTW integration
+- Adapted to use uv package manager

--- a/containers/chem-plugin/indigo/service/app.py
+++ b/containers/chem-plugin/indigo/service/app.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python
-# This file was modified for eLabFTW
-# Apache 2.0 LICENSE
+# Copyright 2026 Nicolas CARPI - Deltablot
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import logging
 import sys

--- a/containers/chem-plugin/indigo/service/v2/common/config.py
+++ b/containers/chem-plugin/indigo/service/v2/common/config.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Nicolas CARPI - Deltablot
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Flask config
 MAX_CONTENT_LENGTH = 1024 * 1024 * 1024
 UPLOAD_FOLDER = "/tmp/indigo-service/upload"

--- a/containers/chem-plugin/indigo/service/v2/common/util.py
+++ b/containers/chem-plugin/indigo/service/v2/common/util.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Nicolas CARPI - Deltablot
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 def highlight(indigo, target, query):
     query.aromatize()
     matcher = indigo.substructureMatcher(target)

--- a/containers/chem-plugin/indigo/service/v2/common_api.py
+++ b/containers/chem-plugin/indigo/service/v2/common_api.py
@@ -1,5 +1,17 @@
-# This file was modified for eLabFTW
-# Apache 2.0 LICENSE
+# Copyright 2024 eLabFTW
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 
 from flask import Blueprint, jsonify  # type: ignore

--- a/containers/chem-plugin/indigo/service/v2/indigo_api.py
+++ b/containers/chem-plugin/indigo/service/v2/indigo_api.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*
-# This file was modified for eLabFTW
-# Apache 2.0 LICENSE
+# Copyright 2026 Nicolas CARPI - Deltablot
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import base64
 import collections

--- a/containers/chem-plugin/indigo/service/v2/validation.py
+++ b/containers/chem-plugin/indigo/service/v2/validation.py
@@ -1,5 +1,18 @@
-# This file was modified for eLabFTW
-# Apache 2.0 LICENSE
+# Copyright 2026 Nicolas CARPI - Deltablot
+# Originally from epam/indigo (Apache 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright 2024 eLabFTW
 from marshmallow import Schema, fields  # type: ignore
 from marshmallow.decorators import (  # type: ignore
     post_load,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Apache 2.0 licensing and attribution headers across chemistry plugin components.
  * Added a NOTICE file documenting the Indigo Toolkit license, attribution, and notes about removed/adjusted parts for integration.
  * No functional or behavioral changes to the plugin’s runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->