### PR TITLE
bug/minor: uploads: scope thumbnail dropdown z-index to button (supersedes #6681)

### DIFF
--- a/src/Make/MakeEvidencyTimestamp.php
+++ b/src/Make/MakeEvidencyTimestamp.php
@@ -17,6 +17,8 @@ use Elabftw\Services\EvidencyTimestampUtils;
 use GuzzleHttp\Client;
 use Override;
 
+use function sprintf;
+
 /**
  * RFC3161 timestamping with Evidency service
  * https://docs.evidency.io/docs/timestamping-service#timestamp-rfc3161-request

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1053,6 +1053,11 @@ the form-control fails to do that so we do the border ourselves */
 .thumbnail {
   overflow: hidden;
   overflow-wrap: break-word;
+
+  .dropdown button {
+    position: relative;
+    z-index: 10;
+  }
 }
 
 .thumb {


### PR DESCRIPTION
supersedes #6681

Fix an issue where dropdown buttons inside thumbnails were not clickable in certain contexts due to stacking (z-index) conflicts.

This change scopes the z-index adjustment specifically to the dropdown button within the .thumbnail component instead of applying a broader rule, which previously caused inconsistencies with differently structured buttons in some views.

By targeting `.thumbnail .dropdown button` and assigning it a higher z-index, the dropdown now reliably appears above overlapping elements without affecting other UI components.

<img width="605" height="449" alt="image" src="https://github.com/user-attachments/assets/679bd55d-a2fb-418d-90f2-665c7ea8d60e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dropdown button positioning to ensure correct layering with surrounding content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->