### PR TITLE
Feat: add more detailed inventory search view

### DIFF
--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -18,44 +18,10 @@ use Override;
 
 use function array_merge;
 use function _;
+use function array_values;
 
 final class InventoryController extends AbstractHtmlController
 {
-    #[Override]
-    protected function getTemplate(): string
-    {
-        return 'inventory.html';
-    }
-
-    #[Override]
-    protected function getPageTitle(): string
-    {
-        return _('Inventory');
-    }
-
-    #[Override]
-    protected function getData(): array
-    {
-        $StorageUnits = new StorageUnits($this->app->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1');
-        $containersArr = array();
-        // only make a query if we do a search
-        // set the 'limit' parameter for both readAll and readAllFromStorage. see #6116
-        $this->app->Request->query->set('limit', 9999);
-        if ($this->app->Request->query->has('q')) {
-            $containersArr = $StorageUnits->readAll($StorageUnits->getQueryParams($this->app->Request->query));
-        }
-        if ($this->app->Request->query->has('storage_unit')) {
-            $containersArr = $StorageUnits->readAllFromStorage($this->app->Request->query->getInt('storage_unit'));
-        }
-        return array_merge(
-            parent::getData(),
-            array(
-                'containersArr' => self::aggregateContainers($containersArr),
-                'storageUnitsArr' => $StorageUnits->readAllRecursive(),
-            ),
-        );
-    }
-
     /**
      * Collapse the raw SQL output into one row per (page, entity, storage).
      *
@@ -90,5 +56,40 @@ final class InventoryController extends AbstractHtmlController
             }
         }
         return array_values($grouped);
+    }
+
+    #[Override]
+    protected function getTemplate(): string
+    {
+        return 'inventory.html';
+    }
+
+    #[Override]
+    protected function getPageTitle(): string
+    {
+        return _('Inventory');
+    }
+
+    #[Override]
+    protected function getData(): array
+    {
+        $StorageUnits = new StorageUnits($this->app->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1');
+        $containersArr = array();
+        // only make a query if we do a search
+        // set the 'limit' parameter for both readAll and readAllFromStorage. see #6116
+        $this->app->Request->query->set('limit', 9999);
+        if ($this->app->Request->query->has('q')) {
+            $containersArr = $StorageUnits->readAll($StorageUnits->getQueryParams($this->app->Request->query));
+        }
+        if ($this->app->Request->query->has('storage_unit')) {
+            $containersArr = $StorageUnits->readAllFromStorage($this->app->Request->query->getInt('storage_unit'));
+        }
+        return array_merge(
+            parent::getData(),
+            array(
+                'containersArr' => self::aggregateContainers($containersArr),
+                'storageUnitsArr' => $StorageUnits->readAllRecursive(),
+            ),
+        );
     }
 }

--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -50,9 +50,45 @@ final class InventoryController extends AbstractHtmlController
         return array_merge(
             parent::getData(),
             array(
-                'containersArr' => $containersArr,
+                'containersArr' => self::aggregateContainers($containersArr),
                 'storageUnitsArr' => $StorageUnits->readAllRecursive(),
             ),
         );
+    }
+
+    /**
+     * Collapse the raw SQL output into one row per (page, entity, storage).
+     *
+     * The recursive query in StorageUnits joins compounds, so a container with N compounds
+     * appears as N rows. We first dedupe by container id, then group those containers by
+     * (page, entity, storage) and aggregate: container_count, and qty_total when all
+     * containers in the group share a unit (qty_mixed_units otherwise).
+     */
+    public static function aggregateContainers(array $rows): array
+    {
+        $byContainer = array();
+        foreach ($rows as $row) {
+            $byContainer[$row['page'] . ':' . $row['container2item_id']] ??= $row;
+        }
+
+        $grouped = array();
+        foreach ($byContainer as $row) {
+            $key = $row['page'] . ':' . $row['entity_id'] . ':' . $row['storage_id'];
+            if (!isset($grouped[$key])) {
+                $row['container_count'] = 1;
+                $row['qty_total'] = $row['qty_stored'];
+                $row['qty_mixed_units'] = false;
+                $grouped[$key] = $row;
+                continue;
+            }
+            $grouped[$key]['container_count']++;
+            if (!$grouped[$key]['qty_mixed_units'] && $grouped[$key]['qty_unit'] === $row['qty_unit']) {
+                $grouped[$key]['qty_total'] = (float) $grouped[$key]['qty_total'] + (float) $row['qty_stored'];
+            } else {
+                $grouped[$key]['qty_mixed_units'] = true;
+                $grouped[$key]['qty_total'] = null;
+            }
+        }
+        return array_values($grouped);
     }
 }

--- a/src/templates/inventory.html
+++ b/src/templates/inventory.html
@@ -26,12 +26,19 @@
     {% endif %}
 
     <ul class='list-group mt-2'>
-    {# If an entity has multiple compounds, it will appear several times in the sql output, and this is fine because we actually would like to have a row for each compound in each container, even if it's a mix #}
-    {# so here we filter on the view by showing only a single Resource/Experiment #}
-    {% set uniqueById = containersArr|reduce((acc, r) => acc|merge((acc[(r.page ~ ':' ~ r.entity_id ~ ':' ~ r.storage_id)] is defined) ? {} : {(r.page ~ ':' ~ r.entity_id ~ ':' ~ r.storage_id): r}), {}) %}
-    {% for container in uniqueById %}
+    {# Rows are aggregated server-side to one entry per (resource, location); see InventoryController::aggregateContainers #}
+    {% for container in containersArr %}
       <li class='list-group-item'>
-        {% if container.entity_custom_id %}<span class='mr-1'>{{ container.entity_custom_id }}</span>{% endif %}<a href='{{ container.page }}.php?mode=view&id={{ container.entity_id }}'>{{ container.entity_title }}</a> {{ container.qty_stored }} {{ container.qty_unit }} in {{ container.full_path }}
+        {% if container.entity_custom_id %}<span class='mr-1'>{{ container.entity_custom_id }}</span>{% endif %}<a href='{{ container.page }}.php?mode=view&id={{ container.entity_id }}'>{{ container.entity_title }}</a>
+        {% if container.container_count > 1 %}
+          {% if container.qty_mixed_units %}
+            {{ '%d containers (mixed units) in %s'|trans|format(container.container_count, container.full_path) }}
+          {% else %}
+            {{ '%s %s total across %d containers in %s'|trans|format(container.qty_total, container.qty_unit, container.container_count, container.full_path) }}
+          {% endif %}
+        {% else %}
+          {{ container.qty_stored }} {{ container.qty_unit }} in {{ container.full_path }}
+        {% endif %}
       </li>
     {% endfor %}
     </ul>

--- a/tests/unit/controllers/InventoryControllerTest.php
+++ b/tests/unit/controllers/InventoryControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Jonathan Griffiths
+ * @copyright 2026 Jonathan Griffiths
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Controllers;
+
+class InventoryControllerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAggregateSingleContainerPassesThrough(): void
+    {
+        $rows = array($this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'));
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(1, $out);
+        $this->assertSame(1, $out[0]['container_count']);
+        $this->assertSame('10', $out[0]['qty_total']);
+        $this->assertFalse($out[0]['qty_mixed_units']);
+    }
+
+    public function testAggregateDedupesMultiCompoundRows(): void
+    {
+        // Same container2item_id appearing twice (one row per compound from the SQL UNION join)
+        $rows = array(
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+        );
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(1, $out);
+        $this->assertSame(1, $out[0]['container_count']);
+        $this->assertSame('10', $out[0]['qty_total']);
+    }
+
+    public function testAggregateSumsMatchingUnits(): void
+    {
+        $rows = array(
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+            $this->row(page: 'database', container2item_id: 2, entity_id: 10, storage_id: 100, qty_stored: '5', qty_unit: 'mL'),
+            $this->row(page: 'database', container2item_id: 3, entity_id: 10, storage_id: 100, qty_stored: '2.5', qty_unit: 'mL'),
+        );
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(1, $out);
+        $this->assertSame(3, $out[0]['container_count']);
+        $this->assertSame(17.5, $out[0]['qty_total']);
+        $this->assertSame('mL', $out[0]['qty_unit']);
+        $this->assertFalse($out[0]['qty_mixed_units']);
+    }
+
+    public function testAggregateMixedUnitsSetsFlagAndNullsTotal(): void
+    {
+        $rows = array(
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+            $this->row(page: 'database', container2item_id: 2, entity_id: 10, storage_id: 100, qty_stored: '5', qty_unit: 'g'),
+        );
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(1, $out);
+        $this->assertSame(2, $out[0]['container_count']);
+        $this->assertNull($out[0]['qty_total']);
+        $this->assertTrue($out[0]['qty_mixed_units']);
+    }
+
+    public function testAggregateSeparatesItemsAndExperimentsWithSamePk(): void
+    {
+        // container2item_id=1 from items and from experiments are different containers — page disambiguates
+        $rows = array(
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+            $this->row(page: 'experiments', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '5', qty_unit: 'mL'),
+        );
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(2, $out);
+        foreach ($out as $r) {
+            $this->assertSame(1, $r['container_count']);
+        }
+    }
+
+    public function testAggregateProducesOneRowPerEntityStorageGroup(): void
+    {
+        $rows = array(
+            // Entity 10 in storage 100: 2 containers
+            $this->row(page: 'database', container2item_id: 1, entity_id: 10, storage_id: 100, qty_stored: '10', qty_unit: 'mL'),
+            $this->row(page: 'database', container2item_id: 2, entity_id: 10, storage_id: 100, qty_stored: '5', qty_unit: 'mL'),
+            // Entity 10 in storage 101: 1 container (different location)
+            $this->row(page: 'database', container2item_id: 3, entity_id: 10, storage_id: 101, qty_stored: '20', qty_unit: 'mL'),
+            // Entity 11 in storage 100: 1 container (different entity)
+            $this->row(page: 'database', container2item_id: 4, entity_id: 11, storage_id: 100, qty_stored: '1', qty_unit: 'g'),
+        );
+
+        $out = InventoryController::aggregateContainers($rows);
+
+        $this->assertCount(3, $out);
+        $byKey = array();
+        foreach ($out as $r) {
+            $byKey[$r['entity_id'] . ':' . $r['storage_id']] = $r;
+        }
+        $this->assertSame(2, $byKey['10:100']['container_count']);
+        $this->assertSame(15.0, $byKey['10:100']['qty_total']);
+        $this->assertSame(1, $byKey['10:101']['container_count']);
+        $this->assertSame(1, $byKey['11:100']['container_count']);
+    }
+
+    public function testAggregateEmptyInput(): void
+    {
+        $this->assertSame(array(), InventoryController::aggregateContainers(array()));
+    }
+
+    /**
+     * Build a minimal row matching the shape returned by StorageUnits::getRecursiveSql().
+     * Only the fields aggregateContainers reads are populated; the rest is empty so
+     * the test breaks loudly if the helper starts depending on additional columns.
+     */
+    private function row(
+        string $page,
+        int $container2item_id,
+        int $entity_id,
+        int $storage_id,
+        string $qty_stored,
+        string $qty_unit,
+    ): array {
+        return array(
+            'page' => $page,
+            'container2item_id' => $container2item_id,
+            'entity_id' => $entity_id,
+            'entity_title' => 'whatever',
+            'storage_id' => $storage_id,
+            'full_path' => 'Lab > Box',
+            'qty_stored' => $qty_stored,
+            'qty_unit' => $qty_unit,
+        );
+    }
+}


### PR DESCRIPTION
# PR — Feature: aggregate inventory search results by resource and location

> **Base branch**: `master`

---

### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [x] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation) — UI-only display change to an existing page; no API or schema change.

---

### Pull Request Description

**What issue does this PR address?**

The inventory search page silently hid containers. The Twig template was deduping rows on `(page, entity_id, storage_id)`, so two distinct containers of the same resource in the same storage unit (e.g. two 10 mL aliquots in Box 7) collapsed into one row showing one container's qty as if it were the location total — no count, no aggregate, no hint that other containers existed. This was deliberate behaviour as indicated from a comment in the code.

**How did you approach the solution?**

- *Backend* (`src/Controllers/InventoryController.php`): new `aggregateContainers()` helper. Step 1 dedupes raw SQL rows by `(page, container2item_id)` to collapse multi-compound duplicates the query intentionally produces. Step 2 groups deduped containers by `(page, entity_id, storage_id)` and emits `container_count`, `qty_total` (sum when units match), and `qty_mixed_units` (set when units differ; nulls `qty_total`). Applied to both call sites (`?q=` and `?storage_unit=`).
- *Frontend* (`src/templates/inventory.html`): dropped the `reduce()`. Single-container rows render as before; multi-container groups render either `qty_total qty_unit total across N containers in <path>` or `N containers (mixed units) in <path>`.

Aggregation lives in the controller (view-shaping concern) so the CSV export and other model callers keep raw rows. The helper is `public static` so the unit test can call it directly; class is `final` and method is stateless.

**Out of scope**

- Per-container drill-down from the search results.
- Exact-precision summing — `qty_total` uses `float` (PDO returns DECIMAL as strings).
- Unit normalisation — "mL" vs "ml" are treated as different units.
- CSV export still emits one row per `(container × compound)`.
- Cypress E2E coverage of the rendered page (unit-tested only via `tests/unit/controllers/InventoryControllerTest.php`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inventory display now aggregates and deduplicates containers, showing accurate container counts per resource/location, computing quantity totals when units match and marking mixed-unit cases when they don't; template rendering updated to show multiple containers without filtering duplicates.

* **Tests**
  * Added unit tests covering aggregation, deduplication, mixed units, grouping behavior, and empty input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->