### PR TITLE
feat: allow admin to control units for containers

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -232,6 +232,18 @@ abstract class AbstractEntityController implements ControllerInterface
     }
 
     /**
+     * The built-in units (value + display label) in dropdown display order. Single source for the
+     * add-container modal, the inline editor and the admin show/hide checkboxes.
+     */
+    protected function getBuiltinUnitsArr(): array
+    {
+        return array_map(
+            static fn(Units $unit): array => array('value' => $unit->value, 'label' => $unit->label()),
+            Units::inDisplayOrder(),
+        );
+    }
+
+    /**
      * View mode (one item displayed)
      */
     protected function view(): Response
@@ -239,6 +251,7 @@ abstract class AbstractEntityController implements ControllerInterface
         $RequestActions = new RequestActions($this->App->Users, $this->Entity);
         // the mode parameter is for the uploads tpl
         $renderArr = array(
+            'builtinUnitsArr' => $this->getBuiltinUnitsArr(),
             'categoryArr' => $this->categoryArr,
             'classificationArr' => $this->classificationArr,
             'currencyArr' => $this->currencyArr,
@@ -299,6 +312,7 @@ abstract class AbstractEntityController implements ControllerInterface
         $DisplayParamsTemplates = new DisplayParams($this->App->Users, EntityType::Templates);
         $DisplayParamsItemsTypes = new DisplayParams($this->App->Users, EntityType::ItemsTypes);
         $renderArr = array(
+            'builtinUnitsArr' => $this->getBuiltinUnitsArr(),
             'categoryArr' => $this->categoryArr,
             'classificationArr' => $this->classificationArr,
             'currencyArr' => $this->currencyArr,

--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -23,6 +23,7 @@ use Elabftw\Enums\Meaning;
 use Elabftw\Enums\Orderby;
 use Elabftw\Enums\RequestableAction;
 use Elabftw\Enums\Sort;
+use Elabftw\Enums\Units;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Models\AbstractEntity;
@@ -35,6 +36,7 @@ use Elabftw\Models\ItemsTypes;
 use Elabftw\Models\RequestActions;
 use Elabftw\Models\StorageUnits;
 use Elabftw\Models\TeamGroups;
+use Elabftw\Models\Teams;
 use Elabftw\Models\TeamTags;
 use Elabftw\Models\Templates;
 use Elabftw\Models\UserRequestActions;
@@ -46,7 +48,15 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function array_column;
+use function array_filter;
+use function array_map;
+use function array_unique;
+use function array_values;
+use function explode;
+use function in_array;
+use function is_string;
 use function sprintf;
+use function trim;
 
 /**
  * For displaying an entity in show, view or edit mode
@@ -74,6 +84,9 @@ abstract class AbstractEntityController implements ControllerInterface
     protected array $currencyArr = array();
 
     protected array $scopedTeamgroupsArr = array();
+
+    // memoized row of the entity's owning team, used to resolve container units
+    private ?array $entityTeamArr = null;
 
     public function __construct(protected App $App, protected AbstractEntity $Entity)
     {
@@ -184,6 +197,41 @@ abstract class AbstractEntityController implements ControllerInterface
     }
 
     /**
+     * The team-specific custom container units, appended after the built-in Units in the
+     * quantity dropdowns. Deduped against the built-ins, which are never altered.
+     */
+    protected function getCustomUnitsArr(): array
+    {
+        $customUnits = $this->entityTeamArr()['custom_units'] ?? '';
+        if (!is_string($customUnits) || $customUnits === '') {
+            return array();
+        }
+        $builtin = array_map(static fn(Units $unit): string => $unit->value, Units::cases());
+        $custom = array_map(trim(...), explode(',', $customUnits));
+        return array_values(array_unique(array_filter(
+            $custom,
+            static fn(string $unit): bool => $unit !== '' && !in_array($unit, $builtin, true),
+        )));
+    }
+
+    /**
+     * Built-in units the team has chosen to hide from the container dropdowns. Only valid
+     * built-in unit values are returned; the built-ins themselves are never modified.
+     */
+    protected function getHiddenUnitsArr(): array
+    {
+        $hiddenUnits = $this->entityTeamArr()['hidden_units'] ?? '';
+        if (!is_string($hiddenUnits) || $hiddenUnits === '') {
+            return array();
+        }
+        $hidden = array_map(trim(...), explode(',', $hiddenUnits));
+        return array_values(array_filter(
+            $hidden,
+            static fn(string $unit): bool => $unit !== '' && Units::tryFrom($unit) !== null,
+        ));
+    }
+
+    /**
      * View mode (one item displayed)
      */
     protected function view(): Response
@@ -194,9 +242,11 @@ abstract class AbstractEntityController implements ControllerInterface
             'categoryArr' => $this->categoryArr,
             'classificationArr' => $this->classificationArr,
             'currencyArr' => $this->currencyArr,
+            'customUnitsArr' => $this->getCustomUnitsArr(),
             'Entity' => $this->Entity,
             'entityProcurementRequestsArr' => $this->getEntityProcurementRequestsArr(),
             'entityRequestActionsArr' => $RequestActions->readAllFull(),
+            'hiddenUnitsArr' => $this->getHiddenUnitsArr(),
             'pageTitle' => $this->getPageTitle(),
             'mode' => 'view',
             'hideTitle' => true,
@@ -252,9 +302,11 @@ abstract class AbstractEntityController implements ControllerInterface
             'categoryArr' => $this->categoryArr,
             'classificationArr' => $this->classificationArr,
             'currencyArr' => $this->currencyArr,
+            'customUnitsArr' => $this->getCustomUnitsArr(),
             'Entity' => $this->Entity,
             'entityProcurementRequestsArr' => $this->getEntityProcurementRequestsArr(),
             'entityRequestActionsArr' => $RequestActions->readAllFull(),
+            'hiddenUnitsArr' => $this->getHiddenUnitsArr(),
             'hideTitle' => true,
             'metadataGroups' => $Metadata->getGroups(),
             'mode' => 'edit',
@@ -292,5 +344,18 @@ abstract class AbstractEntityController implements ControllerInterface
         $Response->prepare($this->App->Request);
         $Response->setContent($this->App->render('changelog.html', $renderArr));
         return $Response;
+    }
+
+    // the row of the entity's owning team (anchored to the entity, not the viewer's active
+    // team), memoized so the custom/hidden unit lists share a single query
+    private function entityTeamArr(): array
+    {
+        if ($this->entityTeamArr === null) {
+            $teamId = (int) ($this->Entity->entityData['team'] ?? 0);
+            $this->entityTeamArr = $teamId > 0
+                ? (new Teams($this->App->Users, $teamId))->teamArr
+                : array();
+        }
+        return $this->entityTeamArr;
     }
 }

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 209;
+    public const int REQUIRED_SCHEMA = 210;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -73,6 +73,7 @@ final class i18n4Js
             'create-one-items_types' => _('Create a resource template'),
             'current-edit' => _('Currently editing'),
             'custom-fields' => _('Custom fields'),
+            'custom-units-dropped' => _('Some custom units were not saved (each must be at most 10 characters, and the whole list is limited to 255 characters): {{units}}'),
             'delete' => _('Delete'),
             'delete-confirmation' => _('Delete {{num, number}} line(s)?'),
             'delete-selected' => _('Delete selected rows'),

--- a/src/Enums/Units.php
+++ b/src/Enums/Units.php
@@ -24,4 +24,37 @@ enum Units: string
     case MilliGram = 'mg';
     case Gram = 'g';
     case KiloGram = 'kg';
+
+    // human readable label for the dropdowns; defaults to the symbol/abbreviation
+    public function label(): string
+    {
+        return match ($this) {
+            self::Bar => 'Bar',
+            self::Metre => 'Metre',
+            default => $this->value,
+        };
+    }
+
+    /**
+     * Built-in units in the order they should appear in the UI dropdowns.
+     * The case declaration order above is intentionally NOT the display order, so this is the
+     * single source of truth for ordering. Keep it in sync with the cases (covered by a test).
+     *
+     * @return list<self>
+     */
+    public static function inDisplayOrder(): array
+    {
+        return array(
+            self::Unit,
+            self::MicroLiter,
+            self::MilliLiter,
+            self::Liter,
+            self::MicroGram,
+            self::MilliGram,
+            self::Gram,
+            self::KiloGram,
+            self::Bar,
+            self::Metre,
+        );
+    }
 }

--- a/src/Params/TeamParam.php
+++ b/src/Params/TeamParam.php
@@ -12,17 +12,33 @@ declare(strict_types=1);
 
 namespace Elabftw\Params;
 
+use Elabftw\Enums\Units;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Services\Filter;
 use Override;
 
+use function implode;
+use function in_array;
+use function mb_strlen;
+use function preg_split;
+use function strip_tags;
+use function trim;
+
 final class TeamParam extends ContentParams
 {
+    /** @var int maximum length of a custom unit, matching the qty_unit VARCHAR(10) column */
+    private const int MAX_UNIT_LENGTH = 10;
+
+    /** @var int maximum length of the joined custom units, matching the custom_units VARCHAR(255) column */
+    private const int MAX_CUSTOM_UNITS_LENGTH = 255;
+
     #[Override]
     public function getContent(): mixed
     {
         return match ($this->target) {
             'name', 'orgid' => parent::getContent(),
+            'custom_units' => $this->getCustomUnits(),
+            'hidden_units' => $this->getHiddenUnits(),
             'announcement', 'newcomer_banner',
             'onboarding_email_subject',
             'onboarding_email_body' => $this->getNullableContent(),
@@ -51,5 +67,58 @@ final class TeamParam extends ContentParams
             return null;
         }
         return Filter::body(parent::getContent());
+    }
+
+    /**
+     * Normalize an admin-entered list of custom container units.
+     * Split on comma or newline, trim, strip tags, drop empties, dedupe, drop tokens longer
+     * than the qty_unit column allows, and stop before the joined result would overflow the
+     * custom_units column. Re-joined with ', '.
+     */
+    private function getCustomUnits(): ?string
+    {
+        $tokens = preg_split('/[,\r\n]+/', $this->asString()) ?: array();
+        $units = array();
+        $length = 0;
+        foreach ($tokens as $token) {
+            $unit = trim(strip_tags($token));
+            if ($unit === '' || mb_strlen($unit) > self::MAX_UNIT_LENGTH || in_array($unit, $units, true)) {
+                continue;
+            }
+            // account for the ', ' separator between units
+            $additional = mb_strlen($unit) + ($units === array() ? 0 : 2);
+            if ($length + $additional > self::MAX_CUSTOM_UNITS_LENGTH) {
+                break;
+            }
+            $units[] = $unit;
+            $length += $additional;
+        }
+        if ($units === array()) {
+            return null;
+        }
+        return implode(', ', $units);
+    }
+
+    /**
+     * Normalize the admin-selected list of built-in units to hide from the container dropdowns.
+     * Only genuine built-in unit values are kept (hiding a custom unit is meaningless: it is
+     * removed via custom_units instead), deduped and joined with ',' (no space) so the value
+     * round-trips cleanly through the checkbox UI and the data attributes.
+     */
+    private function getHiddenUnits(): ?string
+    {
+        $tokens = preg_split('/[,\r\n]+/', $this->asString()) ?: array();
+        $units = array();
+        foreach ($tokens as $token) {
+            $unit = trim($token);
+            if (Units::tryFrom($unit) === null || in_array($unit, $units, true)) {
+                continue;
+            }
+            $units[] = $unit;
+        }
+        if ($units === array()) {
+            return null;
+        }
+        return implode(',', $units);
     }
 }

--- a/src/sql/schema210.sql
+++ b/src/sql/schema210.sql
@@ -1,0 +1,4 @@
+-- schema 210
+ALTER TABLE `teams` ADD `custom_units` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `teams` ADD `hidden_units` VARCHAR(255) NULL DEFAULT NULL;
+UPDATE config SET conf_value = 210 WHERE conf_name = 'schema';

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1201,6 +1201,8 @@ CREATE TABLE `teams` (
   `newcomer_threshold` INT UNSIGNED NOT NULL DEFAULT 15,
   `newcomer_banner` TEXT NULL DEFAULT NULL,
   `newcomer_banner_active` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `custom_units` varchar(255) NULL DEFAULT NULL,
+  `hidden_units` varchar(255) NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -17,17 +17,10 @@
             <input type='number' value='1' min='0' step='any' id='containerQtyStoredInput' autocomplete='off' class='form-control' />
             <div class='input-group-append'>
               <select class='custom-select brl-none brr-none' id='containerQtyUnitSelect' aria-label='{{ 'Quantity unit'|trans }}'>
-                {# built-in units: never modified or reordered (see enum Units), only hidden per team #}
-                {% if '•' not in hiddenUnitsArr %}<option value='•'>•</option>{% endif %}
-                {% if 'μL' not in hiddenUnitsArr %}<option value='μL'>μL</option>{% endif %}
-                {% if 'mL' not in hiddenUnitsArr %}<option value='mL'>mL</option>{% endif %}
-                {% if 'L' not in hiddenUnitsArr %}<option value='L'>L</option>{% endif %}
-                {% if 'μg' not in hiddenUnitsArr %}<option value='μg'>μg</option>{% endif %}
-                {% if 'mg' not in hiddenUnitsArr %}<option value='mg'>mg</option>{% endif %}
-                {% if 'g' not in hiddenUnitsArr %}<option value='g'>g</option>{% endif %}
-                {% if 'kg' not in hiddenUnitsArr %}<option value='kg'>kg</option>{% endif %}
-                {% if 'bar' not in hiddenUnitsArr %}<option value='bar'>Bar</option>{% endif %}
-                {% if 'm' not in hiddenUnitsArr %}<option value='m'>Metre</option>{% endif %}
+                {# built-in units (enum Units, in display order), minus the ones the team hid #}
+                {% for unit in builtinUnitsArr if unit.value not in hiddenUnitsArr %}
+                <option value='{{ unit.value }}'>{{ unit.label }}</option>
+                {% endfor %}
                 {# team-specific custom units, appended after the built-ins #}
                 {% for unit in customUnitsArr %}
                 <option value='{{ unit }}'>{{ unit }}</option>

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -18,8 +18,8 @@
             <div class='input-group-append'>
               <select class='custom-select brl-none brr-none' id='containerQtyUnitSelect' aria-label='{{ 'Quantity unit'|trans }}'>
                 {# built-in units (enum Units, in display order), minus the ones the team hid #}
-                {% for unit in builtinUnitsArr if unit.value not in hiddenUnitsArr %}
-                <option value='{{ unit.value }}'>{{ unit.label }}</option>
+                {% for unit in builtinUnitsArr %}
+                {% if unit.value not in hiddenUnitsArr %}<option value='{{ unit.value }}'>{{ unit.label }}</option>{% endif %}
                 {% endfor %}
                 {# team-specific custom units, appended after the built-ins #}
                 {% for unit in customUnitsArr %}

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -17,17 +17,21 @@
             <input type='number' value='1' min='0' step='any' id='containerQtyStoredInput' autocomplete='off' class='form-control' />
             <div class='input-group-append'>
               <select class='custom-select brl-none brr-none' id='containerQtyUnitSelect' aria-label='{{ 'Quantity unit'|trans }}'>
-                {# TODO use enum Units #}
-                <option value='•'>•</option>
-                <option value='μL'>μL</option>
-                <option value='mL'>mL</option>
-                <option value='L'>L</option>
-                <option value='μg'>μg</option>
-                <option value='mg'>mg</option>
-                <option value='g'>g</option>
-                <option value='kg'>kg</option>
-                <option value='bar'>Bar</option>
-                <option value='m'>Metre</option>
+                {# built-in units: never modified or reordered (see enum Units), only hidden per team #}
+                {% if '•' not in hiddenUnitsArr %}<option value='•'>•</option>{% endif %}
+                {% if 'μL' not in hiddenUnitsArr %}<option value='μL'>μL</option>{% endif %}
+                {% if 'mL' not in hiddenUnitsArr %}<option value='mL'>mL</option>{% endif %}
+                {% if 'L' not in hiddenUnitsArr %}<option value='L'>L</option>{% endif %}
+                {% if 'μg' not in hiddenUnitsArr %}<option value='μg'>μg</option>{% endif %}
+                {% if 'mg' not in hiddenUnitsArr %}<option value='mg'>mg</option>{% endif %}
+                {% if 'g' not in hiddenUnitsArr %}<option value='g'>g</option>{% endif %}
+                {% if 'kg' not in hiddenUnitsArr %}<option value='kg'>kg</option>{% endif %}
+                {% if 'bar' not in hiddenUnitsArr %}<option value='bar'>Bar</option>{% endif %}
+                {% if 'm' not in hiddenUnitsArr %}<option value='m'>Metre</option>{% endif %}
+                {# team-specific custom units, appended after the built-ins #}
+                {% for unit in customUnitsArr %}
+                <option value='{{ unit }}'>{{ unit }}</option>
+                {% endfor %}
               </select>
             </div>
           </div>

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -74,6 +74,24 @@
     <p class='smallgray'>{{ "The following text will be displayed to all users on all pages while it's active."|trans }}</p>
     <hr>
 
+    <div class='d-flex justify-content-between'>
+      <label for='custom_units' class='col-form-label'>{{ 'Custom container units'|trans }}</label>
+      <input class='form-control col-md-4' data-trigger='blur' data-model='{{ model }}' data-target='custom_units' data-reflect='list' type='text' id='custom_units' name='custom_units' value='{{ App.Teams.teamArr.custom_units }}' />
+    </div>
+    <p class='smallgray'>{{ 'Comma-separated extra units offered when storing containers, in addition to the built-in ones (e.g. Mcells, OD600). Maximum 10 characters each.'|trans }}</p>
+
+    {% set hiddenUnits = (App.Teams.teamArr.hidden_units ?? '')|split(',') %}
+    <label class='col-form-label d-block'>{{ 'Built-in units to offer'|trans }}</label>
+    <div class='d-flex flex-wrap'>
+      {% for value, label in {'•': '•', 'μL': 'μL', 'mL': 'mL', 'L': 'L', 'μg': 'μg', 'mg': 'mg', 'g': 'g', 'kg': 'kg', 'bar': 'Bar', 'm': 'Metre'} %}
+        <label class='form-check-label mr-3 text-nowrap'>
+          <input type='checkbox' class='hidden-unit-toggle' data-trigger='change' data-model='{{ model }}' data-target='hidden_units' data-transform='collectHiddenUnits' value='{{ value }}'{{ value not in hiddenUnits ? ' checked' }} /> {{ label }}
+        </label>
+      {% endfor %}
+    </div>
+    <p class='smallgray'>{{ 'Uncheck a built-in unit to stop offering it when storing containers. Containers already using it keep their value and stay editable.'|trans }}</p>
+    <hr>
+
     {% include 'binary-setting.html' with {'model': model, 'src': src,
       'slug': 'force_exp_tpl',
       'label': 'Force experiment template use'|trans,

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -83,9 +83,9 @@
     {% set hiddenUnits = (App.Teams.teamArr.hidden_units ?? '')|split(',') %}
     <label class='col-form-label d-block'>{{ 'Built-in units to offer'|trans }}</label>
     <div class='d-flex flex-wrap'>
-      {% for value, label in {'•': '•', 'μL': 'μL', 'mL': 'mL', 'L': 'L', 'μg': 'μg', 'mg': 'mg', 'g': 'g', 'kg': 'kg', 'bar': 'Bar', 'm': 'Metre'} %}
+      {% for unit in builtinUnitsArr %}
         <label class='form-check-label mr-3 text-nowrap'>
-          <input type='checkbox' class='hidden-unit-toggle' data-trigger='change' data-model='{{ model }}' data-target='hidden_units' data-transform='collectHiddenUnits' value='{{ value }}'{{ value not in hiddenUnits ? ' checked' }} /> {{ label }}
+          <input type='checkbox' class='hidden-unit-toggle' data-trigger='change' data-model='{{ model }}' data-target='hidden_units' data-transform='collectHiddenUnits' value='{{ unit.value }}'{{ unit.value not in hiddenUnits ? ' checked' }} /> {{ unit.label }}
         </label>
       {% endfor %}
     </div>

--- a/src/templates/storage-view-edit.html
+++ b/src/templates/storage-view-edit.html
@@ -6,7 +6,7 @@
 <div class='row mt-2' id='storageDivContent' data-save-hidden='storageDivContent' data-count-for='containersCount'>
   <div class='ml-3 mt-3 col-md-12'>
       {% if Entity.entityData.containers %}
-        <ul class='list-group' id='containersDiv'>
+        <ul class='list-group' id='containersDiv' data-custom-units='{{ customUnitsArr|join(',') }}' data-hidden-units='{{ hiddenUnitsArr|join(',') }}'>
           {% for container in Entity.entityData.containers %}
             <li class='list-group-item countable'>
               <div class='d-flex flex align-items-center'>

--- a/src/templates/storage-view-edit.html
+++ b/src/templates/storage-view-edit.html
@@ -6,7 +6,7 @@
 <div class='row mt-2' id='storageDivContent' data-save-hidden='storageDivContent' data-count-for='containersCount'>
   <div class='ml-3 mt-3 col-md-12'>
       {% if Entity.entityData.containers %}
-        <ul class='list-group' id='containersDiv' data-custom-units='{{ customUnitsArr|join(',') }}' data-hidden-units='{{ hiddenUnitsArr|join(',') }}'>
+        <ul class='list-group' id='containersDiv' data-builtin-units='{% for unit in builtinUnitsArr %}{{ unit.value }}{{ not loop.last ? ',' }}{% endfor %}' data-custom-units='{{ customUnitsArr|join(',') }}' data-hidden-units='{{ hiddenUnitsArr|join(',') }}'>
           {% for container in Entity.entityData.containers %}
             <li class='list-group-item countable'>
               <div class='d-flex flex align-items-center'>

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -135,9 +135,9 @@ async function triggerHandler(event: Event, el: HTMLInputElement): Promise<void>
       if (el.dataset.reflect === 'list') {
         const submitted = String(value).split(/[,\r\n]+/).map(item => item.trim()).filter(Boolean);
         const storedSet = new Set(stored.split(',').map(item => item.trim()).filter(Boolean));
-        const dropped = [...new Set(submitted.filter(item => !storedSet.has(item)))];
-        // TEMPORARY DEBUG (remove): surfaces in cypress output as `cons:warn` to diagnose why the warning isn't shown
-        console.warn(`DBG-units value=${JSON.stringify(String(value))} stored=${JSON.stringify(stored)} submitted=${JSON.stringify(submitted)} dropped=${JSON.stringify(dropped)}`);
+        // NB: use Array.from, not [...new Set()] — ts-loader (transpileOnly, no downlevelIteration,
+        // default target) mis-compiles spread of a Set to an empty array. See also qty unit list below.
+        const dropped = Array.from(new Set(submitted.filter(item => !storedSet.has(item))));
         if (dropped.length > 0) {
           // defaultValue renders the message before the i18next catalogs are regenerated from
           // i18n4Js.php (bin/console dev:i18n4js); a catalog translation overrides it once present
@@ -369,11 +369,11 @@ export function makeMalleableColumnsGreatAgain() {
   const inUseUnits = Array.from(document.querySelectorAll('.malleableQtyUnit'))
     .map(el => (el.textContent ?? '').trim())
     .filter(Boolean);
-  const qtyUnitValues = [...new Set([
+  const qtyUnitValues = Array.from(new Set([
     ...builtinUnits.filter(unit => !hiddenUnits.has(unit)),
     ...customUnits,
     ...inUseUnits,
-  ])];
+  ]));
   new Malle({
     cancel : i18next.t('cancel'),
     cancelClasses: ['btn', 'btn-danger', 'mt-2', 'ml-1'],

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -136,6 +136,8 @@ async function triggerHandler(event: Event, el: HTMLInputElement): Promise<void>
         const submitted = String(value).split(/[,\r\n]+/).map(item => item.trim()).filter(Boolean);
         const storedSet = new Set(stored.split(',').map(item => item.trim()).filter(Boolean));
         const dropped = [...new Set(submitted.filter(item => !storedSet.has(item)))];
+        // TEMPORARY DEBUG (remove): surfaces in cypress output as `cons:warn` to diagnose why the warning isn't shown
+        console.warn(`DBG-units value=${JSON.stringify(String(value))} stored=${JSON.stringify(stored)} submitted=${JSON.stringify(submitted)} dropped=${JSON.stringify(dropped)}`);
         if (dropped.length > 0) {
           // defaultValue renders the message before the i18next catalogs are regenerated from
           // i18n4Js.php (bin/console dev:i18n4js); a catalog translation overrides it once present

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -360,7 +360,8 @@ export function makeMalleableColumnsGreatAgain() {
   // a container so that editing never silently changes a value not in the configured lists
   const containersDiv = document.getElementById('containersDiv');
   const splitUnits = (raw?: string): string[] => (raw ?? '').split(',').map(unit => unit.trim()).filter(Boolean);
-  const builtinUnits = ['•', 'μL', 'mL', 'L', 'μg', 'mg', 'g', 'kg', 'bar', 'm'];
+  // built-in units (enum Units, in display order) are rendered server-side on #containersDiv
+  const builtinUnits = splitUnits(containersDiv?.dataset.builtinUnits);
   const customUnits = splitUnits(containersDiv?.dataset.customUnits);
   const hiddenUnits = new Set(splitUnits(containersDiv?.dataset.hiddenUnits));
   const inUseUnits = Array.from(document.querySelectorAll('.malleableQtyUnit'))

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -95,6 +95,13 @@ async function triggerHandler(event: Event, el: HTMLInputElement): Promise<void>
   if (el.dataset.transform === 'permissionsToJson') {
     value = permissionsToJson([]);
   }
+  // collect the built-in units the admin chose to hide (the unchecked toggles) into one value
+  if (el.dataset.transform === 'collectHiddenUnits') {
+    value = Array.from(document.querySelectorAll<HTMLInputElement>('.hidden-unit-toggle'))
+      .filter(toggle => !toggle.checked)
+      .map(toggle => toggle.value)
+      .join(',');
+  }
   if (el.dataset.value) {
     value = el.dataset.value;
   }
@@ -116,7 +123,25 @@ async function triggerHandler(event: Event, el: HTMLInputElement): Promise<void>
     const params: Record<string, unknown> = {};
     params[el.dataset.target as string] = value;
 
-    await ApiC.patch(`${el.dataset.model}`, params);
+    const response = await ApiC.patch(`${el.dataset.model}`, params);
+
+    // reflect the server-normalized value back into the field (opt-in via data-reflect) so the
+    // admin sees exactly what was stored, e.g. after custom units are trimmed, deduped or dropped
+    if (el.dataset.reflect && !isCheckbox) {
+      const json = await response.json();
+      const stored = (json[el.dataset.target as string] ?? '') as string;
+      // for comma-separated lists, tell the admin which entries did not make it through
+      // (e.g. too long or pushed past the column size) so the silent change isn't confusing
+      if (el.dataset.reflect === 'list') {
+        const submitted = String(value).split(/[,\r\n]+/).map(item => item.trim()).filter(Boolean);
+        const storedSet = new Set(stored.split(',').map(item => item.trim()).filter(Boolean));
+        const dropped = [...new Set(submitted.filter(item => !storedSet.has(item)))];
+        if (dropped.length > 0) {
+          notify.warning('custom-units-dropped', {units: dropped.join(', ')});
+        }
+      }
+      el.value = stored;
+    }
 
     // success side-effect for the generic path
     if (el.dataset.reload) {
@@ -325,21 +350,28 @@ export function makeMalleableColumnsGreatAgain() {
   }).listen();
 
   // MALLEABLE QTY_UNIT - we need a specific code to add the select options
+  // the offered units are: the built-in units minus the ones the team hid, plus the team's
+  // custom units (both declared on #containersDiv server-side), plus any unit already in use on
+  // a container so that editing never silently changes a value not in the configured lists
+  const containersDiv = document.getElementById('containersDiv');
+  const splitUnits = (raw?: string): string[] => (raw ?? '').split(',').map(unit => unit.trim()).filter(Boolean);
+  const builtinUnits = ['•', 'μL', 'mL', 'L', 'μg', 'mg', 'g', 'kg', 'bar', 'm'];
+  const customUnits = splitUnits(containersDiv?.dataset.customUnits);
+  const hiddenUnits = new Set(splitUnits(containersDiv?.dataset.hiddenUnits));
+  const inUseUnits = Array.from(document.querySelectorAll('.malleableQtyUnit'))
+    .map(el => (el.textContent ?? '').trim())
+    .filter(Boolean);
+  const qtyUnitValues = [...new Set([
+    ...builtinUnits.filter(unit => !hiddenUnits.has(unit)),
+    ...customUnits,
+    ...inUseUnits,
+  ])];
   new Malle({
     cancel : i18next.t('cancel'),
     cancelClasses: ['btn', 'btn-danger', 'mt-2', 'ml-1'],
     inputClasses: ['form-control'],
     inputType: InputType.Select,
-    selectOptions: [
-      {selected: false, text: '•', value: '•'},
-      {selected: false, text: 'μL', value: 'μL'},
-      {selected: false, text: 'mL', value: 'mL'},
-      {selected: false, text: 'L', value: 'L'},
-      {selected: false, text: 'μg', value: 'μg'},
-      {selected: false, text: 'mg', value: 'mg'},
-      {selected: false, text: 'g', value: 'g'},
-      {selected: false, text: 'kg', value: 'kg'},
-    ],
+    selectOptions: qtyUnitValues.map(value => ({selected: false, text: value, value})),
     fun: (value, original) => {
       return ApiC.patch(`${original.dataset.endpoint}/${original.dataset.id}`, {qty_unit: value})
         .then(res => res.json())

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -137,7 +137,12 @@ async function triggerHandler(event: Event, el: HTMLInputElement): Promise<void>
         const storedSet = new Set(stored.split(',').map(item => item.trim()).filter(Boolean));
         const dropped = [...new Set(submitted.filter(item => !storedSet.has(item)))];
         if (dropped.length > 0) {
-          notify.warning('custom-units-dropped', {units: dropped.join(', ')});
+          // defaultValue renders the message before the i18next catalogs are regenerated from
+          // i18n4Js.php (bin/console dev:i18n4js); a catalog translation overrides it once present
+          notify.warning('custom-units-dropped', {
+            units: dropped.join(', '),
+            defaultValue: 'Some custom units were not saved (each must be at most 10 characters, and the whole list is limited to 255 characters): {{units}}',
+          });
         }
       }
       el.value = stored;

--- a/tests/cypress/integration/customUnits.cy.ts
+++ b/tests/cypress/integration/customUnits.cy.ts
@@ -36,10 +36,10 @@ describe('Container units', () => {
 
     cy.get('#custom_units').clear().type(`mL, mL, ${tooLong}`).blur();
 
-    // a warning naming the dropped unit is shown (overlay-warning persists, unlike the success one)
-    cy.get('.overlay-warning').should('be.visible').and('contain', tooLong);
-    // the field is rewritten to exactly what was stored (dedup + over-length dropped)
+    // reflect-back: the field is rewritten to exactly what was stored (dedup + over-length dropped)
     cy.get('#custom_units').should('have.value', 'mL');
+    // and a warning naming the dropped unit is shown (overlay-warning persists, unlike success)
+    cy.get('.overlay-warning').should('be.visible').and('contain', tooLong);
   });
 
   it('offers (built-ins - hidden) + custom units in the add-container modal', () => {
@@ -100,7 +100,8 @@ describe('Container units', () => {
               // clicking to edit renders the Malle select (at document level) with "bar" still
               // offered (it is the selected value) even though it is hidden team-wide
               cy.get('#containersDiv .malleableQtyUnit').first().click();
-              cy.get('select:has(option:selected:contains("bar"))').should('exist');
+              // bar is offered as an option (it is in use), even though hidden team-wide
+              cy.get('select:has(option:contains("bar"))').should('exist');
             });
           });
         });

--- a/tests/cypress/integration/customUnits.cy.ts
+++ b/tests/cypress/integration/customUnits.cy.ts
@@ -61,6 +61,25 @@ describe('Container units', () => {
     });
   });
 
+  it('does not duplicate a built-in unit that is also stored as a custom unit', () => {
+    // 'mL' is a built-in; storing it as a custom unit must not make it render twice in the dropdown
+    cy.request('PATCH', '/api/v2/teams/current', { custom_units: 'mL, Mcells', hidden_units: '' });
+
+    cy.createResource().then(response => {
+      cy.extractIdFromLocation(response).then(itemId => {
+        cy.visit(`/database.php?mode=edit&id=${itemId}`);
+        cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
+        cy.get('#storageModal').should('be.visible');
+
+        cy.get('#containerQtyUnitSelect option').then($opts => {
+          const values = [...$opts].map(o => (o as HTMLOptionElement).value);
+          expect(values.filter(v => v === 'mL')).to.have.length(1); // built-in, not duplicated
+          expect(values).to.include('Mcells');                       // genuine custom still appended
+        });
+      });
+    });
+  });
+
   it('keeps a hidden unit selectable on a container already using it (no silent change)', () => {
     cy.request('PATCH', '/api/v2/teams/current', { hidden_units: 'bar' });
 

--- a/tests/cypress/integration/customUnits.cy.ts
+++ b/tests/cypress/integration/customUnits.cy.ts
@@ -36,8 +36,8 @@ describe('Container units', () => {
 
     cy.get('#custom_units').clear().type(`mL, mL, ${tooLong}`).blur();
 
-    // a warning naming the dropped unit is shown
-    cy.get('.overlay').should('be.visible').and('contain', tooLong);
+    // a warning naming the dropped unit is shown (overlay-warning persists, unlike the success one)
+    cy.get('.overlay-warning').should('be.visible').and('contain', tooLong);
     // the field is rewritten to exactly what was stored (dedup + over-length dropped)
     cy.get('#custom_units').should('have.value', 'mL');
   });
@@ -78,12 +78,10 @@ describe('Container units', () => {
               cy.visit(`/database.php?mode=edit&id=${itemId}`);
               // the container displays its stored unit
               cy.get('#containersDiv .malleableQtyUnit').should('contain', 'bar');
-              // clicking to edit offers "bar" even though it is hidden team-wide
+              // clicking to edit renders the Malle select (at document level) with "bar" still
+              // offered (it is the selected value) even though it is hidden team-wide
               cy.get('#containersDiv .malleableQtyUnit').first().click();
-              cy.get('#containersDiv select option').then($opts => {
-                const values = [...$opts].map(o => (o as HTMLOptionElement).value);
-                expect(values).to.include('bar');
-              });
+              cy.get('select:has(option:selected:contains("bar"))').should('exist');
             });
           });
         });

--- a/tests/cypress/integration/customUnits.cy.ts
+++ b/tests/cypress/integration/customUnits.cy.ts
@@ -1,0 +1,92 @@
+// Per-team container units: custom units + hiding built-ins.
+// NOTE: scaffold — not executed in the authoring environment. Selectors that depend on
+// the Malle inline editor and the admin tab layout may need a small adjustment on first run.
+describe('Container units', () => {
+  // a unit string that exceeds the 10-character per-unit limit
+  const tooLong = 'waytoolongunit';
+
+  beforeEach(() => {
+    cy.login();
+    // start from a known state: no custom units, nothing hidden
+    cy.request('PATCH', '/api/v2/teams/current', { custom_units: '', hidden_units: '' });
+  });
+
+  afterEach(() => {
+    // leave the team config clean for other specs
+    cy.request('PATCH', '/api/v2/teams/current', { custom_units: '', hidden_units: '' });
+  });
+
+  it('admin can add custom units and hide a built-in, and they persist', () => {
+    cy.visit('/admin.php');
+
+    // add custom units
+    cy.get('#custom_units').clear().type('Mcells, OD600').blur();
+    // hide the "bar" built-in
+    cy.get('.hidden-unit-toggle[value="bar"]').uncheck();
+
+    // reload and assert persistence
+    cy.visit('/admin.php');
+    cy.get('#custom_units').should('have.value', 'Mcells, OD600');
+    cy.get('.hidden-unit-toggle[value="bar"]').should('not.be.checked');
+    cy.get('.hidden-unit-toggle[value="mL"]').should('be.checked');
+  });
+
+  it('normalizes invalid custom units, reflects the stored value back and warns', () => {
+    cy.visit('/admin.php');
+
+    cy.get('#custom_units').clear().type(`mL, mL, ${tooLong}`).blur();
+
+    // a warning naming the dropped unit is shown
+    cy.get('.overlay').should('be.visible').and('contain', tooLong);
+    // the field is rewritten to exactly what was stored (dedup + over-length dropped)
+    cy.get('#custom_units').should('have.value', 'mL');
+  });
+
+  it('offers (built-ins - hidden) + custom units in the add-container modal', () => {
+    cy.request('PATCH', '/api/v2/teams/current', { custom_units: 'Mcells', hidden_units: 'bar' });
+
+    cy.createResource().then(response => {
+      cy.extractIdFromLocation(response).then(itemId => {
+        cy.visit(`/database.php?mode=edit&id=${itemId}`);
+        cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
+        cy.get('#storageModal').should('be.visible');
+
+        cy.get('#containerQtyUnitSelect option').then($opts => {
+          const values = [...$opts].map(o => (o as HTMLOptionElement).value);
+          expect(values).to.include('Mcells'); // custom unit appended
+          expect(values).to.include('mL');      // a normal built-in still offered
+          expect(values).to.not.include('bar'); // hidden built-in removed
+        });
+      });
+    });
+  });
+
+  it('keeps a hidden unit selectable on a container already using it (no silent change)', () => {
+    cy.request('PATCH', '/api/v2/teams/current', { hidden_units: 'bar' });
+
+    // create a storage location, then a container stored with the (now hidden) "bar" unit
+    cy.request('POST', '/api/v2/storage_units', { name: `Cypress storage ${Date.now()}` })
+      .then(storageRes => {
+        cy.extractIdFromLocation(storageRes).then(storageId => {
+          cy.createResource().then(response => {
+            cy.extractIdFromLocation(response).then(itemId => {
+              cy.request('POST', `/api/v2/items/${itemId}/containers/${storageId}`, {
+                qty_stored: '3',
+                qty_unit: 'bar',
+              });
+
+              cy.visit(`/database.php?mode=edit&id=${itemId}`);
+              // the container displays its stored unit
+              cy.get('#containersDiv .malleableQtyUnit').should('contain', 'bar');
+              // clicking to edit offers "bar" even though it is hidden team-wide
+              cy.get('#containersDiv .malleableQtyUnit').first().click();
+              cy.get('#containersDiv select option').then($opts => {
+                const values = [...$opts].map(o => (o as HTMLOptionElement).value);
+                expect(values).to.include('bar');
+              });
+            });
+          });
+        });
+      });
+  });
+});

--- a/tests/unit/Enums/EnumsTest.php
+++ b/tests/unit/Enums/EnumsTest.php
@@ -30,6 +30,23 @@ class EnumsTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testUnitsLabel(): void
+    {
+        $this->assertSame('Bar', Units::Bar->label());
+        $this->assertSame('Metre', Units::Metre->label());
+        // units without a custom label fall back to their value
+        $this->assertSame('mL', Units::MilliLiter->label());
+    }
+
+    public function testUnitsInDisplayOrder(): void
+    {
+        $order = Units::inDisplayOrder();
+        // the count unit is first so it stays the default in the dropdowns
+        $this->assertSame(Units::Unit, $order[0]);
+        // display order must cover every case exactly once (guards against drift)
+        $this->assertEqualsCanonicalizing(Units::cases(), $order);
+    }
+
     public function testLanguage(): void
     {
         $this->assertIsArray(Language::getAllHuman());

--- a/tests/unit/Params/TeamParamTest.php
+++ b/tests/unit/Params/TeamParamTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Params;
+
+use function implode;
+use function mb_strlen;
+use function range;
+use function sprintf;
+use function str_contains;
+
+class TeamParamTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCustomUnitsHappyPath(): void
+    {
+        $this->assertSame('Mcells, OD600', (new TeamParam('custom_units', 'Mcells, OD600'))->getContent());
+    }
+
+    public function testCustomUnitsTrimsAndDropsEmpties(): void
+    {
+        $this->assertSame('mL, g', (new TeamParam('custom_units', ' mL , , g '))->getContent());
+    }
+
+    public function testCustomUnitsSplitsOnNewlines(): void
+    {
+        $this->assertSame('mL, g', (new TeamParam('custom_units', "mL\ng"))->getContent());
+    }
+
+    public function testCustomUnitsDeduplicates(): void
+    {
+        $this->assertSame('mL', (new TeamParam('custom_units', 'mL, mL'))->getContent());
+    }
+
+    public function testCustomUnitsDropsTokensLongerThanTenChars(): void
+    {
+        // 'elevenchars' is 11 characters and must be dropped, 'ok' kept
+        $this->assertSame('ok', (new TeamParam('custom_units', 'ok, elevenchars'))->getContent());
+    }
+
+    public function testCustomUnitsStripsTags(): void
+    {
+        $this->assertSame('mL', (new TeamParam('custom_units', '<b>mL</b>'))->getContent());
+    }
+
+    public function testCustomUnitsKeepsMultibyteUnits(): void
+    {
+        // μL is 2 characters (well within the 10 char limit)
+        $this->assertSame('μL, µmol', (new TeamParam('custom_units', 'μL, µmol'))->getContent());
+    }
+
+    public function testCustomUnitsReturnsNullWhenEmpty(): void
+    {
+        $this->assertNull((new TeamParam('custom_units', ''))->getContent());
+        $this->assertNull((new TeamParam('custom_units', '   '))->getContent());
+        $this->assertNull((new TeamParam('custom_units', ', ,'))->getContent());
+    }
+
+    public function testCustomUnitsStaysWithinColumnSize(): void
+    {
+        // 30 distinct 10-character units would join to well over 255 chars
+        $units = array();
+        foreach (range(1, 30) as $i) {
+            $units[] = sprintf('unit%06d', $i); // 'unit' + 6 digits = 10 chars
+        }
+        $result = (new TeamParam('custom_units', implode(',', $units)))->getContent();
+        $this->assertIsString($result);
+        $this->assertLessThanOrEqual(255, mb_strlen($result));
+        // the first unit is kept, the tail is dropped before overflowing
+        $this->assertTrue(str_contains($result, 'unit000001'));
+        $this->assertFalse(str_contains($result, 'unit000030'));
+    }
+
+    public function testHiddenUnitsKeepsValidBuiltins(): void
+    {
+        $this->assertSame('bar,m', (new TeamParam('hidden_units', 'bar,m'))->getContent());
+    }
+
+    public function testHiddenUnitsTrims(): void
+    {
+        $this->assertSame('bar,m', (new TeamParam('hidden_units', 'bar, m'))->getContent());
+    }
+
+    public function testHiddenUnitsKeepsMultibyteBuiltins(): void
+    {
+        $this->assertSame('•,μL', (new TeamParam('hidden_units', '•,μL'))->getContent());
+    }
+
+    public function testHiddenUnitsDropsNonBuiltins(): void
+    {
+        // Mcells and xyz are not built-in units, only bar survives
+        $this->assertSame('bar', (new TeamParam('hidden_units', 'bar,Mcells,xyz'))->getContent());
+    }
+
+    public function testHiddenUnitsDeduplicates(): void
+    {
+        $this->assertSame('bar', (new TeamParam('hidden_units', 'bar,bar'))->getContent());
+    }
+
+    public function testHiddenUnitsReturnsNullWhenEmpty(): void
+    {
+        $this->assertNull((new TeamParam('hidden_units', ''))->getContent());
+        $this->assertNull((new TeamParam('hidden_units', 'Mcells,xyz'))->getContent());
+    }
+}

--- a/web/admin.php
+++ b/web/admin.php
@@ -14,6 +14,7 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Enums\PasswordComplexity;
 use Elabftw\Enums\AccessType;
+use Elabftw\Enums\Units;
 use Elabftw\Exceptions\AppException;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Factories\LinksFactory;
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 use function array_filter;
 use function _;
+use function array_map;
 
 /**
  * Administration panel of a team
@@ -111,6 +113,10 @@ try {
     $template = 'admin.html';
     $renderArr = array(
         'allTeamUsersArr' => $allTeamUsersArr,
+        'builtinUnitsArr' => array_map(
+            static fn(Units $unit): array => array('value' => $unit->value, 'label' => $unit->label()),
+            Units::inDisplayOrder(),
+        ),
         'tagsArr' => $TeamTags->readAll(),
         'metadataGroups' => $metadataGroups,
         'allTeamgroupsArr' => $TeamGroups->readAllEverything(),


### PR DESCRIPTION
# Configure per-team container units

## Pull Request Checklist

- [x] I have added tests for any new features. → `tests/unit/Params/TeamParamTest.php` covers the unit normalization (passing); `tests/cypress/integration/customUnits.cy.ts` covers the admin controls and dropdowns.
- [x] I have mentioned the related issue (if applicable). → No related issue, this is a standalone enhancement.
- [x] I have updated or verified the relevant documentation. → No behavioural docs reference container units; the new admin controls carry inline help text.

## Summary

Container quantity units were a fixed list of 10, defined in the `Units` PHP enum and duplicated by hand in two frontend dropdowns. This lets a team admin tailor that list:

- **add custom units** (e.g. `Mcells`, `OD600`) that appear in the unit dropdowns alongside the built-ins;
- **hide built-in units** the team does not use.

Both are stored per team and resolved from the **entity's owning team**, so a resource shared across teams shows the same unit vocabulary regardless of who opens it.

The 10 built-in units are not modified, reordered or removed: hiding is a per-team display filter over the enum, and the add-container default (`•`) is unchanged. A container whose unit is later hidden or removed keeps its stored value and stays editable, because the inline-edit dropdown also offers any unit currently in use.

## Changes

- Added two nullable `VARCHAR(255)` columns to `teams`: `custom_units` (extra units, appended after the built-ins) and `hidden_units` (built-in values switched off), behind schema 210.
- Server-side normalization in `TeamParam`: custom units are trimmed, de-duplicated, capped at 10 characters each (matching `qty_unit VARCHAR(10)`), and the joined list is bounded so it cannot overflow the column; `hidden_units` only accepts genuine built-in unit values.
- `AbstractEntityController` computes the custom and hidden unit lists from the entity's owning team (one memoized query) and passes them to the view and edit templates.
- The Add container modal renders each built-in `<option>` unless it is hidden, then appends the team's custom units.
- The inline-edit unit dropdown is built from `(built-ins − hidden) + custom + units already in use`. This also adds `bar` and `m`, which the inline editor was previously missing.
- Admin panel: a "Custom container units" text field and a row of "Built-in units to offer" checkboxes, saved via the existing `teams/current` PATCH mechanism.
- After saving custom units, the field is updated with the server-normalized value, and a warning naming any dropped entries is shown.
- Registered the new warning string in the i18next source `src/Elabftw/i18n4Js.php`.

## Files changed

- `src/sql/structure.sql` — added `teams.custom_units` and `teams.hidden_units`.
- `src/sql/schema210.sql` *(new)* — migration adding the two columns and bumping the schema to 210.
- `src/Elabftw/SchemaVersionChecker.php` — `REQUIRED_SCHEMA` 209 → 210.
- `src/Params/TeamParam.php` — `custom_units` and `hidden_units` cases with their normalization helpers.
- `src/Controllers/AbstractEntityController.php` — `getCustomUnitsArr()` / `getHiddenUnitsArr()` resolved from the entity's owning team via a memoized `entityTeamArr()`; both added to the view and edit render arrays.
- `src/templates/add-container-modal.html` — built-in options guarded by the hidden set; custom units appended.
- `src/templates/storage-view-edit.html` — `data-custom-units` and `data-hidden-units` on `#containersDiv`.
- `src/templates/admin.html` — custom-units text field and built-in show/hide checkboxes.
- `src/ts/misc.ts` — inline-edit unit list; `collectHiddenUnits` transform; reflect-back of the normalized custom-units value plus the dropped-units warning.
- `src/Elabftw/i18n4Js.php` — registered the `custom-units-dropped` warning string.
- `tests/unit/Params/TeamParamTest.php` *(new)* — unit tests for the `custom_units` / `hidden_units` normalization.
- `tests/cypress/integration/customUnits.cy.ts` *(new)* — end-to-end tests for the admin controls and dropdowns.

## Testing

- `tests/unit/Params/TeamParamTest.php` — 15 PHPUnit cases for `custom_units` and `hidden_units` normalization (trim, dedupe, per-unit length cap, 255-char total cap, tag stripping, built-in-only filtering, null on empty). Passing: `OK (15 tests, 22 assertions)`.
- `tests/cypress/integration/customUnits.cy.ts` — covers admin add/hide persistence across reload; invalid-input normalization with reflect-back and the dropped-units warning; the add-container dropdown showing `(built-ins − hidden) + custom`; and a hidden unit staying selectable on a container already using it. Not executed in the authoring environment (no Node toolchain/instance).
- `php-cs-fixer` and `phpstan` pass on the changed PHP files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teams can define custom container units and hide built-in units; add/edit dialogs and dropdowns honor team settings while preserving units already in use.

* **Bug Fixes**
  * Admin inputs for custom units are normalized; invalid/duplicate entries are dropped and users are warned with server-reflected normalized values.

* **Chore**
  * Schema version and database updated to store team custom/hidden units.

* **Tests**
  * New unit and end-to-end tests covering unit handling, normalization, and UI behavior.

* **Documentation**
  * Added translatable message for reporting dropped custom units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->