### PR TITLE
feat: distribute new containers to various storage locations

### DIFF
--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -31,9 +31,17 @@
               </select>
             </div>
           </div>
-          <h5><label for='containerMultiplierInput'>{{ 'Adjust number of containers stored'|trans }}</label></h5>
+          <h5><label for='containerMultiplierInput'>{{ 'Total number of containers to distribute'|trans }}</label></h5>
           <input type='number' value='1' min='1' id='containerMultiplierInput' autocomplete='off' class='form-control' />
-          <h5 class='mt-2'>{{ 'Select a storage location below'|trans }}</h5>
+          <div class='sticky-top bg-white py-2 border-bottom mb-2 mt-2' style='top:0; z-index:1'>
+            <div class='d-flex align-items-center'>
+              <span class='mr-auto'>
+                <span id='containerAssignedCount'>0</span> / <span id='containerTargetCount'>1</span> {{ 'assigned'|trans }}
+              </span>
+              <button type='button' class='btn btn-primary' id='storeContainersBtn' data-action='store-containers-distributed' disabled>{{ 'Store containers'|trans }}</button>
+            </div>
+          </div>
+          <h5 class='mt-2'>{{ 'Distribute containers across the storage locations below'|trans }}</h5>
           {% include 'storage-list.html' with {'storage_editable': false, 'is_entity': true} %}
         </div>
       </div>

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -32,7 +32,7 @@
             </div>
           </div>
           <h5><label for='containerMultiplierInput'>{{ 'Total number of containers to distribute'|trans }}</label></h5>
-          <input type='number' value='1' min='1' id='containerMultiplierInput' autocomplete='off' class='form-control' />
+          <input type='number' value='1' min='1' step='1' id='containerMultiplierInput' autocomplete='off' class='form-control' />
           <div class='sticky-top bg-white py-2 border-bottom mb-2 mt-2' style='top:0; z-index:1'>
             <div class='d-flex align-items-center'>
               <span class='mr-auto'>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -13,6 +13,18 @@
   <!-- [html-validate-disable-block prefer-native-element: suppress errors] -->
 {%- endif %}
 <div id='storageDiv'>
+  {# stepper used in the entity-create flow to pick how many containers go in this location #}
+  {% macro render_stepper(storage_id) %}
+    <div class='input-group input-group-sm mt-1' style='max-width:160px' data-storage-id='{{ storage_id }}'>
+      <div class='input-group-prepend'>
+        <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Decrease'|trans }}'><i class='fas fa-minus'></i></button>
+      </div>
+      <input type='number' class='form-control text-center' min='0' value='0' inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ storage_id }}' aria-label='{{ 'Number of containers here'|trans }}' />
+      <div class='input-group-append'>
+        <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Increase'|trans }}'><i class='fas fa-plus'></i></button>
+      </div>
+    </div>
+  {% endmacro %}
   {% macro render_items(items, groupedItems, storage_editable, is_entity=true, is_move=false, is_move_storage=false) %}
     <ul class='list-group'>
       {% for item in items %}
@@ -26,7 +38,7 @@
               {% elseif is_entity and is_move %}
                 <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(item.name) }}</button>
               {% elseif is_entity %}
-                <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' data-dismiss='modal' data-action='create-container'><i class='fas fa-location-dot mr-1'></i>{{ 'Store in %s'|trans|format(item.name) }}</button>
+                {{ _self.render_stepper(item.id) }}
               {% else %}
                 <a class='btn btn-secondary btn-sm' href='?storage_unit={{ item.id }}'><i class='fas fa-magnifying-glass mr-1'></i>{{ 'Display content'|trans }}</a>
               {% endif %}
@@ -70,6 +82,10 @@
         {% elseif is_entity and is_move %}
           <div class='ml-auto'>
             <button type='button' class='btn btn-primary btn-sm' data-id='{{ root.id }}' data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(root.name) }}</button>
+          </div>
+        {% elseif is_entity %}
+          <div class='ml-auto'>
+            {{ _self.render_stepper(root.id) }}
           </div>
         {% endif %}
       </div>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -14,14 +14,14 @@
 {%- endif %}
 <div id='storageDiv'>
   {# stepper used in the entity-create flow to pick how many containers go in this location #}
-  {% macro render_stepper(storage_id) %}
+  {% macro render_stepper(storage_id, storage_name) %}
     <div class='input-group input-group-sm mt-1' style='max-width:160px' data-storage-id='{{ storage_id }}'>
       <div class='input-group-prepend'>
-        <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Decrease'|trans }}'><i class='fas fa-minus'></i></button>
+        <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Decrease containers for %s'|trans|format(storage_name) }}'><i class='fas fa-minus'></i></button>
       </div>
-      <input type='number' class='form-control text-center' min='0' value='0' inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ storage_id }}' aria-label='{{ 'Number of containers here'|trans }}' />
+      <input type='number' class='form-control text-center' min='0' step='1' value='0' inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ storage_id }}' aria-label='{{ 'Number of containers for %s'|trans|format(storage_name) }}' />
       <div class='input-group-append'>
-        <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Increase'|trans }}'><i class='fas fa-plus'></i></button>
+        <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Increase containers for %s'|trans|format(storage_name) }}'><i class='fas fa-plus'></i></button>
       </div>
     </div>
   {% endmacro %}
@@ -38,7 +38,7 @@
               {% elseif is_entity and is_move %}
                 <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(item.name) }}</button>
               {% elseif is_entity %}
-                {{ _self.render_stepper(item.id) }}
+                {{ _self.render_stepper(item.id, item.name) }}
               {% else %}
                 <a class='btn btn-secondary btn-sm' href='?storage_unit={{ item.id }}'><i class='fas fa-magnifying-glass mr-1'></i>{{ 'Display content'|trans }}</a>
               {% endif %}
@@ -85,7 +85,7 @@
           </div>
         {% elseif is_entity %}
           <div class='ml-auto'>
-            {{ _self.render_stepper(root.id) }}
+            {{ _self.render_stepper(root.id, root.name) }}
           </div>
         {% endif %}
       </div>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -818,25 +818,119 @@ on('add-storage-children', (el: HTMLElement) => {
     });
   });
 });
-on('create-container', (el: HTMLElement) => {
+// CONTAINER DISTRIBUTION across multiple storage locations
+// Each storage location in the "Add container" modal has a -/number/+ stepper.
+// The user distributes a target number of containers (#containerMultiplierInput) across
+// the locations; the steppers can never sum above the target, and the "Store containers"
+// button is only enabled once they sum exactly to it.
+const containerStepperInputs = (): HTMLInputElement[] =>
+  Array.from(document.querySelectorAll('input[data-action="container-qty-input"]'));
+
+const containerTarget = (): number => {
+  const target = parseInt((document.getElementById('containerMultiplierInput') as HTMLInputElement)?.value, 10);
+  return (isNaN(target) || target < 0) ? 0 : target;
+};
+
+const containerAssigned = (): number =>
+  containerStepperInputs().reduce((sum, input) => sum + (parseInt(input.value, 10) || 0), 0);
+
+function refreshContainerDistribution(): void {
+  const target = containerTarget();
+  const assigned = containerAssigned();
+  const assignedEl = document.getElementById('containerAssignedCount');
+  const targetEl = document.getElementById('containerTargetCount');
+  if (assignedEl) assignedEl.textContent = String(assigned);
+  if (targetEl) targetEl.textContent = String(target);
+  const submitBtn = document.getElementById('storeContainersBtn') as HTMLButtonElement | null;
+  if (submitBtn) submitBtn.disabled = target === 0 || assigned !== target;
+}
+
+// sum of every stepper except the one passed in (identity match, robust whether or not
+// the input's own value has already been updated by the browser)
+const otherSteppersTotal = (except: HTMLInputElement): number =>
+  containerStepperInputs()
+    .filter(input => input !== except)
+    .reduce((sum, input) => sum + (parseInt(input.value, 10) || 0), 0);
+
+// set a stepper to a value, clamped so the total assigned can never exceed the target
+function setStepperValue(input: HTMLInputElement, value: number): void {
+  const max = Math.max(0, containerTarget() - otherSteppersTotal(input));
+  input.value = String(Math.min(Math.max(0, value), max));
+  refreshContainerDistribution();
+}
+
+// clamp every stepper down when the target total is reduced below what is already assigned
+function reclampAllSteppers(): void {
+  const target = containerTarget();
+  let running = 0;
+  containerStepperInputs().forEach(input => {
+    let value = parseInt(input.value, 10) || 0;
+    if (running + value > target) {
+      value = Math.max(0, target - running);
+    }
+    input.value = String(value);
+    running += value;
+  });
+  refreshContainerDistribution();
+}
+
+const stepperFor = (el: HTMLElement): HTMLInputElement | null =>
+  document.querySelector(`input[data-action="container-qty-input"][data-storage-id="${el.dataset.storageId}"]`);
+
+on('container-qty-plus', (el: HTMLElement) => {
+  const input = stepperFor(el);
+  if (input) setStepperValue(input, (parseInt(input.value, 10) || 0) + 1);
+});
+on('container-qty-minus', (el: HTMLElement) => {
+  const input = stepperFor(el);
+  if (input) setStepperValue(input, (parseInt(input.value, 10) || 0) - 1);
+});
+
+on('store-containers-distributed', () => {
   const qty_stored = (document.getElementById('containerQtyStoredInput') as HTMLInputElement).value;
   const qty_unit = (document.getElementById('containerQtyUnitSelect') as HTMLSelectElement).value;
-  let multiplier = parseInt((document.getElementById('containerMultiplierInput') as HTMLInputElement).value, 10);
-  if (isNaN(multiplier) || multiplier <= 0) {
-    multiplier = 1;
+  const postCalls = containerStepperInputs().flatMap(input => {
+    const count = parseInt(input.value, 10) || 0;
+    return Array.from({ length: count }, () =>
+      ApiC.post(`${entity.type}/${entity.id}/containers/${input.dataset.storageId}`, {
+        qty_stored: qty_stored,
+        qty_unit: qty_unit,
+      }),
+    );
+  });
+  if (postCalls.length === 0) {
+    return;
   }
-
-  const postCalls = Array.from({ length: multiplier }, () =>
-    ApiC.post(`${entity.type}/${entity.id}/containers/${el.dataset.id}`, {
-      qty_stored: qty_stored,
-      qty_unit: qty_unit,
-    }),
-  );
   // Execute all POST calls and reload elements after all are resolved
   Promise.all(postCalls)
-    .then(() => reloadElements(['storageDivContent']))
+    .then(() => {
+      reloadElements(['storageDivContent']);
+      $('#storageModal').modal('hide');
+    })
     .catch((error) => notify.error(error));
 });
+
+// the steppers' number inputs and the target total fire 'input', not 'click', so they are
+// handled with a delegated listener rather than via on()
+const storageModalEl = document.getElementById('storageModal');
+if (storageModalEl) {
+  document.getElementById('container')?.addEventListener('input', (event: Event) => {
+    const target = event.target as HTMLElement | null;
+    const stepper = target?.closest('input[data-action="container-qty-input"]') as HTMLInputElement | null;
+    if (stepper) {
+      setStepperValue(stepper, parseInt(stepper.value, 10) || 0);
+      return;
+    }
+    if (target?.id === 'containerMultiplierInput') {
+      reclampAllSteppers();
+    }
+  });
+  // reset all steppers each time the modal opens so a reopened modal starts clean
+  $('#storageModal').on('show.bs.modal', () => {
+    containerStepperInputs().forEach(input => { input.value = '0'; });
+    refreshContainerDistribution();
+  });
+}
 
 on('delete-storage-root', (el: HTMLElement) => ApiC.delete(`storage_units/${el.dataset.id}`).then(() => reloadElements(['storageDiv'])));
 

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -823,17 +823,30 @@ on('add-storage-children', (el: HTMLElement) => {
 // The user distributes a target number of containers (#containerMultiplierInput) across
 // the locations; the steppers can never sum above the target, and the "Store containers"
 // button is only enabled once they sum exactly to it.
+
+/**
+ * Read a non-negative integer from a number input. Blank, negative or non-integer
+ * values (e.g. a manually typed 1.9) collapse to 0 so a fractional entry can never
+ * feed the distribution math or submit a different count than what is shown.
+ */
+const intFromInput = (el: HTMLInputElement | null): number => {
+  const value = el?.valueAsNumber ?? NaN;
+  return Number.isInteger(value) && value >= 0 ? value : 0;
+};
+
+/** All the per-location quantity inputs currently rendered in the modal. */
 const containerStepperInputs = (): HTMLInputElement[] =>
   Array.from(document.querySelectorAll('input[data-action="container-qty-input"]'));
 
-const containerTarget = (): number => {
-  const target = parseInt((document.getElementById('containerMultiplierInput') as HTMLInputElement)?.value, 10);
-  return (isNaN(target) || target < 0) ? 0 : target;
-};
+/** The target total number of containers to distribute. */
+const containerTarget = (): number =>
+  intFromInput(document.getElementById('containerMultiplierInput') as HTMLInputElement | null);
 
+/** The number of containers currently assigned across all locations. */
 const containerAssigned = (): number =>
-  containerStepperInputs().reduce((sum, input) => sum + (parseInt(input.value, 10) || 0), 0);
+  containerStepperInputs().reduce((sum, input) => sum + intFromInput(input), 0);
 
+/** Update the assigned/target counter and enable submit only at an exact match. */
 function refreshContainerDistribution(): void {
   const target = containerTarget();
   const assigned = containerAssigned();
@@ -845,26 +858,28 @@ function refreshContainerDistribution(): void {
   if (submitBtn) submitBtn.disabled = target === 0 || assigned !== target;
 }
 
-// sum of every stepper except the one passed in (identity match, robust whether or not
-// the input's own value has already been updated by the browser)
+/**
+ * Sum of every stepper except the one passed in (identity match, robust whether or
+ * not the input's own value has already been updated by the browser).
+ */
 const otherSteppersTotal = (except: HTMLInputElement): number =>
   containerStepperInputs()
     .filter(input => input !== except)
-    .reduce((sum, input) => sum + (parseInt(input.value, 10) || 0), 0);
+    .reduce((sum, input) => sum + intFromInput(input), 0);
 
-// set a stepper to a value, clamped so the total assigned can never exceed the target
+/** Set a stepper to a value, clamped so the total assigned can never exceed the target. */
 function setStepperValue(input: HTMLInputElement, value: number): void {
   const max = Math.max(0, containerTarget() - otherSteppersTotal(input));
   input.value = String(Math.min(Math.max(0, value), max));
   refreshContainerDistribution();
 }
 
-// clamp every stepper down when the target total is reduced below what is already assigned
+/** Clamp every stepper down when the target total is reduced below what is already assigned. */
 function reclampAllSteppers(): void {
   const target = containerTarget();
   let running = 0;
   containerStepperInputs().forEach(input => {
-    let value = parseInt(input.value, 10) || 0;
+    let value = intFromInput(input);
     if (running + value > target) {
       value = Math.max(0, target - running);
     }
@@ -874,23 +889,29 @@ function reclampAllSteppers(): void {
   refreshContainerDistribution();
 }
 
+/** Resolve the quantity input that belongs to a clicked +/- button. */
 const stepperFor = (el: HTMLElement): HTMLInputElement | null =>
   document.querySelector(`input[data-action="container-qty-input"][data-storage-id="${el.dataset.storageId}"]`);
 
 on('container-qty-plus', (el: HTMLElement) => {
   const input = stepperFor(el);
-  if (input) setStepperValue(input, (parseInt(input.value, 10) || 0) + 1);
+  if (input) setStepperValue(input, intFromInput(input) + 1);
 });
 on('container-qty-minus', (el: HTMLElement) => {
   const input = stepperFor(el);
-  if (input) setStepperValue(input, (parseInt(input.value, 10) || 0) - 1);
+  if (input) setStepperValue(input, intFromInput(input) - 1);
 });
 
 on('store-containers-distributed', () => {
+  const submitBtn = document.getElementById('storeContainersBtn') as HTMLButtonElement | null;
+  // guard against double submit: a disabled button means a batch is already in flight
+  if (submitBtn?.disabled) {
+    return;
+  }
   const qty_stored = (document.getElementById('containerQtyStoredInput') as HTMLInputElement).value;
   const qty_unit = (document.getElementById('containerQtyUnitSelect') as HTMLSelectElement).value;
   const postCalls = containerStepperInputs().flatMap(input => {
-    const count = parseInt(input.value, 10) || 0;
+    const count = intFromInput(input);
     return Array.from({ length: count }, () =>
       ApiC.post(`${entity.type}/${entity.id}/containers/${input.dataset.storageId}`, {
         qty_stored: qty_stored,
@@ -901,13 +922,18 @@ on('store-containers-distributed', () => {
   if (postCalls.length === 0) {
     return;
   }
+  // lock the button while the batch runs so a second click cannot create a duplicate distribution
+  if (submitBtn) submitBtn.disabled = true;
   // Execute all POST calls and reload elements after all are resolved
   Promise.all(postCalls)
     .then(() => {
       reloadElements(['storageDivContent']);
       $('#storageModal').modal('hide');
     })
-    .catch((error) => notify.error(error));
+    .catch((error) => notify.error(error))
+    .finally(() => {
+      if (submitBtn) submitBtn.disabled = false;
+    });
 });
 
 // the steppers' number inputs and the target total fire 'input', not 'click', so they are
@@ -918,7 +944,7 @@ if (storageModalEl) {
     const target = event.target as HTMLElement | null;
     const stepper = target?.closest('input[data-action="container-qty-input"]') as HTMLInputElement | null;
     if (stepper) {
-      setStepperValue(stepper, parseInt(stepper.value, 10) || 0);
+      setStepperValue(stepper, intFromInput(stepper));
       return;
     }
     if (target?.id === 'containerMultiplierInput') {

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -43,41 +43,42 @@ describe('Containers', () => {
             for (let i = 0; i < 3; i++) {
               cy.get(`${stepper(storageA)} [data-action="container-qty-plus"]`).click();
             }
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '3');
+            cy.get(`${stepper(storageA)} input[data-action="container-qty-input"]`).should('have.value', '3');
 
             // clamp check: the sum cannot exceed the target of 5
             for (let i = 0; i < 5; i++) {
               cy.get(`${stepper(storageA)} [data-action="container-qty-plus"]`).click();
             }
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '5');
+            cy.get(`${stepper(storageA)} input[data-action="container-qty-input"]`).should('have.value', '5');
 
             // back down to 3 in Freezer A
             for (let i = 0; i < 2; i++) {
               cy.get(`${stepper(storageA)} [data-action="container-qty-minus"]`).click();
             }
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '3');
+            cy.get(`${stepper(storageA)} input[data-action="container-qty-input"]`).should('have.value', '3');
 
             // type 2 directly into Freezer B
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageB)}`).invoke('val', '2').trigger('input');
+            cy.get(`${stepper(storageB)} input[data-action="container-qty-input"]`).invoke('val', '2').trigger('input');
 
             // now fully distributed: counter reads 5 / 5 and submit is enabled
             cy.get('#containerAssignedCount').should('have.text', '5');
             cy.get('#storeContainersBtn').should('be.enabled');
 
-            // re-clamp check: lowering the target below the assigned sum clamps the steppers and disables submit
+            // re-clamp check: lowering the target re-distributes the steppers down to exactly the new target
             cy.get('#containerMultiplierInput').invoke('val', '4').trigger('input');
-            cy.get('#storeContainersBtn').should('be.disabled');
-            // total assigned must now be <= 4
+            cy.get('#containerAssignedCount').should('have.text', '4');
+            cy.get('#storeContainersBtn').should('be.enabled');
+            // total assigned must now be exactly 4
             cy.get('input[data-action="container-qty-input"]').then($inputs => {
               const total = Cypress.$.makeArray($inputs)
                 .reduce((sum, el) => sum + (parseInt((el as HTMLInputElement).value, 10) || 0), 0);
-              expect(total).to.be.at.most(4);
+              expect(total).to.eq(4);
             });
 
             // restore a valid 3 + 2 = 5 distribution and submit
             cy.get('#containerMultiplierInput').invoke('val', '5').trigger('input');
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).invoke('val', '3').trigger('input');
-            cy.get(`input[data-action="container-qty-input"]${stepper(storageB)}`).invoke('val', '2').trigger('input');
+            cy.get(`${stepper(storageA)} input[data-action="container-qty-input"]`).invoke('val', '3').trigger('input');
+            cy.get(`${stepper(storageB)} input[data-action="container-qty-input"]`).invoke('val', '2').trigger('input');
             cy.get('#storeContainersBtn').should('be.enabled').click();
 
             // modal closes after submit

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -1,0 +1,100 @@
+describe('Containers', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  // create a storage location via the API and return its id (parsed from the Location header)
+  const createStorageUnit = (name: string): Cypress.Chainable<number> =>
+    cy.request({ method: 'POST', url: '/api/v2/storage_units', body: { name } })
+      .then(resp => {
+        expect(resp.status).to.eq(201);
+        return parseInt(resp.headers['location'].toString().split('/').pop(), 10);
+      });
+
+  it('distributes containers across multiple storage locations', () => {
+    // set up two storage locations and a resource to store them in
+    createStorageUnit(`Freezer A ${Date.now()}`).then(storageA => {
+      createStorageUnit(`Freezer B ${Date.now()}`).then(storageB => {
+        cy.request({ method: 'POST', url: '/api/v2/items', body: { title: `Cypress container item ${Date.now()}` } })
+          .then(resp => {
+            expect(resp.status).to.eq(201);
+            const itemId = parseInt(resp.headers['location'].toString().split('/').pop(), 10);
+
+            cy.visit(`/database.php?mode=edit&id=${itemId}`);
+
+            // open the "Add container" modal
+            cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
+            cy.get('#storageModal').should('be.visible');
+
+            // set per-container capacity/unit and the target total
+            cy.get('#containerQtyStoredInput').invoke('val', '10').trigger('input');
+            cy.get('#containerQtyUnitSelect').select('mL');
+            cy.get('#containerMultiplierInput').invoke('val', '5').trigger('input');
+
+            // initial state: nothing assigned, submit disabled
+            cy.get('#containerAssignedCount').should('have.text', '0');
+            cy.get('#containerTargetCount').should('have.text', '5');
+            cy.get('#storeContainersBtn').should('be.disabled');
+
+            const stepper = (storageId: number) =>
+              `[data-storage-id="${storageId}"]`;
+
+            // put 3 in Freezer A via the + button
+            for (let i = 0; i < 3; i++) {
+              cy.get(`${stepper(storageA)} [data-action="container-qty-plus"]`).click();
+            }
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '3');
+
+            // clamp check: the sum cannot exceed the target of 5
+            for (let i = 0; i < 5; i++) {
+              cy.get(`${stepper(storageA)} [data-action="container-qty-plus"]`).click();
+            }
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '5');
+
+            // back down to 3 in Freezer A
+            for (let i = 0; i < 2; i++) {
+              cy.get(`${stepper(storageA)} [data-action="container-qty-minus"]`).click();
+            }
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).should('have.value', '3');
+
+            // type 2 directly into Freezer B
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageB)}`).invoke('val', '2').trigger('input');
+
+            // now fully distributed: counter reads 5 / 5 and submit is enabled
+            cy.get('#containerAssignedCount').should('have.text', '5');
+            cy.get('#storeContainersBtn').should('be.enabled');
+
+            // re-clamp check: lowering the target below the assigned sum clamps the steppers and disables submit
+            cy.get('#containerMultiplierInput').invoke('val', '4').trigger('input');
+            cy.get('#storeContainersBtn').should('be.disabled');
+            // total assigned must now be <= 4
+            cy.get('input[data-action="container-qty-input"]').then($inputs => {
+              const total = Cypress.$.makeArray($inputs)
+                .reduce((sum, el) => sum + (parseInt((el as HTMLInputElement).value, 10) || 0), 0);
+              expect(total).to.be.at.most(4);
+            });
+
+            // restore a valid 3 + 2 = 5 distribution and submit
+            cy.get('#containerMultiplierInput').invoke('val', '5').trigger('input');
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageA)}`).invoke('val', '3').trigger('input');
+            cy.get(`input[data-action="container-qty-input"]${stepper(storageB)}`).invoke('val', '2').trigger('input');
+            cy.get('#storeContainersBtn').should('be.enabled').click();
+
+            // modal closes after submit
+            cy.get('#storageModal').should('not.be.visible');
+
+            // verify persistence: 5 containers, split 3 in Freezer A and 2 in Freezer B
+            cy.request({ method: 'GET', url: `/api/v2/items/${itemId}/containers` }).then(containersResp => {
+              expect(containersResp.status).to.eq(200);
+              const containers = containersResp.body as Array<{ storage_id: number }>;
+              expect(containers).to.have.length(5);
+              const inA = containers.filter(c => c.storage_id === storageA).length;
+              const inB = containers.filter(c => c.storage_id === storageB).length;
+              expect(inA).to.eq(3);
+              expect(inB).to.eq(2);
+            });
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Distribute containers across multiple storage locations

## Pull Request Checklist

- [x] I have added tests for any new features. → Added a Cypress acceptance test (`tests/cypress/integration/containers.cy.ts`) covering the distribution flow.
- [x] I have mentioned the related issue (if applicable). → No related issue, this is a standalone enhancement.
- [x] I have updated or verified the relevant documentation. → No behavioural docs reference this flow; the modal's UI labels were updated to match the new behaviour.

## Summary

This lets a user distribute multiple containers across several storage locations when adding them to a resource/entity, instead of being limited to placing the whole batch in a single location.

Previously the "Add container" modal had one "Store in X" button per location, and clicking it created all N containers there. Now each storage location carries a −/number/+ stepper, and the user spreads the target total across as many locations as they like before committing.

This patch:

- replaces the per-location "Store in X" button with a −/number/+ stepper on every selectable location (both root and nested), in the entity-create flow only; the move container and admin move storage flows are untouched;
- treats the existing "number of containers" field as a fixed target total, with a live assigned / target counter and a single "Store containers" button that only enables once the steppers sum exactly to the target;
- clamps the steppers so the distribution can never exceed the target, and re-clamps automatically if the target is lowered after distributing;
- pins the counter and submit button in a sticky bar at the top of the modal body, so it stays visible above a long list of locations;
- commits the distribution with one create call per container against the existing endpoint (no backend or schema changes, the containers2* tables already store one row per container);
- resets the steppers each time the modal is reopened.

## Files changed

- `src/templates/storage-list.html` — new render_stepper() macro; the stepper replaces the "Store in X" button in the entity-create branch only (root and nested nodes). Move/admin branches untouched.
- `src/templates/add-container-modal.html` — relabelled the count input as the target total; added the sticky assigned / target counter and "Store containers" button.
- `src/ts/common.ts` — removed the old create-container handler; added the stepper logic (live counter, clamping, re-clamp on target change, reset on modal open) and the distributed submit handler.
- `tests/cypress/integration/containers.cy.ts` — new acceptance test (see below).

## Testing

### Automated (Cypress)

Added `tests/cypress/integration/containers.cy.ts`. It:

1. creates two storage locations and a resource via the API;
2. opens the Add container modal in the resource's edit view;
3. sets a per-container capacity/unit and a target total of 5;
4. asserts the initial 0 / 5 counter and disabled submit button;
5. distributes 3 to Freezer A (via the + button) and 2 to Freezer B (via direct entry);
6. asserts the steppers clamp, clicking + past the target leaves the value at the max;
7. asserts that lowering the target below the assigned sum re-clamps the steppers and disables the submit button;
8. submits a valid 3 + 2 = 5 distribution and asserts the modal closes;
9. verifies persistence via GET /api/v2/items/<id>/containers, exactly 5 containers, 3 in Freezer A and 2 in Freezer B.

I haven't been able to test visually on my side unfortunately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distribute containers across multiple storage locations in one operation.
  * Per-location numeric steppers with plus/minus controls and live assigned/target status.
  * Automatic clamping so per-location totals never exceed the target; steppers reset when modal opens.
  * Submit button enabled only when assigned equals target; successful submit closes modal and refreshes the list.

* **Tests**
  * End-to-end tests covering multi-location distribution, clamping, and submit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->