### PR TITLE
bug/minor: tinymce dark: fix path

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -226,7 +226,7 @@ export function getTinymceBaseConfig(page: string): object {
     // location of the skin directory
     skin_url: isDark ? '/assets/tinymce_skins_dark' : '/assets/tinymce_skins',
     skin: isDark ? 'oxide-dark' : 'oxide',
-    content_css: isDark ? ['/assets/tinymce_skins/content/dark/content.min.css', '/assets/tinymce_content.min.css'] : ['/assets/tinymce_content.min.css'],
+    content_css: isDark ? ['/assets/tinymce_content_dark.min.css', '/assets/tinymce_content.min.css'] : ['/assets/tinymce_content.min.css'],
     emoticons_database_url: 'assets/tinymce_emojis.js',
     // remove the "Upgrade" button
     promotion: false,


### PR DESCRIPTION
<img width="1373" height="169" alt="image" src="https://github.com/user-attachments/assets/8195ffc5-454c-440b-812d-0b1cfce16938" />

To reproduce:
- Open any page with tinymce in dark mode and see console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text editor content styling to properly display in dark and light modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->