### PR TITLE
style: ux/ui: some additional fixes

### DIFF
--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -204,7 +204,7 @@ final class Scheduler extends AbstractRest
                 CONCAT('[', items.title, '] ', team_events.title, ' (', u.firstname, ' ', u.lastname, ')') AS title,
                 items.title AS item_title,
                 items.book_is_cancellable,
-                CONCAT('#', items_categories.color) AS color,
+                COALESCE(NULLIF(CONCAT('#', items_categories.color), '#'), '#0c58ab') AS color,
                 items_categories.title AS items_category_title,
                 team_events.experiment,
                 items.category AS items_category,

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -371,7 +371,7 @@ final class Scheduler extends AbstractRest
         $sql = "SELECT team_events.*,
             CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ') ', COALESCE(experiments.title, '')) AS title,
             team_events.title AS title_only,
-            CONCAT('#', items_categories.color) AS color,
+            COALESCE(NULLIF(CONCAT('#', items_categories.color), '#'), '#0c58ab') AS color,
             experiments.title AS experiment_title,
             items_linkt.title AS item_link_title,
             items.title AS item_title, items.book_is_cancellable

--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -43,7 +43,6 @@
   &:hover {
     background-color: var(--mainbackground);
     border-color: var(--strongest);
-    border-color: var(--strongest);
     color: var(--strongest);
 
     .fas,

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -707,10 +707,6 @@ tr:first-child td {
 
 .overlay-error {
   background-color: var(--lightred);
-
-  p {
-    color: var(--chrome-bg) !important;
-  }
 }
 
 .overlay-warning {
@@ -945,9 +941,8 @@ tr:first-child td {
 /* this is a hack to make the steps that are long work fine in multiline
 the form-control fails to do that so we do the border ourselves */
 .step-static {
-  border: 1px solid var(--secondary-muted);
-  border-bottom-right-radius: 4px;
-  border-top-right-radius: 4px;
+  border: 1px solid var(--secondary);
+  border-radius: 0 4px 4px 0;
 }
 
 .finished {
@@ -1192,11 +1187,6 @@ the form-control fails to do that so we do the border ourselves */
 
 .box {
   background-color: var(--white);
-}
-
-/* background for archived users */
-.bg-medium {
-  background-color: var(--secondlevel) !important;
 }
 
 .border-secondlevel {
@@ -1796,11 +1786,6 @@ input:user-invalid {
 
 .calendar-event-disabled {
   opacity: 0.5;
-}
-
-.flash:hover {
-  background-color: var(--primary);
-  transition: background-color 0.1s ease;
 }
 
 .color-input {

--- a/src/templates/interface.html
+++ b/src/templates/interface.html
@@ -33,10 +33,7 @@ This page exists to have a single page holding all buttons, links and notificati
     <button type='button' class='btn btn-primary' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='Dropdown menu' aria-label='Dropdown menu'>
       <i class='far fa-square-caret-down mr-1'></i>Dropdown menu
     </button>
-    <div class='overlay overlay-success mt-2'><p>Success notification</p></div>
-
     <div class='overlay overlay-warning mt-2'><p>Warning notification</p></div>
-
     <div class='overlay overlay-error mt-2'><p>Error notification</p></div>
 
     <div class='dropdown-menu dropdown-menu-right'>

--- a/src/templates/interface.html
+++ b/src/templates/interface.html
@@ -33,6 +33,7 @@ This page exists to have a single page holding all buttons, links and notificati
     <button type='button' class='btn btn-primary' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='Dropdown menu' aria-label='Dropdown menu'>
       <i class='far fa-square-caret-down mr-1'></i>Dropdown menu
     </button>
+    <div class='overlay overlay-success mt-2'><p>Success notification</p></div>
 
     <div class='overlay overlay-warning mt-2'><p>Warning notification</p></div>
 

--- a/src/templates/interface.html
+++ b/src/templates/interface.html
@@ -34,6 +34,10 @@ This page exists to have a single page holding all buttons, links and notificati
       <i class='far fa-square-caret-down mr-1'></i>Dropdown menu
     </button>
 
+    <div class='overlay overlay-warning mt-2'><p>Warning notification</p></div>
+
+    <div class='overlay overlay-error mt-2'><p>Error notification</p></div>
+
     <div class='dropdown-menu dropdown-menu-right'>
         <button type='button' class='dropdown-item'>
           <i class='fas fa-fw fa-image mr-1'></i>Normal item

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1072,10 +1072,6 @@ on('toggle-anonymous-access', () => {
 });
 
 on('reload-color', (el: HTMLElement) => {
-  el.classList.add('flash');
-  setTimeout(() => {
-    el.classList.remove('flash');
-  }, 100);
   (el.nextElementSibling as HTMLInputElement).value = getRandomColor();
 });
 

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -212,7 +212,7 @@ if (window.location.pathname === '/scheduler.php') {
       const colorCircle = document.createElement('i');
       colorCircle.classList.add('fas', 'fa-circle');
       const rawColor = opt.dataset.color;
-      colorCircle.style.color = rawColor?.startsWith('#') ? rawColor : `#${rawColor || 'fff'}`;
+      colorCircle.style.color = rawColor?.startsWith('#') ? rawColor : `#${rawColor || '# 0c58ab'}`;
       const badge = document.createElement('span');
       badge.appendChild(colorCircle);
       badge.className = 'selected-item-badge';

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -212,7 +212,7 @@ if (window.location.pathname === '/scheduler.php') {
       const colorCircle = document.createElement('i');
       colorCircle.classList.add('fas', 'fa-circle');
       const rawColor = opt.dataset.color;
-      colorCircle.style.color = rawColor?.startsWith('#') ? rawColor : `#${rawColor || '# 0c58ab'}`;
+      colorCircle.style.color = rawColor?.startsWith('#') ? rawColor : `#${rawColor || '0c58ab'}`;
       const badge = document.createElement('span');
       badge.appendChild(colorCircle);
       badge.className = 'selected-item-badge';

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -212,8 +212,7 @@ if (window.location.pathname === '/scheduler.php') {
       const colorCircle = document.createElement('i');
       colorCircle.classList.add('fas', 'fa-circle');
       const rawColor = opt.dataset.color;
-      const categoryColor = rawColor?.startsWith('#') ? rawColor : `#${rawColor || 'fff'}`;
-      colorCircle.style.color = categoryColor;
+      colorCircle.style.color = rawColor?.startsWith('#') ? rawColor : `#${rawColor || 'fff'}`;
       const badge = document.createElement('span');
       badge.appendChild(colorCircle);
       badge.className = 'selected-item-badge';
@@ -222,8 +221,8 @@ if (window.location.pathname === '/scheduler.php') {
       link.href = `database.php?mode=view&id=${encodeURIComponent(id)}`;
       link.target = '_blank';
       link.rel = 'noopener';
-      // firstlevel
-      badge.style.setProperty('--badge-color', '#dbdbdb');
+      // background color for badges
+      badge.style.backgroundColor = 'var(--superlight)';
 
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
@@ -307,7 +306,7 @@ if (window.location.pathname === '/scheduler.php') {
       // remove possibility to book whole day, might add it later
       allDaySlot: false,
       // background color before event validation
-      eventBackgroundColor: 'var(--secondlevel)',
+      eventBackgroundColor: 'var(--chrome-bg)',
       // user can see events as disabled if they don't have booking permissions. See #5930
       eventClassNames: (info) => {
         const canBook = Number(info.event.extendedProps.canbook);

--- a/src/ts/users-table.jsx
+++ b/src/ts/users-table.jsx
@@ -68,7 +68,7 @@ if (document.getElementById('users-table')) {
     const TeamsRenderer = ({ value }) => {
       return (
         <span>{value.map(team => (
-          <span key={team.id} data-id={team.id} className={`mr-2 ${team.is_admin ? 'admin' : 'user'}-badge ${team.is_archived ? 'bg-medium' : ''}`}>{team.name}</span>))}
+          <span key={team.id} data-id={team.id} className={`mr-2 ${team.is_admin ? 'admin' : 'user'}-badge ${team.is_archived ? 'color-disabled' : ''}`}>{team.name}</span>))}
         </span>
       );
     };


### PR DESCRIPTION
add fallback color and clean up UI styles.

Ensures scheduler events always have a primary color by adding a
fallback when the category color is empty.

Also includes UI cleanups:
- Removed duplicate border-color rule in buttons
- Simplified .step-static border styling
- Removed unused flash animation and bg-medium class
- Updated overlay styles and demo blocks
- Harmonized badge background and default event background color

added notifications check in `interface.html`

### before
<img width="258" height="110" alt="Capture d’écran du 2026-04-23 11-35-48" src="https://github.com/user-attachments/assets/545a56f9-6f3a-4f73-b383-2810042c7fc6" />
<img width="258" height="110" alt="Capture d’écran du 2026-04-23 11-35-37" src="https://github.com/user-attachments/assets/732f30e5-1c15-47c0-a640-23afa4c6068f" />
<img width="399" height="143" alt="Capture d’écran du 2026-04-23 11-35-17" src="https://github.com/user-attachments/assets/48b1b430-0873-4a29-9103-ab6a74271f06" />
<img width="612" height="82" alt="Capture d’écran du 2026-04-23 11-35-03" src="https://github.com/user-attachments/assets/f46c20ca-a4b3-4270-ab83-9d73717a5efb" />
<img width="1129" height="174" alt="Capture d’écran du 2026-04-23 11-03-23" src="https://github.com/user-attachments/assets/f047dba8-4cbb-4dee-bdf9-711e03fe6e48" />
<img width="596" height="221" alt="Capture d’écran du 2026-04-23 11-01-41" src="https://github.com/user-attachments/assets/df6a42e9-510e-497a-bceb-a82c9c3dd1bd" />

### after

<img width="730" height="147" alt="Capture d’écran du 2026-04-23 12-54-35" src="https://github.com/user-attachments/assets/0b5c137e-9ed6-411e-a4fd-e85e83316f1d" />
<img width="730" height="147" alt="Capture d’écran du 2026-04-23 12-54-41" src="https://github.com/user-attachments/assets/1a6c6158-00f1-4036-bb8e-9d091ef14963" />
<img width="407" height="249" alt="image" src="https://github.com/user-attachments/assets/54b17d93-db1a-41dc-81f5-c66e927b76c8" />
<img width="1121" height="297" alt="image" src="https://github.com/user-attachments/assets/015307da-46c8-4993-b3bc-59dccc72415e" />
<img width="536" height="77" alt="image" src="https://github.com/user-attachments/assets/21f727eb-c20b-47ed-a23a-99217ff081da" />
<img width="363" height="151" alt="image" src="https://github.com/user-attachments/assets/cd5934fa-cd74-423e-b6d3-b3de0eec1d9c" />
<img width="353" height="107" alt="image" src="https://github.com/user-attachments/assets/ad84147c-943f-4d23-9622-2136cad3116c" />




These changes improve visual consistency and prevent rendering
issues caused by missing category colors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static warning and error notification overlays in the interface.

* **Style**
  * Standardized category/event color fallback to a consistent default (#0c58ab).
  * Refined badge visuals, event background styling, and archived-team appearance.
  * Removed a redundant button hover rule, a transient flash hover effect, and a deprecated background utility; simplified overlay/error styling.

* **Bug Fixes**
  * Color reload now updates the input color without a transient flash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->