### PR TITLE
chem-plugin: allow running it with read-only filesystem

### DIFF
--- a/containers/chem-plugin/conf/supervisord.conf
+++ b/containers/chem-plugin/conf/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 logfile=/dev/stderr
 logfile_maxbytes=0
-pidfile=/tmp/supervisor/supervisord.pid
+pidfile=/tmp/supervisord.pid
 user=nobody
 
 [include]

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -430,9 +430,18 @@ services:
       - elabftw-net
 
   #chem-plugin:
-  #  image: elabftw/chem-plugin
+  #  # note: use elabftw version here instead of latest tag
+  #  # e.g. image: elabftw/chem-plugin:5.6.2
+  #  image: elabftw/chem-plugin:latest
   #  container_name: chem-plugin
   #  restart: always
+  #  read_only: true
+  #  cap_drop:
+  #      - ALL
+  #  tmpfs:
+  #    - /tmp
+  #  security_opt:
+  #    - no-new-privileges:true
   #  networks:
   #    - elabftw-net
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal daemon configuration paths.
  * Added optional security hardening configuration options for Docker deployments, including read-only filesystem mode, capability restrictions, and privilege protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->