### PR TITLE
bug/major: idp endpoints: fix upgrade from 5.3

### DIFF
--- a/src/sql/schema192.sql
+++ b/src/sql/schema192.sql
@@ -80,6 +80,19 @@ CREATE TABLE IF NOT EXISTS `idps_endpoints`
 
     UNIQUE KEY uniq_idp_bdg_loc (idp, binding, location)
 );
+
+-- this is schema199 that we copy here so it's working fine for update
+-- fix idps_endpoints incorrect unique key for IdPs with same URL
+-- we need to first create an index on idp column or it will refuse to drop compound idx
+ALTER TABLE `idps_endpoints` ADD INDEX `idx_idps_endpoints_idp` (`idp`);
+CALL DropIdx('idps_endpoints', 'uniq_idp_bdg_loc');
+ALTER TABLE `idps_endpoints`
+  ADD UNIQUE KEY `uniq_idp_bdg_loc` (`idp`, `binding`, `location`, `is_slo`);
+-- cleanup that index that we don't need now
+ALTER TABLE `idps_endpoints` DROP INDEX `idx_idps_endpoints_idp`;
+-- end copy from schema199
+
+
 -- SSO
 INSERT IGNORE INTO idps_endpoints (idp, binding, location)
 (


### PR DESCRIPTION
fix in schema199 did not apply during first migration of idps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated identity provider endpoint configuration to properly support different Single Logout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->