### PR TITLE
bug/minor: restrict 'valid_until' to admin requesters

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -698,7 +698,7 @@ class Users extends AbstractRest
             $this->requester->isSysadminOrExplode();
         }
         // columns that can only be modified by admin requester
-        if (in_array($params->getTarget(), array('validated'), true)) {
+        if (in_array($params->getTarget(), array('validated', 'valid_until'), true)) {
             $this->requester->isAdminOrExplode();
         }
         // early bail out if existing and new values are the same

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use DateTimeImmutable;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Scope;
 use Elabftw\Enums\Usergroup;
@@ -224,6 +225,14 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Users = $this->getUserInTeam(1);
         $this->expectException(IllegalActionException::class);
         $Users->patch(Action::Update, array('validated' => 1));
+    }
+
+    public function testUpdateValidUntilAsNonAdmin(): void
+    {
+        $Users = $this->getUserInTeam(1);
+        $date = new DateTimeImmutable('tomorrow');
+        $this->expectException(IllegalActionException::class);
+        $Users->patch(Action::Update, array('valid_until' => $date->format('Y-m-d')));
     }
 
     public function testResetPassword(): void

--- a/tests/unit/services/ExpirationNotifierTest.php
+++ b/tests/unit/services/ExpirationNotifierTest.php
@@ -15,18 +15,20 @@ use DateTimeImmutable;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Usergroup;
 use Elabftw\Models\Users\ValidatedUser;
-use Elabftw\Models\Users\Users;
+use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ExpirationNotifierTest extends \PHPUnit\Framework\TestCase
 {
+    use TestsUtilsTrait;
+
     public function testSendEmails(): void
     {
         // first make a user close to expiration
         $user = ValidatedUser::fromAdmin('expire@soon.example', array(1), 'expire', 'soon', Usergroup::User);
         $date = new DateTimeImmutable('tomorrow');
         // valid_until can only be modified by admin requester
-        $admin = new Users(1, 1);
+        $admin = $this->getRandomUserInTeam(1, 1);
         $user->requester = $admin;
         $user->patch(Action::Update, array('valid_until' => $date->format('Y-m-d')));
         // now alert user and admin

--- a/tests/unit/services/ExpirationNotifierTest.php
+++ b/tests/unit/services/ExpirationNotifierTest.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Usergroup;
 use Elabftw\Models\Users\ValidatedUser;
+use Elabftw\Models\Users\Users;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ExpirationNotifierTest extends \PHPUnit\Framework\TestCase
@@ -24,6 +25,9 @@ class ExpirationNotifierTest extends \PHPUnit\Framework\TestCase
         // first make a user close to expiration
         $user = ValidatedUser::fromAdmin('expire@soon.example', array(1), 'expire', 'soon', Usergroup::User);
         $date = new DateTimeImmutable('tomorrow');
+        // valid_until can only be modified by admin requester
+        $admin = new Users(1, 1);
+        $user->requester = $admin;
         $user->patch(Action::Update, array('valid_until' => $date->format('Y-m-d')));
         // now alert user and admin
         $stub = $this->createStub(Email::class);


### PR DESCRIPTION
GHSA-j75q-fh4q-hm4h

Ensure only admins can edit account validity periods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization controls for the user expiration date field. Non-admin users can no longer modify user expiration dates via API patches. Only system administrators may change this field.

* **Tests**
  * Added unit test coverage verifying authorization restrictions on the user expiration date field, ensuring non-admin requests are properly rejected with appropriate exceptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->