### PR TITLE
dev: add missing use function calls for internal functions

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -61,6 +61,11 @@ return (new Config())
             'import_functions' => true,
             'import_constants' => true,
         ],
+        'native_function_invocation' => [
+            'include' => ['@internal'],
+            'scope' => 'namespaced',
+            'strict' => true,
+        ],
     ))
     ->setFinder($finder)
     ->setRiskyAllowed(true)

--- a/src/AuditEvent/AbstractAuditEvent.php
+++ b/src/AuditEvent/AbstractAuditEvent.php
@@ -16,6 +16,8 @@ use Elabftw\Enums\AuditCategory;
 use Elabftw\Interfaces\AuditEventInterface;
 use Override;
 
+use function json_encode;
+
 abstract class AbstractAuditEvent implements AuditEventInterface
 {
     public function __construct(private int $requesterUserid = 0, private int $targetUserid = 0) {}

--- a/src/AuditEvent/ActionRequested.php
+++ b/src/AuditEvent/ActionRequested.php
@@ -17,6 +17,10 @@ use Elabftw\Enums\EntityType;
 use Elabftw\Enums\RequestableAction;
 use Override;
 
+use function array_merge;
+use function json_encode;
+use function sprintf;
+
 final class ActionRequested extends AbstractAuditEvent
 {
     public function __construct(int $requesterUserid, int $targetUserid, private int $entityId, private EntityType $entityType, private RequestableAction $action)

--- a/src/AuditEvent/ConfigModified.php
+++ b/src/AuditEvent/ConfigModified.php
@@ -15,6 +15,9 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function in_array;
+use function sprintf;
+
 final class ConfigModified extends AbstractAuditEvent
 {
     public function __construct(private string $name, private string $old, private string $new)

--- a/src/AuditEvent/Export.php
+++ b/src/AuditEvent/Export.php
@@ -15,6 +15,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function sprintf;
+
 final class Export extends AbstractAuditEvent
 {
     public function __construct(int $requesterUserid, private int $count)

--- a/src/AuditEvent/Import.php
+++ b/src/AuditEvent/Import.php
@@ -15,6 +15,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function sprintf;
+
 final class Import extends AbstractAuditEvent
 {
     public function __construct(int $requesterUserid, private int $count)

--- a/src/AuditEvent/OnboardingEmailSent.php
+++ b/src/AuditEvent/OnboardingEmailSent.php
@@ -16,6 +16,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function sprintf;
+
 final class OnboardingEmailSent extends AbstractAuditEvent
 {
     public function __construct(private int $teamId = 0, private int $targetUserid = 0, private bool $forAdmin = false)

--- a/src/AuditEvent/PasswordResetRequested.php
+++ b/src/AuditEvent/PasswordResetRequested.php
@@ -15,6 +15,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function sprintf;
+
 final class PasswordResetRequested extends AbstractAuditEvent
 {
     public function __construct(private string $email)

--- a/src/AuditEvent/PermissionLevelChanged.php
+++ b/src/AuditEvent/PermissionLevelChanged.php
@@ -15,6 +15,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\Users2TeamsTargets;
 use Override;
 
+use function sprintf;
+
 final class PermissionLevelChanged extends AbstractUsers2TeamsModifiedEvent
 {
     public function __construct(int $requesterUserid, int $userid, private Users2TeamsTargets $target, private int $value, private int $teamid)

--- a/src/AuditEvent/SignatureCreated.php
+++ b/src/AuditEvent/SignatureCreated.php
@@ -16,6 +16,9 @@ use Elabftw\Enums\AuditCategory;
 use Elabftw\Enums\EntityType;
 use Override;
 
+use function array_merge;
+use function json_encode;
+
 final class SignatureCreated extends AbstractAuditEvent
 {
     public function __construct(int $requesterUserid, private int $entityId, private EntityType $entityType)

--- a/src/AuditEvent/SignatureKeysCreated.php
+++ b/src/AuditEvent/SignatureKeysCreated.php
@@ -16,6 +16,8 @@ use Elabftw\Enums\AuditCategory;
 use Override;
 
 use function array_merge;
+use function json_encode;
+use function sprintf;
 
 final class SignatureKeysCreated extends AbstractAuditEvent
 {

--- a/src/AuditEvent/TeamAddition.php
+++ b/src/AuditEvent/TeamAddition.php
@@ -14,6 +14,8 @@ namespace Elabftw\AuditEvent;
 
 use Override;
 
+use function sprintf;
+
 final class TeamAddition extends AbstractUsers2TeamsModifiedEvent
 {
     public function __construct(private int $teamid, private int $isAdmin, int $requester, int $userid)

--- a/src/AuditEvent/TeamRemoval.php
+++ b/src/AuditEvent/TeamRemoval.php
@@ -14,6 +14,8 @@ namespace Elabftw\AuditEvent;
 
 use Override;
 
+use function sprintf;
+
 final class TeamRemoval extends AbstractUsers2TeamsModifiedEvent
 {
     public function __construct(private int $teamid, int $requester, int $userid)

--- a/src/AuditEvent/TeamStatusModified.php
+++ b/src/AuditEvent/TeamStatusModified.php
@@ -16,6 +16,8 @@ use Elabftw\Enums\BinaryValue;
 use Elabftw\Enums\Users2TeamsTargets;
 use Override;
 
+use function sprintf;
+
 final class TeamStatusModified extends AbstractUsers2TeamsModifiedEvent
 {
     public function __construct(private int $teamid, private Users2TeamsTargets $target, private BinaryValue $content, int $requester, int $userid)

--- a/src/AuditEvent/UserAttributeChanged.php
+++ b/src/AuditEvent/UserAttributeChanged.php
@@ -15,6 +15,8 @@ namespace Elabftw\AuditEvent;
 use Elabftw\Enums\AuditCategory;
 use Override;
 
+use function sprintf;
+
 class UserAttributeChanged extends AbstractAuditEvent
 {
     public function __construct(

--- a/src/Auth/AuthResponse.php
+++ b/src/Auth/AuthResponse.php
@@ -17,6 +17,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\UsersHelper;
 use Override;
 
+use function count;
+
 /**
  * Response object sent by an Auth service
  */

--- a/src/Auth/Cookie.php
+++ b/src/Auth/Cookie.php
@@ -19,6 +19,8 @@ use Elabftw\Interfaces\AuthResponseInterface;
 use Elabftw\Services\TeamsHelper;
 use Override;
 
+use function sprintf;
+
 /**
  * Authenticate with the cookie
  */

--- a/src/Auth/CookieToken.php
+++ b/src/Auth/CookieToken.php
@@ -20,6 +20,7 @@ use PDO;
 use function bin2hex;
 use function hash;
 use function random_bytes;
+use function mb_strlen;
 
 /**
  * The cookie "token" acts as a key to login back thanks to the cookie value and the value stored in database

--- a/src/Auth/Demo.php
+++ b/src/Auth/Demo.php
@@ -20,6 +20,8 @@ use Elabftw\Models\Users\ExistingUser;
 use Elabftw\Services\UsersHelper;
 use Override;
 
+use function in_array;
+
 /**
  * Demo auth service: auto login with just an email
  */

--- a/src/Auth/External.php
+++ b/src/Auth/External.php
@@ -21,6 +21,8 @@ use Elabftw\Models\Users\ValidatedUser;
 use Elabftw\Services\UsersHelper;
 use Override;
 
+use function _;
+
 /**
  * Authenticate with server provided values
  */

--- a/src/Auth/Ldap.php
+++ b/src/Auth/Ldap.php
@@ -31,6 +31,9 @@ use Override;
 
 use function explode;
 use function is_array;
+use function _;
+use function is_string;
+use function trim;
 
 /**
  * LDAP auth service

--- a/src/Auth/Local.php
+++ b/src/Auth/Local.php
@@ -30,6 +30,8 @@ use Override;
 use function password_hash;
 use function password_needs_rehash;
 use function password_verify;
+use function _;
+use function sleep;
 
 /**
  * Local auth service

--- a/src/Auth/None.php
+++ b/src/Auth/None.php
@@ -18,6 +18,8 @@ use Elabftw\Interfaces\AuthResponseInterface;
 use Override;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 
+use function _;
+
 /**
  * When you're not logged in at all, or abandon a login
  */

--- a/src/Auth/Saml.php
+++ b/src/Auth/Saml.php
@@ -41,6 +41,10 @@ use Override;
 
 use function is_array;
 use function is_string;
+use function _;
+use function implode;
+use function is_int;
+use function sprintf;
 
 /**
  * SAML auth service

--- a/src/Commands/CheckDatabase.php
+++ b/src/Commands/CheckDatabase.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * Check the the current schema version versus the required one
  */

--- a/src/Commands/CheckUploads.php
+++ b/src/Commands/CheckUploads.php
@@ -21,6 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Override;
 
+use function count;
+use function sprintf;
+
 /**
  * Check uploaded files
  */

--- a/src/Commands/ClearNotifications.php
+++ b/src/Commands/ClearNotifications.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * Remove all notifications
  */

--- a/src/Commands/ExperimentsTimestamp.php
+++ b/src/Commands/ExperimentsTimestamp.php
@@ -26,6 +26,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function count;
+use function implode;
+use function sprintf;
+use function strtotime;
+
 /**
  * Timestamp experiments in bulk
  */

--- a/src/Commands/ExportEln.php
+++ b/src/Commands/ExportEln.php
@@ -25,6 +25,12 @@ use ZipStream\ZipStream;
 use Override;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 
+use function array_map;
+use function date;
+use function fclose;
+use function fopen;
+use function sprintf;
+
 /**
  * Export data in .eln format
  */

--- a/src/Commands/FingerprintCompounds.php
+++ b/src/Commands/FingerprintCompounds.php
@@ -26,6 +26,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 use Throwable;
 
+use function count;
+use function is_array;
+use function sprintf;
+
 /**
  * (Re)calculate fingerprints for stored compounds
  */

--- a/src/Commands/ForceSchema.php
+++ b/src/Commands/ForceSchema.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * For dev purposes: force the schema to a particular version
  */

--- a/src/Commands/GenI18n4Js.php
+++ b/src/Commands/GenI18n4Js.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function dirname;
+
 /**
  * Generate the translation files for typescript/javascript
  */

--- a/src/Commands/GenSchema.php
+++ b/src/Commands/GenSchema.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * For dev purposes: generate a new empty schema file
  */

--- a/src/Commands/ImportEln.php
+++ b/src/Commands/ImportEln.php
@@ -30,6 +30,10 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Override;
 
+use function array_map;
+use function implode;
+use function sprintf;
+
 /**
  * Import an ELN archive
  */

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -31,6 +31,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\Question;
 
 use function dirname;
+use function sprintf;
 
 /**
  * Import database structure

--- a/src/Commands/MfaCode.php
+++ b/src/Commands/MfaCode.php
@@ -21,6 +21,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+use function str_replace;
+
 /**
  * Command line tool to emulate a 2FA phone app. It returns a 2FA code calculated from the provided secret.
  */

--- a/src/Commands/MigrateUploads.php
+++ b/src/Commands/MigrateUploads.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * To move local filesystem uploads to S3 storage
  */

--- a/src/Commands/PopulateDatabase.php
+++ b/src/Commands/PopulateDatabase.php
@@ -29,6 +29,7 @@ use function is_string;
 use function floor;
 use function microtime;
 use function sprintf;
+use function str_repeat;
 
 /**
  * Populate the database with example data. Useful to get a fresh dev env.

--- a/src/Commands/PruneExperiments.php
+++ b/src/Commands/PruneExperiments.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * To remove deleted files completely
  */

--- a/src/Commands/PruneItems.php
+++ b/src/Commands/PruneItems.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * To remove deleted items completely
  */

--- a/src/Commands/PruneUploads.php
+++ b/src/Commands/PruneUploads.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * To remove deleted files completely
  */

--- a/src/Commands/RevertSchema.php
+++ b/src/Commands/RevertSchema.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * Use this to revert a specific schema
  */

--- a/src/Commands/SendExpirationNotifications.php
+++ b/src/Commands/SendExpirationNotifications.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * Send the notifications emails for accounts close to expiration
  */

--- a/src/Commands/SendNotifications.php
+++ b/src/Commands/SendNotifications.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function sprintf;
+
 /**
  * Send the notifications emails
  */

--- a/src/Commands/TagsTeamsSync.php
+++ b/src/Commands/TagsTeamsSync.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function implode;
+use function sprintf;
+
 /**
  * Synchronize tags between teams
  */

--- a/src/Commands/UpdateDatabase.php
+++ b/src/Commands/UpdateDatabase.php
@@ -25,6 +25,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function dirname;
+use function sprintf;
+
 /**
  * Update the database schema
  */

--- a/src/Commands/UpdateTo3.php
+++ b/src/Commands/UpdateTo3.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function dirname;
+
 /**
  * Prepare the database for the 3.0 update
  */

--- a/src/Commands/UpdateTo34.php
+++ b/src/Commands/UpdateTo34.php
@@ -23,6 +23,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
 
+use function dirname;
+
 /**
  * Prepare the database for the 3.4 update
  * Issue: for old databases, the FK fk_users_teams_id will not exist and cause error

--- a/src/Controllers/AbstractApiController.php
+++ b/src/Controllers/AbstractApiController.php
@@ -18,6 +18,10 @@ use Elabftw\Exceptions\InvalidEndpointException;
 use Elabftw\Services\Check;
 use Symfony\Component\HttpFoundation\Request;
 
+use function explode;
+use function rtrim;
+use function trim;
+
 /**
  * For API requests
  */

--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -46,6 +46,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function array_column;
+use function sprintf;
+
 /**
  * For displaying an entity in show, view or edit mode
  * Preloads shared data like templates (experiments/items), statuses, team info.

--- a/src/Controllers/AbstractStatusController.php
+++ b/src/Controllers/AbstractStatusController.php
@@ -16,6 +16,8 @@ use Elabftw\Models\AbstractStatus;
 use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function array_merge;
+
 /**
  * For {experiments|resources}-status.php
  */

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -85,6 +85,13 @@ use Override;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport;
 
+use function implode;
+use function in_array;
+use function json_decode;
+use function sprintf;
+use function str_starts_with;
+use function trim;
+
 /**
  * For API V2 requests
  */

--- a/src/Controllers/ChemEditorController.php
+++ b/src/Controllers/ChemEditorController.php
@@ -16,6 +16,7 @@ use Elabftw\Models\ItemsTypes;
 use Override;
 
 use function array_merge;
+use function _;
 
 final class ChemEditorController extends AbstractHtmlController
 {

--- a/src/Controllers/CompoundsController.php
+++ b/src/Controllers/CompoundsController.php
@@ -14,6 +14,8 @@ namespace Elabftw\Controllers;
 
 use Override;
 
+use function _;
+
 final class CompoundsController extends AbstractHtmlController
 {
     #[Override]

--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -30,6 +30,7 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function array_merge;
+use function _;
 
 /**
  * For dashboard.php

--- a/src/Controllers/DatabaseController.php
+++ b/src/Controllers/DatabaseController.php
@@ -17,6 +17,9 @@ use Elabftw\Models\Items;
 use Elabftw\Models\ItemsTypes;
 use Override;
 
+use function _;
+use function ngettext;
+
 /**
  * For database.php
  */

--- a/src/Controllers/DownloadController.php
+++ b/src/Controllers/DownloadController.php
@@ -27,6 +27,10 @@ use function fopen;
 use function in_array;
 use function stream_copy_to_stream;
 use function mb_substr;
+use function dirname;
+use function ob_end_clean;
+use function ob_get_level;
+use function strtolower;
 
 /**
  * To download uploaded files

--- a/src/Controllers/ExperimentsCategoriesController.php
+++ b/src/Controllers/ExperimentsCategoriesController.php
@@ -14,6 +14,8 @@ namespace Elabftw\Controllers;
 
 use Override;
 
+use function _;
+
 /**
  * For experiments-categories.php
  */

--- a/src/Controllers/ExperimentsController.php
+++ b/src/Controllers/ExperimentsController.php
@@ -17,6 +17,9 @@ use Elabftw\Models\Experiments;
 use Elabftw\Models\Templates;
 use Override;
 
+use function _;
+use function ngettext;
+
 /**
  * For experiments.php
  */

--- a/src/Controllers/ExperimentsStatusController.php
+++ b/src/Controllers/ExperimentsStatusController.php
@@ -15,6 +15,8 @@ namespace Elabftw\Controllers;
 use Elabftw\Models\ExperimentsStatus;
 use Override;
 
+use function _;
+
 /**
  * For experiments-status.php
  */

--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -17,6 +17,7 @@ use Elabftw\Models\StorageUnits;
 use Override;
 
 use function array_merge;
+use function _;
 
 final class InventoryController extends AbstractHtmlController
 {

--- a/src/Controllers/ItemsStatusController.php
+++ b/src/Controllers/ItemsStatusController.php
@@ -15,6 +15,8 @@ namespace Elabftw\Controllers;
 use Elabftw\Models\ItemsStatus;
 use Override;
 
+use function _;
+
 /**
  * For resources-status.php
  */

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,6 +64,10 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use function rawurldecode;
 use function setcookie;
 use function str_starts_with;
+use function _;
+use function basename;
+use function explode;
+use function time;
 
 /**
  * For all your authentication/login needs

--- a/src/Controllers/MakeController.php
+++ b/src/Controllers/MakeController.php
@@ -51,6 +51,9 @@ use Override;
 
 use function array_map;
 use function count;
+use function explode;
+use function sprintf;
+use function str_starts_with;
 
 /**
  * Create zip, csv, pdf or report

--- a/src/Controllers/ResourcesCategoriesController.php
+++ b/src/Controllers/ResourcesCategoriesController.php
@@ -14,6 +14,8 @@ namespace Elabftw\Controllers;
 
 use Override;
 
+use function _;
+
 /**
  * For resources-categories.php
  */

--- a/src/Controllers/SycController.php
+++ b/src/Controllers/SycController.php
@@ -14,6 +14,8 @@ namespace Elabftw\Controllers;
 
 use Override;
 
+use function _;
+
 final class SycController extends AbstractHtmlController
 {
     #[Override]

--- a/src/Elabftw/App.php
+++ b/src/Elabftw/App.php
@@ -44,6 +44,9 @@ use function intdiv;
 use function putenv;
 use function setlocale;
 use function textdomain;
+use function array_merge;
+use function bind_textdomain_codeset;
+use function sprintf;
 
 /**
  * This is a super class holding various global objects

--- a/src/Elabftw/Compound.php
+++ b/src/Elabftw/Compound.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Elabftw;
 
 use function json_decode;
+use function is_array;
 
 /**
  * Representation of a chemical compound

--- a/src/Elabftw/CreateUpload.php
+++ b/src/Elabftw/CreateUpload.php
@@ -21,6 +21,9 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Override;
 
+use function basename;
+use function dirname;
+
 class CreateUpload implements CreateUploadParamsInterface
 {
     public function __construct(

--- a/src/Elabftw/CreateUploadFromLocalFile.php
+++ b/src/Elabftw/CreateUploadFromLocalFile.php
@@ -20,6 +20,8 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Override;
 
+use function dirname;
+
 final class CreateUploadFromLocalFile extends CreateUpload
 {
     public function __construct(

--- a/src/Elabftw/CreateUploadFromUploadedFile.php
+++ b/src/Elabftw/CreateUploadFromUploadedFile.php
@@ -20,6 +20,8 @@ use League\Flysystem\FilesystemOperator;
 use Override;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function basename;
+
 final class CreateUploadFromUploadedFile extends CreateUpload
 {
     public function __construct(

--- a/src/Elabftw/Db.php
+++ b/src/Elabftw/Db.php
@@ -18,6 +18,8 @@ use PDO;
 use PDOException;
 use PDOStatement;
 
+use function debug_print_backtrace;
+
 /**
  * Connect to the database with a singleton class
  */

--- a/src/Elabftw/EntitySlug.php
+++ b/src/Elabftw/EntitySlug.php
@@ -14,6 +14,8 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Enums\EntityType;
 
+use function explode;
+
 final class EntitySlug
 {
     public function __construct(public readonly EntityType $type, public readonly int $id) {}

--- a/src/Elabftw/EntitySlugsSqlBuilder.php
+++ b/src/Elabftw/EntitySlugsSqlBuilder.php
@@ -18,6 +18,10 @@ use Elabftw\Models\Users\Users;
 use PDO;
 
 use function sprintf;
+use function array_column;
+use function array_map;
+use function is_int;
+use function str_contains;
 
 final class EntitySlugsSqlBuilder
 {

--- a/src/Elabftw/Env.php
+++ b/src/Elabftw/Env.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Validation;
 use function getenv;
 use function strtolower;
 use function trim;
+use function count;
+use function sprintf;
 
 /**
  * For dealing with Environment values passed to php-fpm

--- a/src/Elabftw/Extensions.php
+++ b/src/Elabftw/Extensions.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
+use function in_array;
+
 /**
  * Define extensions groups
  */

--- a/src/Elabftw/Invoker.php
+++ b/src/Elabftw/Invoker.php
@@ -14,6 +14,11 @@ namespace Elabftw\Elabftw;
 
 use RuntimeException;
 
+use function fclose;
+use function fwrite;
+use function sprintf;
+use function stream_socket_client;
+
 final class Invoker
 {
     private const string SOCKET_PATH = 'unix:///run/invoker/invoker.sock';

--- a/src/Elabftw/Metadata.php
+++ b/src/Elabftw/Metadata.php
@@ -21,6 +21,12 @@ use function array_combine;
 use function count;
 use function json_decode;
 use function json_encode;
+use function _;
+use function array_merge;
+use function in_array;
+use function is_array;
+use function sprintf;
+use function uasort;
 
 final class Metadata
 {

--- a/src/Elabftw/MinisignKeys.php
+++ b/src/Elabftw/MinisignKeys.php
@@ -24,6 +24,14 @@ use function preg_match;
 use function sodium_crypto_generichash;
 use function sodium_memzero;
 use function unpack;
+use function _;
+use function pack;
+use function random_bytes;
+use function sodium_crypto_pwhash_scryptsalsa208sha256;
+use function sodium_crypto_sign_keypair;
+use function sodium_crypto_sign_publickey;
+use function sodium_crypto_sign_secretkey;
+use function sprintf;
 
 use const SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES;
 use const SODIUM_CRYPTO_SIGN_SECRETKEYBYTES;

--- a/src/Elabftw/OpenMetrics.php
+++ b/src/Elabftw/OpenMetrics.php
@@ -15,6 +15,17 @@ namespace Elabftw\Elabftw;
 use Elabftw\Models\Info;
 use Symfony\Component\HttpFoundation\Response;
 
+use function apcu_entry;
+use function implode;
+use function ini_set;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function rtrim;
+use function setlocale;
+use function sprintf;
+use function time;
+
 class OpenMetrics
 {
     private const METRICS_TTL_SECONDS = 60;

--- a/src/Elabftw/Permissions.php
+++ b/src/Elabftw/Permissions.php
@@ -20,6 +20,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\TeamsHelper;
 
 use function json_decode;
+use function array_column;
+use function in_array;
 
 /**
  * Determine read and write access for a user and an entity

--- a/src/Elabftw/PermissionsHelper.php
+++ b/src/Elabftw/PermissionsHelper.php
@@ -20,6 +20,8 @@ use Elabftw\Models\Teams;
 
 use function array_flip;
 use function array_map;
+use function array_key_exists;
+use function json_decode;
 
 /**
  * Help with translation of permission json into meaningful data

--- a/src/Elabftw/Sql.php
+++ b/src/Elabftw/Sql.php
@@ -25,6 +25,8 @@ use function str_repeat;
 use function strlen;
 use function strtoupper;
 use function trim;
+use function preg_match;
+use function sprintf;
 
 /**
  * For SQL operations from files

--- a/src/Elabftw/TimestampResponse.php
+++ b/src/Elabftw/TimestampResponse.php
@@ -15,6 +15,12 @@ namespace Elabftw\Elabftw;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Traits\ProcessTrait;
 
+use function explode;
+use function is_readable;
+use function json_encode;
+use function preg_match;
+use function sprintf;
+
 /**
  * Trusted Timestamping (RFC3161) response object
  * @final mocked in tests

--- a/src/Elabftw/Tools.php
+++ b/src/Elabftw/Tools.php
@@ -25,6 +25,14 @@ use function mb_substr;
 use function sha1;
 use function str_split;
 use function trim;
+use function chr;
+use function explode;
+use function floor;
+use function is_array;
+use function ord;
+use function sprintf;
+use function strlen;
+use function vsprintf;
 
 /**
  * Toolbelt full of useful functions

--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -30,6 +30,9 @@ use function is_string;
 use function json_decode;
 use function sprintf;
 use function nl2br;
+use function _;
+use function array_key_exists;
+use function in_array;
 
 /**
  * Twig filters

--- a/src/Elabftw/TwigFunctions.php
+++ b/src/Elabftw/TwigFunctions.php
@@ -23,6 +23,11 @@ use Symfony\Component\HttpFoundation\Request;
 use function memory_get_usage;
 use function microtime;
 use function round;
+use function array_rand;
+use function array_splice;
+use function count;
+use function in_array;
+use function json_decode;
 
 /**
  * Functions used by Twig in templates

--- a/src/Elabftw/UserStats.php
+++ b/src/Elabftw/UserStats.php
@@ -23,6 +23,7 @@ use function array_key_last;
 use function implode;
 use function round;
 use function sprintf;
+use function _;
 
 /**
  * Generate experiments statistics for a user (shown on profile page)

--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -16,6 +16,14 @@ use Elabftw\Enums\Language;
 use Elabftw\Traits\TwigTrait;
 use League\Flysystem\FilesystemOperator;
 
+use function _;
+use function bind_textdomain_codeset;
+use function bindtextdomain;
+use function dirname;
+use function putenv;
+use function setlocale;
+use function textdomain;
+
 /**
  * This class is used to generate the translations files for i18next (javascript)
  * Use it with: bin/console dev:i18n4js

--- a/src/Enums/BasePermissions.php
+++ b/src/Enums/BasePermissions.php
@@ -14,6 +14,8 @@ namespace Elabftw\Enums;
 
 use InvalidArgumentException;
 
+use function _;
+
 enum BasePermissions: int
 {
     case Full = 50;

--- a/src/Enums/Classification.php
+++ b/src/Enums/Classification.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Classification: int
 {
     case None = 0;

--- a/src/Enums/Currency.php
+++ b/src/Enums/Currency.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Currency: int
 {
     case CAD = 0;

--- a/src/Enums/EnforceMfa.php
+++ b/src/Enums/EnforceMfa.php
@@ -16,6 +16,7 @@ namespace Elabftw\Enums;
 use function array_column;
 use function array_combine;
 use function array_map;
+use function _;
 
 enum EnforceMfa: int
 {

--- a/src/Enums/Language.php
+++ b/src/Enums/Language.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Enums;
 
 use function array_map;
+use function array_combine;
 
 enum Language: string
 {

--- a/src/Enums/Messages.php
+++ b/src/Enums/Messages.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Messages
 {
     case CriticalError;

--- a/src/Enums/PasswordComplexity.php
+++ b/src/Enums/PasswordComplexity.php
@@ -15,6 +15,7 @@ namespace Elabftw\Enums;
 use function array_column;
 use function array_combine;
 use function array_map;
+use function _;
 
 enum PasswordComplexity: int
 {

--- a/src/Enums/ProcurementState.php
+++ b/src/Enums/ProcurementState.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum ProcurementState: int
 {
     case Pending = 10;

--- a/src/Enums/RequestableAction.php
+++ b/src/Enums/RequestableAction.php
@@ -14,6 +14,8 @@ namespace Elabftw\Enums;
 
 use Elabftw\Traits\EnumsTrait;
 
+use function _;
+
 enum RequestableAction: int
 {
     use EnumsTrait;

--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Scope: int
 {
     case User = 1;

--- a/src/Enums/Usergroup.php
+++ b/src/Enums/Usergroup.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Usergroup: int
 {
     case Sysadmin = 1;

--- a/src/Enums/Users2TeamsTargets.php
+++ b/src/Enums/Users2TeamsTargets.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Enums;
 
+use function _;
+
 enum Users2TeamsTargets: string
 {
     case IsAdmin = 'is_admin';

--- a/src/Exceptions/DemoModeException.php
+++ b/src/Exceptions/DemoModeException.php
@@ -14,6 +14,8 @@ namespace Elabftw\Exceptions;
 
 use Override;
 
+use function _;
+
 /**
  * For things disabled by demo_mode
  */

--- a/src/Exceptions/InvalidCredentialsException.php
+++ b/src/Exceptions/InvalidCredentialsException.php
@@ -14,6 +14,8 @@ namespace Elabftw\Exceptions;
 
 use Override;
 
+use function _;
+
 /**
  * Throw this if the auth is not good
  */

--- a/src/Exceptions/InvalidDeviceTokenException.php
+++ b/src/Exceptions/InvalidDeviceTokenException.php
@@ -14,6 +14,8 @@ namespace Elabftw\Exceptions;
 
 use Exception;
 
+use function _;
+
 /**
  * Throw this if the device token is not valid
  */

--- a/src/Exceptions/InvalidEndpointException.php
+++ b/src/Exceptions/InvalidEndpointException.php
@@ -14,6 +14,9 @@ namespace Elabftw\Exceptions;
 
 use Elabftw\Enums\ApiEndpoint;
 
+use function implode;
+use function sprintf;
+
 /**
  * For invalid api endpoint
  */

--- a/src/Exceptions/InvalidMfaCodeException.php
+++ b/src/Exceptions/InvalidMfaCodeException.php
@@ -15,6 +15,8 @@ namespace Elabftw\Exceptions;
 
 use Override;
 
+use function _;
+
 /**
  * Throw this if the MFA code verification failed
  */

--- a/src/Factories/NotificationsFactory.php
+++ b/src/Factories/NotificationsFactory.php
@@ -29,6 +29,9 @@ use Elabftw\Models\Notifications\UserCreated;
 use Elabftw\Models\Notifications\UserNeedValidation;
 use Elabftw\Models\Users\Users;
 
+use function json_decode;
+use function sprintf;
+
 /**
  * Get a Notification instance based on data from sql row
  */

--- a/src/Hash/LocalFileHash.php
+++ b/src/Hash/LocalFileHash.php
@@ -15,6 +15,9 @@ namespace Elabftw\Hash;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 
+use function basename;
+use function dirname;
+
 /**
  * To hash a file stored on local filesystem
  */

--- a/src/Hash/StringHash.php
+++ b/src/Hash/StringHash.php
@@ -14,6 +14,8 @@ namespace Elabftw\Hash;
 
 use Override;
 
+use function mb_strlen;
+
 class StringHash extends AbstractHash
 {
     // length of input above which we don't process it

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -24,6 +24,7 @@ use function array_diff_key;
 use function array_flip;
 use function json_encode;
 use function filter_var;
+use function key;
 
 /**
  * Parent class for processing a CSV file during import

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -28,6 +28,9 @@ use Override;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+use function in_array;
+use function sprintf;
+
 /**
  * Import data from a file
  */

--- a/src/Import/AbstractZip.php
+++ b/src/Import/AbstractZip.php
@@ -24,6 +24,10 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use RuntimeException;
 
+use function fclose;
+use function sprintf;
+use function str_replace;
+
 /**
  * Mother class for importing zip file
  */

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -31,6 +31,9 @@ use Symfony\Component\HttpFoundation\InputBag;
 use function sprintf;
 use function strcasecmp;
 use function trim;
+use function count;
+use function explode;
+use function is_array;
 
 /**
  * Import a CSV into compounds

--- a/src/Import/Csv.php
+++ b/src/Import/Csv.php
@@ -23,6 +23,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Override;
 
+use function array_key_exists;
+use function explode;
+
 /**
  * Import entries from a csv file.
  */

--- a/src/Import/Eln.php
+++ b/src/Import/Eln.php
@@ -41,6 +41,20 @@ use function json_decode;
 use function rawurlencode;
 use function sprintf;
 use function strtr;
+use function _;
+use function array_key_exists;
+use function count;
+use function date;
+use function explode;
+use function filter_var;
+use function is_string;
+use function json_encode;
+use function parse_str;
+use function parse_url;
+use function preg_replace;
+use function str_replace;
+use function str_starts_with;
+use function ucfirst;
 
 /**
  * Import a .eln file.

--- a/src/Import/Handler.php
+++ b/src/Import/Handler.php
@@ -28,6 +28,10 @@ use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function _;
+use function implode;
+use function sprintf;
+
 /**
  * Handle import request
  */

--- a/src/Import/TrustedEln.php
+++ b/src/Import/TrustedEln.php
@@ -19,6 +19,8 @@ use Elabftw\Models\Users\ValidatedUser;
 use Override;
 
 use function sprintf;
+use function array_key_exists;
+use function is_array;
 
 /**
  * Import a trusted .eln file: the Author will be respected, and users created

--- a/src/Make/AbstractMake.php
+++ b/src/Make/AbstractMake.php
@@ -17,6 +17,8 @@ use Elabftw\Interfaces\FileMakerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Override;
 
+use function gmdate;
+
 /**
  * Mother class of the Make* services
  */

--- a/src/Make/AbstractMakeCsv.php
+++ b/src/Make/AbstractMakeCsv.php
@@ -18,6 +18,7 @@ use League\Csv\Writer;
 use Override;
 
 use function strlen;
+use function array_keys;
 
 /**
  * Mother class of the Make*Csv services

--- a/src/Make/AbstractMakePdf.php
+++ b/src/Make/AbstractMakePdf.php
@@ -19,6 +19,8 @@ use Elabftw\Enums\Classification;
 use Mpdf\Mpdf;
 use Override;
 
+use function dirname;
+
 /**
  * Mother class of the Make*Pdf services
  */

--- a/src/Make/AbstractMakeTimestamp.php
+++ b/src/Make/AbstractMakeTimestamp.php
@@ -27,6 +27,10 @@ use GuzzleHttp\Client;
 use PDO;
 use Override;
 
+use function _;
+use function date;
+use function sprintf;
+
 /**
  * Mother class for all timestamping actions (trusted or blockchain)
  */

--- a/src/Make/AbstractMakeTrustedTimestamp.php
+++ b/src/Make/AbstractMakeTrustedTimestamp.php
@@ -27,6 +27,7 @@ use function preg_last_error_msg;
 use function preg_replace;
 use function sprintf;
 use function trim;
+use function str_replace;
 
 /**
  * Timestamp an experiment with RFC 3161 protocol: https://www.ietf.org/rfc/rfc3161.txt

--- a/src/Make/AbstractMakeZip.php
+++ b/src/Make/AbstractMakeZip.php
@@ -17,6 +17,10 @@ use Elabftw\Interfaces\ZipMakerInterface;
 use ZipStream\ZipStream;
 use Override;
 
+use function hash;
+use function in_array;
+use function sprintf;
+
 /**
  * Mother class of the Make*Zip services
  */

--- a/src/Make/Exports.php
+++ b/src/Make/Exports.php
@@ -39,6 +39,12 @@ use ValueError;
 use ZipStream\ZipStream;
 
 use function hash_file;
+use function _;
+use function count;
+use function date;
+use function fclose;
+use function fopen;
+use function sprintf;
 
 /**
  * Handle data exports

--- a/src/Make/MakeBloxberg.php
+++ b/src/Make/MakeBloxberg.php
@@ -26,6 +26,14 @@ use ZipArchive;
 
 use function json_decode;
 use function json_encode;
+use function _;
+use function basename;
+use function date;
+use function dirname;
+use function hash;
+use function implode;
+use function sprintf;
+use function trim;
 
 /**
  * Send data to Bloxberg server

--- a/src/Make/MakeCompoundsReport.php
+++ b/src/Make/MakeCompoundsReport.php
@@ -18,6 +18,7 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function date;
+use function _;
 
 /**
  * Make a CSV file with all the compounds

--- a/src/Make/MakeCsv.php
+++ b/src/Make/MakeCsv.php
@@ -15,6 +15,9 @@ namespace Elabftw\Make;
 use Override;
 
 use function date;
+use function html_entity_decode;
+use function htmlspecialchars_decode;
+use function strip_tags;
 
 /**
  * Export entities as CSV

--- a/src/Make/MakeCustomTimestamp.php
+++ b/src/Make/MakeCustomTimestamp.php
@@ -14,6 +14,8 @@ namespace Elabftw\Make;
 
 use Override;
 
+use function in_array;
+
 /**
  * RFC3161 timestamping with a custom TSA
  */

--- a/src/Make/MakeEln.php
+++ b/src/Make/MakeEln.php
@@ -34,6 +34,24 @@ use RuntimeException;
 
 use function array_push;
 use function ksort;
+use function array_column;
+use function array_key_exists;
+use function array_key_first;
+use function array_merge;
+use function array_reduce;
+use function date;
+use function explode;
+use function fclose;
+use function fopen;
+use function hash;
+use function hash_file;
+use function implode;
+use function in_array;
+use function json_decode;
+use function json_encode;
+use function random_bytes;
+use function sprintf;
+use function strtr;
 
 /**
  * Make an ELN archive

--- a/src/Make/MakeElnHtml.php
+++ b/src/Make/MakeElnHtml.php
@@ -18,6 +18,8 @@ use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+use function json_encode;
+
 /**
  * Make an ELN html file
  */

--- a/src/Make/MakeInventoryReport.php
+++ b/src/Make/MakeInventoryReport.php
@@ -17,6 +17,7 @@ use Elabftw\Models\StorageUnits;
 use Override;
 
 use function date;
+use function _;
 
 /**
  * Make a CSV file with all the inventory

--- a/src/Make/MakeJson.php
+++ b/src/Make/MakeJson.php
@@ -21,6 +21,7 @@ use Override;
 
 use function json_encode;
 use function ksort;
+use function mb_strlen;
 
 /**
  * Make a JSON export from one or several entities

--- a/src/Make/MakeKeeex.php
+++ b/src/Make/MakeKeeex.php
@@ -19,6 +19,8 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7;
 
+use function sprintf;
+
 /**
  * Keeex a file
  */

--- a/src/Make/MakeMultiPdf.php
+++ b/src/Make/MakeMultiPdf.php
@@ -15,6 +15,9 @@ namespace Elabftw\Make;
 use DateTimeImmutable;
 use Override;
 
+use function _;
+use function sprintf;
+
 /**
  * Create a pdf from several Entities
  */

--- a/src/Make/MakePdf.php
+++ b/src/Make/MakePdf.php
@@ -40,6 +40,16 @@ use function implode;
 use function str_replace;
 use function strlen;
 use function strtolower;
+use function base64_encode;
+use function basename;
+use function count;
+use function error_reporting;
+use function htmlspecialchars_decode;
+use function is_array;
+use function parse_str;
+use function parse_url;
+use function preg_match_all;
+use function sprintf;
 
 /**
  * Create a pdf from an Entity

--- a/src/Make/MakeProcurementRequestsCsv.php
+++ b/src/Make/MakeProcurementRequestsCsv.php
@@ -17,6 +17,7 @@ use Elabftw\Models\ProcurementRequests;
 use Override;
 
 use function date;
+use function _;
 
 /**
  * Make a CSV file from the team's procurement requests

--- a/src/Make/MakeQrPdf.php
+++ b/src/Make/MakeQrPdf.php
@@ -18,6 +18,10 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TwigTrait;
 use Override;
 
+use function html_entity_decode;
+use function sprintf;
+use function strlen;
+
 /**
  * Make a PDF from several experiments or db items showing only minimal info with QR codes
  */

--- a/src/Make/MakeQrPng.php
+++ b/src/Make/MakeQrPng.php
@@ -22,6 +22,11 @@ use RobThree\Auth\Providers\Qr\IQRCodeProvider;
 use Override;
 
 use function strlen;
+use function count;
+use function dirname;
+use function mb_strlen;
+use function mb_substr;
+use function sprintf;
 
 /**
  * Generate a PNG image with a QR Code pointing to the URL of the Entity, and optionally include the title

--- a/src/Make/MakeReport.php
+++ b/src/Make/MakeReport.php
@@ -19,6 +19,7 @@ use PDO;
 use Override;
 
 use function date;
+use function implode;
 
 /**
  * Create a report of usage for users provided in construct

--- a/src/Make/MakeTeamEln.php
+++ b/src/Make/MakeTeamEln.php
@@ -19,6 +19,11 @@ use ZipStream\ZipStream;
 use Override;
 use Psr\Log\LoggerInterface;
 
+use function array_column;
+use function array_map;
+use function implode;
+use function sprintf;
+
 /**
  * Make an ELN archive for a full team. Only accessible from command line.
  */

--- a/src/Models/AbstractCategory.php
+++ b/src/Models/AbstractCategory.php
@@ -17,6 +17,9 @@ use Elabftw\Traits\EntityTrait;
 use Elabftw\Traits\SortableTrait;
 use PDO;
 
+use function is_int;
+use function sprintf;
+
 /**
  * A category is a status for experiments and item type for db item
  */

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -91,6 +91,16 @@ use function ksort;
 use function mb_substr;
 use function sprintf;
 use function str_contains;
+use function _;
+use function array_key_exists;
+use function explode;
+use function intval;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function str_ends_with;
+use function str_replace;
+use function ucfirst;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;

--- a/src/Models/AbstractStatus.php
+++ b/src/Models/AbstractStatus.php
@@ -28,6 +28,9 @@ use PDO;
 use Symfony\Component\HttpFoundation\InputBag;
 use Override;
 
+use function _;
+use function sprintf;
+
 /**
  * Status for experiments or items
  */

--- a/src/Models/AbstractTemplateEntity.php
+++ b/src/Models/AbstractTemplateEntity.php
@@ -22,6 +22,8 @@ use Elabftw\Factories\LinksFactory;
 use Override;
 use PDO;
 
+use function is_int;
+
 /**
  * An entity like Templates or ItemsTypes. Template as opposed to Concrete: Experiments and Items
  */

--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -27,6 +27,10 @@ use function bin2hex;
 use function password_hash;
 use function password_verify;
 use function random_bytes;
+use function _;
+use function explode;
+use function sprintf;
+use function str_contains;
 
 /**
  * Api keys CRUD class

--- a/src/Models/Batch.php
+++ b/src/Models/Batch.php
@@ -25,6 +25,9 @@ use Elabftw\Params\DisplayParams;
 use Elabftw\Params\Guard;
 use Override;
 
+use function array_map;
+use function array_merge;
+
 /**
  * Process a single request targeting multiple entities
  */

--- a/src/Models/Comments.php
+++ b/src/Models/Comments.php
@@ -24,6 +24,10 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function array_unique;
+use function array_values;
+use function sprintf;
+
 /**
  * All about the comments
  */

--- a/src/Models/Compounds.php
+++ b/src/Models/Compounds.php
@@ -33,6 +33,17 @@ use Override;
 use PDO;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function _;
+use function array_flip;
+use function array_intersect_key;
+use function array_keys;
+use function array_map;
+use function array_sum;
+use function implode;
+use function rtrim;
+use function sprintf;
+use function str_contains;
+
 /**
  * Compounds are chemical entities stored in the `compounds` SQL table
  */

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -31,6 +31,12 @@ use Override;
 use function array_map;
 use function urlencode;
 use function in_array;
+use function array_key_exists;
+use function count;
+use function dirname;
+use function file_get_contents;
+use function sprintf;
+use function str_starts_with;
 
 /**
  * The general config table

--- a/src/Models/Dspace.php
+++ b/src/Models/Dspace.php
@@ -30,6 +30,17 @@ use function str_starts_with;
 use function rtrim;
 use function sprintf;
 use function json_decode;
+use function _;
+use function array_column;
+use function array_merge;
+use function date;
+use function explode;
+use function fopen;
+use function implode;
+use function is_int;
+use function json_encode;
+use function str_replace;
+use function trim;
 
 /**
  * Connect with DSpace Repository

--- a/src/Models/ExclusiveEditMode.php
+++ b/src/Models/ExclusiveEditMode.php
@@ -20,6 +20,7 @@ use Elabftw\Exceptions\ImproperActionException;
 use PDO;
 
 use function sprintf;
+use function _;
 
 /**
  * For dealing with exclusive edit mode aka write lock

--- a/src/Models/Experiments.php
+++ b/src/Models/Experiments.php
@@ -28,6 +28,8 @@ use Elabftw\Traits\InsertTagsTrait;
 use PDO;
 use Override;
 
+use function _;
+
 /**
  * All about the experiments
  */

--- a/src/Models/ExtraFieldsKeys.php
+++ b/src/Models/ExtraFieldsKeys.php
@@ -21,6 +21,9 @@ use Elabftw\Models\Users\Users;
 use Override;
 use PDO;
 
+use function implode;
+use function sprintf;
+
 /**
  * Get extra fields keys of items and experiments used for autocomplete on search page.
  */

--- a/src/Models/FavTags.php
+++ b/src/Models/FavTags.php
@@ -21,6 +21,8 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function _;
+
 /**
  * The favorite tags of a user
  */

--- a/src/Models/Fingerprints.php
+++ b/src/Models/Fingerprints.php
@@ -18,6 +18,8 @@ use PDO;
 
 use function array_sum;
 use function count;
+use function rtrim;
+use function sprintf;
 
 /**
  * Fingerprints for compounds

--- a/src/Models/Idps.php
+++ b/src/Models/Idps.php
@@ -22,6 +22,11 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function array_map;
+use function count;
+use function json_decode;
+use function sprintf;
+
 /**
  * An IDP is an Identity Provider. Used in SAML2 authentication context.
  */

--- a/src/Models/IdpsCerts.php
+++ b/src/Models/IdpsCerts.php
@@ -24,6 +24,12 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function array_fill_keys;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function sprintf;
+
 /**
  * For IDPS certificates
  */

--- a/src/Models/IdpsEndpoints.php
+++ b/src/Models/IdpsEndpoints.php
@@ -22,6 +22,12 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function array_fill_keys;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function sprintf;
+
 /**
  * For IDPS endpoints
  */

--- a/src/Models/IdpsSources.php
+++ b/src/Models/IdpsSources.php
@@ -28,6 +28,8 @@ use GuzzleHttp\Client;
 use Override;
 use PDO;
 
+use function sprintf;
+
 /**
  * For IDPS sources: .xml urls
  */

--- a/src/Models/Info.php
+++ b/src/Models/Info.php
@@ -19,6 +19,9 @@ use Elabftw\Models\Users\Users;
 use Override;
 use PDO;
 
+use function array_merge;
+use function json_decode;
+
 /**
  * Display information about the instance
  */

--- a/src/Models/Instance.php
+++ b/src/Models/Instance.php
@@ -21,6 +21,10 @@ use Elabftw\Services\Filter;
 use Override;
 use Symfony\Component\Mime\Address;
 
+use function explode;
+use function in_array;
+use function str_starts_with;
+
 /**
  * Instance level actions
  */

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -33,6 +33,8 @@ use PDO;
 use Symfony\Component\HttpFoundation\Request;
 use Override;
 
+use function _;
+
 /**
  * All about the database items
  */

--- a/src/Models/ItemsTypes.php
+++ b/src/Models/ItemsTypes.php
@@ -23,6 +23,8 @@ use Elabftw\Traits\RandomColorTrait;
 use Override;
 use PDO;
 
+use function _;
+
 /**
  * The kind of items you can have in the database for a team
  * TODO rename ResourcesTemplates

--- a/src/Models/Links/AbstractCompoundsLinks.php
+++ b/src/Models/Links/AbstractCompoundsLinks.php
@@ -27,6 +27,9 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function _;
+use function sprintf;
+
 /**
  * Compounds linking to entities
  */

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -29,6 +29,7 @@ use PDO;
 
 use function intval;
 use function json_encode;
+use function sprintf;
 
 /**
  * All about containers links with entities

--- a/src/Models/Links/AbstractLinks.php
+++ b/src/Models/Links/AbstractLinks.php
@@ -31,6 +31,9 @@ use PDO;
 
 use function intval;
 use function json_encode;
+use function _;
+use function array_all;
+use function sprintf;
 
 /**
  * All about Links

--- a/src/Models/Notifications/AbstractNotifications.php
+++ b/src/Models/Notifications/AbstractNotifications.php
@@ -20,6 +20,8 @@ use Elabftw\Traits\QueryParamsTrait;
 use Elabftw\Traits\SetIdTrait;
 use PDO;
 
+use function json_encode;
+
 /**
  * Mother class for notifications that can be sent to a user
  */

--- a/src/Models/Notifications/ActionRequested.php
+++ b/src/Models/Notifications/ActionRequested.php
@@ -20,6 +20,9 @@ use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Users\Users;
 use Override;
 
+use function _;
+use function sprintf;
+
 final class ActionRequested extends AbstractNotifications implements MailableInterface
 {
     protected const PREF = 'notif_action_requested';

--- a/src/Models/Notifications/CommentCreated.php
+++ b/src/Models/Notifications/CommentCreated.php
@@ -18,6 +18,9 @@ use Elabftw\Interfaces\MailableInterface;
 use Elabftw\Models\Users\Users;
 use Override;
 
+use function _;
+use function sprintf;
+
 final class CommentCreated extends AbstractNotifications implements MailableInterface
 {
     protected const PREF = 'notif_comment_created';

--- a/src/Models/Notifications/EventDeleted.php
+++ b/src/Models/Notifications/EventDeleted.php
@@ -24,6 +24,10 @@ use Elabftw\Services\Email;
 use Elabftw\Services\Filter;
 use Override;
 
+use function _;
+use function count;
+use function sprintf;
+
 final class EventDeleted extends AbstractNotifications implements MailableInterface, RestInterface
 {
     protected const PREF = 'notif_event_deleted';

--- a/src/Models/Notifications/SelfIsValidated.php
+++ b/src/Models/Notifications/SelfIsValidated.php
@@ -17,6 +17,9 @@ use Elabftw\Enums\Notifications;
 use Elabftw\Interfaces\MailableInterface;
 use Override;
 
+use function _;
+use function sprintf;
+
 /**
  * When our account has been validated
  */

--- a/src/Models/Notifications/SelfNeedValidation.php
+++ b/src/Models/Notifications/SelfNeedValidation.php
@@ -16,6 +16,8 @@ use Elabftw\Enums\Notifications;
 use Elabftw\Interfaces\MailableInterface;
 use Override;
 
+use function _;
+
 /**
  * Send an email to a new user to notify that admin validation is required.
  * This exists because experience shows that users don't read the notification and expect

--- a/src/Models/Notifications/StepDeadline.php
+++ b/src/Models/Notifications/StepDeadline.php
@@ -19,6 +19,9 @@ use Elabftw\Models\Users\Users;
 use PDO;
 use Override;
 
+use function _;
+use function sprintf;
+
 final class StepDeadline extends AbstractNotifications implements MailableInterface
 {
     /**

--- a/src/Models/Notifications/UserCreated.php
+++ b/src/Models/Notifications/UserCreated.php
@@ -17,6 +17,9 @@ use Elabftw\Interfaces\MailableInterface;
 use Elabftw\Models\Users\Users;
 use Override;
 
+use function _;
+use function sprintf;
+
 class UserCreated extends AbstractNotifications implements MailableInterface
 {
     protected const PREF = 'notif_user_created';

--- a/src/Models/Notifications/UserNeedValidation.php
+++ b/src/Models/Notifications/UserNeedValidation.php
@@ -18,6 +18,9 @@ use Elabftw\Interfaces\MailableInterface;
 use Elabftw\Models\Users\Users;
 use Override;
 
+use function _;
+use function sprintf;
+
 final class UserNeedValidation extends UserCreated implements MailableInterface
 {
     protected const PREF = 'notif_user_need_validation';

--- a/src/Models/Notifications/UserNotifications.php
+++ b/src/Models/Notifications/UserNotifications.php
@@ -22,6 +22,7 @@ use Override;
 use PDO;
 
 use function json_decode;
+use function sprintf;
 
 /**
  * Notifications for a user

--- a/src/Models/Pins.php
+++ b/src/Models/Pins.php
@@ -17,6 +17,9 @@ use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\AccessType;
 use PDO;
 
+use function array_column;
+use function sprintf;
+
 /**
  * For dealing with pinned items
  */

--- a/src/Models/ProcurementRequests.php
+++ b/src/Models/ProcurementRequests.php
@@ -24,6 +24,8 @@ use Override;
 use PDO;
 use RuntimeException;
 
+use function array_map;
+
 /**
  * Procurement requests are purchase orders in a team
  */

--- a/src/Models/RequestActions.php
+++ b/src/Models/RequestActions.php
@@ -25,6 +25,12 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function _;
+use function array_map;
+use function preg_replace;
+use function sprintf;
+use function strtolower;
+
 /**
  * Request action for users
  */

--- a/src/Models/Revisions.php
+++ b/src/Models/Revisions.php
@@ -24,6 +24,9 @@ use Override;
 use PDO;
 
 use function mb_strlen;
+use function _;
+use function abs;
+use function sprintf;
 
 /**
  * All about the revisions

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -31,6 +31,14 @@ use PDO;
 
 use function preg_replace;
 use function ksort;
+use function _;
+use function array_filter;
+use function array_key_exists;
+use function array_map;
+use function implode;
+use function sprintf;
+use function str_replace;
+use function trim;
 
 /**
  * All about the team's scheduler

--- a/src/Models/SigKeys.php
+++ b/src/Models/SigKeys.php
@@ -24,6 +24,8 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function sprintf;
+
 /**
  * Signature keys CRUD class
  */

--- a/src/Models/Steps.php
+++ b/src/Models/Steps.php
@@ -27,6 +27,12 @@ use PDO;
 
 use function array_intersect;
 use function array_keys;
+use function _;
+use function array_key_exists;
+use function count;
+use function in_array;
+use function sprintf;
+use function str_replace;
 
 /**
  * All about the steps

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -26,6 +26,10 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function _;
+use function sprintf;
+use function trim;
+
 /**
  * All about storage_units
  */

--- a/src/Models/Tags.php
+++ b/src/Models/Tags.php
@@ -23,6 +23,11 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function _;
+use function is_array;
+use function is_string;
+use function sprintf;
+
 /**
  * All about the tag
  */

--- a/src/Models/Tags2Entity.php
+++ b/src/Models/Tags2Entity.php
@@ -18,6 +18,12 @@ use Elabftw\Enums\Scope;
 use Elabftw\Models\Users\Users;
 use PDO;
 
+use function array_keys;
+use function array_map;
+use function count;
+use function implode;
+use function sprintf;
+
 final class Tags2Entity
 {
     private Db $Db;

--- a/src/Models/TeamGroups.php
+++ b/src/Models/TeamGroups.php
@@ -29,6 +29,8 @@ use function array_map;
 use function json_decode;
 use function trim;
 use function sprintf;
+use function _;
+use function implode;
 
 /**
  * Everything related to the team groups

--- a/src/Models/TeamTags.php
+++ b/src/Models/TeamTags.php
@@ -22,6 +22,10 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
+use function array_pop;
+use function explode;
+use function sprintf;
+
 /**
  * All about the tag but seen from a team perspective, not an entity
  */

--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -31,6 +31,11 @@ use RuntimeException;
 
 use function array_diff;
 use function trim;
+use function array_column;
+use function array_intersect;
+use function array_map;
+use function implode;
+use function is_array;
 
 /**
  * All about the teams

--- a/src/Models/Templates.php
+++ b/src/Models/Templates.php
@@ -23,6 +23,8 @@ use Elabftw\Traits\SortableTrait;
 use Override;
 use PDO;
 
+use function _;
+
 /**
  * All about the templates
  */

--- a/src/Models/UnfinishedSteps.php
+++ b/src/Models/UnfinishedSteps.php
@@ -21,6 +21,10 @@ use Elabftw\Services\UsersHelper;
 use Override;
 use PDO;
 
+use function array_column;
+use function explode;
+use function sprintf;
+
 /**
  * Read the unfinished steps of items or experiments to display in to-do list.
  * By default the unfinished steps of a user are returned.

--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -42,6 +42,20 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 
 use function mb_substr;
+use function _;
+use function array_map;
+use function base64_decode;
+use function basename;
+use function dirname;
+use function fclose;
+use function fopen;
+use function implode;
+use function rewind;
+use function sprintf;
+use function str_replace;
+use function stream_copy_to_stream;
+use function stream_get_meta_data;
+use function strpos;
 
 /**
  * All about the file uploads

--- a/src/Models/UserRequestActions.php
+++ b/src/Models/UserRequestActions.php
@@ -20,6 +20,10 @@ use Elabftw\Models\Users\Users;
 use Override;
 use PDO;
 
+use function array_map;
+use function implode;
+use function sprintf;
+
 /**
  * Request action for users
  */

--- a/src/Models/UserUploads.php
+++ b/src/Models/UserUploads.php
@@ -20,6 +20,8 @@ use Override;
 use PDO;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function sprintf;
+
 final class UserUploads extends AbstractRest
 {
     public function __construct(private Users $owner, private ?int $id = null)

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -53,6 +53,15 @@ use Symfony\Component\HttpFoundation\Request;
 use Override;
 use RuntimeException;
 
+use function _;
+use function array_column;
+use function array_map;
+use function implode;
+use function in_array;
+use function json_decode;
+use function sprintf;
+use function strtolower;
+
 /**
  * Users
  */

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -27,6 +27,8 @@ use Elabftw\Services\TeamsHelper;
 use Elabftw\Services\UserArchiver;
 use PDO;
 
+use function count;
+
 /**
  * Manage the link between users and teams
  */

--- a/src/Params/BaseQueryParams.php
+++ b/src/Params/BaseQueryParams.php
@@ -22,6 +22,11 @@ use Elabftw\Services\Check;
 use Symfony\Component\HttpFoundation\InputBag;
 use Override;
 
+use function array_map;
+use function explode;
+use function implode;
+use function sprintf;
+
 /**
  * This class holds the values for limit, offset, order and sort
  */

--- a/src/Params/CompoundParams.php
+++ b/src/Params/CompoundParams.php
@@ -19,6 +19,9 @@ use Override;
 use function array_map;
 use function str_split;
 use function trim;
+use function count;
+use function explode;
+use function preg_match;
 
 final class CompoundParams extends ContentParams
 {

--- a/src/Params/ContentParams.php
+++ b/src/Params/ContentParams.php
@@ -23,6 +23,9 @@ use Override;
 
 use function mb_strlen;
 use function filter_var;
+use function _;
+use function is_subclass_of;
+use function sprintf;
 
 class ContentParams implements ContentParamsInterface
 {

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -28,6 +28,9 @@ use Symfony\Component\HttpFoundation\InputBag;
 use function explode;
 use function sprintf;
 use function trim;
+use function implode;
+use function rtrim;
+use function strtolower;
 
 /**
  * This class holds the values for limit, offset, order and sort

--- a/src/Params/Guard.php
+++ b/src/Params/Guard.php
@@ -18,6 +18,8 @@ use Elabftw\Exceptions\MissingRequiredKeyException;
 
 use function array_filter;
 use function array_key_exists;
+use function is_string;
+use function sprintf;
 
 final class Guard
 {

--- a/src/Params/OrderingParams.php
+++ b/src/Params/OrderingParams.php
@@ -16,6 +16,7 @@ use Elabftw\Enums\Orderable;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function array_map;
+use function explode;
 
 /**
  * Parameters passed for ordering stuff

--- a/src/Params/StepParams.php
+++ b/src/Params/StepParams.php
@@ -18,6 +18,8 @@ use Override;
 
 use function mb_strlen;
 use function str_replace;
+use function _;
+use function sprintf;
 
 final class StepParams extends ContentParams
 {

--- a/src/Params/TagParam.php
+++ b/src/Params/TagParam.php
@@ -16,6 +16,12 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\ParamInterface;
 use Override;
 
+use function _;
+use function mb_strlen;
+use function sprintf;
+use function str_replace;
+use function trim;
+
 final class TagParam implements ParamInterface
 {
     protected const int MIN_CONTENT_SIZE = 1;

--- a/src/Params/UserParams.php
+++ b/src/Params/UserParams.php
@@ -29,6 +29,10 @@ use Elabftw\Services\PasswordValidator;
 use Override;
 
 use function mb_substr;
+use function password_hash;
+use function preg_match;
+use function str_replace;
+use function strlen;
 
 final class UserParams extends ContentParams
 {

--- a/src/Services/AbstractRemoteDirectory.php
+++ b/src/Services/AbstractRemoteDirectory.php
@@ -15,6 +15,8 @@ namespace Elabftw\Services;
 use Elabftw\Interfaces\RemoteDirectoryInterface;
 use GuzzleHttp\ClientInterface;
 
+use function json_decode;
+
 /**
  * Search a remote directory for users that can be added to the local database.
  */

--- a/src/Services/AccessKeyHelper.php
+++ b/src/Services/AccessKeyHelper.php
@@ -16,6 +16,8 @@ use Elabftw\Elabftw\Db;
 use Elabftw\Enums\EntityType;
 use PDO;
 
+use function is_int;
+
 /**
  * A utility class to deal with access key stuff
  */

--- a/src/Services/AdvancedSearchQuery.php
+++ b/src/Services/AdvancedSearchQuery.php
@@ -23,6 +23,12 @@ use Elabftw\Services\AdvancedSearchQuery\Visitors\FieldValidatorVisitor;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\QueryBuilderVisitor;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
 
+use function _;
+use function array_slice;
+use function explode;
+use function implode;
+use function sprintf;
+
 final class AdvancedSearchQuery
 {
     protected string $exception = '';

--- a/src/Services/AdvancedSearchQuery/Exceptions/LimitDepthIsExceededException.php
+++ b/src/Services/AdvancedSearchQuery/Exceptions/LimitDepthIsExceededException.php
@@ -15,6 +15,8 @@ namespace Elabftw\Services\AdvancedSearchQuery\Exceptions;
 
 use Exception;
 
+use function _;
+
 final class LimitDepthIsExceededException extends Exception
 {
     public function __construct()

--- a/src/Services/AdvancedSearchQuery/Grammar/Field.php
+++ b/src/Services/AdvancedSearchQuery/Grammar/Field.php
@@ -21,6 +21,8 @@ use Elabftw\Services\AdvancedSearchQuery\Interfaces\Visitor;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
 use Override;
 
+use function htmlspecialchars;
+
 final class Field implements Term, Visitable, FieldType
 {
     public function __construct(private string $field, private SimpleValueWrapper $valueWrapper, private ?bool $strict = null) {}

--- a/src/Services/AdvancedSearchQuery/Visitors/FieldValidatorVisitor.php
+++ b/src/Services/AdvancedSearchQuery/Visitors/FieldValidatorVisitor.php
@@ -31,6 +31,11 @@ use Override;
 
 use function sprintf;
 use function ucfirst;
+use function array_column;
+use function array_merge;
+use function implode;
+use function in_array;
+use function intval;
 
 /** @psalm-suppress UnusedParam */
 final class FieldValidatorVisitor implements Visitor

--- a/src/Services/AdvancedSearchQuery/Visitors/QueryBuilderVisitor.php
+++ b/src/Services/AdvancedSearchQuery/Visitors/QueryBuilderVisitor.php
@@ -34,6 +34,14 @@ use function array_merge;
 use function bin2hex;
 use function random_bytes;
 use function ucfirst;
+use function array_column;
+use function array_push;
+use function array_unique;
+use function htmlspecialchars;
+use function implode;
+use function in_array;
+use function json_encode;
+use function sprintf;
 
 /** @psalm-suppress UnusedParam */
 final class QueryBuilderVisitor implements Visitor

--- a/src/Services/Check.php
+++ b/src/Services/Check.php
@@ -30,6 +30,12 @@ use function array_keys;
 use function in_array;
 use function sprintf;
 use function strlen;
+use function _;
+use function implode;
+use function is_array;
+use function json_decode;
+use function preg_match;
+use function str_starts_with;
 
 /**
  * When values need to be checked

--- a/src/Services/EairefRemoteDirectory.php
+++ b/src/Services/EairefRemoteDirectory.php
@@ -17,6 +17,10 @@ use Override;
 
 use function in_array;
 use function strtolower;
+use function array_merge;
+use function json_decode;
+use function preg_quote;
+use function str_replace;
 
 /**
  * Implements requests to EAIREF directory

--- a/src/Services/Email.php
+++ b/src/Services/Email.php
@@ -30,6 +30,11 @@ use Symfony\Component\Mime\Email as Memail;
 use Symfony\Component\Mime\RawMessage;
 
 use function count;
+use function _;
+use function array_column;
+use function array_map;
+use function preg_replace;
+use function sprintf;
 
 /**
  * Email service

--- a/src/Services/EmailNotifications.php
+++ b/src/Services/EmailNotifications.php
@@ -29,6 +29,8 @@ use function dirname;
 use function putenv;
 use function setlocale;
 use function textdomain;
+use function array_key_exists;
+use function sprintf;
 
 /**
  * Email notification system

--- a/src/Services/EmailValidator.php
+++ b/src/Services/EmailValidator.php
@@ -18,6 +18,10 @@ use Elabftw\Exceptions\ImproperActionException;
 use function array_map;
 use function filter_var;
 use function in_array;
+use function _;
+use function explode;
+use function implode;
+use function sprintf;
 
 /**
  * Validate an email address for several parameters

--- a/src/Services/ExpirationNotifier.php
+++ b/src/Services/ExpirationNotifier.php
@@ -19,6 +19,10 @@ use Symfony\Component\Mime\Address;
 use Override;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function _;
+use function implode;
+use function sprintf;
+
 /**
  * Warn users and their Admins about account expiration
  * Note: this class structure isn't great, and full of nested foreach. While it is possible to do everything in one nice query (probably), it's difficult and error prone, so we adopt the pragmatic approach of doing inefficient code because this code runs from CLI once a week so we don't really care if it takes long

--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -25,6 +25,12 @@ use function grapheme_strlen;
 use function strlen;
 use function strtolower;
 use function trim;
+use function _;
+use function ctype_alpha;
+use function explode;
+use function pathinfo;
+use function preg_replace;
+use function str_replace;
 
 /**
  * When values need to be filtered

--- a/src/Services/Fingerprinter.php
+++ b/src/Services/Fingerprinter.php
@@ -17,6 +17,9 @@ use Elabftw\Interfaces\FingerprinterInterface;
 use JsonException;
 use Override;
 
+use function json_decode;
+use function trim;
+
 /**
  * Use an external fingerprinting service to calculate compounds fingerprints
  */

--- a/src/Services/HttpGetter.php
+++ b/src/Services/HttpGetter.php
@@ -17,6 +17,10 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use Psr\Http\Message\ResponseInterface;
 
+use function array_merge;
+use function in_array;
+use function sprintf;
+
 /**
  * HTTP wrapper
  * @final mocked in tests

--- a/src/Services/LoginHelper.php
+++ b/src/Services/LoginHelper.php
@@ -25,6 +25,9 @@ use PDO;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 use function time;
+use function _;
+use function array_column;
+use function setcookie;
 
 /**
  * Methods to login the user (once the authentication is done)

--- a/src/Services/MfaHelper.php
+++ b/src/Services/MfaHelper.php
@@ -17,6 +17,9 @@ use Elabftw\Elabftw\Env;
 use RobThree\Auth\Algorithm;
 use RobThree\Auth\TwoFactorAuth;
 
+use function parse_url;
+use function sprintf;
+
 /**
  * Provide methods for multi/two-factor authentication
  */

--- a/src/Services/MpdfProvider.php
+++ b/src/Services/MpdfProvider.php
@@ -19,6 +19,7 @@ use Mpdf\Mpdf;
 use Override;
 
 use function dirname;
+use function array_merge;
 
 /**
  * Get an instance of mpdf

--- a/src/Services/PasswordValidator.php
+++ b/src/Services/PasswordValidator.php
@@ -18,6 +18,7 @@ use Elabftw\Exceptions\ImproperActionException;
 use function mb_strlen;
 use function preg_match;
 use function sprintf;
+use function _;
 
 /**
  * Validate a password against instance configuration for length and complexity

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -58,6 +58,8 @@ use function bin2hex;
 use function dirname;
 use function random_bytes;
 use function sprintf;
+use function explode;
+use function shuffle;
 
 /**
  * This is used to generate data for dev purposes

--- a/src/Services/PubChemImporter.php
+++ b/src/Services/PubChemImporter.php
@@ -17,6 +17,8 @@ use JsonException;
 
 use function usleep;
 use function rawurlencode;
+use function json_decode;
+use function sprintf;
 
 /**
  * Import a compound from PubChem

--- a/src/Services/ResetPasswordKey.php
+++ b/src/Services/ResetPasswordKey.php
@@ -23,6 +23,8 @@ use Elabftw\Models\Users\ValidatedUser;
 use function explode;
 use function implode;
 use function sprintf;
+use function _;
+use function count;
 
 /**
  * Generator and validator for key in reset password feature

--- a/src/Services/SignatureHelper.php
+++ b/src/Services/SignatureHelper.php
@@ -22,6 +22,9 @@ use Elabftw\Models\Users\Users;
 use ParagonIE\ConstantTime\Base64;
 
 use function sodium_crypto_generichash;
+use function json_encode;
+use function sodium_crypto_sign_detached;
+use function sprintf;
 
 use const SODIUM_CRYPTO_GENERICHASH_BYTES_MAX;
 use const JSON_THROW_ON_ERROR;

--- a/src/Services/Tex2Svg.php
+++ b/src/Services/Tex2Svg.php
@@ -28,6 +28,9 @@ use function preg_match_all;
 use function preg_replace;
 use function str_replace;
 use function unlink;
+use function base64_encode;
+use function sprintf;
+use function substr_count;
 
 /**
  * Process HTML and transform tex into svg

--- a/src/Services/TimestampUtils.php
+++ b/src/Services/TimestampUtils.php
@@ -24,6 +24,8 @@ use GuzzleHttp\Exception\RequestException;
 use League\Flysystem\FilesystemOperator;
 
 use function is_readable;
+use function basename;
+use function file_get_contents;
 
 /**
  * Trusted Timestamping (RFC3161) utility class

--- a/src/Services/Transform.php
+++ b/src/Services/Transform.php
@@ -18,6 +18,7 @@ use Elabftw\Enums\Notifications;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function sprintf;
+use function _;
 
 /**
  * When values need to be transformed before display

--- a/src/Services/UploadsChecker.php
+++ b/src/Services/UploadsChecker.php
@@ -21,6 +21,10 @@ use League\Flysystem\UnableToRetrieveMetadata;
 use PDO;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function count;
+use function dirname;
+use function sprintf;
+
 /**
  * Check uploads for correct hash and filesize
  */

--- a/src/Services/UploadsMigrator.php
+++ b/src/Services/UploadsMigrator.php
@@ -19,6 +19,7 @@ use PDO;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function count;
+use function sprintf;
 
 /**
  * Migrate uploads to S3

--- a/src/Services/UserArchiver.php
+++ b/src/Services/UserArchiver.php
@@ -25,6 +25,8 @@ use Elabftw\Models\Config;
 use Elabftw\Models\Users\Users;
 use PDO;
 
+use function _;
+
 /**
  * Archive/Unarchive a user
  */

--- a/src/Services/UsersHelper.php
+++ b/src/Services/UsersHelper.php
@@ -18,6 +18,7 @@ use Elabftw\Models\Users\Users;
 use PDO;
 
 use function array_column;
+use function sprintf;
 
 /**
  * When we want to check for something.

--- a/src/Services/Xml2Idps.php
+++ b/src/Services/Xml2Idps.php
@@ -20,6 +20,12 @@ use Elabftw\Enums\SamlBinding;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function openssl_x509_parse;
+use function count;
+use function openssl_error_string;
+use function openssl_x509_export;
+use function openssl_x509_fingerprint;
+use function openssl_x509_read;
+use function sprintf;
 
 /**
  * Convert XML metadata about IDPs into eLabFTW's IDP

--- a/src/Storage/Local.php
+++ b/src/Storage/Local.php
@@ -16,6 +16,8 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Override;
 
+use function dirname;
+
 /**
  * For locally stored uploads
  */

--- a/src/Traits/EnumsTrait.php
+++ b/src/Traits/EnumsTrait.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 namespace Elabftw\Traits;
 
 use function array_map;
+use function _;
+use function implode;
+use function sprintf;
 
 trait EnumsTrait
 {

--- a/src/Traits/TestsUtilsTrait.php
+++ b/src/Traits/TestsUtilsTrait.php
@@ -23,6 +23,8 @@ use Elabftw\Models\Templates;
 use Elabftw\Models\Users\Users;
 use PDO;
 
+use function array_rand;
+
 trait TestsUtilsTrait
 {
     protected function getUserInTeam(int $team, int $admin = 0, int $archived = 0): AuthenticatedUser

--- a/src/tools/cleanup.php
+++ b/src/tools/cleanup.php
@@ -17,6 +17,7 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 
 use function dirname;
+use function printf;
 
 /**
  * This is used to find out if there are untracked files that should have been deleted

--- a/src/tools/mkbuildinfo.php
+++ b/src/tools/mkbuildinfo.php
@@ -15,6 +15,9 @@ namespace Elabftw\Elabftw;
 use function bin2hex;
 use function preg_match;
 use function random_bytes;
+use function dirname;
+use function file_put_contents;
+use function getenv;
 
 $version = getenv('ELABFTW_VERSION') ?: 'dev';
 

--- a/src/tools/mkfp.php
+++ b/src/tools/mkfp.php
@@ -18,6 +18,10 @@ use Elabftw\Services\Fingerprinter;
 use Elabftw\Services\HttpGetter;
 use GuzzleHttp\Client;
 
+use function dirname;
+use function microtime;
+use function printf;
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $smiles = array(

--- a/src/tools/mknotif.php
+++ b/src/tools/mknotif.php
@@ -20,6 +20,8 @@ use Elabftw\Models\Notifications\UserCreated;
 use Elabftw\Models\Notifications\UserNeedValidation;
 use Elabftw\Models\Users\Users;
 
+use function dirname;
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $user = new Users(1);

--- a/src/tools/mkstorage.php
+++ b/src/tools/mkstorage.php
@@ -15,6 +15,8 @@ namespace Elabftw\Elabftw;
 use Elabftw\Models\StorageUnits;
 use Elabftw\Models\Users\Users;
 
+use function dirname;
+
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 
 $StorageUnits = new StorageUnits(new Users(1, 1), false);

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -28,6 +28,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use OneLogin\Saml2\Auth as SamlAuthLib;
 
+use function count;
+
 class SamlTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/Hash/HashTest.php
+++ b/tests/unit/Hash/HashTest.php
@@ -14,6 +14,8 @@ namespace Elabftw\Hash;
 
 use Elabftw\Storage\Memory;
 
+use function str_repeat;
+
 class HashTest extends \PHPUnit\Framework\TestCase
 {
     public function testHash(): void

--- a/tests/unit/Import/CompoundsCsvTest.php
+++ b/tests/unit/Import/CompoundsCsvTest.php
@@ -26,6 +26,8 @@ use GuzzleHttp\Psr7\Response;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function dirname;
+
 use const UPLOAD_ERR_OK;
 
 class CompoundsCsvTest extends \PHPUnit\Framework\TestCase

--- a/tests/unit/Import/CsvTest.php
+++ b/tests/unit/Import/CsvTest.php
@@ -21,6 +21,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function dirname;
+
 use const UPLOAD_ERR_OK;
 
 class CsvTest extends \PHPUnit\Framework\TestCase

--- a/tests/unit/Import/HandlerTest.php
+++ b/tests/unit/Import/HandlerTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function dirname;
+
 class HandlerTest extends \PHPUnit\Framework\TestCase
 {
     private Handler $handler;

--- a/tests/unit/Make/MakeCsvTest.php
+++ b/tests/unit/Make/MakeCsvTest.php
@@ -21,6 +21,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\Response;
 
+use function str_ends_with;
+
 class MakeCsvTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/Make/MakePdfTest.php
+++ b/tests/unit/Make/MakePdfTest.php
@@ -21,6 +21,8 @@ use Elabftw\Traits\TestsUtilsTrait;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
 
+use function dirname;
+
 class MakePdfTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/Make/MakeSchedulerReportTest.php
+++ b/tests/unit/Make/MakeSchedulerReportTest.php
@@ -19,6 +19,13 @@ use Elabftw\Models\Scheduler;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function array_filter;
+use function array_map;
+use function array_search;
+use function count;
+use function explode;
+use function str_getcsv;
+
 class MakeSchedulerReportTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/Make/MakeStreamZipTest.php
+++ b/tests/unit/Make/MakeStreamZipTest.php
@@ -15,6 +15,9 @@ use Elabftw\Elabftw\CreateUploadFromLocalFile;
 use Elabftw\Traits\TestsUtilsTrait;
 use ZipStream\ZipStream;
 
+use function dirname;
+use function str_ends_with;
+
 class MakeStreamZipTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/Make/MakeTimestampTest.php
+++ b/tests/unit/Make/MakeTimestampTest.php
@@ -19,6 +19,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function dirname;
+
 class MakeTimestampTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/classes/EnvTest.php
+++ b/tests/unit/classes/EnvTest.php
@@ -15,6 +15,7 @@ namespace Elabftw\Elabftw;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function putenv;
+use function sprintf;
 
 class EnvTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/classes/MetadataTest.php
+++ b/tests/unit/classes/MetadataTest.php
@@ -14,6 +14,8 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Exceptions\ImproperActionException;
 
+use function count;
+
 class MetadataTest extends \PHPUnit\Framework\TestCase
 {
     public function testNoMetadata(): void

--- a/tests/unit/classes/UpdateTest.php
+++ b/tests/unit/classes/UpdateTest.php
@@ -16,6 +16,8 @@ use Elabftw\Exceptions\InvalidSchemaException;
 use League\Flysystem\Filesystem as Fs;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 
+use function sprintf;
+
 class UpdateTest extends \PHPUnit\Framework\TestCase
 {
     private Fs $Fs;

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+use function json_decode;
+
 /**
  * To emulate nginx rewrite rule, query is done with req param
  */

--- a/tests/unit/controllers/DownloadControllerTest.php
+++ b/tests/unit/controllers/DownloadControllerTest.php
@@ -15,6 +15,10 @@ use Elabftw\Enums\Storage;
 use League\Flysystem\Filesystem;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+use function ob_end_clean;
+use function ob_get_contents;
+use function ob_start;
+
 class DownloadControllerTest extends \PHPUnit\Framework\TestCase
 {
     private Filesystem $fs;

--- a/tests/unit/models/BatchTest.php
+++ b/tests/unit/models/BatchTest.php
@@ -23,6 +23,8 @@ use Elabftw\Exceptions\UnprocessableContentException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function sprintf;
+
 class BatchTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/CommentsTest.php
+++ b/tests/unit/models/CommentsTest.php
@@ -17,6 +17,9 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Params\CommentParam;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function count;
+use function sprintf;
+
 class CommentsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/CompoundsLinksTest.php
+++ b/tests/unit/models/CompoundsLinksTest.php
@@ -23,6 +23,8 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 
+use function sprintf;
+
 class CompoundsLinksTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/ConfigTest.php
+++ b/tests/unit/models/ConfigTest.php
@@ -16,6 +16,8 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnprocessableContentException;
 
+use function urlencode;
+
 class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     private Config $Config;

--- a/tests/unit/models/DspaceTest.php
+++ b/tests/unit/models/DspaceTest.php
@@ -25,6 +25,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function json_encode;
+
 class DspaceTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/ExclusiveEditModeTest.php
+++ b/tests/unit/models/ExclusiveEditModeTest.php
@@ -17,6 +17,8 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function strlen;
+
 class ExclusiveEditModeTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -28,6 +28,11 @@ use Elabftw\Services\Check;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function count;
+use function is_array;
+use function json_decode;
+use function sprintf;
+
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/IdpsCertsTest.php
+++ b/tests/unit/models/IdpsCertsTest.php
@@ -22,6 +22,8 @@ use Elabftw\Services\Filter;
 use Elabftw\Services\Xml2Idps;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function sprintf;
+
 class IdpsCertsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/IdpsEndpointsTest.php
+++ b/tests/unit/models/IdpsEndpointsTest.php
@@ -20,6 +20,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function sprintf;
+
 class IdpsEndpointsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/IdpsSourcesTest.php
+++ b/tests/unit/models/IdpsSourcesTest.php
@@ -22,6 +22,9 @@ use Elabftw\Services\Url2Xml;
 use Elabftw\Services\Xml2Idps;
 use GuzzleHttp\Psr7\Response;
 
+use function dirname;
+use function file_get_contents;
+
 class IdpsSourcesTest extends \PHPUnit\Framework\TestCase
 {
     private IdpsSources $IdpsSources;

--- a/tests/unit/models/InfoTest.php
+++ b/tests/unit/models/InfoTest.php
@@ -14,6 +14,8 @@ namespace Elabftw\Models;
 use Elabftw\Params\BaseQueryParams;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function is_array;
+
 class InfoTest extends \PHPUnit\Framework\TestCase
 {
     private Info $Info;

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -25,6 +25,7 @@ use Elabftw\Services\Check;
 use Elabftw\Traits\TestsUtilsTrait;
 
 use function date;
+use function array_column;
 
 class ItemsTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/models/LinksTest.php
+++ b/tests/unit/models/LinksTest.php
@@ -21,6 +21,10 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use PDO;
 
+use function array_column;
+use function count;
+use function sprintf;
+
 class LinksTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/PermissionsTest.php
+++ b/tests/unit/models/PermissionsTest.php
@@ -17,6 +17,9 @@ use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Models\Users\AuthenticatedUser;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function json_decode;
+use function json_encode;
+
 class PermissionsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/PinsTest.php
+++ b/tests/unit/models/PinsTest.php
@@ -13,6 +13,8 @@ namespace Elabftw\Models;
 
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function count;
+
 class PinsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/RequestActionsTest.php
+++ b/tests/unit/models/RequestActionsTest.php
@@ -18,6 +18,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function sprintf;
+
 class RequestActionsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/RevisionsTest.php
+++ b/tests/unit/models/RevisionsTest.php
@@ -16,6 +16,9 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function count;
+use function sprintf;
+
 class RevisionsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/SchedulerTest.php
+++ b/tests/unit/models/SchedulerTest.php
@@ -26,6 +26,10 @@ use Elabftw\Params\EntityParams;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function array_column;
+use function json_encode;
+use function sprintf;
+
 class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/StepsTest.php
+++ b/tests/unit/models/StepsTest.php
@@ -15,6 +15,9 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function array_filter;
+use function array_values;
+
 class StepsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -19,6 +19,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
+use function array_column;
+
 class StorageUnitsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/TagsTest.php
+++ b/tests/unit/models/TagsTest.php
@@ -16,6 +16,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function sprintf;
+
 class TagsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/TeamTagsTest.php
+++ b/tests/unit/models/TeamTagsTest.php
@@ -17,6 +17,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Params\TagParam;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function count;
+
 class TeamTagsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/TemplatesTest.php
+++ b/tests/unit/models/TemplatesTest.php
@@ -17,6 +17,8 @@ use Elabftw\Enums\State;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\DisplayParams;
 
+use function json_decode;
+
 class TemplatesTest extends \PHPUnit\Framework\TestCase
 {
     private Templates $Templates;

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -25,6 +25,9 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
+use function count;
+use function dirname;
+
 class UploadsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -22,6 +22,9 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Params\UserParams;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function count;
+use function is_array;
+
 class UsersTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/services/CacheGeneratorTest.php
+++ b/tests/unit/services/CacheGeneratorTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Services;
 
+use function dirname;
+
 class CacheGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     public function testGenerate(): void

--- a/tests/unit/services/EairefRemoteDirectoryTest.php
+++ b/tests/unit/services/EairefRemoteDirectoryTest.php
@@ -16,6 +16,8 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 
+use function json_encode;
+
 class EairefRemoteDirectoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testSearch(): void

--- a/tests/unit/services/EmailTest.php
+++ b/tests/unit/services/EmailTest.php
@@ -24,6 +24,8 @@ use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 
+use function count;
+
 class EmailTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/services/FilterTest.php
+++ b/tests/unit/services/FilterTest.php
@@ -15,6 +15,8 @@ use DateTimeImmutable;
 use Elabftw\Exceptions\ImproperActionException;
 
 use function str_repeat;
+use function hash;
+use function uniqid;
 
 class FilterTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/services/MpdfQrProviderTest.php
+++ b/tests/unit/services/MpdfQrProviderTest.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Services;
 
+use function sha1;
+
 class MpdfQrProviderTest extends \PHPUnit\Framework\TestCase
 {
     private MpdfQrProvider $Provider;

--- a/tests/unit/services/TransformTest.php
+++ b/tests/unit/services/TransformTest.php
@@ -17,6 +17,8 @@ use Elabftw\Enums\EntityType;
 use Elabftw\Enums\Notifications;
 use ValueError;
 
+use function sprintf;
+
 class TransformTest extends \PHPUnit\Framework\TestCase
 {
     public function testCsrf(): void

--- a/tests/unit/services/UploadsPrunerTest.php
+++ b/tests/unit/services/UploadsPrunerTest.php
@@ -17,6 +17,8 @@ use Elabftw\Models\Config;
 use Elabftw\Traits\TestsUtilsTrait;
 use League\Flysystem\UnableToDeleteFile;
 
+use function dirname;
+
 class UploadsPrunerTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;

--- a/tests/unit/services/Url2XmlTest.php
+++ b/tests/unit/services/Url2XmlTest.php
@@ -19,6 +19,9 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 
+use function dirname;
+use function file_get_contents;
+
 class Url2XmlTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetEmptyResponse(): void

--- a/tests/unit/services/Xml2IdpsTest.php
+++ b/tests/unit/services/Xml2IdpsTest.php
@@ -18,6 +18,10 @@ use DOMDocument;
 use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\ImproperActionException;
 
+use function count;
+use function dirname;
+use function file_get_contents;
+
 class Xml2IdpsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetIdpsFromDomNoEntityDescriptor(): void

--- a/web/admin.php
+++ b/web/admin.php
@@ -33,6 +33,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
 use function array_filter;
+use function _;
 
 /**
  * Administration panel of a team

--- a/web/app/controllers/ApiController.php
+++ b/web/app/controllers/ApiController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 use function dirname;
+use function str_contains;
+use function str_starts_with;
 
 /**
  * Entrypoint for API requests. Nginx redirects all the /api/vN requests here.

--- a/web/app/controllers/HeartBeat.php
+++ b/web/app/controllers/HeartBeat.php
@@ -14,6 +14,9 @@ namespace Elabftw\Elabftw;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+use function dirname;
+use function time;
+
 /**
  * Make sure that the user is still logged in
  */

--- a/web/app/controllers/RegisterController.php
+++ b/web/app/controllers/RegisterController.php
@@ -22,6 +22,8 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 use function dirname;
+use function _;
+use function filter_var;
 
 require_once dirname(__DIR__) . '/init.inc.php';
 

--- a/web/app/controllers/ResetPasswordController.php
+++ b/web/app/controllers/ResetPasswordController.php
@@ -33,6 +33,9 @@ use function nl2br;
 use function random_int;
 use function sleep;
 use function time;
+use function _;
+use function filter_var;
+use function sprintf;
 
 require_once dirname(__DIR__) . '/init.inc.php';
 

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -34,6 +34,8 @@ use JsonException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 use function dirname;
+use function _;
+use function json_decode;
 
 /**
  * Update ordering of various things

--- a/web/app/controllers/UcpController.php
+++ b/web/app/controllers/UcpController.php
@@ -21,6 +21,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 use function dirname;
+use function _;
 
 /**
  * Deal with requests sent from the user control panel

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -29,6 +29,7 @@ use function header;
 use function in_array;
 use function setcookie;
 use function stripos;
+use function time;
 
 /**
  *   _       _ _

--- a/web/app/logout.php
+++ b/web/app/logout.php
@@ -27,6 +27,11 @@ use OneLogin\Saml2\Settings as SamlSettings;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
+use function count;
+use function implode;
+use function setcookie;
+use function time;
+
 require_once 'init.inc.php';
 
 $redirectUrl = '/login.php';

--- a/web/change-pass.php
+++ b/web/change-pass.php
@@ -22,6 +22,7 @@ use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
 use function time;
+use function _;
 
 /**
  * Form to reset the password

--- a/web/healthcheck.php
+++ b/web/healthcheck.php
@@ -14,6 +14,8 @@ namespace Elabftw\Elabftw;
 
 use Symfony\Component\HttpFoundation\Response;
 
+use function dirname;
+
 /**
  * Make sure everything is fine and dandy as far as we can tell
  * This page exists because other monitoring endpoints are not complete (they do not include the db)

--- a/web/index.php
+++ b/web/index.php
@@ -28,6 +28,11 @@ use OneLogin\Saml2\Settings as SamlSettings;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+use function session_get_cookie_params;
+use function setcookie;
+use function time;
+
 require_once 'app/init.inc.php';
 
 $Response = new Response();

--- a/web/login.php
+++ b/web/login.php
@@ -21,6 +21,10 @@ use Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+use function setcookie;
+use function time;
+
 /**
  * Login page
  */

--- a/web/metadata.php
+++ b/web/metadata.php
@@ -22,6 +22,8 @@ use OneLogin\Saml2\Error;
 use OneLogin\Saml2\Settings;
 use Symfony\Component\HttpFoundation\Response;
 
+use function implode;
+
 /**
  *  This page displays an XML file with all the settings of the Service Provider
  */

--- a/web/profile.php
+++ b/web/profile.php
@@ -23,6 +23,9 @@ use Exception;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+use function ini_get;
+
 /**
  * Display profile of current user
  */

--- a/web/register.php
+++ b/web/register.php
@@ -19,6 +19,9 @@ use Elabftw\Exceptions\ImproperActionException;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+use function sprintf;
+
 /**
  * Local account creation page
  */

--- a/web/revisions.php
+++ b/web/revisions.php
@@ -19,6 +19,8 @@ use Elabftw\Models\Revisions;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+
 /**
  * Show history of body of experiment or db item
  */

--- a/web/scheduler.php
+++ b/web/scheduler.php
@@ -18,6 +18,11 @@ use Elabftw\Models\ResourcesCategories;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+use function array_column;
+use function array_filter;
+use function in_array;
+
 /**
  * Scheduler to book resources
  */

--- a/web/sysconfig.php
+++ b/web/sysconfig.php
@@ -34,6 +34,8 @@ use Symfony\Component\HttpFoundation\Response;
 use ValueError;
 
 use function array_walk;
+use function _;
+use function ini_get;
 
 /**
  * Instance level settings and tools

--- a/web/team.php
+++ b/web/team.php
@@ -18,6 +18,8 @@ use Elabftw\Models\TeamGroups;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+
 /**
  * The TEAM page
  */

--- a/web/ucp.php
+++ b/web/ucp.php
@@ -26,6 +26,8 @@ use Elabftw\Services\MfaHelper;
 use Exception;
 use Symfony\Component\HttpFoundation\Response;
 
+use function _;
+
 /**
  * Settings for user
  */


### PR DESCRIPTION
by adding a phpcs fixer rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup to improve maintainability and consistency by standardizing function imports across the codebase. No user-facing behavior, APIs, or data formats changed; tests updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->