### PR TITLE
ci: fix and update cimon

### DIFF
--- a/.github/workflows/build_edge.yaml
+++ b/.github/workflows/build_edge.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # https://github.com/CycodeLabs/cimon-action
       - name: Cimon supply chain attack protection
-        uses: cycodelabs/cimon-action@f99ad5557cb80964bc2b2e76a47bf4b5ba6e323b # v0.10
+        uses: cycodelabs/cimon-action@a0870cc3d9e3bf3cedd28bdb67bf3fd3281e5941 # v1.0.1
         with:
           prevent: true
           allowed-hosts: >
@@ -31,7 +31,9 @@ jobs:
             codeload.github.com
             dl-cdn.alpinelinux.org
             docker.io
+            fulcio.sigstore.dev
             ghcr.io
+            hooks.deltablot.dev
             index.docker.io
             mirror.gcr.io
             nginx.org
@@ -42,7 +44,6 @@ jobs:
             registry.yarnpkg.com
             repo.yarnpkg.com
             registry.npmjs.org
-            hooks.deltablot.dev
 
       - name: Checkout elabimg repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
attestation needs to access fulcio.sigstore.dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supply chain security tooling to the latest version.
  * Expanded security policy configuration for build verification processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elabftw/elabftw/pull/6882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->