### PR TITLE
feat: tinymce: add php language to codeblock options

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -71,8 +71,10 @@ module.exports = (env) => {
         'prismjs/components/prism-latex.js',
         'prismjs/components/prism-lua.js',
         'prismjs/components/prism-makefile.js',
+        'prismjs/components/prism-markup-templating.js', // necessary for php
         'prismjs/components/prism-matlab.js',
         'prismjs/components/prism-perl.js',
+        'prismjs/components/prism-php.js',
         'prismjs/components/prism-python.js',
         'prismjs/components/prism-r.js',
         'prismjs/components/prism-ruby.js',

--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -229,6 +229,7 @@ final class Filter
             'language-makefile',
             'language-matlab',
             'language-perl',
+            'language-php',
             'language-python',
             'language-r',
             'language-ruby',

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -282,6 +282,7 @@ export function getTinymceBaseConfig(page: string): object {
       {text: 'Makefile', value: 'makefile'},
       {text: 'Matlab', value: 'matlab'},
       {text: 'Perl', value: 'perl'},
+      {text: 'PHP', value: 'php'},
       {text: 'Python', value: 'python'},
       {text: 'R', value: 'r'},
       {text: 'Ruby', value: 'ruby'},


### PR DESCRIPTION
Like, this app is coded in PHP!

![come on](https://ftp.ntu.edu.tw/php/images/ele-running.gif)

<img width="1275" height="616" alt="image" src="https://github.com/user-attachments/assets/20e713c5-1ed0-4c84-8ecc-5cff91fcc659" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved code sample syntax highlighting with enhanced support for additional programming languages, including PHP and other commonly used languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6821)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->