### PR TITLE
bug/minor: scheduler: prevent false success notification on event cancellation

### DIFF
--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -540,7 +540,7 @@ if (window.location.pathname === '/scheduler.php') {
       ApiC.notifOnSaved = false;
       ApiC.post(`event/${el.dataset.id}/notifications`, payload)
         .then(() => ApiC.delete(`event/${el.dataset.id}`).then(() => calendar.refetchEvents()).catch())
-        .then(() => notify.success());
+        .then(() => notify.success()).finally(() => ApiC.notifOnSaved = true);
     });
 
     on('edit-event', async (_, e: Event) => {

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -536,9 +536,11 @@ if (window.location.pathname === '/scheduler.php') {
         payload.range_value = parseInt((document.getElementById('cancelEventRangeValue') as HTMLInputElement).value, 10);
         payload.range_unit = (document.getElementById('cancelEventRangeUnit') as HTMLSelectElement).value;
       }
-      ApiC.post(`event/${el.dataset.id}/notifications`, payload).then(() => {
-        ApiC.delete(`event/${el.dataset.id}`).then(() => calendar.refetchEvents()).catch();
-      });
+      // The notification must be sent before deletion, otherwise the event ID is lost (Nothing to show with this id)
+      ApiC.notifOnSaved = false;
+      ApiC.post(`event/${el.dataset.id}/notifications`, payload)
+        .then(() => ApiC.delete(`event/${el.dataset.id}`).then(() => calendar.refetchEvents()).catch())
+        .then(() => notify.success());
     });
 
     on('edit-event', async (_, e: Event) => {


### PR DESCRIPTION
When attempting to cancel an event that cannot be deleted, a success ("Saved") notification was displayed before the deletion request failed, resulting in a confusing UX (success message followed by an error).

Notifications are now disabled during the intermediate notification request, and a single success message is shown only after the deletion completes successfully.

This ensures users receive accurate feedback about the actual outcome of the cancellation attempt.

<img width="401" height="148" alt="image" src="https://github.com/user-attachments/assets/dc3e0e39-326b-4356-98e9-3302a97146da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event cancellation flow so notification sending is temporarily suppressed during processing and restored afterward, preventing duplicate or spurious notifications.
  * Added an explicit success confirmation after cancellation completes to reassure users that the event was removed and notifications were handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->