### PR TITLE
Feature/enforce mfa for local users only

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,7 @@ A reverse proxy in front of an eLabFTW container can allow you to enable additio
 
 ### Enable 2FA
 
-You can enforce multi factor authentication (with TOTP mechanism) for Sysadmins, Admins or all users. It is also important to educate users on the importance of password managers and the use of unique and long passwords.
+You can enforce multi factor authentication (with TOTP mechanism) for Sysadmins, Admins, local users only or all users. It is also important to educate users on the importance of password managers and the use of unique and long passwords.
 
 ### Using single sign-on? Turn off local user (password) registration and login
 

--- a/src/Auth/MfaGate.php
+++ b/src/Auth/MfaGate.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Auth;
 
 use Elabftw\Enums\EnforceMfa;
+use Elabftw\Enums\AuthType;
 use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 
@@ -36,6 +37,7 @@ final class MfaGate
             EnforceMfa::Everyone => true,
             EnforceMfa::SysAdmins => $loggingInUser->userData['is_sysadmin'] === 1,
             EnforceMfa::Admins => $loggingInUser->isAdminSomewhere(),
+            EnforceMfa::LocalUsers => ($loggingInUser->userData['auth_service'] ?? 0) === AuthType::Local->asService(),
             EnforceMfa::Disabled => false,
         };
     }

--- a/src/Enums/EnforceMfa.php
+++ b/src/Enums/EnforceMfa.php
@@ -24,6 +24,7 @@ enum EnforceMfa: int
     case SysAdmins = 1;
     case Admins = 2;
     case Everyone = 3;
+    case LocalUsers = 4;
 
     public static function toHuman(self $case): string
     {
@@ -32,6 +33,7 @@ enum EnforceMfa: int
             EnforceMfa::SysAdmins => _('Sysadmins'),
             EnforceMfa::Admins => _('Admins'),
             EnforceMfa::Everyone => _('Everyone'),
+            EnforceMfa::LocalUsers => _('Local users'),
         };
     }
 

--- a/src/langs/fr_FR/LC_MESSAGES/messages.po
+++ b/src/langs/fr_FR/LC_MESSAGES/messages.po
@@ -741,6 +741,10 @@ msgstr "Administrateurs"
 msgid "Everyone"
 msgstr "Tout le monde"
 
+#: src/Enums/EnforceMfa.php:36
+msgid "Local users"
+msgstr "Comptes locaux"
+
 #: src/Enums/Messages.php:39
 msgid ""
 "An internal error occurred. This should never happen! Please contact support "


### PR DESCRIPTION

### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation).
---

### Pull Request Description

Related issue(s): #6090 

This feature allows to enforce MFA only for local users (then not enforcing MFA for account type like SAML).
It is an alternative to the option of enforcing MFA for all users.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enforcing multi-factor authentication exclusively for local user accounts, alongside existing options for sysadmins, admins, or all users.

* **Documentation**
  * Updated security guidance to include the new local users-only 2FA enforcement option.

* **Internationalization**
  * Added French localization for the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->