### PR TITLE
refactor: uploads: unify action menu for table and grid layouts

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -259,6 +259,11 @@ select.form-control {
 .dropdown-item {
   color: var(--medium);
   cursor: pointer;
+
+  a,
+  i {
+    color: var(--strongest);
+  }
 }
 
 .dropdown-item > a {
@@ -268,13 +273,6 @@ select.form-control {
 .dropdown-item:hover {
   background-color: var(--superlight);
   color: var(--strongest);
-}
-
-.dropdown-item {
-  a,
-  i {
-    color: var(--strongest);
-  }
 }
 
 /* BLOCKQUOTE */
@@ -513,10 +511,6 @@ button:disabled {
   th,
   td {
     color: var(--mediumstrong);
-  }
-
-  td button {
-    color: var(--chrome-fg);
   }
 
   td,

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -69,11 +69,10 @@
 
       {# JSON EDITOR #}
       {% set isJson = ext matches '/(json)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isJson %}disabled{% endif %} data-action='json-load-file' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-file-code mr-1'></i>{{ 'JSON editor'|trans }}</button>
-
+      <button type='button' class='dropdown-item' {% if not isJson %}disabled{% endif %} data-action='json-load-file' data-uploadid='{{ upload.id }}' data-link='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-file-code mr-1'></i>{{ 'JSON editor'|trans }}</button>
       {# SHEET EDITOR #}
       {% set isSheet = ext in constant('Elabftw\\Elabftw\\Extensions::SPREADSHEET') %}
-      <button type='button' class='dropdown-item' {% if not isSheet %}disabled{% endif %} data-action='xls-load-file' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-file-excel mr-1'></i>{{ 'Spreadsheet editor'|trans }}</button>
+      <button type='button' class='dropdown-item' {% if not isSheet %}disabled{% endif %} data-action='xls-load-file' data-uploadid='{{ upload.id }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-file-excel mr-1'></i>{{ 'Spreadsheet editor'|trans }}</button>
 
       {# NMRium #}
       {% set isJdx = ext matches '/jdx$/i' %}
@@ -83,7 +82,7 @@
     {% endif %}
     {# Preview #}
     {% set isPreview = ext matches '/(txt|md|json)$/i' %}
-    <button type='button' class='dropdown-item' {% if not isPreview %}disabled{% endif %} data-action='toggle-modal' data-target='plainTextModal' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-eye mr-1'></i>{{ 'Preview'|trans }}</button>
+    <button type='button' class='dropdown-item' {% if not isPreview %}disabled{% endif %} data-action='toggle-modal' data-target='plainTextModal' data-uploadid='{{ upload.id }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}' data-ext='{{ ext }}'><i class='fas fa-fw fa-eye mr-1'></i>{{ 'Preview'|trans }}</button>
 
     {% if App.Users.userData.uploads_layout != 0 %}
       <button type='button' class='dropdown-item' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}</button>

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -1,118 +1,90 @@
-{# DROPDOWN MENU FOR UPLOAD #}
+{% set isGrid = layout is defined and layout == 'grid' %}
+{% if not isGrid %}
 <div class='dropdown'>
   <button type='button' class='btn btn-transparent float-right' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}'>
     <i class='fas fa-ellipsis-v fa-fw'></i>
   </button>
-
   <div class='dropdown-menu dropdown-menu-right'>
+{% endif %}
 
   {% if mode == 'edit' %}
     {# INSERT IN TEXT in edit mode for images #}
     {% if ext matches '/(jpg|jpeg|png|gif|svg|bmp)$/i' %}
-      <button type='button' class='dropdown-item' data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
-        <i class='fas fa-fw fa-image mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
-      </button>
+      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-image {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for videos #}
     {% if ext matches '/(mkv|mp4|ogv|webm)$/i' %}
-      <button type='button' class='dropdown-item' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
-        <i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
-      </button>
+      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-video {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for audio #}
     {% if ext matches '/(aac|flac|mp3|ogg|opus|wav)$/i' %}
-      <button type='button' class='dropdown-item' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'>
-        <i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
-      </button>
+      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-volume-low {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
     {% endif %}
 
     {# INSERT IN TEXT in edit mode for plain text #}
     {% if ext matches '/txt$/i' %}
-      <button type='button' class='dropdown-item' data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'>
-        <i class='fas fa-fw fa-file-import mr-1'></i>{{ 'Insert in text at cursor position'|trans }}
-      </button>
+      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-file-import {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
     {% endif %}
   {% endif %}
 
   {# Edit filename (available in view mode too) #}
   {% if not upload.immutable and not Entity.isReadOnly and App.Users.userData.uploads_layout != 0 %}
-    <button type='button' class='dropdown-item' data-action='rename-upload' data-id='{{ upload.id }}'>
-      <i class='fas fa-fw fa-pencil-alt mr-1'></i>{{ 'Edit filename'|trans }}
-    </button>
+    <button type='button' title='{{ 'Edit filename'|trans }}' aria-label='{{ 'Edit filename'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='rename-upload' data-id='{{ upload.id }}'><i class='fas fa-fw fa-pencil-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Edit filename'|trans }}{% endif %}</button>
   {% endif %}
 
   {% if mode == 'edit' %}
 
     {# Annotate image #}
     {% if ext matches '/(jpg|jpeg|png|gif|bmp)$/i' %}
-      <button type='button' class='dropdown-item' data-action='annotate-image' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'>
-        <i class='fas fa-fw fa-paint-brush mr-1'></i>{{ 'Annotate this image'|trans }}
-      </button>
+      <button type='button' title='{{ 'Annotate this image'|trans }}' aria-label='{{ 'Annotate this image'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='annotate-image' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-paint-brush {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Annotate this image'|trans }}{% endif %}</button>
     {% endif %}
 
     {# LOAD IN JSON EDITOR #}
     {% if ext matches '/(json)$/i' %}
-      <button type='button' class='dropdown-item' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-link='{{ upload.long_name|e('html_attr') }}' data-action='json-load-file'>
-        <i class='fas fa-fw fa-{{ mode == 'edit' ? 'pencil-alt' : 'eye' }} mr-1'></i>{{ 'Load into JSON Editor'|trans }}
-      </button>
+      <button type='button' title='{{ 'Load into JSON Editor'|trans }}' aria-label='{{ 'Load into JSON Editor'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-link='{{ upload.long_name|e('html_attr') }}' data-action='json-load-file'><i class='fas fa-fw fa-{{ mode == 'edit' ? 'file-code' : 'eye' }} {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Load into JSON Editor'|trans }}{% endif %}</button>
     {% endif %}
 
     {# LOAD IN SHEET EDITOR #}
     {% if ext in constant('Elabftw\\Elabftw\\Extensions::SPREADSHEET') %}
-      <button type='button' class='dropdown-item' data-action='xls-load-file' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-path='{{ upload.long_name|e('html_attr') }}' data-storage='{{ upload.storage }}'>
-        <i class='fas fa-fw fa-{{ mode == 'edit' ? 'pencil-alt' : 'eye' }} mr-1'></i>{{ 'Load into Spreadsheet Editor'|trans }}
-      </button>
+      <button type='button' title='{{ 'Load into Spreadsheet Editor'|trans }}' aria-label='{{ 'Load into Spreadsheet Editor'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='xls-load-file' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-path='{{ upload.long_name|e('html_attr') }}' data-storage='{{ upload.storage }}'><i class='fas fa-fw fa-{{ mode == 'edit' ? 'file-excel' : 'eye' }} {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Load into Spreadsheet Editor'|trans }}{% endif %}</button>
     {% endif %}
 
     {# Duplicate an upload #}
-    {% if not upload.immutable and not Entity.isReadOnly and App.Users.userData.uploads_layout != 0 %}
-      <button type='button' class='dropdown-item' data-action='duplicate-upload' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}'>
-        <i class='fas fa-fw fa-clone mr-1'></i>{{ 'Duplicate'|trans }}
-      </button>
+    {% if not upload.immutable and not Entity.isReadOnly %}
+      <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='duplicate-upload' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-clone {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Duplicate'|trans }}{% endif %}</button>
     {% endif %}
 
     {# Upload a new version: only in edit mode because currently it'll look into the editor to change the image, but it might be convenient to also have it in view mode #}
     {% if not upload.immutable %}
-      <button type='button' class='dropdown-item' data-action='replace-upload' data-uploadid='{{ upload.id }}'>
-        <i class='fas fa-fw fa-sync-alt mr-1'></i>{{ 'Upload a new version of this file'|trans }}
-      </button>
+      <button type='button' title='{{ 'Upload a new version of this file'|trans }}' aria-label='{{ 'Upload a new version of this file'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='replace-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-sync-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Upload a new version of this file'|trans }}{% endif %}</button>
     {% endif %}
-
   {% endif %}
 
   {# Show content of plain text #}
   {% if ext matches '/(txt|md|json)$/i' %}
-    <button type='button' class='dropdown-item' data-action='toggle-modal' data-target='plainTextModal' data-ext='{{ ext }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'>
-      <i class='fas fa-fw fa-eye mr-1'></i>{{ 'Show content of file'|trans }}
-    </button>
+    <button type='button' title='{{ 'Show content of file'|trans }}' aria-label='{{ 'Show content of file'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='toggle-modal' data-target='plainTextModal' data-ext='{{ ext }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-eye {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Show content of file'|trans }}{% endif %}</button>
   {% endif %}
 
   {# Load in NMRium #}
   {% if ext matches '/jdx$/i' %}
-    <button type='button' class='dropdown-item' data-uploadid='{{ upload.id }}' data-action='open-in-nmrium'>
-      <i class='fas fa-fw fa-square-poll-vertical mr-1'></i>{{ 'Open in NMRium'|trans }}
-    </button>
+    <button type='button' title='{{ 'Open in NMRium'|trans }}' aria-label='{{ 'Open in NMRium'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-uploadid='{{ upload.id }}' data-action='open-in-nmrium'><i class='fas fa-fw fa-square-poll-vertical {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Open in NMRium'|trans }}{% endif %}</button>
   {% endif %}
 
   {# More info #}
   {% if App.Users.userData.uploads_layout != 0 %}
-    <button type='button' class='dropdown-item' data-action='more-info-upload' data-uploadid='{{ upload.id }}'>
-      <i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}
-    </button>
+    <button type='button' title='{{ 'More information'|trans }}' aria-label='{{ 'More information'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'More information'|trans }}{% endif %}</button>
   {% endif %}
 
   {% if not upload.immutable and not Entity.isReadOnly %}
+    {% if not isGrid %}<div class='dropdown-divider'></div>{% endif %}
     {# ARCHIVE #}
-    <div class='dropdown-divider'></div>
-    <button type='button' class='dropdown-item hover-warning' data-action='archive-upload' data-uploadid='{{ upload.id }}'>
-      <i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Archive/Unarchive'|trans }}
-    </button>
+    <button type='button' title='{{ 'Archive/Unarchive'|trans }}' aria-label='{{ 'Archive/Unarchive'|trans }}' class='{{ isGrid ? 'btn btn-danger-ghost' : 'dropdown-item hover-warning' }}' data-action='archive-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-box-archive {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Archive/Unarchive'|trans }}{% endif %}</button>
     {# DESTROY #}
-    <button type='button' class='dropdown-item hover-danger' data-action='destroy-upload' data-uploadid='{{ upload.id }}'>
-      <i class='fas fa-fw fa-trash-alt mr-1'></i>{{ 'Delete'|trans }}
-    </button>
+    <button type='button' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}' class='{{ isGrid ? 'btn btn-danger' : 'dropdown-item hover-danger' }}' data-action='destroy-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-trash-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Delete'|trans }}{% endif %}</button>
   {% endif %}
+  {% if not isGrid %}
   </div>
 </div>
+{% endif %}

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -1,6 +1,6 @@
 {% import _self as ui %}
-{% macro action_btn(action, icon, uploadId, extra='') %}
-  <button type='button' class='btn btn-ghost {{ extra }}' data-action='{{ action }}' data-uploadid='{{ uploadId }}'>
+{% macro action_btn(action, icon, label, uploadId, extra='') %}
+  <button type='button' class='btn btn-ghost {{ extra }}' data-action='{{ action }}' data-uploadid='{{ uploadId }}' title='{{ label }}'>
     <i class='fas fa-fw fa-{{ icon }}'></i>
   </button>
 {% endmacro %}
@@ -14,10 +14,10 @@
 
 {# In grid mode, primary buttons are inline #}
 {% if isGrid %}
-  {{ ui.action_btn('rename-upload', 'pencil-alt', upload.id) }}
+  {{ ui.action_btn('rename-upload', 'pencil-alt', 'Edit filename'|trans, upload.id) }}
   {% if not upload.immutable and not Entity.isReadOnly %}
-    {{ ui.action_btn('archive-upload', 'box-archive', upload.id) }}
-    {{ ui.action_btn('destroy-upload', 'trash-alt', upload.id, 'btn-danger') }}
+    {{ ui.action_btn('archive-upload', 'box-archive', 'Archive/Unarchive'|trans, upload.id) }}
+    {{ ui.action_btn('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'btn-danger') }}
   {% endif %}
 {% endif %}
 

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -1,90 +1,93 @@
+{% import _self as ui %}
+{% macro action_btn(action, icon, uploadId, extra='') %}
+  <button type='button' class='btn btn-ghost {{ extra }}' data-action='{{ action }}' data-uploadid='{{ uploadId }}'>
+    <i class='fas fa-fw fa-{{ icon }}'></i>
+  </button>
+{% endmacro %}
+{% macro dropdown_item(action, icon, label, uploadId, extra='') %}
+  <button type='button' class='dropdown-item {{ extra }}' data-action='{{ action }}' data-uploadid='{{ uploadId }}'>
+    <i class='fas fa-fw fa-{{ icon }} mr-1'></i>{{ label }}
+  </button>
+{% endmacro %}
+
 {% set isGrid = layout is defined and layout == 'grid' %}
-{% if not isGrid %}
-<div class='dropdown'>
-  <button type='button' class='btn btn-transparent float-right' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}'>
+
+{# In grid mode, primary buttons are inline #}
+{% if isGrid %}
+  {{ ui.action_btn('rename-upload', 'pencil-alt', upload.id) }}
+  {% if not upload.immutable and not Entity.isReadOnly %}
+    {{ ui.action_btn('archive-upload', 'box-archive', upload.id) }}
+    {{ ui.action_btn('destroy-upload', 'trash-alt', upload.id, 'btn-danger') }}
+  {% endif %}
+{% endif %}
+
+{# Dropdown list is always present #}
+<div class='dropdown d-inline'>
+  <button type='button' class='btn btn-transparent {{ not isGrid ? 'float-right' }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}'>
     <i class='fas fa-ellipsis-v fa-fw'></i>
   </button>
   <div class='dropdown-menu dropdown-menu-right'>
-{% endif %}
+    {# table mode: primary actions are in dropdown too #}
+    {% if not isGrid %}
+      {{ ui.dropdown_item('rename-upload', 'pencil-alt', 'Edit filename'|trans, upload.id) }}
+      {% if not upload.immutable and not Entity.isReadOnly %}
+        {{ ui.dropdown_item('archive-upload', 'box-archive', 'Archive/Unarchive'|trans, upload.id) }}
+        {{ ui.dropdown_item('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'text-danger') }}
+      {% endif %}
 
-  {% if mode == 'edit' %}
-    {# INSERT IN TEXT in edit mode for images #}
-    {% if ext matches '/(jpg|jpeg|png|gif|svg|bmp)$/i' %}
-      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-image {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
+      <div class='dropdown-divider'></div>
+    {% endif %}
+    {% if mode == 'edit' %}
+      {% if not upload.immutable and not Entity.isReadOnly %}
+        <button type='button' class='dropdown-item' data-action='duplicate-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-clone mr-1'></i>{{ 'Duplicate'|trans }}</button>
+      {% endif %}
+
+      {% if not upload.immutable %}
+        <button type='button' class='dropdown-item' data-action='replace-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-sync-alt mr-1'></i>{{ 'Upload new version'|trans }}</button>
+      {% endif %}
+
+      {# INSERT IN TEXT in edit mode for images #}
+      {% set isImage = ext matches '/(jpg|jpeg|png|gif|svg|bmp)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isImage %}disabled{% endif %} data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-image mr-1'></i>{{ 'Insert image'|trans }}</button>
+
+      {# INSERT VIDEO #}
+      {% set isVideo = ext matches '/(mkv|mp4|ogv|webm)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isVideo %}disabled{% endif %} data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert video'|trans }}</button>
+
+      {# INSERT AUDIO #}
+      {% set isAudio = ext matches '/(aac|flac|mp3|ogg|opus|wav)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isAudio %}disabled{% endif %} data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert audio'|trans }}</button>
+
+      {# INSERT TEXT #}
+      {% set isTxt = ext matches '/txt$/i' %}
+      <button type='button' class='dropdown-item' {% if not isTxt %}disabled{% endif %} data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-file-import mr-1'></i>{{ 'Insert text'|trans }}</button>
+
+      <div class='dropdown-divider'></div>
+      {# Annotate image #}
+      {% set isAnnotImage = ext matches '/(jpg|jpeg|png|gif|bmp)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isAnnotImage %}disabled{% endif %} data-action='annotate-image' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-paint-brush mr-1'></i>{{ 'Annotate image'|trans }}</button>
+
+      {# JSON EDITOR #}
+      {% set isJson = ext matches '/(json)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isJson %}disabled{% endif %} data-action='json-load-file' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-file-code mr-1'></i>{{ 'JSON editor'|trans }}</button>
+
+      {# SHEET EDITOR #}
+      {% set isSheet = ext in constant('Elabftw\\Elabftw\\Extensions::SPREADSHEET') %}
+      <button type='button' class='dropdown-item' {% if not isSheet %}disabled{% endif %} data-action='xls-load-file' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-file-excel mr-1'></i>{{ 'Spreadsheet editor'|trans }}</button>
+
+      {# NMRium #}
+      {% set isJdx = ext matches '/jdx$/i' %}
+      <button type='button' class='dropdown-item' {% if not isJdx %}disabled{% endif %} data-action='open-in-nmrium' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-square-poll-vertical mr-1'></i>{{ 'Open in NMRium'|trans }}</button>
+
+    <div class='dropdown-divider'></div>
+    {% endif %}
+    {# Preview #}
+    {% set isPreview = ext matches '/(txt|md|json)$/i' %}
+    <button type='button' class='dropdown-item' {% if not isPreview %}disabled{% endif %} data-action='toggle-modal' data-target='plainTextModal' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-eye mr-1'></i>{{ 'Preview'|trans }}</button>
+
+    {% if App.Users.userData.uploads_layout != 0 %}
+      <button type='button' class='dropdown-item' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}</button>
     {% endif %}
 
-    {# INSERT IN TEXT in edit mode for videos #}
-    {% if ext matches '/(mkv|mp4|ogv|webm)$/i' %}
-      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-video {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# INSERT IN TEXT in edit mode for audio #}
-    {% if ext matches '/(aac|flac|mp3|ogg|opus|wav)$/i' %}
-      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-volume-low {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# INSERT IN TEXT in edit mode for plain text #}
-    {% if ext matches '/txt$/i' %}
-      <button type='button' title='{{ 'Insert in text at cursor position'|trans }}' aria-label='{{ 'Insert in text at cursor position'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-file-import {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Insert in text at cursor position'|trans }}{% endif %}</button>
-    {% endif %}
-  {% endif %}
-
-  {# Edit filename (available in view mode too) #}
-  {% if not upload.immutable and not Entity.isReadOnly and App.Users.userData.uploads_layout != 0 %}
-    <button type='button' title='{{ 'Edit filename'|trans }}' aria-label='{{ 'Edit filename'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='rename-upload' data-id='{{ upload.id }}'><i class='fas fa-fw fa-pencil-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Edit filename'|trans }}{% endif %}</button>
-  {% endif %}
-
-  {% if mode == 'edit' %}
-
-    {# Annotate image #}
-    {% if ext matches '/(jpg|jpeg|png|gif|bmp)$/i' %}
-      <button type='button' title='{{ 'Annotate this image'|trans }}' aria-label='{{ 'Annotate this image'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='annotate-image' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-paint-brush {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Annotate this image'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# LOAD IN JSON EDITOR #}
-    {% if ext matches '/(json)$/i' %}
-      <button type='button' title='{{ 'Load into JSON Editor'|trans }}' aria-label='{{ 'Load into JSON Editor'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-link='{{ upload.long_name|e('html_attr') }}' data-action='json-load-file'><i class='fas fa-fw fa-{{ mode == 'edit' ? 'file-code' : 'eye' }} {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Load into JSON Editor'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# LOAD IN SHEET EDITOR #}
-    {% if ext in constant('Elabftw\\Elabftw\\Extensions::SPREADSHEET') %}
-      <button type='button' title='{{ 'Load into Spreadsheet Editor'|trans }}' aria-label='{{ 'Load into Spreadsheet Editor'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='xls-load-file' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}' data-path='{{ upload.long_name|e('html_attr') }}' data-storage='{{ upload.storage }}'><i class='fas fa-fw fa-{{ mode == 'edit' ? 'file-excel' : 'eye' }} {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Load into Spreadsheet Editor'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# Duplicate an upload #}
-    {% if not upload.immutable and not Entity.isReadOnly %}
-      <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='duplicate-upload' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-clone {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Duplicate'|trans }}{% endif %}</button>
-    {% endif %}
-
-    {# Upload a new version: only in edit mode because currently it'll look into the editor to change the image, but it might be convenient to also have it in view mode #}
-    {% if not upload.immutable %}
-      <button type='button' title='{{ 'Upload a new version of this file'|trans }}' aria-label='{{ 'Upload a new version of this file'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='replace-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-sync-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Upload a new version of this file'|trans }}{% endif %}</button>
-    {% endif %}
-  {% endif %}
-
-  {# Show content of plain text #}
-  {% if ext matches '/(txt|md|json)$/i' %}
-    <button type='button' title='{{ 'Show content of file'|trans }}' aria-label='{{ 'Show content of file'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='toggle-modal' data-target='plainTextModal' data-ext='{{ ext }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-eye {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Show content of file'|trans }}{% endif %}</button>
-  {% endif %}
-
-  {# Load in NMRium #}
-  {% if ext matches '/jdx$/i' %}
-    <button type='button' title='{{ 'Open in NMRium'|trans }}' aria-label='{{ 'Open in NMRium'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-uploadid='{{ upload.id }}' data-action='open-in-nmrium'><i class='fas fa-fw fa-square-poll-vertical {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Open in NMRium'|trans }}{% endif %}</button>
-  {% endif %}
-
-  {# More info #}
-  {% if App.Users.userData.uploads_layout != 0 %}
-    <button type='button' title='{{ 'More information'|trans }}' aria-label='{{ 'More information'|trans }}' class='{{ isGrid ? 'btn btn-ghost' : 'dropdown-item' }}' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'More information'|trans }}{% endif %}</button>
-  {% endif %}
-
-  {% if not upload.immutable and not Entity.isReadOnly %}
-    {% if not isGrid %}<div class='dropdown-divider'></div>{% endif %}
-    {# ARCHIVE #}
-    <button type='button' title='{{ 'Archive/Unarchive'|trans }}' aria-label='{{ 'Archive/Unarchive'|trans }}' class='{{ isGrid ? 'btn btn-danger-ghost' : 'dropdown-item hover-warning' }}' data-action='archive-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-box-archive {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Archive/Unarchive'|trans }}{% endif %}</button>
-    {# DESTROY #}
-    <button type='button' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}' class='{{ isGrid ? 'btn btn-danger' : 'dropdown-item hover-danger' }}' data-action='destroy-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-trash-alt {{ isGrid ? '' : 'mr-1' }}'></i>{% if not isGrid %}{{ 'Delete'|trans }}{% endif %}</button>
-  {% endif %}
-  {% if not isGrid %}
   </div>
 </div>
-{% endif %}

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -23,7 +23,7 @@
 
 {# Dropdown list is always present #}
 <div class='dropdown d-inline'>
-  <button type='button' class='btn btn-transparent {{ not isGrid ? 'float-right' }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}'>
+  <button type='button' class='btn btn-ghost {{ not isGrid ? 'float-right' }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' title='{{ 'More options'|trans }}' aria-label='{{ 'More options'|trans }}'>
     <i class='fas fa-ellipsis-v fa-fw'></i>
   </button>
   <div class='dropdown-menu dropdown-menu-right'>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -101,10 +101,6 @@
                   </a>
                   {% if not upload.immutable %}
                     {% if mode == 'edit' %}
-                      {# EDIT FILENAME #}
-                      <button type='button' title='{{ 'Edit filename'|trans }}' aria-label='{{ 'Edit filename'|trans }}' class='btn btn-ghost' data-action='rename-upload' data-id='{{ upload.id }}'>
-                        <i class='fas fa-fw fa-pencil-alt'></i>
-                      </button>
                       {# UPLOAD NEW VERSION #}
                       {% include('upload-dropdown-menu.html') with {layout: 'grid'} %}
                       {# UPLOAD NEW VERSION OF A FILE #}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -69,6 +69,7 @@
           </thead>
           <tbody id='uploadsTable'>
             {% for upload in Entity.entityData.uploads %}
+              {% set ext = upload.real_name|getExt %}
               <tr class='countable' id='uploadDiv_{{ upload.id }}'>
                 <td>
                   {# keep btn-ghost border-0 here because in table with zebra #}
@@ -95,7 +96,7 @@
                   {% if loop.first %}
                     <div id='last-uploaded-link' data-url='app/download.php?f={{ upload.long_name|e('url') }}' hidden></div>
                   {% endif %}
-                  <a target='_blank' href='app/download.php?f={{ upload.long_name|e('url') }}&amp;name={{ upload.real_name|e('url') }}&amp;storage={{ upload.storage }}' rel='noopener' title='{{ 'Download'|trans }}' aria-label='{{ 'Download'|trans }}' class='btn btn-ghost mr-1'>
+                  <a target='_blank' href='app/download.php?f={{ upload.long_name|e('url') }}&amp;name={{ upload.real_name|e('url') }}&amp;storage={{ upload.storage }}' rel='noopener' title='{{ 'Download'|trans }}' aria-label='{{ 'Download'|trans }}' class='btn btn-ghost'>
                     <i class='fas fa-download fa-fw'></i>
                   </a>
                   {% if not upload.immutable %}
@@ -105,24 +106,9 @@
                         <i class='fas fa-fw fa-pencil-alt'></i>
                       </button>
                       {# UPLOAD NEW VERSION #}
-                      <button type='button' title='{{ 'Upload a new version of this file'|trans }}' aria-label='{{ 'Upload a new version of this file'|trans }}' class='btn btn-ghost' data-action='replace-upload' data-uploadid='{{ upload.id }}'>
-                        <i class='fas fa-fw fa-sync-alt'></i>
-                      </button>
+                      {% include('upload-dropdown-menu.html') with {layout: 'grid'} %}
+                      {# UPLOAD NEW VERSION OF A FILE #}
                       {% include('upload-replace-form.html') %}
-                    {% endif %}
-                    {% if not Entity.isReadOnly %}
-                      {# DUPLICATE #}
-                      <button type='button' title='{{ 'Duplicate'|trans }}' aria-label='{{ 'Duplicate'|trans }}' class='btn p-1 mr-1' data-action='duplicate-upload' data-uploadid='{{ upload.id }}' data-name='{{ upload.real_name|e('html_attr') }}'>
-                        <i class='fas fa-clone'></i>
-                      </button>
-                      {# ARCHIVE #}
-                      <button type='button' title='{{ 'Archive/Unarchive'|trans }}' aria-label='{{ 'Archive/Unarchive'|trans }}' class='btn btn-danger-ghost' data-action='archive-upload' data-uploadid='{{ upload.id }}'>
-                        <i class='fas fa-box-archive'></i>
-                      </button>
-                      {# DESTROY #}
-                      <button type='button' title='{{ 'Delete'|trans }}' aria-label='{{ 'Delete'|trans }}' class='btn btn-danger' data-action='destroy-upload' data-uploadid='{{ upload.id }}'>
-                        <i class='fas fa-trash-alt'></i>
-                      </button>
                     {% endif %}
                   {% endif %}
                 </td>
@@ -141,7 +127,7 @@
             <div id='last-uploaded-link' data-url='app/download.php?f={{ upload.long_name }}' hidden></div>
           {% endif %}
           <div class='thumbnail box {{ upload.state == enum('Elabftw\\Enums\\State').Archived.value ? 'bg-light' }}' data-type='{{ Entity.entityType.value }}' data-id='{{ Entity.id }}' style='overflow: visible'>
-            {% include('upload-dropdown-menu.html') %}
+            {% include('upload-dropdown-menu.html') with {layout: 'dropdown'} %}
             {% if upload.state == enum('Elabftw\\Enums\\State').Archived.value %}
             <p class='mb-0'><i class='fas fa-fw fa-box-archive mr-1'></i>{{ 'Archived'|trans }}</p>
             {% endif %}

--- a/src/ts/uploads.ts
+++ b/src/ts/uploads.ts
@@ -71,9 +71,9 @@ async function blob2table(blob: Blob, container: HTMLDivElement, sheetName: stri
 on('rename-upload', (el: HTMLElement) => {
   // find the corresponding filename element
   // we replace the parent span to also remove the link for download
-  const filenameLink = document.getElementById('upload-filename_' + el.dataset.id);
+  const filenameLink = document.getElementById('upload-filename_' + el.dataset.uploadid);
   const filenameInput = document.createElement('input');
-  filenameInput.dataset.id = el.dataset.id;
+  filenameInput.dataset.id = el.dataset.uploadid;
   filenameInput.classList.add('form-control');
   filenameInput.value = filenameLink.textContent;
   const parentSpan = filenameLink.parentElement;


### PR DESCRIPTION
fix #6773

Refactors the upload action menu to support both table (dropdown) and grid (inline button) layouts using a single reusable template.

Introduces a layout-aware rendering mode:
- `dropdown` layout preserves the classic ellipsis menu
- `grid` layout renders ghost/danger buttons inline

This way, we don't duplicate everything and have an evolving uploads actions menu.

Changes include:
- Consolidated actions into upload-dropdown-menu.html
- Added conditional wrapper and styling based on layout
- Improved accessibility with explicit title and aria-label attributes
- Simplified uploads.html by removing duplicated action buttons
- Minor spacing and class cleanup

This reduces template duplication, improves maintainability, and keeps action behavior consistent across layouts.
<img width="1484" height="472" alt="Capture d’écran du 2026-05-05 15-55-08" src="https://github.com/user-attachments/assets/9ecffa46-f1f3-4b8c-a9af-4a381d8db887" />
<img width="1484" height="472" alt="Capture d’écran du 2026-05-05 15-54-58" src="https://github.com/user-attachments/assets/e6646b6a-39e4-49fa-8029-7d2b0adcbb12" />
<img width="1555" height="686" alt="Capture d’écran du 2026-05-05 15-54-44" src="https://github.com/user-attachments/assets/01d0bb9f-da1d-424a-819c-c9e0aa2e7357" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Primary upload actions now render inline in grid layout and inside a consistent dropdown in list/layout modes.

* **Style**
  * Consolidated dropdown/item styling and refined table/download control spacing; updated labels/icons for insert and editor actions.

* **Bug Fix**
  * Rename flow corrected so renamed files update reliably in the UI.

* **Behavior**
  * In edit mode, a broader set of insert/preview actions is always shown with enablement based on file type; “Preview” relabeled and present consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->