### PR TITLE
bug/minor: editor: allow custom table background colors in view mode

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -655,6 +655,7 @@ tr:first-child td {
   }
 
   table tbody {
+    /* table in view mode, allow custom color configuration via tinyMce plugin, see #6476 */
     background-color: transparent !important;
   }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -592,12 +592,12 @@ button:disabled {
   }
 }
 
-/* color one row every other row */
-tr:nth-child(even) {
+/* zebra only when the actual table does not have inline background-color */
+table:not([style*='background-color']) > tbody > tr:nth-child(even) {
   background-color: var(--white);
 }
 
-tr:nth-child(odd) {
+table:not([style*='background-color']) > tbody > tr:nth-child(odd) {
   background-color: var(--mainbackground);
 }
 
@@ -647,20 +647,6 @@ tr:first-child td {
   td,
   tr {
     border: 1px solid var(--secondary-muted);
-  }
-
-  table tr:nth-child(even),
-  table tr:nth-child(odd) {
-    background-color: unset !important;
-  }
-
-  table tbody {
-    /* table in view mode, allow custom color configuration via tinyMce plugin, see #6476 */
-    background-color: transparent !important;
-  }
-
-  table td {
-    background-color: inherit !important;
   }
 }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -648,6 +648,19 @@ tr:first-child td {
   tr {
     border: 1px solid var(--secondary-muted);
   }
+
+  table tr:nth-child(even),
+  table tr:nth-child(odd) {
+    background-color: unset !important;
+  }
+
+  table tbody {
+    background-color: transparent !important;
+  }
+
+  table td {
+    background-color: inherit !important;
+  }
 }
 
 /* required labels/input */


### PR DESCRIPTION
fix #6746

Custom background colors applied to tables in the TinyMCE editor were not rendered in view mode due to global table styling that overrode background-color rules.

Global selectors for table rows and cells have been adjusted to avoid forcing alternating or inherited backgrounds inside entry content. This allows background-color styles applied directly to <table>, <tbody>, or <td> elements to render correctly in view mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined table row striping so alternating row backgrounds are applied only to tables that do not have inline background-color styles. This preserves zebra styling for standard tables while allowing tables with custom or external background colors to display their intended look without enforced alternating backgrounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->