### PR TITLE
ci: use persist-credentials: false for actions/checkout

### DIFF
--- a/.github/workflows/build_chem_plugin.yaml
+++ b/.github/workflows/build_chem_plugin.yaml
@@ -35,6 +35,8 @@ jobs:
 
             - name: Checkout repo
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                persist-credentials: false
 
             # https://github.com/docker/setup-qemu-action#usage
             - name: Set up QEMU

--- a/.github/workflows/build_edge.yaml
+++ b/.github/workflows/build_edge.yaml
@@ -45,6 +45,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                 ref: ${{ github.ref_name }}
+                persist-credentials: false
 
             # https://github.com/marketplace/actions/docker-setup-buildx
             - name: Set up Docker Buildx

--- a/.github/workflows/build_nigthly.yaml
+++ b/.github/workflows/build_nigthly.yaml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # https://github.com/marketplace/actions/docker-setup-buildx
       - name: Set up Docker Buildx

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -50,6 +50,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                 ref: ${{ github.ref_name }}
+                persist-credentials: false
 
             # https://github.com/marketplace/actions/docker-setup-buildx
             - name: Set up Docker Buildx

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Start SSH agent and add key
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       # codespell github action does not yet allow for --config option
       # https://github.com/codespell-project/actions-codespell/issues/67
       # so we need to install and invoke "manually"

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -10,6 +10,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Upload asset
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2


### PR DESCRIPTION
https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials/ 
https://github.com/actions/checkout/issues/485



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated credential handling configuration in multiple CI/CD workflows including build pipelines (release, nightly, edge), code quality analysis (CodeQL), spell checking, API documentation, and repository synchronization to adjust how credentials are persisted during repository checkout operations across all verification and deployment stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->