### PR TITLE
refactor(units): centralize quantity units using Units enum

### DIFF
--- a/src/Enums/Units.php
+++ b/src/Enums/Units.php
@@ -24,4 +24,13 @@ enum Units: string
     case MilliGram = 'mg';
     case Gram = 'g';
     case KiloGram = 'kg';
+
+    public function toHuman(): string
+    {
+        return match ($this) {
+            self::Bar => 'Bar',
+            self::Metre => 'Metre',
+            default => $this->value,
+        };
+    }
 }

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -17,17 +17,9 @@
             <input type='number' value='1' min='0' step='any' id='containerQtyStoredInput' autocomplete='off' class='form-control' />
             <div class='input-group-append'>
               <select class='custom-select brl-none brr-none' id='containerQtyUnitSelect' aria-label='{{ 'Quantity unit'|trans }}'>
-                {# TODO use enum Units #}
-                <option value='•'>•</option>
-                <option value='μL'>μL</option>
-                <option value='mL'>mL</option>
-                <option value='L'>L</option>
-                <option value='μg'>μg</option>
-                <option value='mg'>mg</option>
-                <option value='g'>g</option>
-                <option value='kg'>kg</option>
-                <option value='bar'>Bar</option>
-                <option value='m'>Metre</option>
+                {% for case in enum('Elabftw\\Enums\\Units').cases %}
+                  <option value='{{ case.value }}'>{{ case.toHuman() }}</option>
+                {% endfor %}
               </select>
             </div>
           </div>

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -204,6 +204,19 @@ interface Entity {
   id: number;
 }
 
+enum Unit {
+  Bar = 'bar',
+  Unit = '•',
+  Metre = 'm',
+  MicroLiter = 'μL',
+  MilliLiter = 'mL',
+  Liter = 'L',
+  MicroGram = 'μg',
+  MilliGram = 'mg',
+  Gram = 'g',
+  KiloGram = 'kg',
+}
+
 export {
   Action,
   BinaryValue,
@@ -221,5 +234,6 @@ export {
   Target,
   Todoitem,
   UnfinishedEntities,
+  Unit,
   Upload,
 };

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import 'jquery-ui/ui/widgets/sortable';
-import { Action, CheckableItem, EntityType, Entity, Model, Target, FileType } from './interfaces';
+import {Action, CheckableItem, EntityType, Entity, Model, Target, FileType, Unit} from './interfaces';
 import { DateTime } from 'luxon';
 import { MathJaxObject } from 'mathjax-full/js/components/startup';
 import tinymce from 'tinymce/tinymce';
@@ -293,6 +293,11 @@ export function getEntity(useParent: boolean = false): Entity {
   };
 }
 
+const unitLabels: Partial<Record<Unit, string>> = {
+  [Unit.Bar]: 'Bar',
+  [Unit.Metre]: 'Metre',
+};
+
 // Listen for malleable columns
 export function makeMalleableColumnsGreatAgain() {
   new Malle({
@@ -330,16 +335,8 @@ export function makeMalleableColumnsGreatAgain() {
     cancelClasses: ['btn', 'btn-danger', 'mt-2', 'ml-1'],
     inputClasses: ['form-control'],
     inputType: InputType.Select,
-    selectOptions: [
-      {selected: false, text: '•', value: '•'},
-      {selected: false, text: 'μL', value: 'μL'},
-      {selected: false, text: 'mL', value: 'mL'},
-      {selected: false, text: 'L', value: 'L'},
-      {selected: false, text: 'μg', value: 'μg'},
-      {selected: false, text: 'mg', value: 'mg'},
-      {selected: false, text: 'g', value: 'g'},
-      {selected: false, text: 'kg', value: 'kg'},
-    ],
+    selectOptions: Object.values(Unit).map(unit =>
+      ({selected: false, text: unitLabels[unit] ?? unit, value: unit})),
     fun: (value, original) => {
       return ApiC.patch(`${original.dataset.endpoint}/${original.dataset.id}`, {qty_unit: value})
         .then(res => res.json())

--- a/tests/unit/Enums/EnumsTest.php
+++ b/tests/unit/Enums/EnumsTest.php
@@ -76,6 +76,12 @@ class EnumsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray(Currency::getAssociativeArray());
     }
 
+    public function testUnit(): void
+    {
+        $this->assertSame('Bar', Units::Bar->toHuman());
+        $this->assertSame('Metre', Units::Metre->toHuman());
+    }
+
     public function testApiSubModels(): void
     {
         array_map(


### PR DESCRIPTION
fix #6656

Replace hardcoded quantity unit lists with the Units enum across backend and frontend.

- Add Units::toHuman() for display-friendly labels
- Generate unit options dynamically in templates
- Introduce Unit enum in TypeScript
- Refactor malleable select options to derive from enum values

Improves consistency, maintainability, and prevents duplication of unit definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit selection now shows human-readable labels for improved clarity.

* **Refactor**
  * Unit options are generated from a centralized source instead of hardcoded values, keeping selections consistent across the app.
  * TypeScript definitions updated to expose unit values to frontend code.

* **Tests**
  * Added unit tests to verify human-readable unit labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->