### PR TITLE
bug/minor: scheduler: read bound entities subject to rw permissions

### DIFF
--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -65,6 +65,10 @@ final class Scheduler extends AbstractRest
 
     private array $filterBindings = array();
 
+    private ?string $experimentTitleSelect = null;
+
+    private ?string $itemLinkTitleSelect = null;
+
     public function __construct(
         AbstractEntity $Items,
         ?int $id = null,
@@ -187,8 +191,8 @@ final class Scheduler extends AbstractRest
             $canBookExpr = '0';
         }
 
-        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
-        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
+        $experimentTitleSelect = $this->getExperimentTitleSelect();
+        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
         // the title of the event is title + Firstname Lastname of the user who booked it
         $sql = sprintf(
             "SELECT
@@ -376,8 +380,8 @@ final class Scheduler extends AbstractRest
     {
         // the title of the event is title + Firstname Lastname of the user who booked it
         // the color is used by fullcalendar for the bg color of the event
-        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
-        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
+        $experimentTitleSelect = $this->getExperimentTitleSelect();
+        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
         $sql = sprintf(
             "SELECT team_events.*,
             CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ')') AS title,
@@ -422,8 +426,8 @@ final class Scheduler extends AbstractRest
 
     private function readOneEvent(): array
     {
-        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
-        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
+        $experimentTitleSelect = $this->getExperimentTitleSelect();
+        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
         $sql = sprintf(
             'SELECT
                 team_events.id,
@@ -690,5 +694,15 @@ final class Scheduler extends AbstractRest
             $table,
             $field
         );
+    }
+
+    private function getExperimentTitleSelect(): string
+    {
+        return $this->experimentTitleSelect ??= $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
+    }
+
+    private function getItemLinkTitleSelect(): string
+    {
+        return $this->itemLinkTitleSelect ??= $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
     }
 }

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -187,6 +187,11 @@ final class Scheduler extends AbstractRest
             $canBookExpr = '0';
         }
 
+        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
+        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
+
+        $builderItemsLink = new EntitySqlBuilder($this->Items);
+        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
         // the title of the event is title + Firstname Lastname of the user who booked it
         $sql = sprintf(
             "SELECT
@@ -213,9 +218,9 @@ final class Scheduler extends AbstractRest
                 team_events.experiment,
                 items.category AS items_category,
                 items.id AS items_id,
-                experiments.title AS experiment_title,
+                CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
                 team_events.item_link,
-                items_linkt.title AS item_link_title,
+                CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title,
                 CASE WHEN %s THEN 1 ELSE 0 END AS canbook
             FROM team_events
             LEFT JOIN teams ON (team_events.team = teams.id)
@@ -229,6 +234,8 @@ final class Scheduler extends AbstractRest
                 AND team_events.start <= :end
                 AND team_events.end >= :start
                 %s",
+            $experimentCanRead,
+            $itemLinkCanRead,
             $canBookExpr,
             implode(' ', $this->filterSqlParts)
         );
@@ -372,26 +379,40 @@ final class Scheduler extends AbstractRest
     {
         // the title of the event is title + Firstname Lastname of the user who booked it
         // the color is used by fullcalendar for the bg color of the event
-        $sql = "SELECT team_events.*,
-            CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ') ', COALESCE(experiments.title, '')) AS title,
+        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
+        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
+
+        $builderItemsLink = new EntitySqlBuilder($this->Items);
+        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
+
+        $sql = sprintf(
+            "SELECT team_events.*,
+            CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ')') AS title,
             team_events.title AS title_only,
             COALESCE(NULLIF(CONCAT('#', items_categories.color), '#'), '#0c58ab') AS color,
-            experiments.title AS experiment_title,
-            items_linkt.title AS item_link_title,
-            items.title AS item_title, items.book_is_cancellable
+            CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
+            CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title,
+            items.title AS item_title,
+            items.book_is_cancellable
             FROM team_events
             LEFT JOIN items ON (team_events.item = items.id)
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)
             LEFT JOIN experiments ON (experiments.id = team_events.experiment)
             LEFT JOIN items_categories ON (items.category = items_categories.id)
             LEFT JOIN users AS u ON team_events.userid = u.userid
+            LEFT JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = team_events.team)
             WHERE team_events.item = :item
                 AND team_events.start <= :end
-                AND team_events.end >= :start";
+                AND team_events.end >= :start",
+            $experimentCanRead,
+            $itemLinkCanRead
+        );
+
         $req = $this->Db->prepare($sql);
         $req->bindParam(':item', $this->Items->id, PDO::PARAM_INT);
         $req->bindValue(':start', $this->normalizeDate($this->start));
         $req->bindValue(':end', $this->normalizeDate($this->end, true));
+        $req->bindValue(':userid', $this->Items->Users->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
 
         return $req->fetchAll();
@@ -409,7 +430,13 @@ final class Scheduler extends AbstractRest
 
     private function readOneEvent(): array
     {
-        $sql = 'SELECT
+        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
+        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
+
+        $builderItemsLink = new EntitySqlBuilder($this->Items);
+        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
+        $sql = sprintf(
+            'SELECT
                 team_events.id,
                 team_events.team,
                 team_events.item,
@@ -424,16 +451,22 @@ final class Scheduler extends AbstractRest
                 items.book_is_cancellable,
                 items.book_cancel_minutes,
                 team_events.title AS title_only,
-                experiments.title AS experiment_title,
-                items_linkt.title AS item_link_title
+                CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
+                CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title
             FROM team_events
             LEFT JOIN items ON (team_events.item = items.id)
             LEFT JOIN experiments ON (experiments.id = team_events.experiment)
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)
-            WHERE team_events.id = :id';
+            LEFT JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = team_events.team)
+            WHERE team_events.id = :id',
+            $experimentCanRead,
+            $itemLinkCanRead
+        );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $req->bindValue(':userid', $this->Items->Users->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
+
         $event = $this->Db->fetch($req);
         $this->Items->setId($event['item']);
         ksort($event);

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -65,10 +65,6 @@ final class Scheduler extends AbstractRest
 
     private array $filterBindings = array();
 
-    private ?string $experimentTitleSelect = null;
-
-    private ?string $itemLinkTitleSelect = null;
-
     public function __construct(
         AbstractEntity $Items,
         ?int $id = null,
@@ -190,9 +186,7 @@ final class Scheduler extends AbstractRest
         if ($canBookExpr === '') {
             $canBookExpr = '0';
         }
-
-        $experimentTitleSelect = $this->getExperimentTitleSelect();
-        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
+        $boundSelects = $this->getBoundSelects();
         // the title of the event is title + Firstname Lastname of the user who booked it
         $sql = sprintf(
             "SELECT
@@ -216,11 +210,9 @@ final class Scheduler extends AbstractRest
                 (items.booking_hourly_rate_tax * TIMESTAMPDIFF(MINUTE, team_events.start, team_events.end)) / 60.0 AS booking_cost_tax,
                 COALESCE(NULLIF(CONCAT('#', items_categories.color), '#'), '#0c58ab') AS color,
                 items_categories.title AS items_category_title,
-                team_events.experiment,
+                %s,
                 items.category AS items_category,
                 items.id AS items_id,
-                %s,
-                team_events.item_link,
                 %s,
                 CASE WHEN %s THEN 1 ELSE 0 END AS canbook
             FROM team_events
@@ -235,8 +227,7 @@ final class Scheduler extends AbstractRest
                 AND team_events.start <= :end
                 AND team_events.end >= :start
                 %s",
-            $experimentTitleSelect,
-            $itemLinkTitleSelect,
+            $boundSelects['experiment'], $boundSelects['item_link'],
             $canBookExpr,
             implode(' ', $this->filterSqlParts)
         );
@@ -380,8 +371,7 @@ final class Scheduler extends AbstractRest
     {
         // the title of the event is title + Firstname Lastname of the user who booked it
         // the color is used by fullcalendar for the bg color of the event
-        $experimentTitleSelect = $this->getExperimentTitleSelect();
-        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
+        $boundSelects = $this->getBoundSelects();
         $sql = sprintf(
             "SELECT team_events.*,
             CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ')') AS title,
@@ -400,8 +390,7 @@ final class Scheduler extends AbstractRest
             WHERE team_events.item = :item
                 AND team_events.start <= :end
                 AND team_events.end >= :start",
-            $experimentTitleSelect,
-            $itemLinkTitleSelect
+            $boundSelects['experiment'], $boundSelects['item_link'],
         );
 
         $req = $this->Db->prepare($sql);
@@ -426,8 +415,7 @@ final class Scheduler extends AbstractRest
 
     private function readOneEvent(): array
     {
-        $experimentTitleSelect = $this->getExperimentTitleSelect();
-        $itemLinkTitleSelect = $this->getItemLinkTitleSelect();
+        $boundSelects = $this->getBoundSelects();
         $sql = sprintf(
             'SELECT
                 team_events.id,
@@ -451,8 +439,7 @@ final class Scheduler extends AbstractRest
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)
             LEFT JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = team_events.team)
             WHERE team_events.id = :id',
-            $experimentTitleSelect,
-            $itemLinkTitleSelect
+            $boundSelects['experiment'], $boundSelects['item_link'],
         );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
@@ -681,28 +668,23 @@ final class Scheduler extends AbstractRest
     /**
      * Bound entities have their own read permissions, independent from the scheduler event.
      * The event itself can be visible to the user, but the linked experiment/item may still be private.
-     * Only expose the bound entity title when the current user can read that entity.
+     * Only expose the bound entity id and title when the current user can read that entity.
      */
-    private function getBoundTitleSelect(AbstractEntity $entity, string $table, string $field): string
+    private function getBoundSelect(AbstractEntity $entity, string $table, string $idColumn, string $idField, string $titleField): string
     {
         $builder = new EntitySqlBuilder($entity);
         $canRead = str_replace('entity.', $table . '.', $builder->getCanFilter('canread'));
         return sprintf(
-            'CASE WHEN %s.id IS NOT NULL %s THEN %s.title ELSE NULL END AS %s',
-            $table,
-            $canRead,
-            $table,
-            $field
+            'CASE WHEN %1$s.id IS NOT NULL %2$s THEN %3$s ELSE NULL END AS %4$s, CASE WHEN %1$s.id IS NOT NULL %2$s THEN %1$s.title ELSE NULL END AS %5$s',
+            $table, $canRead, $idColumn, $idField, $titleField
         );
     }
 
-    private function getExperimentTitleSelect(): string
+    private function getBoundSelects(): array
     {
-        return $this->experimentTitleSelect ??= $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
-    }
-
-    private function getItemLinkTitleSelect(): string
-    {
-        return $this->itemLinkTitleSelect ??= $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
+        return array(
+            'experiment' => $this->getBoundSelect(new Experiments($this->Items->Users), 'experiments', 'team_events.experiment', 'experiment', 'experiment_title'),
+            'item_link' => $this->getBoundSelect($this->Items, 'items_linkt', 'team_events.item_link', 'item_link', 'item_link_title'),
+        );
     }
 }

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -227,7 +227,8 @@ final class Scheduler extends AbstractRest
                 AND team_events.start <= :end
                 AND team_events.end >= :start
                 %s",
-            $boundSelects['experiment'], $boundSelects['item_link'],
+            $boundSelects['experiment'],
+            $boundSelects['item_link'],
             $canBookExpr,
             implode(' ', $this->filterSqlParts)
         );
@@ -390,7 +391,8 @@ final class Scheduler extends AbstractRest
             WHERE team_events.item = :item
                 AND team_events.start <= :end
                 AND team_events.end >= :start",
-            $boundSelects['experiment'], $boundSelects['item_link'],
+            $boundSelects['experiment'],
+            $boundSelects['item_link'],
         );
 
         $req = $this->Db->prepare($sql);
@@ -439,7 +441,8 @@ final class Scheduler extends AbstractRest
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)
             LEFT JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = team_events.team)
             WHERE team_events.id = :id',
-            $boundSelects['experiment'], $boundSelects['item_link'],
+            $boundSelects['experiment'],
+            $boundSelects['item_link'],
         );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
@@ -676,7 +679,11 @@ final class Scheduler extends AbstractRest
         $canRead = str_replace('entity.', $table . '.', $builder->getCanFilter('canread'));
         return sprintf(
             'CASE WHEN %1$s.id IS NOT NULL %2$s THEN %3$s ELSE NULL END AS %4$s, CASE WHEN %1$s.id IS NOT NULL %2$s THEN %1$s.title ELSE NULL END AS %5$s',
-            $table, $canRead, $idColumn, $idField, $titleField
+            $table,
+            $canRead,
+            $idColumn,
+            $idField,
+            $titleField
         );
     }
 

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -440,7 +440,7 @@ final class Scheduler extends AbstractRest
                 items.book_is_cancellable,
                 items.book_cancel_minutes,
                 team_events.title AS title_only,
-                %s, %s,
+                %s, %s
             FROM team_events
             LEFT JOIN items ON (team_events.item = items.id)
             LEFT JOIN experiments ON (experiments.id = team_events.experiment)

--- a/src/Models/Scheduler.php
+++ b/src/Models/Scheduler.php
@@ -187,11 +187,8 @@ final class Scheduler extends AbstractRest
             $canBookExpr = '0';
         }
 
-        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
-        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
-
-        $builderItemsLink = new EntitySqlBuilder($this->Items);
-        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
+        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
+        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
         // the title of the event is title + Firstname Lastname of the user who booked it
         $sql = sprintf(
             "SELECT
@@ -218,9 +215,9 @@ final class Scheduler extends AbstractRest
                 team_events.experiment,
                 items.category AS items_category,
                 items.id AS items_id,
-                CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
+                %s,
                 team_events.item_link,
-                CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title,
+                %s,
                 CASE WHEN %s THEN 1 ELSE 0 END AS canbook
             FROM team_events
             LEFT JOIN teams ON (team_events.team = teams.id)
@@ -234,8 +231,8 @@ final class Scheduler extends AbstractRest
                 AND team_events.start <= :end
                 AND team_events.end >= :start
                 %s",
-            $experimentCanRead,
-            $itemLinkCanRead,
+            $experimentTitleSelect,
+            $itemLinkTitleSelect,
             $canBookExpr,
             implode(' ', $this->filterSqlParts)
         );
@@ -379,19 +376,14 @@ final class Scheduler extends AbstractRest
     {
         // the title of the event is title + Firstname Lastname of the user who booked it
         // the color is used by fullcalendar for the bg color of the event
-        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
-        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
-
-        $builderItemsLink = new EntitySqlBuilder($this->Items);
-        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
-
+        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
+        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
         $sql = sprintf(
             "SELECT team_events.*,
             CONCAT(team_events.title, ' (', u.firstname, ' ', u.lastname, ')') AS title,
             team_events.title AS title_only,
             COALESCE(NULLIF(CONCAT('#', items_categories.color), '#'), '#0c58ab') AS color,
-            CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
-            CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title,
+            %s, %s,
             items.title AS item_title,
             items.book_is_cancellable
             FROM team_events
@@ -404,8 +396,8 @@ final class Scheduler extends AbstractRest
             WHERE team_events.item = :item
                 AND team_events.start <= :end
                 AND team_events.end >= :start",
-            $experimentCanRead,
-            $itemLinkCanRead
+            $experimentTitleSelect,
+            $itemLinkTitleSelect
         );
 
         $req = $this->Db->prepare($sql);
@@ -430,11 +422,8 @@ final class Scheduler extends AbstractRest
 
     private function readOneEvent(): array
     {
-        $builderExperiments = new EntitySqlBuilder(new Experiments($this->Items->Users));
-        $experimentCanRead = str_replace('entity.', 'experiments.', $builderExperiments->getCanFilter('canread'));
-
-        $builderItemsLink = new EntitySqlBuilder($this->Items);
-        $itemLinkCanRead = str_replace('entity.', 'items_linkt.', $builderItemsLink->getCanFilter('canread'));
+        $experimentTitleSelect = $this->getBoundTitleSelect(new Experiments($this->Items->Users), 'experiments', 'experiment_title');
+        $itemLinkTitleSelect = $this->getBoundTitleSelect($this->Items, 'items_linkt', 'item_link_title');
         $sql = sprintf(
             'SELECT
                 team_events.id,
@@ -451,16 +440,15 @@ final class Scheduler extends AbstractRest
                 items.book_is_cancellable,
                 items.book_cancel_minutes,
                 team_events.title AS title_only,
-                CASE WHEN experiments.id IS NOT NULL %s THEN experiments.title ELSE NULL END AS experiment_title,
-                CASE WHEN items_linkt.id IS NOT NULL %s THEN items_linkt.title ELSE NULL END AS item_link_title
+                %s, %s,
             FROM team_events
             LEFT JOIN items ON (team_events.item = items.id)
             LEFT JOIN experiments ON (experiments.id = team_events.experiment)
             LEFT JOIN items AS items_linkt ON (team_events.item_link = items_linkt.id)
             LEFT JOIN users2teams ON (users2teams.users_id = :userid AND users2teams.teams_id = team_events.team)
             WHERE team_events.id = :id',
-            $experimentCanRead,
-            $itemLinkCanRead
+            $experimentTitleSelect,
+            $itemLinkTitleSelect
         );
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
@@ -684,5 +672,23 @@ final class Scheduler extends AbstractRest
         }
         $this->filterSqlParts[] = sprintf('AND %s = :%s', $column, $paramName);
         $this->filterBindings[$paramName] = $value;
+    }
+
+    /**
+     * Bound entities have their own read permissions, independent from the scheduler event.
+     * The event itself can be visible to the user, but the linked experiment/item may still be private.
+     * Only expose the bound entity title when the current user can read that entity.
+     */
+    private function getBoundTitleSelect(AbstractEntity $entity, string $table, string $field): string
+    {
+        $builder = new EntitySqlBuilder($entity);
+        $canRead = str_replace('entity.', $table . '.', $builder->getCanFilter('canread'));
+        return sprintf(
+            'CASE WHEN %s.id IS NOT NULL %s THEN %s.title ELSE NULL END AS %s',
+            $table,
+            $canRead,
+            $table,
+            $field
+        );
     }
 }

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -197,10 +197,10 @@ if (window.location.pathname === '/scheduler.php') {
       // start by clearing the divs
       clearBoundDiv('experiment');
       clearBoundDiv('item');
-      if (extendedProps.experiment) {
+      if (extendedProps.experiment && extendedProps.experiment_title) {
         createBoundDiv('experiment', extendedProps.experiment_title, `experiments.php?mode=view&id=${extendedProps.experiment}`);
       }
-      if (extendedProps.item_link) {
+      if (extendedProps.item_link && extendedProps.item_link_title) {
         createBoundDiv('item', extendedProps.item_link_title, `database.php?mode=view&id=${extendedProps.item_link}`);
       }
     }

--- a/tests/unit/models/SchedulerTest.php
+++ b/tests/unit/models/SchedulerTest.php
@@ -420,8 +420,8 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         $User2Scheduler->setId($eventId);
 
         $event = $User2Scheduler->readOne();
-
-        $this->assertSame($PrivateExperiment->id, (int) $event['experiment']);
+        // the experiment's ID is also not shown
+        $this->assertEquals(0, (int) $event['experiment']);
         $this->assertNull($event['experiment_title']);
     }
 

--- a/tests/unit/models/SchedulerTest.php
+++ b/tests/unit/models/SchedulerTest.php
@@ -382,6 +382,49 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->Scheduler->patch(Action::Update, array('target' => 'item_link', 'id' => null)));
     }
 
+    public function testReadOneDoesNotLeakPrivateBoundEntityTitles(): void
+    {
+        $Owner = $this->getUserInTeam(1);
+        $User2 = $this->getUserInTeam(2);
+
+        $BookableItem = $this->getFreshItemWithGivenUser($Owner);
+        $BookableItem->patch(Action::Update, array(
+            'is_bookable' => 1,
+            'canread_base' => BasePermissions::User->value,
+            'canread' => json_encode(array(
+                'users' => array($User2->userid),
+                'teams' => array(),
+                'teamgroups' => array(),
+            )),
+        ));
+
+        $PrivateExperiment = $this->getFreshExperimentWithGivenUser($Owner);
+        $PrivateExperiment->patch(Action::Update, array(
+            'canread_base' => BasePermissions::UserOnly->value,
+            'canwrite_base' => BasePermissions::UserOnly->value,
+        ));
+
+        $OwnerScheduler = new Scheduler($BookableItem);
+        $eventId = $OwnerScheduler->postAction(Action::Create, array(
+            'start' => $this->start,
+            'end' => $this->end,
+        ));
+
+        $OwnerScheduler->setId($eventId);
+        $OwnerScheduler->patch(Action::Update, array(
+            'target' => 'experiment',
+            'id' => $PrivateExperiment->id,
+        ));
+
+        $User2Scheduler = new Scheduler(new Items($User2, $BookableItem->id));
+        $User2Scheduler->setId($eventId);
+
+        $event = $User2Scheduler->readOne();
+
+        $this->assertSame($PrivateExperiment->id, (int) $event['experiment']);
+        $this->assertNull($event['experiment_title']);
+    }
+
     public function testCanWriteAndWeAreAdmin(): void
     {
         $Items = $this->getFreshBookableItem(2);


### PR DESCRIPTION
A user can read an event, but the event's bound experiment.title or item.title can sometimes be private.
This addition makes sure the user needs read permission on that entity to view that it is bound to the event.

### Pull Request Checklist

- [X] I have added **tests** for any new features.
- [X] I have mentioned the related **issue** (if applicable).
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented private bound entity titles from being exposed to users without read access in scheduled events.
  * Client now only displays a bound experiment when its display title is available.

* **Security**
  * Enforced team membership and per-entity read permissions when showing linked entity information in events.

* **Tests**
  * Added a unit test to ensure private bound entity titles are not leaked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->