### PR TITLE
refactor(users): use getUserid() and getTeam() consistently across codebase

### DIFF
--- a/src/Auth/Ldap.php
+++ b/src/Auth/Ldap.php
@@ -117,7 +117,7 @@ final class Ldap implements AuthInterface
         if ($this->configArr['ldap_sync_teams'] === '1' && $teamFromLdap !== null && !empty($teamFromLdap)) {
             $Teams = new Teams($Users);
             $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teamFromLdap, $allowTeamCreation);
-            $Teams->synchronize($Users->userid ?? 0, $teams);
+            $Teams->synchronize($Users->getUserid(), $teams);
         }
 
         return $AuthResponse->setAuthenticatedUserid($Users->userData['userid'])

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -328,7 +328,7 @@ final class Apiv2Controller extends AbstractApiController
                 $this->requester,
                 $this->Request->query->get('scope') === 'team',
             ),
-            ApiEndpoint::Users => new Users($this->id, $this->requester->team, $this->requester),
+            ApiEndpoint::Users => new Users($this->id, $this->requester->getTeam(), $this->requester),
         };
     }
 

--- a/src/Controllers/MakeController.php
+++ b/src/Controllers/MakeController.php
@@ -185,7 +185,7 @@ final class MakeController extends AbstractController
         // generate audit log event if exporting more than $threshold entries
         $count = count($this->entityArr);
         if ($count > self::AUDIT_THRESHOLD) {
-            AuditLogs::create(new Export($this->requester->userid ?? 0, $count));
+            AuditLogs::create(new Export($this->requester->getUserid(), $count));
         }
     }
 

--- a/src/Elabftw/CanSqlBuilder.php
+++ b/src/Elabftw/CanSqlBuilder.php
@@ -70,7 +70,7 @@ final class CanSqlBuilder
                 AND entity.team = %d)',
             $this->accessType->value,
             BasePermissions::Team->value,
-            $this->requester->team ?? 0,
+            $this->requester->getTeam(),
         );
     }
 
@@ -108,7 +108,7 @@ final class CanSqlBuilder
                 AND entity.userid = %d)',
             $this->accessType->value,
             BasePermissions::UserOnly->value,
-            $this->requester->userid ?? 0,
+            $this->requester->getUserid(),
         );
     }
 
@@ -154,6 +154,6 @@ final class CanSqlBuilder
      */
     protected function canUsers(): string
     {
-        return sprintf("%d MEMBER OF (entity.%s->>'$.users')", $this->requester->userid ?? 0, $this->accessType->value);
+        return sprintf("%d MEMBER OF (entity.%s->>'$.users')", $this->requester->getUserid(), $this->accessType->value);
     }
 }

--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -400,7 +400,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
             'LEFT JOIN users2teams
                 ON (users2teams.users_id = entity.userid and users2teams.teams_id = %d)
             LEFT JOIN teams ON (entity.team = teams.id)',
-            $this->entity->Users->team ?? 0,
+            $this->entity->Users->getTeam(),
         );
     }
 }

--- a/src/Import/Handler.php
+++ b/src/Import/Handler.php
@@ -58,7 +58,7 @@ final class Handler extends AbstractRest
         $inserted = $Importer->getInserted();
         if ($inserted > self::AUDIT_THRESHOLD) {
             /** @psalm-suppress RedundantCast had an error during eln import where userid was a string for some reason... */
-            AuditLogs::create(new AuditEventImport((int) ($this->requester->userid ?? 0), $inserted));
+            AuditLogs::create(new AuditEventImport((int) ($this->requester->getUserid()), $inserted));
         }
         return $inserted;
     }

--- a/src/Import/TrustedEln.php
+++ b/src/Import/TrustedEln.php
@@ -47,7 +47,7 @@ final class TrustedEln extends Eln
         try {
             $Author = ExistingUser::fromEmail($author['email'] ?? 'nope');
         } catch (ResourceNotFoundException) {
-            $Author = ValidatedUser::createFromPerson($author, $this->requester->team ?? 0);
+            $Author = ValidatedUser::createFromPerson($author, $this->requester->getTeam());
             $this->logger->info(sprintf('Created user with email: %s', $author['email']));
         }
         $Author->team = $this->requester->team;

--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -126,7 +126,7 @@ final class ApiKeys extends AbstractRest
         $req->bindValue(':userid', $this->Users->requester->getUserid(), PDO::PARAM_INT);
 
         if ($res = $this->Db->execute($req)) {
-            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->getUserid(), $this->Users->userid ?? 0));
+            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->getUserid(), $this->Users->getUserid()));
         }
         return $res;
     }
@@ -142,7 +142,7 @@ final class ApiKeys extends AbstractRest
         $req->bindValue(':userid', $this->Users->requester->userid ?? 0, PDO::PARAM_INT);
 
         if ($res = $this->Db->execute($req)) {
-            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->userid ?? 0, $this->Users->userid ?? 0));
+            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->getUserid(), $this->Users->getUserid()));
         }
         return $res;
     }

--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -139,7 +139,7 @@ final class ApiKeys extends AbstractRest
         $sql = 'DELETE FROM api_keys WHERE team = :team AND userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':team', $team, PDO::PARAM_INT);
-        $req->bindValue(':userid', $this->Users->requester->userid ?? 0, PDO::PARAM_INT);
+        $req->bindValue(':userid', $this->Users->requester->getUserid(), PDO::PARAM_INT);
 
         if ($res = $this->Db->execute($req)) {
             AuditLogs::create(new ApiKeyDeleted($this->Users->requester->getUserid(), $this->Users->getUserid()));

--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -123,10 +123,10 @@ final class ApiKeys extends AbstractRest
         $sql = 'DELETE FROM api_keys WHERE id = :id AND userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':id', $this->id, PDO::PARAM_INT);
-        $req->bindValue(':userid', $this->Users->requester->userid ?? 0, PDO::PARAM_INT);
+        $req->bindValue(':userid', $this->Users->requester->getUserid(), PDO::PARAM_INT);
 
         if ($res = $this->Db->execute($req)) {
-            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->userid ?? 0, $this->Users->userid ?? 0));
+            AuditLogs::create(new ApiKeyDeleted($this->Users->requester->getUserid(), $this->Users->userid ?? 0));
         }
         return $res;
     }

--- a/src/Models/Links/AbstractLinks.php
+++ b/src/Models/Links/AbstractLinks.php
@@ -300,7 +300,7 @@ abstract class AbstractLinks extends AbstractRest
     private function prepareBindExecuteFetch(string $sql): array
     {
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':team_id', $this->Entity->Users->team ?? 0, PDO::PARAM_INT);
+        $req->bindValue(':team_id', $this->Entity->Users->getTeam(), PDO::PARAM_INT);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $req->bindValue(':state_normal', State::Normal->value, PDO::PARAM_INT);
         $req->bindValue(':state_archived', State::Archived->value, PDO::PARAM_INT);

--- a/src/Models/Notifications/AbstractNotifications.php
+++ b/src/Models/Notifications/AbstractNotifications.php
@@ -42,7 +42,7 @@ abstract class AbstractNotifications
 
     public function create(): int
     {
-        if (TeamsHelper::isArchivedInAllTeams($this->targetUser->userid ?? 0)) {
+        if (TeamsHelper::isArchivedInAllTeams($this->targetUser->getUserid())) {
             return 0;
         }
 

--- a/src/Models/Tags.php
+++ b/src/Models/Tags.php
@@ -46,8 +46,8 @@ final class Tags extends AbstractRest
     public function postAction(Action $action, array $reqBody): int
     {
         // check if we can actually create tags (for non-admins)
-        $teamConfigArr = (new Teams($this->Entity->Users, $this->Entity->Users->team))->readOne();
-        $TeamsHelper = new TeamsHelper($this->Entity->Users->team ?? 0);
+        $teamConfigArr = (new Teams($this->Entity->Users, $this->Entity->Users->getTeam()))->readOne();
+        $TeamsHelper = new TeamsHelper($this->Entity->Users->getTeam());
         $canCreate = $teamConfigArr['user_create_tag'] === 1 || $TeamsHelper->isAdminInTeam($this->Entity->Users->userData['userid']);
         $tags = array();
         if (isset($reqBody['tag']) && is_string($reqBody['tag'])) {

--- a/src/Models/Tags2Entity.php
+++ b/src/Models/Tags2Entity.php
@@ -55,8 +55,8 @@ final class Tags2Entity
     {
         return match ($scope) {
             Scope::Everything => '',
-            Scope::Team => sprintf('AND entity.team = %d', $this->requester->team ?? 0),
-            Scope::User => sprintf('AND entity.userid = %d', $this->requester->userid ?? 0),
+            Scope::Team => sprintf('AND entity.team = %d', $this->requester->getTeam()),
+            Scope::User => sprintf('AND entity.userid = %d', $this->requester->getUserid()),
         };
     }
 }

--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -130,7 +130,7 @@ final class Teams extends AbstractRest
         // allow sysadmin to read any team from api, but a non sysadmin can only query a team they are part of
         $TeamsHelper = new TeamsHelper($this->id ?? -1);
 
-        if (!$TeamsHelper->isUserInTeam($this->Users->userid ?? -1) && !$this->Users->userData['is_sysadmin']) {
+        if (!$TeamsHelper->isUserInTeam($this->Users->getUserid()) && !$this->Users->userData['is_sysadmin']) {
             throw new ImproperActionException('Cannot query team information if not part of that team or not Sysadmin!');
         }
         return $this->readOneComplete();

--- a/src/Models/Users/UltraAdmin.php
+++ b/src/Models/Users/UltraAdmin.php
@@ -19,7 +19,7 @@ use Override;
  */
 final class UltraAdmin extends Users
 {
-    public function __construct(public ?int $userid = null, public ?int $team = null)
+    public function __construct(public ?int $userid = 1, public ?int $team = null)
     {
         $this->userData['is_sysadmin'] = 1;
         $this->userData['userid'] = $userid;
@@ -35,6 +35,6 @@ final class UltraAdmin extends Users
     #[Override]
     public function getUserid(): int
     {
-        return 1;
+        return $this->userid ?? 1;
     }
 }

--- a/src/Models/Users/UltraAdmin.php
+++ b/src/Models/Users/UltraAdmin.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Models\Users;
 
+use Override;
+
 /**
  * A user interacting with the app from CLI, so has full rights on everything
  */
@@ -28,5 +30,11 @@ final class UltraAdmin extends Users
         $this->userData['scope_items'] = 3;
         $this->userData['scope_items_types'] = 3;
         $this->userData['scope_teamgroups'] = 3;
+    }
+
+    #[Override]
+    public function getUserid(): int
+    {
+        return 1;
     }
 }

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -70,7 +70,7 @@ class Users extends AbstractRest
     {
         parent::__construct();
         if ($team !== null && $userid !== null) {
-            $TeamsHelper = new TeamsHelper($this->team ?? 0);
+            $TeamsHelper = new TeamsHelper($this->getTeam());
             $this->isAdmin = $TeamsHelper->isAdmin($userid);
         }
         if ($userid !== null) {
@@ -202,7 +202,7 @@ class Users extends AbstractRest
             $this->needValidation = true;
         }
         // it's okay to not have requester for this (register page)
-        AuditLogs::create(new UserRegister($this->requester->userid ?? 0, $this->userid));
+        AuditLogs::create(new UserRegister($this->requester->getUserid(), $this->userid));
         return $this->userid;
     }
 
@@ -380,7 +380,7 @@ class Users extends AbstractRest
         $team = $Request->query->getInt('team', 0);
         $currentTeam = $Request->query->getInt('currentTeam');
         if ($currentTeam === 1) {
-            $team = $this->requester->team ?? 0;
+            $team = $this->requester->getTeam();
         }
         $users = $this->readFromQuery(
             $Request->query->getString('q'),

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -201,7 +201,8 @@ class Users extends AbstractRest
             // set a flag to show correct message to user
             $this->needValidation = true;
         }
-        AuditLogs::create(new UserRegister($this->requester->getUserid(), $this->userid));
+        // it's okay to not have requester for this (register page)
+        AuditLogs::create(new UserRegister($this->requester->userid ?? 0, $this->userid));
         return $this->userid;
     }
 

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -171,14 +171,14 @@ class Users extends AbstractRest
         $req->bindValue(':can_manage_compounds', $canManageCompounds->value);
         $req->bindValue(':can_manage_inventory_locations', $canManageInventoryLocations->value);
         $this->Db->execute($req);
-        $userid = $this->Db->lastInsertId();
+        $this->userid = $this->Db->lastInsertId();
 
         // check if the team is empty before adding the user to the team
         $isFirstUser = $TeamsHelper->isFirstUserInTeam();
         // now add the user to the team
         $Users2Teams = new Users2Teams($this->requester);
         $Users2Teams->addUserToTeams(
-            $userid,
+            $this->userid,
             array_column($teams, 'id'),
             // transform Sysadmin to Admin because users2teams.is_admin is 1 (Admin) or 0 (User)
             ($usergroup === Usergroup::Sysadmin || $usergroup === Usergroup::Admin)
@@ -187,9 +187,9 @@ class Users extends AbstractRest
             $isValidated,
         );
         if ($alertAdmin && !$isFirstUser) {
-            $this->notifyAdmins($TeamsHelper->getAllAdminsUserid(), $userid, $isValidated, $teams[0]['name']);
+            $this->notifyAdmins($TeamsHelper->getAllAdminsUserid(), $this->userid, $isValidated, $teams[0]['name']);
         }
-        $targetUser = new self($userid);
+        $targetUser = new self($this->userid);
         if ($isValidated) {
             // send the instance level onboarding email
             if ($Config->configArr['onboarding_email_active'] === '1') {
@@ -201,8 +201,8 @@ class Users extends AbstractRest
             // set a flag to show correct message to user
             $this->needValidation = true;
         }
-        AuditLogs::create(new UserRegister($this->requester->userid ?? 0, $userid));
-        return $userid;
+        AuditLogs::create(new UserRegister($this->requester->getUserid(), $this->userid));
+        return $this->userid;
     }
 
     /**
@@ -476,13 +476,13 @@ class Users extends AbstractRest
                 }
             )(),
             Action::Disable2fa => $this->disable2fa(),
-            Action::PatchUser2Team => (new Users2Teams($this->requester))->patchUser2Team($params, $this->userid ?? 0),
+            Action::PatchUser2Team => (new Users2Teams($this->requester))->patchUser2Team($params, $this->getUserid()),
             Action::Unreference => (new Users2Teams($this->requester))->destroy($this->userData['userid'], (int) $params['team']),
             Action::UpdatePassword => $this->updatePassword($params),
             Action::Update => (
                 function () use ($params) {
                     // only a sysadmin can edit anything about another sysadmin
-                    if (!$this->requester->isSysadmin() && $this->userid !== $this->requester->userid && $this->isSysadmin()) {
+                    if (!$this->requester->isSysadmin() && $this->getUserid() !== $this->requester->getUserid() && $this->isSysadmin()) {
                         throw new IllegalActionException('A sysadmin level account is required to edit another sysadmin account.');
                     }
                     $Config = Config::getConfig();
@@ -559,7 +559,7 @@ class Users extends AbstractRest
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
         $res = $this->Db->execute($req);
         if ($res) {
-            AuditLogs::create(new UserDeleted($this->requester->userid ?? 0, $this->userid ?? 0));
+            AuditLogs::create(new UserDeleted($this->requester->getUserid(), $this->getUserid()));
         }
         return $res;
     }
@@ -570,7 +570,7 @@ class Users extends AbstractRest
     public function isAdminOf(int $userid): bool
     {
         // consider that we are admin of ourselves and that if you have can_manage_users2teams you're kinda an Admin of the user
-        if ($this->userid === $userid || $this->isSysadmin() || $this->userData['can_manage_users2teams']) {
+        if ($this->getUserid() === $userid || $this->isSysadmin() || $this->userData['can_manage_users2teams']) {
             return true;
         }
         // check if in the teams we have in common, the potential admin is admin
@@ -582,7 +582,7 @@ class Users extends AbstractRest
                     AND u2.users_id = :user_userid
                     AND u1.is_admin = 1';
         $req = $this->Db->prepare($sql);
-        $req->bindParam(':admin_userid', $this->userid, PDO::PARAM_INT);
+        $req->bindValue(':admin_userid', $this->getUserid(), PDO::PARAM_INT);
         $req->bindParam(':user_userid', $userid, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->rowCount() >= 1;
@@ -656,8 +656,8 @@ class Users extends AbstractRest
             && (string) $this->userData[$column->value] !== (string) $content
         ) {
             AuditLogs::create(new UserAttributeChanged(
-                $this->requester->userid ?? 0,
-                $this->userid ?? 0,
+                $this->requester->getUserid(),
+                $this->getUserid(),
                 $column->value,
                 (string) $this->userData[$column->value],
                 (string) $content,
@@ -747,7 +747,7 @@ class Users extends AbstractRest
               sig_keys.pubkey,
               sig_keys.privkey";
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':userid', $this->userid, PDO::PARAM_INT);
+        $req->bindValue(':userid', $this->getUserid(), PDO::PARAM_INT);
         $req->bindValue(':state', State::Normal->value, PDO::PARAM_INT);
         $this->Db->execute($req);
 
@@ -820,14 +820,14 @@ class Users extends AbstractRest
     private function canReadOrExplode(): void
     {
         // it's ourself or we are sysadmin
-        if ($this->requester->userid === $this->userid || $this->requester->isSysadmin()) {
+        if ($this->requester->getUserid() === $this->getUserid() || $this->requester->isSysadmin()) {
             return;
         }
         if (!$this->requester->isAdmin && !$this->isSelf()) {
             throw new IllegalActionException('This endpoint requires admin privileges to access other users.');
         }
         // check we view user of our team, unless we are sysadmin and we can access it
-        if ($this->userid !== null && !$this->requester->isAdminOf($this->userid)) {
+        if (!$this->requester->isAdminOf($this->getUserid())) {
             throw new IllegalActionException('User tried to access user from other team.');
         }
     }
@@ -853,8 +853,8 @@ class Users extends AbstractRest
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
         $res = $this->Db->execute($req);
         AuditLogs::create(new PasswordChanged(
-            $this->requester->userid ?? 0,
-            $this->userid ?? 0,
+            $this->requester->getUserid(),
+            $this->getUserid(),
             'password',
             'the old password',
             'the new password',

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -52,7 +52,6 @@ final class Users2Teams
         $req->bindValue(':is_admin', $isAdmin->value, PDO::PARAM_INT);
         $res = $this->Db->execute($req);
 
-        var_dump($userid);
         AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->userid ?? 0, $userid));
         if ($isValidated) {
             new Teams($this->requester, $teamid)->sendOnboardingEmailToUser($userid, $isAdmin);

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -52,7 +52,7 @@ final class Users2Teams
         $req->bindValue(':is_admin', $isAdmin->value, PDO::PARAM_INT);
         $res = $this->Db->execute($req);
 
-        AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->userid ?? 0, $userid));
+        AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->getUserid(), $userid));
         if ($isValidated) {
             new Teams($this->requester, $teamid)->sendOnboardingEmailToUser($userid, $isAdmin);
         }

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -52,6 +52,7 @@ final class Users2Teams
         $req->bindValue(':is_admin', $isAdmin->value, PDO::PARAM_INT);
         $res = $this->Db->execute($req);
 
+        var_dump($userid);
         AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->userid ?? 0, $userid));
         if ($isValidated) {
             new Teams($this->requester, $teamid)->sendOnboardingEmailToUser($userid, $isAdmin);

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -164,7 +164,7 @@ final class DisplayParams extends BaseQueryParams
         }
         // add filter on team only if scope is not set to everything
         if ($this->requester->userData['scope_' . $this->entityType->value] === Scope::Team->value && $scope !== Scope::Everything) {
-            $this->appendFilterSql(FilterableColumn::Team, $this->requester->team ?? 0);
+            $this->appendFilterSql(FilterableColumn::Team, $this->requester->getTeam());
         }
         // TAGS SEARCH
         if (!empty(($query->all('tags'))[0])) {

--- a/src/Services/UserArchiver.php
+++ b/src/Services/UserArchiver.php
@@ -109,7 +109,7 @@ final class UserArchiver
             throw new IllegalActionException();
         }
         // make sure requester is admin of target user
-        if (!$this->requester->isAdminOf($this->target->userid ?? 0) && $this->requester->userData['can_manage_users2teams'] === 0) {
+        if (!$this->requester->isAdminOf($this->target->getUserId()) && $this->requester->userData['can_manage_users2teams'] === 0) {
             throw new IllegalActionException('User tried to patch is_archived of another user but they are not admin');
         }
     }


### PR DESCRIPTION
Replace direct access to Users properties (userid, team) with the getUserid() and getTeam() accessor methods across the codebase.

This change complements PR #6721 by standardizing user identity access patterns and reducing the risk of null-related bugs.
