### PR TITLE
dev: guard: allow '0' as non empty string

### DIFF
--- a/src/Params/Guard.php
+++ b/src/Params/Guard.php
@@ -18,6 +18,7 @@ use Elabftw\Exceptions\MissingRequiredKeyException;
 
 use function array_filter;
 use function array_key_exists;
+use function is_string;
 
 final class Guard
 {
@@ -29,7 +30,7 @@ final class Guard
     public static function getNonEmptyStringValueOfRequiredParam(string $requiredKey, array $params): string
     {
         $value = self::getValueOfRequiredParam($requiredKey, $params);
-        if (is_string($value) && !empty($value)) {
+        if (is_string($value) && $value !== '') {
             return $value;
         }
         throw new ImproperActionException(sprintf('Empty value found for %s', $requiredKey));


### PR DESCRIPTION
empty('0') === true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation logic for required string parameters to more accurately detect empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->