### PR TITLE
bug/minor: todolist: prevent duplicate component initialization

### DIFF
--- a/src/ts/KeyboardShortcuts.class.ts
+++ b/src/ts/KeyboardShortcuts.class.ts
@@ -19,6 +19,8 @@ export class KeyboardShortcuts {
   favorite: string;
   search: string;
   page: string;
+  private todolist: Todolist;
+  private favTag: FavTag;
 
   constructor(create: string, edit: string, todo: string, favorite: string, search: string) {
     this.create = create;
@@ -27,6 +29,8 @@ export class KeyboardShortcuts {
     this.favorite = favorite;
     this.search = search;
     this.page = document.location.pathname;
+    this.todolist = new Todolist();
+    this.favTag = new FavTag();
   }
 
   init() {
@@ -59,10 +63,10 @@ export class KeyboardShortcuts {
     });
 
     // TODOLIST TOGGLE
-    assignKey(this.todo, () => (new Todolist()).toggle());
+    assignKey(this.todo, () => this.todolist.toggle());
 
     // FAVORITE TAGS TOGGLE
-    assignKey(this.favorite, () => (new FavTag()).toggle());
+    assignKey(this.favorite, () => this.favTag.toggle());
 
     // SEARCH BAR FOCUS
     assignKey(this.search, (event: Event) => {

--- a/src/ts/Todolist.class.ts
+++ b/src/ts/Todolist.class.ts
@@ -16,7 +16,8 @@ import TodolistSv from './components/Todolist.svelte';
 export default class Todolist extends SidePanel {
 
   unfinishedStepsScope: string;
-  initialLoad = true;
+  private static mounted = false;
+
 
   constructor() {
     super(Model.Todolist);
@@ -55,19 +56,22 @@ export default class Todolist extends SidePanel {
   // TOGGLE TODOLIST VISIBILITY
   toggle(): void {
     // force favtags to close if it's open
-    (new FavTag).hide();
+    (new FavTag()).hide();
     super.toggle();
-    // lazy load content only once
-    if (!document.getElementById(this.panelId).hasAttribute('hidden') && this.initialLoad) {
+    const panel = document.getElementById(this.panelId);
+    const isOpen = !!panel && !panel.hasAttribute('hidden');
+    if (isOpen) {
       const host = document.getElementById('todolist');
-      if (host) {
+      // Prevent mounting the Svelte component multiple times
+      // (can happen when toggling via both click and keyboard shortcut)
+      if (host && !Todolist.mounted && host.childElementCount === 0) {
         mount(TodolistSv, {
           target: host,
         });
+        Todolist.mounted = true;
       }
 
       this.loadUnfinishedStep();
-      this.initialLoad = false;
     }
   }
 }


### PR DESCRIPTION
With recently introduced Svelte component, clicking on the todolist toggle & opening
 it with the `t` shortcut would double the component.

- Ensure Todolist Svelte component is mounted only once by introducing a static mount guard and checking existing DOM content.

- Also reuse Todolist and FavTag instances in keyboard shortcuts to avoid creating multiple panel instances when toggling via shortcut.

Fixes issue where using the shortcut (`t`) and UI click could result in duplicated todolist components.

## to reproduce

on `master`, spamm `t` shortcut and see duplicates of the instance:

<img  height="700" alt="image" src="https://github.com/user-attachments/assets/f77ef44a-860b-4c84-abda-3a10841c8dc2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of todolist and favorite tags toggle functionality by preventing redundant component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->