### PR TITLE
ux: improve error message when no IdP are configured

### DIFF
--- a/src/Elabftw/IdpsHelper.php
+++ b/src/Elabftw/IdpsHelper.php
@@ -15,6 +15,7 @@ namespace Elabftw\Elabftw;
 use Elabftw\Enums\CertPurpose;
 use Elabftw\Enums\SamlBinding;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Models\Config;
 use Elabftw\Models\Idps;
 
@@ -39,6 +40,10 @@ final class IdpsHelper
     {
         $idpId = $this->Idps->getEnabled($id);
 
+        // no active IdP
+        if ($idpId === 0) {
+            throw new ResourceNotFoundException();
+        }
         return $this->getSettingsByIdp($idpId);
     }
 

--- a/src/Elabftw/IdpsHelper.php
+++ b/src/Elabftw/IdpsHelper.php
@@ -16,8 +16,8 @@ use Elabftw\Enums\CertPurpose;
 use Elabftw\Enums\SamlBinding;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
+use Elabftw\Interfaces\IdpsInterface;
 use Elabftw\Models\Config;
-use Elabftw\Models\Idps;
 
 use function rtrim;
 
@@ -26,7 +26,7 @@ use function rtrim;
  */
 final class IdpsHelper
 {
-    public function __construct(public Config $Config, private Idps $Idps) {}
+    public function __construct(public Config $Config, private IdpsInterface $Idps) {}
 
     /**
      * Get the settings array

--- a/src/Interfaces/IdpsInterface.php
+++ b/src/Interfaces/IdpsInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @package   Elabftw\Elabftw
+ * @author    Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @see       https://www.elabftw.net Official website
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Interfaces;
+
+/**
+ * Interface for Idps
+ */
+interface IdpsInterface
+{
+    public function setId(?int $id): void;
+
+    public function readAllSimpleEnabled(): array;
+
+    public function readAllLight(): array;
+
+    public function selectOne(): array;
+
+    public function fullUpdate(array $idp): array;
+
+    public function upsert(int $sourceId, array $idps): int;
+
+    public function getEnabled(?int $id = null): int;
+
+    public function getEnabledByEntityId(string $entId): int;
+
+    public function findByEntityId(string $entityId): int;
+
+    public function create(
+        string $name,
+        string $entityid,
+        string $email_attr,
+        ?string $team_attr,
+        string $fname_attr,
+        string $lname_attr,
+        ?string $orgid_attr,
+        int $enabled = 1,
+        ?int $source = null,
+        ?array $certs = array(),
+        ?array $endpoints = array(),
+    ): int;
+}

--- a/src/Models/Idps.php
+++ b/src/Models/Idps.php
@@ -16,6 +16,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\CertPurpose;
 use Elabftw\Enums\IdpsPatchableColumns;
 use Elabftw\Enums\SamlBinding;
+use Elabftw\Interfaces\IdpsInterface;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\SetIdTrait;
@@ -30,7 +31,7 @@ use function sprintf;
 /**
  * An IDP is an Identity Provider. Used in SAML2 authentication context.
  */
-final class Idps extends AbstractRest
+final class Idps extends AbstractRest implements IdpsInterface
 {
     use SetIdTrait;
 
@@ -78,6 +79,7 @@ final class Idps extends AbstractRest
         return $this->selectOne();
     }
 
+    #[Override]
     public function selectOne(): array
     {
         $sql = sprintf($this->getReadSql(), 'WHERE idps.id = :id');
@@ -102,6 +104,7 @@ final class Idps extends AbstractRest
     /**
      * Used to get a list of enabled IDP for the login page, without having to load too much data
      */
+    #[Override]
     public function readAllSimpleEnabled(): array
     {
         $sql = 'SELECT idps.id, idps.name FROM idps WHERE idps.enabled = 1 ORDER BY name ASC';
@@ -114,6 +117,7 @@ final class Idps extends AbstractRest
     /**
      * Used to get a list of IDP for the sysconfig page, without having to load too much data
      */
+    #[Override]
     public function readAllLight(): array
     {
         $sql = 'SELECT idps.id, idps.name, idps.entityid, idps.enabled, idps_sources.url AS source_url
@@ -137,6 +141,7 @@ final class Idps extends AbstractRest
         return $this->readOne();
     }
 
+    #[Override]
     public function fullUpdate(array $idp): array
     {
         $IdpsCerts = new IdpsCerts($this->requester, $this->id);
@@ -151,6 +156,7 @@ final class Idps extends AbstractRest
         return $this->readOne();
     }
 
+    #[Override]
     public function upsert(int $sourceId, array $idps): int
     {
         foreach ($idps as $idp) {
@@ -177,6 +183,7 @@ final class Idps extends AbstractRest
         return count($idps);
     }
 
+    #[Override]
     public function getEnabled(?int $id = null): int
     {
         $sql = 'SELECT id FROM idps WHERE enabled = 1';
@@ -191,6 +198,7 @@ final class Idps extends AbstractRest
         return (int) $req->fetchColumn();
     }
 
+    #[Override]
     public function getEnabledByEntityId(string $entId): int
     {
         $sql = 'SELECT id FROM idps WHERE enabled = 1 AND entityid = :entId';
@@ -211,6 +219,7 @@ final class Idps extends AbstractRest
         return $this->Db->execute($req);
     }
 
+    #[Override]
     public function create(
         string $name,
         string $entityid,
@@ -241,6 +250,7 @@ final class Idps extends AbstractRest
         return $idpId;
     }
 
+    #[Override]
     public function findByEntityId(string $entityId): int
     {
         $sql = 'SELECT id FROM idps WHERE entityid = :entityId';

--- a/tests/unit/models/IdpsTest.php
+++ b/tests/unit/models/IdpsTest.php
@@ -14,6 +14,8 @@ namespace Elabftw\Models;
 use Elabftw\Elabftw\IdpsHelper;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\SamlBinding;
+use Elabftw\Exceptions\ResourceNotFoundException;
+use Elabftw\Interfaces\IdpsInterface;
 use Elabftw\Models\Users\Users;
 
 class IdpsTest extends \PHPUnit\Framework\TestCase
@@ -28,6 +30,15 @@ class IdpsTest extends \PHPUnit\Framework\TestCase
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/idps/', $this->Idps->getApiPath());
+    }
+
+    public function testGetSettingsNoIdpFound(): void
+    {
+        $Idps = $this->createStub(IdpsInterface::class);
+        $Idps->method('getEnabled')->willReturn(0);
+        $helper = new IdpsHelper(Config::getConfig(), $Idps);
+        $this->expectException(ResourceNotFoundException::class);
+        $helper->getSettings();
     }
 
     public function testCreate(): void

--- a/web/metadata.php
+++ b/web/metadata.php
@@ -37,7 +37,7 @@ try {
     try {
         $settingsArr = $IdpsHelper->getSettings();
     } catch (ResourceNotFoundException) {
-        throw new ImproperActionException('No Service Provider configured. Aborting.');
+        throw new ImproperActionException('No active IdP could be found. Configure at least one IdP.');
     }
 
     // Now we only validate SP settings


### PR DESCRIPTION
for instance, trying to get the metedata of the SP with no IdP configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and clearer error message when no active Identity Provider is configured, guiding users to configure at least one IdP.

* **Tests**
  * Added coverage to verify the new “no active IdP” behavior to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6828)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->