### PR TITLE
bump: upgrade lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jsuites": "^5.13.5",
     "ketcher-core": "^3.0.1",
     "ketcher-react": "^3.0.1",
-    "lodash-es": "^4.17.23",
+    "lodash-es": "^4.18.1",
     "luxon": "^3.7.2",
     "marked": "^17.0.5",
     "mathjax-full": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "micromatch": "^4.0.8",
     "path-to-regexp": "^1.9.0",
     "cross-spawn": "^7.0.5",
-    "lodash": "^4.17.23",
-    "lodash-es": "^4.17.23",
+    "lodash": "^4.18.1",
+    "lodash-es": "^4.18.1",
     "diff": "^5.2.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,10 +9191,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -9289,10 +9289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6702,7 +6702,7 @@ __metadata:
     jsuites: "npm:^5.13.5"
     ketcher-core: "npm:^3.0.1"
     ketcher-react: "npm:^3.0.1"
-    lodash-es: "npm:^4.17.23"
+    lodash-es: "npm:^4.18.1"
     luxon: "npm:^3.7.2"
     marked: "npm:^17.0.5"
     mathjax-full: "npm:^3.2.2"


### PR DESCRIPTION
fix CVE-2026-4800
fix CVE-2026-2950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core utility library to a newer, compatible release and adjusted package resolution settings to ensure the newer version is used consistently across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->