### PR TITLE
docs: replace 'docker-compose' with 'docker compose' in READMEs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
   - type: textarea
     id: configuration
     attributes:
-      label: What is your docker-compose configuration?
+      label: What is your docker compose configuration?
       description: |
         Generate a password-less configuration with `grep -vE "^[[:blank:]]*#|^[[:blank:]]*$" /etc/elabftw.yml | grep -vE "PASSWORD|SECRET_KEY"`
       render: yaml

--- a/containers/elabimg/README.md
+++ b/containers/elabimg/README.md
@@ -34,7 +34,7 @@ For dev, add `--build-arg BUILD_ALL=0` to skip the installation of dependencies 
 
 ## Usage
 
-An example configuration file for docker-compose can be fetched like this:
+An example configuration file for docker compose can be fetched like this:
 
 ~~~bash
 curl -so docker-compose.yml "https://get.elabftw.net/?config"

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -1,5 +1,5 @@
 # docker-elabftw configuration file
-# use : "docker-compose up -d" to start containers
+# use : "docker compose up -d" to start containers
 # this config file contains all the possible configuration options, shown with default values
 # https://hub.docker.com/r/elabftw/elabimg/
 # https://www.elabftw.net
@@ -38,7 +38,7 @@ services:
 
     # limit number of processes
     # this option is commented out because it is not in v3 of compose files, only v2
-    # even though it works as expected in a v3 file with recent docker-compose
+    # even though it works as expected in a v3 file with recent docker compose
     #pids_limit: 42
 
     # add a security flag to prevent a process gaining new privileges


### PR DESCRIPTION
completes https://github.com/elabftw/elabctl/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Compose terminology in documentation and configuration examples.

* **Chores**
  * Standardized UI labels and comments to use "docker compose" naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->