### PR TITLE
bug/medium: ownership: enforce dedicated action for ownership transfer

### DIFF
--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -546,10 +546,10 @@ abstract class AbstractEntity extends AbstractRest
             ),
             Action::Update => (
                 function () use ($params) {
+                    if (array_key_exists('userid', $params) || array_key_exists('team', $params)) {
+                        throw new ImproperActionException("Use the 'action:updateowner' to transfer ownership.");
+                    }
                     foreach ($params as $key => $value) {
-                        if (in_array($key, array('userid', 'team'), true)) {
-                            throw new ImproperActionException("Use the 'action:updateowner' to transfer ownership.");
-                        }
                         $this->update(new EntityParams($key, (string) $value));
                     }
                 }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -547,6 +547,9 @@ abstract class AbstractEntity extends AbstractRest
             Action::Update => (
                 function () use ($params) {
                     foreach ($params as $key => $value) {
+                        if (in_array($key, array('userid', 'team'), true)) {
+                            throw new ImproperActionException("Use the 'action:updateowner' to transfer ownership.");
+                        }
                         $this->update(new EntityParams($key, (string) $value));
                     }
                 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -190,6 +190,16 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($user2->team, $entityData['team']);
     }
 
+    public function testUpdateOwnershipWithoutUsingDedicatedAction(): void
+    {
+        $User = $this->getRandomUserInTeam(1);
+        $exp = $this->getFreshExperimentWithGivenUser($User);
+        $params = array('userid' => $User->getUserid(), 'team' => $User->getTeam());
+        // needs to use Action::UpdateOwner if we're using userid/team params)
+        $this->expectException(ImproperActionException::class);
+        $exp->patch(Action::Update, $params);
+    }
+
     public function testUpdateOwnershipWrongTeamCombination(): void
     {
         $user1 = new Users(1, 1);


### PR DESCRIPTION
GHSA-99qj-pc8p-c87g

Ensures that ownership changes (userid, team) cannot be performed through the generic update action.

Ownership transfers must now use the dedicated Action::UpdateOwner endpoint, improving API consistency and preventing unintended updates through Action::Update.

Adds unit test to validate the expected behavior.

### Pull Request Checklist

- [X] I have added **tests** for any new features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents ownership fields (user/team) from being changed via the generic update endpoint; users must use the dedicated ownership update path to modify ownership.
* **Tests**
  * Added a unit test to ensure ownership cannot be updated through the generic update flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->