### PR TITLE
bug/medium: users: patchable field

### DIFF
--- a/src/Models/Users/UltraAdmin.php
+++ b/src/Models/Users/UltraAdmin.php
@@ -30,6 +30,7 @@ final class UltraAdmin extends Users
         $this->userData['scope_items'] = 3;
         $this->userData['scope_items_types'] = 3;
         $this->userData['scope_teamgroups'] = 3;
+        $this->isAdmin = true;
     }
 
     #[Override]

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -698,8 +698,8 @@ class Users extends AbstractRest
             $this->requester->isSysadminOrExplode();
         }
         // columns that can only be modified by admin requester
-        if (in_array($params->getTarget(), array('validated'), true) && !$this->requester->isAdmin) {
-            throw new IllegalActionException();
+        if (in_array($params->getTarget(), array('validated'), true)) {
+            $this->requester->isAdminOrExplode();
         }
         // early bail out if existing and new values are the same
         if ($params->getContent() === $this->userData[$params->getColumn()]) {
@@ -780,6 +780,18 @@ class Users extends AbstractRest
     public function isSysadminOrExplode(): void
     {
         if ($this->isSysadmin() === false) {
+            throw new IllegalActionException(Messages::InsufficientPermissions->toHuman());
+        }
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->isAdmin === true;
+    }
+
+    public function isAdminOrExplode(): void
+    {
+        if ($this->isAdmin() === false) {
             throw new IllegalActionException(Messages::InsufficientPermissions->toHuman());
         }
     }
@@ -898,9 +910,7 @@ class Users extends AbstractRest
      */
     private function validate(): array
     {
-        if (!$this->requester->isAdmin) {
-            throw new IllegalActionException();
-        }
+        $this->requester->isAdminOrExplode();
         $this->rawUpdate(UsersColumn::Validated, 1);
         $Notifications = new SelfIsValidated($this);
         $Notifications->create();

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -697,7 +697,10 @@ class Users extends AbstractRest
         if (in_array($params->getTarget(), array('can_manage_compounds', 'can_manage_inventory_locations', 'can_manage_users2teams', 'is_sysadmin'), true)) {
             $this->requester->isSysadminOrExplode();
         }
-
+        // columns that can only be modified by admin requester
+        if (in_array($params->getTarget(), array('validated'), true) && !$this->requester->isAdmin) {
+            throw new IllegalActionException();
+        }
         // early bail out if existing and new values are the same
         if ($params->getContent() === $this->userData[$params->getColumn()]) {
             return true;
@@ -895,6 +898,9 @@ class Users extends AbstractRest
      */
     private function validate(): array
     {
+        if (!$this->requester->isAdmin) {
+            throw new IllegalActionException();
+        }
         $this->rawUpdate(UsersColumn::Validated, 1);
         $Notifications = new SelfIsValidated($this);
         $Notifications->create();

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -219,6 +219,13 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($Users->patch(Action::UpdatePassword, array('password' => 'demodemodemo', 'current_password' => 'testPassword')));
     }
 
+    public function testUpdateValidatedAsNonAdmin(): void
+    {
+        $Users = $this->getUserInTeam(1);
+        $this->expectException(IllegalActionException::class);
+        $Users->patch(Action::Update, array('validated' => 1));
+    }
+
     public function testResetPassword(): void
     {
         $Users = new Users(4, 2, new Users(4, 2));


### PR DESCRIPTION
Prevents authenticated users from using restricted routes. Add tests

The `validated` column was previously user-patchable and not protected by the same privilege checks as some other fields (e.g. is_sysadmin).

- Enforce admin check in validate() method
- Ensure UltraAdmin correctly sets isAdmin flag
- Add unit test preventing non-admin users from modifying `validated`

Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [X] I have added **tests** for any new features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access controls: only administrators can modify a user's validation status; non-admin attempts are blocked and will return an error.
  * Admin role is now explicitly set when user accounts are prepared, ensuring correct admin behavior on creation.

* **Tests**
  * Added coverage to confirm non-admin users cannot change user validation settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->