### PR TITLE
bug/medium: custom fields: escape metadata parsing errors before rendering

### DIFF
--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -84,7 +84,7 @@ final class TwigFilters
             $Metadata = new Metadata($json);
             $extraFields = $Metadata->getExtraFields();
         } catch (Exception $e) {
-            return self::displayMessage($e->getMessage(), 'ko', false);
+            return self::displayMessage(Tools::eLabHtmlspecialchars($e->getMessage()), 'ko', false);
         }
         if (empty($extraFields)) {
             return $Metadata->getRaw();


### PR DESCRIPTION
GHSA-8245-68hv-fph8

Escape metadata parsing exception messages before rendering them in the UI.

Invalid metadata keys or values could previously be reflected in the error output without HTML escaping. This change keeps the existing error display behavior while ensuring the message is rendered as text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of error messages in metadata formatting to ensure proper display and safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->