### PR TITLE
bug/minor: uploads: ghost attachments on creating/duplicating entries

### DIFF
--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -205,7 +205,7 @@ final class Uploads extends AbstractRest
     // entity is target entity
     public function duplicate(AbstractEntity $entity): void
     {
-        $uploads = $this->selectAll([State::Normal]);
+        $uploads = $this->selectAll(array(State::Normal));
         foreach ($uploads as $upload) {
             if ($upload['storage'] === Storage::LOCAL->value) {
                 $prefix = '/elabftw/uploads/';

--- a/src/Models/Uploads.php
+++ b/src/Models/Uploads.php
@@ -205,7 +205,7 @@ final class Uploads extends AbstractRest
     // entity is target entity
     public function duplicate(AbstractEntity $entity): void
     {
-        $uploads = $this->selectAll();
+        $uploads = $this->selectAll([State::Normal]);
         foreach ($uploads as $upload) {
             if ($upload['storage'] === Storage::LOCAL->value) {
                 $prefix = '/elabftw/uploads/';

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -276,12 +276,9 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($canread->value, $new->entityData['canread_base']);
         $this->assertEquals($canwrite->value, $new->entityData['canwrite_base']);
         $this->assertEquals(1, $new->entityData['hide_main_text']);
-        // assert uploads' states persist
-        $newUploads = $new->Uploads->readAll(new BaseQueryParams(states: array(State::Normal, State::Archived), ));
-        $this->assertCount(2, $newUploads);
-        $states = array_column($newUploads, 'state');
-        $this->assertContains(State::Normal->value, $states);
-        $this->assertContains(State::Archived->value, $states);
+        // assert only active files are duplicated
+        $newUploads = $new->Uploads->readAll();
+        $this->assertCount(1, $newUploads);
     }
 
     public function testInsertTags(): void

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -276,9 +276,8 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($canread->value, $new->entityData['canread_base']);
         $this->assertEquals($canwrite->value, $new->entityData['canwrite_base']);
         $this->assertEquals(1, $new->entityData['hide_main_text']);
-        // assert only active files are duplicated
-        $newUploads = $new->Uploads->readAll();
-        $this->assertCount(1, $newUploads);
+        // only active files are duplicated
+        $this->assertCount(1, $new->Uploads->readAll());
     }
 
     public function testInsertTags(): void


### PR DESCRIPTION
fix #6592

On duplicating uploads, select only active files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload duplication now only copies active (normal) uploads, preventing inactive or archived files from being duplicated.
* **Tests**
  * Adjusted unit tests to expect only active uploads to be duplicated, aligning tests with the updated duplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->