### PR TITLE
dev: add missing resolve.conditionNames in webpack config

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -122,6 +122,7 @@ module.exports = (env) => {
     ],
     resolve: {
       extensions: ['.ts', '.js', '.jsx', '.svelte'],
+      conditionNames: ['svelte', 'browser', '...'],
       mainFields: ['svelte', 'browser', 'module', 'main'],
       fallback: {
         // required by react 18


### PR DESCRIPTION
see: https://webpack.js.org/configuration/resolve/#resolveconditionnames and https://github.com/sveltejs/svelte-loader#resolveconditionnames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized module resolution configuration to improve compatibility during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->