### PR TITLE
bug/minor: tags: enforce write permission on destroy action

### DIFF
--- a/src/Models/Tags.php
+++ b/src/Models/Tags.php
@@ -134,6 +134,7 @@ final class Tags extends AbstractRest
     #[Override]
     public function destroy(): bool
     {
+        $this->Entity->canOrExplode(AccessType::Write);
         $sql = 'DELETE FROM tags2entity WHERE item_id = :id AND item_type = :type';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);

--- a/tests/unit/models/TagsTest.php
+++ b/tests/unit/models/TagsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
@@ -90,5 +91,18 @@ class TagsTest extends \PHPUnit\Framework\TestCase
     public function testDestroy(): void
     {
         $this->assertTrue($this->Experiments->Tags->destroy());
+    }
+
+    public function testDestroyWithoutWriteAccess(): void
+    {
+        $owner = $this->getRandomUserInTeam(1, admin: 1);
+        $experiment = $this->getFreshExperimentWithGivenUser($owner);
+        $experiment->Tags->postAction(Action::Create, array('tag' => 'secure-tag'));
+
+        $otherUser = $this->getRandomUserInTeam(1);
+        // instantiate the same experiment with the other user
+        $experimentAsOtherUser = new Experiments($otherUser, $experiment->id);
+        $this->expectException(ForbiddenException::class);
+        $experimentAsOtherUser->Tags->destroy();
     }
 }


### PR DESCRIPTION
Ensure write access is properly checked before allowing tag associations to be deleted.

Adds a missing canOrExplode(AccessType::Write) guard in the destroy() method to align behavior with other entity operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tags can now only be deleted by users with write access, preventing unauthorized deletions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->