### PR TITLE
bug/minor: uploads: preserve upload state when duplicating entities

### DIFF
--- a/src/Make/MakeEvidencyTimestamp.php
+++ b/src/Make/MakeEvidencyTimestamp.php
@@ -17,6 +17,8 @@ use Elabftw\Services\EvidencyTimestampUtils;
 use GuzzleHttp\Client;
 use Override;
 
+use function sprintf;
+
 /**
  * RFC3161 timestamping with Evidency service
  * https://docs.evidency.io/docs/timestamping-service#timestamp-rfc3161-request

--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -209,9 +209,21 @@ final class Uploads extends AbstractRest
         foreach ($uploads as $upload) {
             if ($upload['storage'] === Storage::LOCAL->value) {
                 $prefix = '/elabftw/uploads/';
-                $param = new CreateUpload($upload['real_name'], $prefix . $upload['long_name'], new ExistingHash($upload['hash']), $upload['comment']);
+                $param = new CreateUpload(
+                    realName: $upload['real_name'],
+                    filePath: $prefix . $upload['long_name'],
+                    hasher: new ExistingHash($upload['hash']),
+                    comment: $upload['comment'],
+                    state: State::from((int) $upload['state']),
+                );
             } else {
-                $param = new CreateUploadFromS3($upload['real_name'], $upload['long_name'], new ExistingHash($upload['hash']), $upload['comment']);
+                $param = new CreateUploadFromS3(
+                    realName: $upload['real_name'],
+                    filePath: $upload['long_name'],
+                    hasher: new ExistingHash($upload['hash']),
+                    comment: $upload['comment'],
+                    state: State::from((int) $upload['state']),
+                );
             }
             $id = $entity->Uploads->create($param);
             $fresh = new self($entity, $id);

--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -214,7 +214,7 @@ final class Uploads extends AbstractRest
                     filePath: $prefix . $upload['long_name'],
                     hasher: new ExistingHash($upload['hash']),
                     comment: $upload['comment'],
-                    state: State::from((int) $upload['state']),
+                    state: State::from($upload['state']),
                 );
             } else {
                 $param = new CreateUploadFromS3(
@@ -222,7 +222,7 @@ final class Uploads extends AbstractRest
                     filePath: $upload['long_name'],
                     hasher: new ExistingHash($upload['hash']),
                     comment: $upload['comment'],
-                    state: State::from((int) $upload['state']),
+                    state: State::from($upload['state']),
                 );
             }
             $id = $entity->Uploads->create($param);

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
+use Elabftw\Enums\FileFromString;
 use Elabftw\Enums\Meaning;
 use Elabftw\Enums\AccessType;
 use Elabftw\Enums\State;
@@ -21,6 +22,7 @@ use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnprocessableContentException;
 use Elabftw\Models\Users\Users;
+use Elabftw\Params\BaseQueryParams;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Params\EntityParams;
 use Elabftw\Params\ExtraFieldsOrderingParams;
@@ -32,6 +34,7 @@ use function count;
 use function is_array;
 use function json_decode;
 use function sprintf;
+use function array_column;
 
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {
@@ -262,12 +265,23 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->Experiments->Steps->postAction(Action::Create, array('body' => 'some step'));
         $this->Experiments->ItemsLinks->postAction(Action::Create, array());
         $this->Experiments->ExperimentsLinks->postAction(Action::Create, array());
-        $id = $this->Experiments->postAction(Action::Duplicate, array());
+        // add some uploads
+        $this->Experiments->Uploads->createFromString(FileFromString::Json, 'normal.json', '{}');
+        $archivedId = $this->Experiments->Uploads->createFromString(FileFromString::Json, 'archived.json', '{}');
+        $this->Experiments->Uploads->setId($archivedId);
+        $this->Experiments->Uploads->patch(Action::Archive, array());
+        $id = $this->Experiments->postAction(Action::Duplicate, array('copyFiles' => 1));
         $this->assertIsInt($id);
         $new = new Experiments($this->Users, $id);
         $this->assertEquals($canread->value, $new->entityData['canread_base']);
         $this->assertEquals($canwrite->value, $new->entityData['canwrite_base']);
         $this->assertEquals(1, $new->entityData['hide_main_text']);
+        // assert uploads' states persist
+        $newUploads = $new->Uploads->readAll(new BaseQueryParams(states: array(State::Normal, State::Archived), ));
+        $this->assertCount(2, $newUploads);
+        $states = array_column($newUploads, 'state');
+        $this->assertContains(State::Normal->value, $states);
+        $this->assertContains(State::Archived->value, $states);
     }
 
     public function testInsertTags(): void


### PR DESCRIPTION
Ensure upload state (normal/archived) is preserved when duplicating entities.

Previously, duplicated uploads did not explicitly propagate their State, which could lead to archived files being restored unintentionally in duplicated entities.

Changes:
- Pass State explicitly to CreateUpload and CreateUploadFromS3 when duplicating uploads.
- Update duplication test to cover both normal and archived uploads.
- Assert that duplicated uploads retain their original state.
- Minor cleanup: add missing sprintf import in MakeEvidencyTimestamp.

This guarantees duplication is a faithful copy of the original entity, including upload lifecycle state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads now correctly preserve their statuses (e.g., normal, archived) and file associations when experiments are duplicated.

* **Tests**
  * Added/updated tests to assert upload status and count are preserved after duplication with file copying.

* **Refactor**
  * Internal improvements to how duplicated uploads are constructed to make file/path and state handling more explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->