### PR TITLE
chem-plugin: dockerfile: use bytecode compilation flag from uv

### DIFF
--- a/containers/chem-plugin/Dockerfile
+++ b/containers/chem-plugin/Dockerfile
@@ -6,6 +6,8 @@ FROM dhi.io/python@sha256:61594a3427b191f6978131c2d94b2d90113e413126f5a17ab9e048
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/home/nobody
 ENV UV_CACHE_DIR=/home/nobody/.cache
+# https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
+ENV UV_COMPILE_BYTECODE=1
 
 # distroless image 0.11.2
 # got index digest with "docker buildx imagetools inspect docker.io/astral/uv:0.11.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image build performance for the chemistry plugin by enabling bytecode compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->