### PR TITLE
bug/minor: openapi: remove default value for enums

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -7031,7 +7031,6 @@ paths:
                   type: integer
                   description: |
                     Purpose for this cert: `0` for Signing, `1` for Encryption.
-                  default: 0
                   enum: [0, 1]
       responses:
         '201':


### PR DESCRIPTION
Remove default value for enums in openapi spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated IdP certificate creation API specification to clarify that the `purpose` field requires explicit specification in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->