### PR TITLE
fix: remove sysadmin option from user creation

### DIFF
--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -44,9 +44,6 @@
       <div class='col-md-6'>
         <label for='create-user-group' class='col-form-label'>{{ 'Permission group'|trans }}</label>
         <select class='form-control custom-control-inline' name='usergroup' id='create-user-group' data-no-blank='1'>
-          {% if App.Users.userData.is_sysadmin %}
-            <option value='1'>Sysadmins</option>
-          {% endif %}
           <option value='2'>Admins</option>
           <option value='4' selected='selected'>Users</option>
         </select>

--- a/tests/cypress/integration/adminUsers.cy.ts
+++ b/tests/cypress/integration/adminUsers.cy.ts
@@ -10,7 +10,7 @@ describe('Users tab in Admin page', () => {
     cy.get('.overlay').first().should('be.visible').should('contain', 'Invalid');
   });
 
-  it('cannot create user directly as sysadmin', () => {
+  it('does not offer sysadmin in the create-user permission group dropdown', () => {
     cy.get('#create-user-group option[value="1"]').should('not.exist');
   });
 

--- a/tests/cypress/integration/adminUsers.cy.ts
+++ b/tests/cypress/integration/adminUsers.cy.ts
@@ -10,6 +10,10 @@ describe('Users tab in Admin page', () => {
     cy.get('.overlay').first().should('be.visible').should('contain', 'Invalid');
   });
 
+  it('cannot create user directly as sysadmin', () => {
+    cy.get('#create-user-group option[value="1"]').should('not.exist');
+  });
+
   it('creates user', () => {
     // Team & Permission group are already filled on this form, by default
     cy.get('#firstname').type('theNewToto');


### PR DESCRIPTION
## Summary
- Remove the Sysadmins option from the Add account permission group dropdown.
- Add a Cypress assertion so new users cannot be created directly with the sysadmin group from that form.

Fixes #6781

## Test plan
- `git diff --check`
- `yarn jslint` could not be run locally because `yarn` is not available in this environment.
- `yarn twigcs` could not be run locally because `yarn` is not available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account creation now prevents assigning the sysadmin group; dropdown only offers Admin and User options, ensuring proper role restrictions for new accounts.

* **Tests**
  * Added a UI test that verifies the sysadmin option is not present in the user group dropdown during account creation, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->