### PR TITLE
refactor/a11y: improve export menu semantics and accessibility

### DIFF
--- a/src/templates/export-menu.html
+++ b/src/templates/export-menu.html
@@ -140,8 +140,8 @@
     </a>
     <hr>
     {% set isDisabled = App.Config.configArr.dspace_host == '' or Entity.isReadOnly %}
-    <button type='button' class='dropdown-item {{ isDisabled ? 'disabled' }}' data-action='open-dspace-modal'{{ isDisabled ? 'disabled aria-disabled="true"' : '' }}>
-      <i class='fas fa-file-export fa-fw {{ isDisabled ? 'color-weak' }}'></i>{{ 'Export to DSpace'|trans }}
+    <button type='button' class='dropdown-item {{ isDisabled ? 'disabled' }}' data-action='open-dspace-modal' {{ isDisabled ? 'disabled aria-disabled="true"' : '' }}>
+      <i class='fas fa-file-export fa-fw {{ isDisabled ? 'color-weak' }}'></i> {{ 'Export to DSpace'|trans }}
     </button>
   </div>
 </div>

--- a/src/templates/export-menu.html
+++ b/src/templates/export-menu.html
@@ -120,14 +120,28 @@
     <i class='fas fa-download fa-fw'></i>
   </button>
   <div class='dropdown-menu'>
-    <div class='dropdown-item' data-action='toggle-modal' data-target='pdfExportModal'><i class='fas fa-file-pdf fa-fw'></i> {{ 'PDF File'|trans }}</div>
-    <div class='dropdown-item' data-action='toggle-modal' data-target='zipExportModal'><i class='fas fa-file-archive fa-fw'></i> {{ 'ZIP Archive'|trans }}</div>
-    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}?format=eln'><i class='fas fa-box-archive fa-fw'></i> {{ 'ELN Archive'|trans }}</a>
-    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}?format=csv'><i class='fas fa-file-csv fa-fw'></i> {{ 'CSV File'|trans }}</a>
-    <div class='dropdown-item' data-action='toggle-modal' data-target='qrpngExportModal'><i class='fas fa-qrcode fa-fw'></i> {{ 'QR Code'|trans }}</div>
-    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}' target='_blank'><i class='fas fa-code fa-fw'></i>{{ 'JSON'|trans }}</a>
+    <button type='button' class='dropdown-item' data-action='toggle-modal' data-target='pdfExportModal'>
+      <i class='fas fa-file-pdf fa-fw'></i> {{ 'PDF File'|trans }}
+    </button>
+    <button type='button' class='dropdown-item' data-action='toggle-modal' data-target='zipExportModal'>
+      <i class='fas fa-file-archive fa-fw'></i> {{ 'ZIP Archive'|trans }}
+    </button>
+    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}?format=eln'>
+      <i class='fas fa-box-archive fa-fw'></i> {{ 'ELN Archive'|trans }}
+    </a>
+    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}?format=csv'>
+      <i class='fas fa-file-csv fa-fw'></i> {{ 'CSV File'|trans }}
+    </a>
+    <button type='button' class='dropdown-item' data-action='toggle-modal' data-target='qrpngExportModal'>
+      <i class='fas fa-qrcode fa-fw'></i> {{ 'QR Code'|trans }}
+    </button>
+    <a class='dropdown-item' href='api/v2/{{ Entity.entityType.value }}/{{ Entity.id }}' target='_blank' rel='noopener noreferrer'>
+      <i class='fas fa-code fa-fw'></i> {{ 'JSON'|trans }}
+    </a>
     <hr>
-      {% set isDisabled = App.Config.configArr.dspace_host == '' or Entity.isReadOnly %}
-    <div class='dropdown-item {{ isDisabled ? 'disabled' }}' data-action='open-dspace-modal'><i class='fas fa-file-export fa-fw {{ isDisabled ? 'color-weak' }}'></i> {{ 'Export to DSpace'|trans }}</div>
+    {% set isDisabled = App.Config.configArr.dspace_host == '' or Entity.isReadOnly %}
+    <button type='button' class='dropdown-item {{ isDisabled ? 'disabled' }}' data-action='open-dspace-modal'{{ isDisabled ? 'disabled aria-disabled="true"' : '' }}>
+      <i class='fas fa-file-export fa-fw {{ isDisabled ? 'color-weak' }}'></i>{{ 'Export to DSpace'|trans }}
+    </button>
   </div>
 </div>


### PR DESCRIPTION
Replaces non-interactive <div> elements used as dropdown items with semantic <button type="button"> elements for actions that trigger modals.

Adds proper disabled and aria-disabled attributes for the "Export to DSpace" action when unavailable, and includes rel="noopener noreferrer" on external JSON link for security.

These changes improve keyboard navigation, screen reader behavior, and overall accessibility compliance without altering functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for disabled export options so they are announced and treated correctly by assistive tech.
  * Export menu items (PDF/ZIP/QRPNG) are now operable as interactive controls, improving keyboard and screen-reader support.
  * Enhanced security for the JSON export link when opened in a new tab.
  * Retained existing export behaviors and visual styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->