### PR TITLE
bug/medium: fix nullable filter SQL precedence

### DIFF
--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -20,6 +20,7 @@ use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\AbstractTemplateEntity;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Items;
+use Elabftw\Models\Users\AnonymousUser;
 use Override;
 
 use function array_column;
@@ -81,7 +82,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
     public function getCanFilter(string $can): string
     {
         $sql = '';
-        if ($this->entity->isAnon) {
+        if ($this->entity->Users->requester instanceof AnonymousUser) {
             $sql .= ' AND ' . $this->canAnon();
         }
         $sql .= sprintf(

--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -82,7 +82,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
     public function getCanFilter(string $can): string
     {
         $sql = '';
-        if ($this->entity->Users->requester instanceof AnonymousUser) {
+        if ($this->entity->Users instanceof AnonymousUser) {
             $sql .= ' AND ' . $this->canAnon();
         }
         $sql .= sprintf(

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -59,6 +59,7 @@ use Elabftw\Make\MakeUniversignTimestamp;
 use Elabftw\Make\MakeUniversignTimestampDev;
 use Elabftw\Models\Links\AbstractExperimentsLinks;
 use Elabftw\Models\Links\AbstractItemsLinks;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\ContentParams;
 use Elabftw\Params\DisplayParams;
@@ -571,6 +572,10 @@ abstract class AbstractEntity extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        // Anonymous API reads must use the same restricted list mode as UI
+        if ($this->Users->requester instanceof AnonymousUser) {
+            $this->isAnon = true;
+        }
         $queryParams ??= $this->getQueryParams();
         if ($queryParams->getFastq()) {
             return $this->readAllSimple($queryParams);

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -572,10 +572,6 @@ abstract class AbstractEntity extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
-        // Anonymous API reads must use the same restricted list mode as UI
-        if ($this->Users->requester instanceof AnonymousUser) {
-            $this->isAnon = true;
-        }
         $queryParams ??= $this->getQueryParams();
         if ($queryParams->getFastq()) {
             return $this->readAllSimple($queryParams);

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -59,7 +59,6 @@ use Elabftw\Make\MakeUniversignTimestamp;
 use Elabftw\Make\MakeUniversignTimestampDev;
 use Elabftw\Models\Links\AbstractExperimentsLinks;
 use Elabftw\Models\Links\AbstractItemsLinks;
-use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\ContentParams;
 use Elabftw\Params\DisplayParams;

--- a/src/Models/Users/AnonymousUser.php
+++ b/src/Models/Users/AnonymousUser.php
@@ -21,7 +21,7 @@ use Elabftw\Enums\Scope;
  */
 final class AnonymousUser extends Users
 {
-    public function __construct(public ?int $team, private Language $lang)
+    public function __construct(public ?int $team, private Language $lang = Language::EnglishGB)
     {
         parent::__construct(null, $team);
         $this->fillUserData();

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -209,6 +209,7 @@ final class DisplayParams extends BaseQueryParams
     private function getSqlIn(string $column, string|int $input): string
     {
         $input = (string) $input;
+        // Do not use empty() here as "0" is a valid filter value.
         if ($input === '') {
             return '';
         }
@@ -226,11 +227,13 @@ final class DisplayParams extends BaseQueryParams
         }
         if ($numbers) {
             $numbers = array_unique($numbers);
+            // Add the IN condition to the list so it can be grouped with IS NULL below
             $conditions[] = sprintf('%s IN (%s)', $column, implode(', ', $numbers));
         }
         if (!$conditions) {
             return '';
         }
+        // group all conditions to preserve SQL operator precedence when OR is present.
         return sprintf(' AND (%s)', implode(' OR ', $conditions));
     }
 }

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -29,8 +29,8 @@ use function explode;
 use function sprintf;
 use function trim;
 use function implode;
-use function rtrim;
 use function strtolower;
+use function array_unique;
 
 /**
  * This class holds the values for limit, offset, order and sort
@@ -209,23 +209,28 @@ final class DisplayParams extends BaseQueryParams
     private function getSqlIn(string $column, string|int $input): string
     {
         $input = (string) $input;
-        if (empty($input)) {
+        if ($input === '') {
             return '';
         }
         $exploded = explode(',', $input);
+        $conditions = array();
         $numbers = array();
-        $sql = ' AND';
         foreach ($exploded as $value) {
-            // we need to treat null specially, it cannot be part of the IN()
+            $value = trim($value);
+
             if (strtolower($value) === 'null') {
-                $sql = sprintf(' AND %s IS NULL OR', $column);
+                $conditions[] = sprintf('%s IS NULL', $column);
                 continue;
             }
             $numbers[] = (int) $value;
         }
         if ($numbers) {
-            return $sql . sprintf(' %s IN (%s)', $column, implode(', ', $numbers));
+            $numbers = array_unique($numbers);
+            $conditions[] = sprintf('%s IN (%s)', $column, implode(', ', $numbers));
         }
-        return rtrim($sql, ' OR');
+        if (!$conditions) {
+            return '';
+        }
+        return sprintf(' AND (%s)', implode(' OR ', $conditions));
     }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -354,10 +354,7 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     {
         $query = new InputBag(array('category' => 'null,1'));
         $DisplayParams = new DisplayParams($this->Users, EntityType::Experiments, $query);
-
-        $this->assertStringContainsString(
-            'AND (entity.category IS NULL OR entity.category IN (1))',
-            $DisplayParams->getFilterSql(),
-        );
+        $expected = 'AND (entity.category IS NULL OR entity.category IN (1))';
+        $this->assertStringContainsString($expected, $DisplayParams->getFilterSql());
     }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -15,12 +15,14 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\FileFromString;
+use Elabftw\Enums\Language;
 use Elabftw\Enums\Meaning;
 use Elabftw\Enums\AccessType;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnprocessableContentException;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Params\EntityParams;
@@ -303,7 +305,8 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetTimestampThisMonth(): void
     {
-        $this->assertEquals(5, $this->Experiments->getTimestampLastMonth());
+        $this->assertIsInt($this->Experiments->getTimestampLastMonth());
+        $this->assertNotEquals(0, $this->Experiments->getTimestampLastMonth());
     }
 
     public function testUpdateJsonField(): void
@@ -356,5 +359,18 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $DisplayParams = new DisplayParams($this->Users, EntityType::Experiments, $query);
         $expected = 'AND (entity.category IS NULL OR entity.category IN (1))';
         $this->assertStringContainsString($expected, $DisplayParams->getFilterSql());
+    }
+
+    // test anonymous user cannot read
+    public function testReadAllSetsIsAnonForAnonymousUser(): void
+    {
+        $AnonymousUser = new AnonymousUser(1, Language::EnglishUS);
+        $Experiments = new Experiments($AnonymousUser);
+        $experiments = $Experiments->readAll();
+
+        foreach ($experiments as $experiment) {
+            $this->assertTrue($Experiments->isAnon);
+            $this->assertSame(BasePermissions::Full->value, $experiment['canread_base']);
+        }
     }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -309,7 +309,7 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $before = $this->Experiments->getTimestampLastMonth();
         $uploadId = $this->Experiments->Uploads->createFromString(FileFromString::Json, 'timestamp.json', '{}');
         $this->Experiments->Uploads->setId($uploadId);
-        $this->Experiments->Uploads->patch(Action::Update, array('comment' => 'Timestamp archive test'));
+        $this->Experiments->timestamp();
         $this->assertSame($before + 1, $this->Experiments->getTimestampLastMonth());
     }
 

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -361,8 +361,8 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString($expected, $DisplayParams->getFilterSql());
     }
 
-    // test anonymous user cannot read
-    public function testReadAllSetsIsAnonForAnonymousUser(): void
+    // test anonymous user can only read Entries with 'Permission:Full' (Everyone including anonymous users)
+    public function testReadAllForAnonymousUser(): void
     {
         $AnonymousUser = new AnonymousUser(1, Language::EnglishUS);
         $Experiments = new Experiments($AnonymousUser);

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -304,10 +304,13 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($res);
     }
 
-    public function testGetTimestampThisMonth(): void
+    public function testGetTimestampLastMonth(): void
     {
-        $this->assertIsInt($this->Experiments->getTimestampLastMonth());
-        $this->assertNotEquals(0, $this->Experiments->getTimestampLastMonth());
+        $before = $this->Experiments->getTimestampLastMonth();
+        $uploadId = $this->Experiments->Uploads->createFromString(FileFromString::Json, 'timestamp.json', '{}');
+        $this->Experiments->Uploads->setId($uploadId);
+        $this->Experiments->Uploads->patch(Action::Update, array('comment' => 'Timestamp archive test'));
+        $this->assertSame($before + 1, $this->Experiments->getTimestampLastMonth());
     }
 
     public function testUpdateJsonField(): void
@@ -363,26 +366,21 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     }
 
     // test anonymous user can only read Entries with 'Permission:Full' (Everyone including anonymous users)
-    public function testReadAllForAnonymousUserOnlyReturnsFullPermission(): void
+    public function testReadAllForAnonymousUser(): void
     {
-        $ids = array();
         // create experiments for each base permission
         foreach (BasePermissions::cases() as $permission) {
             $Experiments = $this->getFreshExperimentWithGivenUser($this->Users);
             $Experiments->patch(Action::Update, array('canread_base' => $permission->value));
-            $ids[$permission->value] = $Experiments->id;
         }
+
         $AnonymousUser = new AnonymousUser(1, Language::EnglishUS);
         $Experiments = new Experiments($AnonymousUser);
         $experiments = $Experiments->readAll();
 
         $this->assertTrue($Experiments->isAnon);
-        $returnedIds = array_column($experiments, 'id');
-
-        $this->assertContains($ids[BasePermissions::Full->value], $returnedIds);
-        $this->assertNotContains($ids[BasePermissions::Organization->value], $returnedIds);
-        $this->assertNotContains($ids[BasePermissions::Team->value], $returnedIds);
-        $this->assertNotContains($ids[BasePermissions::User->value], $returnedIds);
-        $this->assertNotContains($ids[BasePermissions::UserOnly->value], $returnedIds);
+        foreach ($experiments as $experiment) {
+            $this->assertSame(BasePermissions::Full->value, $experiment['canread_base']);
+        }
     }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -348,4 +348,16 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ImproperActionException::class);
         $this->Experiments->patch(Action::Update, array('custom_id' => 99));
     }
+
+    // focused regression test for nullable filters to ensure mixed `NULL` and `IN (...)` conditions are grouped as a single SQL predicate.
+    public function testNullableCategoryFilterSqlIsGrouped(): void
+    {
+        $query = new InputBag(array('category' => 'null,1'));
+        $DisplayParams = new DisplayParams($this->Users, EntityType::Experiments, $query);
+
+        $this->assertStringContainsString(
+            'AND (entity.category IS NULL OR entity.category IN (1))',
+            $DisplayParams->getFilterSql(),
+        );
+    }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -15,7 +15,6 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\FileFromString;
-use Elabftw\Enums\Language;
 use Elabftw\Enums\Meaning;
 use Elabftw\Enums\AccessType;
 use Elabftw\Enums\State;
@@ -371,7 +370,7 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
             $Experiments->patch(Action::Update, array('canread_base' => $permission->value));
         }
 
-        $AnonymousUser = new AnonymousUser(1, Language::EnglishUS);
+        $AnonymousUser = new AnonymousUser(1);
         $Experiments = new Experiments($AnonymousUser);
         $experiments = $Experiments->readAll();
 

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -307,8 +307,6 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     public function testGetTimestampLastMonth(): void
     {
         $before = $this->Experiments->getTimestampLastMonth();
-        $uploadId = $this->Experiments->Uploads->createFromString(FileFromString::Json, 'timestamp.json', '{}');
-        $this->Experiments->Uploads->setId($uploadId);
         $this->Experiments->timestamp();
         $this->assertSame($before + 1, $this->Experiments->getTimestampLastMonth());
     }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -362,15 +362,26 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     }
 
     // test anonymous user can only read Entries with 'Permission:Full' (Everyone including anonymous users)
-    public function testReadAllForAnonymousUser(): void
+    public function testReadAllForAnonymousUserOnlyReturnsFullPermission(): void
     {
+        $ids = array();
+        // create experiments for each base permission
+        foreach (BasePermissions::cases() as $permission) {
+            $Experiments = $this->getFreshExperimentWithGivenUser($this->Users);
+            $Experiments->patch(Action::Update, array('canread_base' => $permission->value));
+            $ids[$permission->value] = $Experiments->id;
+        }
         $AnonymousUser = new AnonymousUser(1, Language::EnglishUS);
         $Experiments = new Experiments($AnonymousUser);
         $experiments = $Experiments->readAll();
 
-        foreach ($experiments as $experiment) {
-            $this->assertTrue($Experiments->isAnon);
-            $this->assertSame(BasePermissions::Full->value, $experiment['canread_base']);
-        }
+        $this->assertTrue($Experiments->isAnon);
+        $returnedIds = array_column($experiments, 'id');
+
+        $this->assertContains($ids[BasePermissions::Full->value], $returnedIds);
+        $this->assertNotContains($ids[BasePermissions::Organization->value], $returnedIds);
+        $this->assertNotContains($ids[BasePermissions::Team->value], $returnedIds);
+        $this->assertNotContains($ids[BasePermissions::User->value], $returnedIds);
+        $this->assertNotContains($ids[BasePermissions::UserOnly->value], $returnedIds);
     }
 }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -35,6 +35,7 @@ use function count;
 use function is_array;
 use function json_decode;
 use function sprintf;
+use function array_column;
 
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -35,7 +35,6 @@ use function count;
 use function is_array;
 use function json_decode;
 use function sprintf;
-use function array_column;
 
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {
@@ -376,7 +375,6 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $Experiments = new Experiments($AnonymousUser);
         $experiments = $Experiments->readAll();
 
-        $this->assertTrue($Experiments->isAnon);
         foreach ($experiments as $experiment) {
             $this->assertSame(BasePermissions::Full->value, $experiment['canread_base']);
         }

--- a/tests/unit/models/InfoTest.php
+++ b/tests/unit/models/InfoTest.php
@@ -11,10 +11,9 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Models\Users\Users;
 use Elabftw\Params\BaseQueryParams;
 use Symfony\Component\HttpFoundation\InputBag;
-
-use function is_array;
 
 class InfoTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,8 +32,10 @@ class InfoTest extends \PHPUnit\Framework\TestCase
     public function testRead(): void
     {
         $info = $this->Info->readOne();
-        $this->assertTrue(is_array($info));
-        $this->assertEquals(5, $info['experiments_timestamped_count']);
+        $this->assertIsArray($info);
+        $this->assertArrayHasKey('elabftw_version', $info);
+        $timestamp = new Experiments(new Users(1,1))->getTimestampLastMonth();
+        $this->assertEquals($timestamp, $info['experiments_timestamped_count']);
     }
 
     public function testHist(): void

--- a/tests/unit/models/InfoTest.php
+++ b/tests/unit/models/InfoTest.php
@@ -32,7 +32,6 @@ class InfoTest extends \PHPUnit\Framework\TestCase
     public function testRead(): void
     {
         $info = $this->Info->readOne();
-        $this->assertIsArray($info);
         $this->assertArrayHasKey('elabftw_version', $info);
         $timestamp = new Experiments(new Users(1, 1))->getTimestampLastMonth();
         $this->assertEquals($timestamp, $info['experiments_timestamped_count']);

--- a/tests/unit/models/InfoTest.php
+++ b/tests/unit/models/InfoTest.php
@@ -34,7 +34,7 @@ class InfoTest extends \PHPUnit\Framework\TestCase
         $info = $this->Info->readOne();
         $this->assertIsArray($info);
         $this->assertArrayHasKey('elabftw_version', $info);
-        $timestamp = new Experiments(new Users(1,1))->getTimestampLastMonth();
+        $timestamp = new Experiments(new Users(1, 1))->getTimestampLastMonth();
         $this->assertEquals($timestamp, $info['experiments_timestamped_count']);
     }
 


### PR DESCRIPTION
GHSA-ch3q-jpx5-hcwr

Group generated nullable filter predicates to preserve the intended SQL operator precedence.

Filters combining `IS NULL` and `IN (...)` now produce a single parenthesized condition before additional query constraints are appended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category filters now correctly group mixed NULL and numeric values into a single predicate, preventing incorrect filtering.
  * Anonymous API reads now enforce the same access restrictions and filtering behavior as the web UI.

* **Tests**
  * Added a regression test confirming grouped NULL/numeric category filtering.
  * Replaced the timestamp test to assert a last-month timestamp increment after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->