### PR TITLE
chem-plugin: gunicorn: add --no-control-socket flag

### DIFF
--- a/containers/chem-plugin/conf/gunicorn.auto.conf
+++ b/containers/chem-plugin/conf/gunicorn.auto.conf
@@ -1,6 +1,6 @@
 [program:gunicorn]
 directory=/srv/indigo
-command=/bin/bash -c "/srv/indigo/.venv/bin/gunicorn --bind 0.0.0.0:8080 --workers=$(nproc) app:app"
+command=/bin/bash -c "/srv/indigo/.venv/bin/gunicorn --bind 0.0.0.0:8080 --no-control-socket --workers=$(nproc) app:app"
 autostart=true
 autorestart=true
 user=nobody

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -307,7 +307,7 @@ services:
         #
         # This service is necessary for the Chemical structure editor (Ketcher)
         #- USE_INDIGO=false
-        #- INDIGO_URL=http://chem-plugin/
+        #- INDIGO_URL=http://chem-plugin:8080/
         # The fingerprinter is necessary to create a fingerprint of chemical compounds so we can do sub-structure search
         #- USE_FINGERPRINTER=false
         #- FINGERPRINTER_URL=http://chem-plugin:8000/


### PR DESCRIPTION
this prevents the app from starting a control socket (which gives an error on read-only filesystems). Also, we don't need it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application server initialization to modify control-socket behavior in deployment configuration.
* **Documentation**
  * Adjusted example plugin endpoint in a sample compose file to include an explicit port (:8080) for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->