### PR TITLE
feat: dashboard: sort scheduled bookings by start time

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -116,7 +116,7 @@
     </div>
     <hr>
     <div class='list-group mt-1' id='scheduledBookings'>
-      {% for booking in bookingsArr %}
+      {% for booking in bookingsArr|sort((a, b) => a.start <=> b.start) %}
         <a href='scheduler.php?items[]={{ booking.items_id }}&amp;start={{ booking.start|url_encode }}' class='list-group-item breakable'>
           {% if booking.items_category_title %}
             <span style='--bg: {{ booking.color }}' class='d-inline-block catstat-btn category-btn mr-2'>{{ booking.items_category_title }}</span>

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -116,7 +116,7 @@
     </div>
     <hr>
     <div class='list-group mt-1' id='scheduledBookings'>
-      {% for booking in bookingsArr|sort((a, b) => a.start <=> b.start) %}
+      {% for booking in bookingsArr|sort((a, b) => (a.start|date('U')) - (b.start|date('U'))) %}
         <a href='scheduler.php?items[]={{ booking.items_id }}&amp;start={{ booking.start|url_encode }}' class='list-group-item breakable'>
           {% if booking.items_category_title %}
             <span style='--bg: {{ booking.color }}' class='d-inline-block catstat-btn category-btn mr-2'>{{ booking.items_category_title }}</span>


### PR DESCRIPTION
implements #6780
Scheduled bookings on the dashboard were previously grouped by item, which could result in entries being displayed out of chronological order (e.g., 1h, 2h, 3h for one item, followed by 10 minutes for another item).

Bookings are now sorted by their start timestamp so that the upcoming events appear first, providing a clearer and more intuitive overview of what is happening next.
<img width="505" height="504" alt="image" src="https://github.com/user-attachments/assets/5d3a7118-d035-494d-90fe-27a625915b7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled bookings now consistently display in chronological order by start time, ensuring upcoming reservations appear first for clearer planning and easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->