### PR TITLE
feat: elabimg: csp: add custom connect-src

### DIFF
--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -300,7 +300,7 @@ services:
         # add the possibility to connect to other systems from the frontend
         # default value: unset (empty)
         # example value: https://example.com https://example.org
-        # CUSTOM_CONNECT_SRC=
+        #- CUSTOM_CONNECT_SRC=
 
         ###########
         # PLUGINS #

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -298,7 +298,7 @@ services:
         #- MAINTENANCE_MODE=false
 
         # add the possibility to connect to other systems from the frontend
-        # default value: none
+        # default value: unset (empty)
         # example value: https://example.com https://example.org
         # CUSTOM_CONNECT_SRC=
 

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -297,6 +297,11 @@ services:
         # default value: false
         #- MAINTENANCE_MODE=false
 
+        # add the possibility to connect to other systems from the frontend
+        # default value: none
+        # example value: https://example.com https://example.org
+        # CUSTOM_CONNECT_SRC=
+
         ###########
         # PLUGINS #
         ###########

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -12,6 +12,7 @@
 # get env values
 # and unset the sensitive ones so they cannot be accessed by a rogue process
 getEnv() {
+    custom_connect_src=${CUSTOM_CONNECT_SRC:-}
     db_host=${DB_HOST:-localhost}
     db_port=${DB_PORT:-3306}
     db_name=${DB_NAME:-elabftw}
@@ -226,6 +227,8 @@ nginxConf() {
     fi
     # set unsafe-eval in CSP
     sed -i -e "s/%UNSAFE-EVAL4DEV%/${unsafe_eval}/" /etc/nginx/common.conf
+    # set custom connect-src in CSP (use # as sed separator because urls will contain /)
+    sed -i -e "s#%CUSTOM_CONNECT_SRC%#${custom_connect_src}#" /etc/nginx/common.conf
     # put a random short string as the server header to prevent fingerprinting
     server_header=$(openssl rand -hex 2 | cut -c1-3)
     sed -i -e "s/%SERVER_HEADER%/${server_header}/" /etc/nginx/common.conf

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -227,8 +227,7 @@ nginxConf() {
     fi
     # set unsafe-eval in CSP
     sed -i -e "s/%UNSAFE-EVAL4DEV%/${unsafe_eval}/" /etc/nginx/common.conf
-    # set custom connect-src in CSP (use # as sed separator because urls will contain /)
-    sed -i -e "s#%CUSTOM_CONNECT_SRC%#${custom_connect_src}#" /etc/nginx/common.conf
+    sed -i -e "s/%CUSTOM_CONNECT_SRC%/$(escape_sed_repl "${custom_connect_src}")/" /etc/nginx/common.conf
     # put a random short string as the server header to prevent fingerprinting
     server_header=$(openssl rand -hex 2 | cut -c1-3)
     sed -i -e "s/%SERVER_HEADER%/${server_header}/" /etc/nginx/common.conf

--- a/containers/elabimg/nginx/common.conf
+++ b/containers/elabimg/nginx/common.conf
@@ -172,7 +172,7 @@ more_set_headers "Strict-Transport-Security: max-age=63072000";
 more_set_headers "X-XSS-Protection: 0";
 more_set_headers "X-Content-Type-Options: nosniff";
 # Note: do NOT add form-action 'self' here as it blocks SAML under Chrome based browsers, see elabftw/elabftw#5903
-more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' %UNSAFE-EVAL4DEV%; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
+more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' %UNSAFE-EVAL4DEV%; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov %CUSTOM_CONNECT_SRC%; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
 more_set_headers "Referrer-Policy: no-referrer";
 # Experimental header: https://caniuse.com/?search=permission-policy
 more_set_headers "Permissions-Policy: autoplay=(), camera=(self), encrypted-media=(), fullscreen=(self), geolocation=(), microphone=(self), midi=(), payment=(), xr-spatial-tracking=()";


### PR DESCRIPTION
allow users to deploy with a richer CSP connect-src policy through env config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for specifying custom allowed connection sources via an environment variable, enabling administrators to extend which external endpoints the application may connect to without code changes.
  * The site’s Content-Security-Policy now incorporates these custom sources into its connect-src directive, permitting additional external endpoints when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->