### PR TITLE
ui/ux: minor change on lockable steps visual

### DIFF
--- a/src/templates/steps-edit.html
+++ b/src/templates/steps-edit.html
@@ -25,8 +25,9 @@
         {# LOCK/UNLOCK A STEP #}
         {% set steps_table = '%s/%d/steps'|format(Entity.entityType.value, Entity.id) %}
         {% if Entity.entityType.value in ['experiments_templates', 'items_types'] %}
+        {% set label = (step.is_immutable ? 'Unlock' : 'Lock')|trans %}
         <div class='input-group-prepend'>
-          <label class='btn btn-ghost d-flex align-items-center mb-0'>
+          <label class='btn btn-ghost d-flex align-items-center mb-0' title='{{ label }}'>
             <input type='checkbox' autocomplete='off' data-trigger='change' data-model='{{ steps_table ~ '/' ~ step.id }}' data-target='is_immutable' id='stepIsImmutable_{{ step.id }}' {{ step.is_immutable ? 'checked' }} data-reload='step_{{ step.id }}' class='d-none'>
             <i class='fas fa-lock {{ not step.is_immutable ? 'd-none' }}'></i>
             <i class='fas fa-lock-open {{ step.is_immutable ? 'd-none' }}'></i>


### PR DESCRIPTION
Little visual discrepency in the actions next to steps on template editing

<img width="290" height="231" alt="image" src="https://github.com/user-attachments/assets/3cfc0fbe-d7a2-4af2-b5b1-f4578dd93a81" />

Also add title for visual indicator

<img width="248" height="231" alt="image" src="https://github.com/user-attachments/assets/9e8642e6-81c6-4fbe-a7dc-ba4d16312288" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Lock/unlock controls now display dynamic, context-aware tooltips that clearly indicate their function based on current state

* **Style**
  - Enhanced the visual layout of lock/unlock button interface with improved alignment and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->