### PR TITLE
bug/minor: teams: use team-specific archive flag for user filtering

### DIFF
--- a/src/templates/team.html
+++ b/src/templates/team.html
@@ -27,7 +27,7 @@
       </thead>
       <tbody id='teamTable'>
         {# archived users are hidden on this page #}
-        {% for user in App.Users.readAllFromTeam()|filter(u => u.archived == 0) %}
+        {% for user in App.Users.readAllFromTeam()|filter(u => u.is_archived_in_current_team == 0) %}
         <tr>
           <td>
             <a href='experiments.php?owner={{ user.userid }}'>


### PR DESCRIPTION
fix #6771

The team page previously filtered users using the global `archived` property, which could lead to incorrect visibility when a user was archived only in the current team.

This change updates the filter to use
`is_archived_in_current_team`, ensuring that only users archived within the current team context are hidden.

<img width="588" height="236" alt="image" src="https://github.com/user-attachments/assets/a560b291-ff52-42be-b50d-7bab03d41bb3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated team members list filtering to correctly identify archived members based on team-specific archival status rather than the global archived flag. This ensures accurate display of active and inactive members within your team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->