### PR TITLE
bug/medium: compounds import: fix import command

### DIFF
--- a/src/Elabftw/App.php
+++ b/src/Elabftw/App.php
@@ -52,12 +52,12 @@ final class App
 {
     use TwigTrait;
 
-    public const string INSTALLED_VERSION = '5.5.11';
+    public const string INSTALLED_VERSION = '5.5.12';
 
     // this version format is used to compare with last_seen_version of users
     // major is untouched, and minor and patch are padded with one 0 each
     // we should be pretty safe from ever reaching 100 as a minor or patch version!
-    public const int INSTALLED_VERSION_INT = 50511;
+    public const int INSTALLED_VERSION_INT = 50512;
 
     /** @psalm-suppress PossiblyUnusedProperty this property is used in twig templates */
     public array $notifsArr = array();

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Import;
 
+use DateTimeImmutable;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Compounds;
 use Elabftw\Models\Links\Compounds2ItemsLinks;
@@ -25,6 +26,7 @@ use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function sprintf;
@@ -172,6 +174,14 @@ final class CompoundsCsv extends AbstractCsv
             $this->output->writeln(sprintf('[warning] Found %d matches for %s. Linking with first one found.', count($results), $value));
         }
         return $results[0] ?? null;
+    }
+
+    // this is only for 5.5
+    protected function emitLog(string $message, string $level): void
+    {
+        $timestamp = new DateTimeImmutable()->format('c');
+        $log = sprintf('%s %s', $timestamp, $message);
+        $this->output->writeln($log);
     }
 
     #[Override]


### PR DESCRIPTION
fix #6833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import logs now include ISO-8601 timestamps for improved debugging and reference tracking.

* **Chores**
  * Version bumped to 5.5.12.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->