### PR TITLE
bug/medium: api: guard user submodels with read permission check

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -354,6 +354,7 @@ final class Apiv2Controller extends AbstractApiController
 
     private function getSubModel(?ApiSubModels $submodel): RestInterface
     {
+        $this->Model->readOne();
         if ($this->Model instanceof AbstractEntity) {
             $Config = Config::getConfig();
             return match ($submodel) {


### PR DESCRIPTION
GHSA-5p9p-hfrw-988f
GHSA-p7hx-hhgx-w56w
GHSA-9366-mh6g-v8cm
GHSA-jp96-xqhr-crr5

Enforce the normal `::readOne()` authorization check before creating scoped API submodels.

This prevents authenticated users from accessing another user's sub endpoints (like notifications or request actions) through /api/v2/users/{id}/... endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of submodel retrieval by ensuring initial data loading completes before type-based processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->