### PR TITLE
bug/minor: metadata: handle empty values for link-type extra fields

### DIFF
--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -90,15 +90,20 @@ export class Metadata {
       // collect all the selected options, and the value will be an array
       value = [...el.selectedOptions].map(option => option.value);
     }
-    // special case for Experiment/Resource/User link
+    // special case for Experiment/Resource/User/Compound link
     if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf(), ExtraFieldInputType.Users.valueOf(), ExtraFieldInputType.Compounds.valueOf()].includes(el.dataset.target)) {
-      value = parseInt(value.split(' ')[0], 10);
-      if (isNaN(value)) {
-        return false;
-      }
-      // also create a link automatically for experiments, resources and compounds.
-      if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf(), ExtraFieldInputType.Compounds.valueOf()].includes(el.dataset.target)) {
-        ApiC.post(`${this.entity.type}/${this.entity.id}/${el.dataset.target}_links/${value}`).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
+      const rawValue = value.trim();
+      if (rawValue === '') {
+        value = '';
+      } else {
+        value = parseInt(rawValue.split(' ')[0], 10);
+        if (isNaN(value)) {
+          return false;
+        }
+        // also create a link automatically for experiments, resources and compounds.
+        if ([ExtraFieldInputType.Experiments.valueOf(), ExtraFieldInputType.Items.valueOf(), ExtraFieldInputType.Compounds.valueOf()].includes(el.dataset.target)) {
+          ApiC.post(`${this.entity.type}/${this.entity.id}/${el.dataset.target}_links/${value}`).then(() => reloadElements(['linksDiv', 'linksExpDiv']));
+        }
       }
     }
     const params = {};


### PR DESCRIPTION
fix #6884

Improve handling of link-type extra fields (Experiments, Items, Users, Compounds) and URLs when the input value is empty.

Previously, parsing always attempted to extract and convert an ID, which could result in invalid parsing behavior. Now:
- empty values are preserved correctly
- ID parsing is only performed when a value is present
- automatic link creation is triggered only for valid IDs

Prevents unnecessary errors and improves robustness of metadata handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced link creation in metadata fields with improved input handling: whitespace is now properly trimmed, fields can be cleared when empty, and links are created only with valid input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->