### PR TITLE
fix: don't send onboarding email when user is already in team

### DIFF
--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -52,14 +52,19 @@ final class Users2Teams
         $req->bindValue(':userid', $userid, PDO::PARAM_INT);
         $req->bindValue(':team', $teamid, PDO::PARAM_INT);
         $req->bindValue(':is_admin', $isAdmin->value, PDO::PARAM_INT);
-        $res = $this->Db->execute($req);
+        $this->Db->execute($req);
+        // INSERT IGNORE silently skips duplicate rows; rowCount() = 0 means the user was already in the team
+        $wasInserted = $req->rowCount() > 0;
 
-        AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->userid ?? 0, $userid));
-        if ($isValidated) {
-            new Teams($this->requester, $teamid)->sendOnboardingEmailToUser($userid, $isAdmin);
+        // only audit and notify when an actual new assignment was created
+        if ($wasInserted) {
+            AuditLogs::create(new TeamAddition($teamid, $isAdmin->value, $this->requester->userid ?? 0, $userid));
+            if ($isValidated) {
+                new Teams($this->requester, $teamid)->sendOnboardingEmailToUser($userid, $isAdmin);
+            }
         }
 
-        return $res;
+        return $wasInserted;
     }
 
     public function patchUser2Team(array $params, int $targetUserid): int

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -84,6 +84,23 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
         $Users2Teams->patchUser2Team($params, 2);
     }
 
+    public function testCreateIdempotent(): void
+    {
+        // create a fresh user in team 2
+        $newUserId = (new Users(1, 1))->postAction(Action::Create, array(
+            'team' => 2,
+            'firstname' => 'idempotent',
+            'lastname' => 'test',
+            'email' => 'idempotent@test-create.com',
+        ));
+        // first call inserts a new row → must return true
+        $this->assertTrue($this->Users2Teams->create($newUserId, 1));
+        // second call hits INSERT IGNORE and skips → must return false
+        $this->assertFalse($this->Users2Teams->create($newUserId, 1));
+        // clean up
+        (new Users($newUserId, 1))->destroy();
+    }
+
     public function testWasAdminAlready(): void
     {
         // create new user


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation).
---

### Pull Request Description

We (ULB Münster) are assigning users to teams via API and when a User is patched and the team has onboarding mails enabled, the user gets an onboarding mail even if they have already been assigned to the team. We identified https://github.com/elabftw/elabftw/blob/90e0b30622a1ac48051ce5a4fd9d1d293b4f2124/src/Models/Users2Teams.php#L47-L63 `INSERT IGNORE` returns `false` if the user is already part of the team but `$res` is not considered and the mail is being sent either way.

The proposed fix:

`Users2Teams::create()` uses `INSERT IGNORE`, but `Db::execute()` always returns `true` — it throws on failure rather than returning `false`. This fix uses `rowCount() > 0` to reliably detect whether a new row was actually inserted, and gate both the audit log and the onboarding email on that result.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate onboarding email notifications and audit log entries when assigning users to teams.

* **Behavior Change**
  * The assignment creation now reliably indicates whether a new team assignment was actually created (true) or was a duplicate (false).

* **Tests**
  * Added a unit test to verify idempotent team assignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->