### PR TITLE
apidoc: add missing endpoints and certs for idps

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6930,13 +6930,15 @@ paths:
           description: The idp endpoint has been created.
           headers:
             location:
-              description: An URL to the idp that was created.
+              description: An URL to the idp endpoint that was created.
               schema:
                 type: string
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   # IDP ENDPOINT WITH ID
   /idps/{id}/endpoints/{endpoint_id}:
@@ -6953,6 +6955,17 @@ paths:
         required: true
         schema:
           type: integer
+    get:
+      tags: ['Idps']
+      summary: Read an endpoint for an IdP.
+      operationId: read-idp-endpoint
+      responses:
+        '200':
+          description: IdP endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/idp_cert'
     delete:
       tags: ['Idps']
       summary: Delete an idp endpoint.
@@ -7012,13 +7025,15 @@ paths:
           description: The idp cert has been created.
           headers:
             location:
-              description: An URL to the idp that was created.
+              description: An URL to the idp cert that was created.
               schema:
                 type: string
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   # IDP cert WITH ID
   /idps/{id}/certs/{cert_id}:
@@ -7035,6 +7050,21 @@ paths:
         required: true
         schema:
           type: integer
+    get:
+      tags: ['Idps']
+      summary: Read a cert for an IdP.
+      operationId: read-idp-cert
+      responses:
+        '200':
+          description: IdP certificate
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/idp_cert'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
     delete:
       tags: ['Idps']
       summary: Delete an idp cert.
@@ -7042,7 +7072,7 @@ paths:
       operationId: delete-idp-cert
       responses:
         '204':
-          description: The idp was deleted.
+          description: The idp cert was deleted.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1669,6 +1669,9 @@ components:
           type: string
         orgid_attr:
           type: string
+        source:
+          type: int
+          nullable: true
         certs:
           type: array
           description: Certificates associated with this IdP.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6876,6 +6876,179 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  # IDP ENDPOINTS
+  /idps/{id}/endpoints:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the idp
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: ['Idps']
+      summary: Read all endpoints for an IdP.
+      operationId: read-idp-endpoints
+      responses:
+        '200':
+          description: A list of endpoints for this IdP.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/idp_endpoint'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: ['Idps']
+      summary: Add an endpoint to this IdP.
+      operationId: post-idp-endpoint
+      requestBody:
+        description: Parameters for adding an endpoint to an IdP.
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ['location']
+              properties:
+                location:
+                  type: string
+                binding:
+                  type: string
+                  enum: [
+                    'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                    'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+                  ]
+                is_slo:
+                  type: integer
+                  enum: [0, 1]
+      responses:
+        '201':
+          description: The idp endpoint has been created.
+          headers:
+            location:
+              description: An URL to the idp that was created.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # IDP ENDPOINT WITH ID
+  /idps/{id}/endpoints/{endpoint_id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the idp
+        required: true
+        schema:
+          type: integer
+      - name: endpoint_id
+        in: path
+        description: ID of the idp endpoint
+        required: true
+        schema:
+          type: integer
+    delete:
+      tags: ['Idps']
+      summary: Delete an idp endpoint.
+      description: The idp endpoint gets deleted.
+      operationId: delete-idp-endpoint
+      responses:
+        '204':
+          description: The idp was deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # IDP CERTS
+  /idps/{id}/certs:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the idp
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: ['Idps']
+      summary: Read all certs for an IdP.
+      operationId: read-idp-certs
+      responses:
+        '200':
+          description: A list of certs for this IdP.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/idp_cert'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: ['Idps']
+      summary: Add a cert to this IdP.
+      operationId: post-idp-cert
+      requestBody:
+        description: Parameters for adding a cert to an IdP.
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ['x509']
+              properties:
+                x509:
+                  type: string
+                  description: PEM representation of the certificate
+      responses:
+        '201':
+          description: The idp cert has been created.
+          headers:
+            location:
+              description: An URL to the idp that was created.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # IDP cert WITH ID
+  /idps/{id}/certs/{cert_id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the idp
+        required: true
+        schema:
+          type: integer
+      - name: cert_id
+        in: path
+        description: ID of the idp cert
+        required: true
+        schema:
+          type: integer
+    delete:
+      tags: ['Idps']
+      summary: Delete an idp cert.
+      description: The idp cert gets deleted.
+      operationId: delete-idp-cert
+      responses:
+        '204':
+          description: The idp was deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+
   # IDPS SOURCES
   /idps_sources:
     get:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6965,7 +6965,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/idp_cert'
+                $ref: '#/components/schemas/idp_endpoint'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
     delete:
       tags: ['Idps']
       summary: Delete an idp endpoint.
@@ -6973,7 +6977,7 @@ paths:
       operationId: delete-idp-endpoint
       responses:
         '204':
-          description: The idp was deleted.
+          description: The idp endpoint was deleted.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -7020,6 +7024,12 @@ paths:
                 x509:
                   type: string
                   description: PEM representation of the certificate
+                purpose:
+                  type: integer
+                  description: |
+                    Purpose for this cert: `0` for Signing, `1` for Encryption.
+                  default: 0
+                  enum: [0, 1]
       responses:
         '201':
           description: The idp cert has been created.

--- a/src/Models/IdpsCerts.php
+++ b/src/Models/IdpsCerts.php
@@ -70,9 +70,10 @@ final class IdpsCerts extends AbstractRest
     public function readOne(): array
     {
         $this->requester->isSysadminOrExplode();
-        $sql = 'SELECT * FROM idps_certs WHERE id = :id';
+        $sql = 'SELECT * FROM idps_certs WHERE id = :id AND idp = :idp';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $req->bindParam(':idp', $this->idpId, PDO::PARAM_INT);
         $this->Db->execute($req);
         $cert = $this->Db->fetch($req);
         $cert['purpose_human'] = CertPurpose::from($cert['purpose'])->name;

--- a/src/Models/IdpsCerts.php
+++ b/src/Models/IdpsCerts.php
@@ -138,9 +138,10 @@ final class IdpsCerts extends AbstractRest
     public function destroy(): bool
     {
         $this->requester->isSysadminOrExplode();
-        $sql = 'DELETE FROM idps_certs WHERE id = :id';
+        $sql = 'DELETE FROM idps_certs WHERE id = :id AND idp = :idp';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $req->bindParam(':idp', $this->idpId, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST endpoints to manage SAML IdP endpoints and certificates (list, create, read, delete).
  * Creation validates required fields (endpoint location, certificate PEM) and constrains binding and SLO/purpose values; creates return 201 with Location and standard 401/404 handling.
  * IdP responses can include an optional numeric "source" field.

* **Bug Fixes**
  * Certificate reads are now correctly scoped to the associated IdP, preventing cross-IdP access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->