### PR TITLE
feat: saml: add orcid attribute

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1661,16 +1661,19 @@ components:
           type: integer
         email_attr:
           type: string
-        team_attr:
-          type: string
         fname_attr:
           type: string
         lname_attr:
           type: string
+        team_attr:
+          type: string
+          nullable: true
         orgid_attr:
           type: string
+          nullable: true
         orcid_attr:
           type: string
+          nullable: true
         source:
           type: int
           nullable: true
@@ -6825,21 +6828,24 @@ paths:
                 email_attr:
                   type: string
                   description: What attribute to look for the email.
-                team_attr:
-                  type: string
-                  description: What attribute to look for the team.
                 fname_attr:
                   type: string
                   description: What attribute to look for the firstname.
                 lname_attr:
                   type: string
                   description: What attribute to look for the lastname.
+                team_attr:
+                  type: string
+                  description: What attribute to look for the team.
+                  nullable: true
                 orgid_attr:
                   type: string
                   description: What attribute to look for the internal id.
+                  nullable: true
                 orcid_attr:
                   type: string
                   description: What attribute to look for the ORCID.
+                  nullable: true
       responses:
         '201':
           description: The idp has been created.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1669,6 +1669,8 @@ components:
           type: string
         orgid_attr:
           type: string
+        orcid_attr:
+          type: string
         source:
           type: int
           nullable: true
@@ -6835,6 +6837,9 @@ paths:
                 orgid_attr:
                   type: string
                   description: What attribute to look for the internal id.
+                orcid_attr:
+                  type: string
+                  description: What attribute to look for the ORCID.
       responses:
         '201':
           description: The idp has been created.

--- a/src/Auth/Saml.php
+++ b/src/Auth/Saml.php
@@ -167,10 +167,13 @@ final class Saml implements AuthInterface
         $email = $this->extractAttribute($this->settings['idp']['emailAttr']);
 
         // GET ORGID
-        $orgid = $this->getOrgid();
+        $orgid = $this->getAttribute('orgidAttr');
+
+        // GET ORCID
+        $orcid = $this->getAttribute('orcidAttr');
 
         // GET POPULATED USERS OBJECT
-        $Users = $this->getUsers($email, $orgid);
+        $Users = $this->getUsers($email, $orgid, $orcid);
         if (!$Users instanceof Users) {
             $this->AuthResponse->setAuthenticatedUserid(0);
             $this->AuthResponse->setInitTeamRequired(true);
@@ -179,6 +182,7 @@ final class Saml implements AuthInterface
                 'firstname' => $this->getName(),
                 'lastname' => $this->getName(true),
                 'orgid' => $orgid,
+                'orcid' => $orcid,
             ));
             return $this->AuthResponse;
         }
@@ -203,6 +207,9 @@ final class Saml implements AuthInterface
         }
         if ($orgid !== null) {
             $Users->update(new UserParams('orgid', $orgid));
+        }
+        if ($orcid !== null) {
+            $Users->update(new UserParams('orcid', $orcid));
         }
 
         // load the teams from db
@@ -235,13 +242,13 @@ final class Saml implements AuthInterface
         return $attr;
     }
 
-    private function getOrgid(): ?string
+    private function getAttribute(string $key): ?string
     {
-        $orgid = $this->samlUserdata[$this->settings['idp']['orgidAttr'] ?? self::UNKNOWN_VALUE] ?? null;
-        if (is_array($orgid)) {
-            return $orgid[0];
+        $attr = $this->samlUserdata[$this->settings['idp'][$key] ?? self::UNKNOWN_VALUE] ?? null;
+        if (is_array($attr)) {
+            return $attr[0];
         }
-        return $orgid;
+        return $attr;
     }
 
     /**
@@ -322,7 +329,7 @@ final class Saml implements AuthInterface
         }
     }
 
-    private function getUsers(string $email, ?string $orgid = null): Users | int
+    private function getUsers(string $email, ?string $orgid = null, ?string $orcid = null): Users | int
     {
         $Users = $this->getExistingUser($email, $orgid);
         if ($Users === false) {
@@ -346,7 +353,7 @@ final class Saml implements AuthInterface
             // CREATE USER (and force validation of user, with user permissions)
             $allowTeamCreation = ($this->configArr['saml_team_create'] ?? '1') === '1';
             /** @psalm-suppress PossiblyInvalidArgument */
-            $Users = ValidatedUser::fromExternal($email, $teams, $this->getName(), $this->getName(true), orgid: $orgid, allowTeamCreation: $allowTeamCreation);
+            $Users = ValidatedUser::fromExternal($email, $teams, $this->getName(), $this->getName(true), orgid: $orgid, orcid: $orcid, allowTeamCreation: $allowTeamCreation);
         }
         return $Users;
     }

--- a/src/Elabftw/IdpsHelper.php
+++ b/src/Elabftw/IdpsHelper.php
@@ -155,6 +155,12 @@ final class IdpsHelper
                             'nameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
                             'friendlyName' => 'uid',
                         ),
+                        array(
+                            'name' => empty($idp['orcid_attr']) ? 'urn:oid:1.3.6.1.4.1.5923.1.1.1.16' : $idp['orcid_attr'],
+                            'isRequired' => false,
+                            'nameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+                            'friendlyName' => 'eduPersonOrcid',
+                        ),
                     ),
                 ),
                 // Specifies info about where and how the <Logout Response> message MUST be
@@ -203,6 +209,7 @@ final class IdpsHelper
                 'fnameAttr' => $idp['fname_attr'],
                 'lnameAttr' => $idp['lname_attr'],
                 'orgidAttr' => $idp['orgid_attr'],
+                'orcidAttr' => $idp['orcid_attr'],
             ),
             // Security settings
             'security' => array(

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 210;
+    public const int REQUIRED_SCHEMA = 211;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Enums/IdpsPatchableColumns.php
+++ b/src/Enums/IdpsPatchableColumns.php
@@ -23,4 +23,5 @@ enum IdpsPatchableColumns: string
     case FnameAttr = 'fname_attr';
     case LnameAttr = 'lname_attr';
     case OrgidAttr = 'orgid_attr';
+    case OrcidAttr = 'orcid_attr';
 }

--- a/src/Interfaces/IdpsInterface.php
+++ b/src/Interfaces/IdpsInterface.php
@@ -43,6 +43,7 @@ interface IdpsInterface
         string $fname_attr,
         string $lname_attr,
         ?string $orgid_attr,
+        ?string $orcid_attr,
         int $enabled = 1,
         ?int $source = null,
         ?array $certs = array(),

--- a/src/Models/Idps.php
+++ b/src/Models/Idps.php
@@ -45,6 +45,8 @@ final class Idps extends AbstractRest implements IdpsInterface
 
     private const string ORGID_ATTR = 'urn:oid:0.9.2342.19200300.100.1.1';
 
+    private const string ORCID_ATTR = 'urn:oid:1.3.6.1.4.1.5923.1.1.1.16';
+
     public function __construct(private Users $requester, ?int $id = null)
     {
         parent::__construct();
@@ -69,6 +71,7 @@ final class Idps extends AbstractRest implements IdpsInterface
             fname_attr: $reqBody['fname_attr'],
             lname_attr: $reqBody['lname_attr'],
             orgid_attr: $reqBody['orgid_attr'] ?? null,
+            orcid_attr: $reqBody['orcid_attr'] ?? null,
         );
     }
 
@@ -174,7 +177,7 @@ final class Idps extends AbstractRest implements IdpsInterface
             }
             $this->setId($id);
             // when coming from XML, we do not overwrite these attributes
-            $immutableFields = array('name', 'email_attr', 'fname_attr', 'lname_attr', 'team_attr', 'orgid_attr');
+            $immutableFields = array('name', 'email_attr', 'fname_attr', 'lname_attr', 'team_attr', 'orgid_attr', 'orcid_attr');
             foreach ($immutableFields as $key) {
                 unset($idp[$key]);
             }
@@ -228,12 +231,13 @@ final class Idps extends AbstractRest implements IdpsInterface
         string $fname_attr = self::FNAME_ATTR,
         string $lname_attr = self::LNAME_ATTR,
         ?string $orgid_attr = self::ORGID_ATTR,
+        ?string $orcid_attr = self::ORCID_ATTR,
         int $enabled = 1,
         ?int $source = null,
         ?array $certs = array(),
         ?array $endpoints = array(),
     ): int {
-        $idpId = $this->createIdp($name, $entityid, $email_attr, $team_attr, $fname_attr, $lname_attr, $orgid_attr, $enabled, $source);
+        $idpId = $this->createIdp($name, $entityid, $email_attr, $team_attr, $fname_attr, $lname_attr, $orgid_attr, $orcid_attr, $enabled, $source);
         if (!empty($certs)) {
             $IdpsCerts = new IdpsCerts($this->requester, $idpId);
             foreach ($certs as $cert) {
@@ -328,11 +332,12 @@ final class Idps extends AbstractRest implements IdpsInterface
         string $fname_attr = self::FNAME_ATTR,
         string $lname_attr = self::LNAME_ATTR,
         ?string $orgid_attr = self::ORGID_ATTR,
+        ?string $orcid_attr = self::ORCID_ATTR,
         int $enabled = 1,
         ?int $source = null,
     ): int {
-        $sql = 'INSERT INTO idps(name, entityid, email_attr, team_attr, fname_attr, lname_attr, orgid_attr, enabled, source)
-            VALUES(:name, :entityid, :email_attr, :team_attr, :fname_attr, :lname_attr, :orgid_attr, :enabled, :source)';
+        $sql = 'INSERT INTO idps(name, entityid, email_attr, team_attr, fname_attr, lname_attr, orgid_attr, orcid_attr, enabled, source)
+            VALUES(:name, :entityid, :email_attr, :team_attr, :fname_attr, :lname_attr, :orgid_attr, :orcid_attr, :enabled, :source)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':name', $name);
         $req->bindParam(':entityid', $entityid);
@@ -341,6 +346,7 @@ final class Idps extends AbstractRest implements IdpsInterface
         $req->bindParam(':fname_attr', $fname_attr);
         $req->bindParam(':lname_attr', $lname_attr);
         $req->bindParam(':orgid_attr', $orgid_attr);
+        $req->bindParam(':orcid_attr', $orcid_attr);
         $req->bindParam(':enabled', $enabled, PDO::PARAM_INT);
         $req->bindParam(':source', $source);
         $this->Db->execute($req);

--- a/src/Models/Users/ExistingUser.php
+++ b/src/Models/Users/ExistingUser.php
@@ -39,11 +39,12 @@ class ExistingUser extends Users
         bool $automaticValidationEnabled = false,
         bool $alertAdmin = true,
         ?string $orgid = null,
+        ?string $orcid = null,
         bool $allowTeamCreation = false,
         bool $skipDomainValidation = false,
     ): Users {
         $Users = new self();
-        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid, allowTeamCreation: $allowTeamCreation, skipDomainValidation: $skipDomainValidation);
+        $userid = $Users->createOne($email, $teams, $firstname, $lastname, '', $usergroup, $automaticValidationEnabled, $alertAdmin, orgid: $orgid, orcid: $orcid, allowTeamCreation: $allowTeamCreation, skipDomainValidation: $skipDomainValidation);
         $fresh = new self($userid);
         // we need to report the needValidation flag into the new object
         $fresh->needValidation = $Users->needValidation;

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -102,6 +102,7 @@ class Users extends AbstractRest
         bool $alertAdmin = true,
         ?string $validUntil = null,
         ?string $orgid = null,
+        ?string $orcid = null,
         bool $allowTeamCreation = false,
         bool $skipDomainValidation = false,
         BinaryValue $canManageCompounds = BinaryValue::False,
@@ -142,6 +143,7 @@ class Users extends AbstractRest
             `lang`,
             `valid_until`,
             `orgid`,
+            `orcid`,
             `is_sysadmin`,
             `default_read`,
             `default_write`,
@@ -157,6 +159,7 @@ class Users extends AbstractRest
             :lang,
             :valid_until,
             :orgid,
+            :orcid,
             :is_sysadmin,
             :default_read,
             :default_write,
@@ -173,6 +176,7 @@ class Users extends AbstractRest
         $req->bindValue(':lang', $Config->configArr['lang']);
         $req->bindValue(':valid_until', $validUntil);
         $req->bindValue(':orgid', $orgid);
+        $req->bindValue(':orcid', $orcid);
         $req->bindValue(':is_sysadmin', $isSysadmin, PDO::PARAM_INT);
         $req->bindValue(':default_read', $defaultCan);
         $req->bindValue(':default_write', $defaultCan);

--- a/src/Models/Users/ValidatedUser.php
+++ b/src/Models/Users/ValidatedUser.php
@@ -34,9 +34,9 @@ final class ValidatedUser extends ExistingUser
         return self::search(UsersColumn::Orgid, $orgid, true);
     }
 
-    public static function fromExternal(string $email, array $teams, string $firstname, string $lastname, ?string $orgid = null, bool $allowTeamCreation = false): Users
+    public static function fromExternal(string $email, array $teams, string $firstname, string $lastname, ?string $orgid = null, ?string $orcid = null, bool $allowTeamCreation = false): Users
     {
-        return parent::fromScratch($email, $teams, $firstname, $lastname, automaticValidationEnabled: true, orgid: $orgid, allowTeamCreation: $allowTeamCreation);
+        return parent::fromScratch($email, $teams, $firstname, $lastname, automaticValidationEnabled: true, orgid: $orgid, orcid: $orcid, allowTeamCreation: $allowTeamCreation);
     }
 
     public static function fromAdmin(string $email, array $teams, string $firstname, string $lastname, Usergroup $usergroup, bool $skipDomainValidation = false): Users

--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -15,7 +15,6 @@ namespace Elabftw\Services;
 use DateTimeImmutable;
 use Elabftw\Elabftw\FsTools;
 use Elabftw\Exceptions\ImproperActionException;
-use Elabftw\Models\Config;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
 

--- a/src/scss/pdf.scss
+++ b/src/scss/pdf.scss
@@ -160,7 +160,7 @@ tr:nth-child(odd) {
   float: right;
   font-size: 90%;
   text-align: right;
-  width: 35%;
+  width: 40%;
 }
 
 .footer-block {

--- a/src/sql/schema211-down.sql
+++ b/src/sql/schema211-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 211
+ALTER TABLE `idps` DROP COLUMN `orcid_attr`;
+UPDATE config SET conf_value = 210 WHERE conf_name = 'schema';

--- a/src/sql/schema211.sql
+++ b/src/sql/schema211.sql
@@ -1,0 +1,2 @@
+-- schema 211
+ALTER TABLE `idps` ADD `orcid_attr` VARCHAR(255) NULL DEFAULT NULL;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -541,6 +541,7 @@ CREATE TABLE `idps` (
   `fname_attr` varchar(255) NULL DEFAULT NULL,
   `lname_attr` varchar(255) NULL DEFAULT NULL,
   `orgid_attr` varchar(255) NULL DEFAULT NULL,
+  `orcid_attr` varchar(255) NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 

--- a/src/templates/idp-modal.html
+++ b/src/templates/idp-modal.html
@@ -55,6 +55,12 @@
             <input class='form-control col-md-4' type='text' data-allow-empty='1' id='idpModal_orgid_attr' name='orgid_attr' />
           </div>
           <p class='smallgray'>{{ 'Note: this attribute will not be synchronized from refresh action.'|trans }}</p>
+
+          <div class='d-flex justify-content-between'>
+            <label for='idpModal_orcid_attr' class='col-form-label'>{{ 'Which attribute should be used for ORCID (optional)'|trans }}</label>
+            <input class='form-control col-md-4' type='text' data-allow-empty='1' id='idpModal_orcid_attr' name='orcid_attr' />
+          </div>
+          <p class='smallgray'>{{ 'Note: this attribute will not be synchronized from refresh action.'|trans }}</p>
         </div>
         <div class='modal-footer'>
           <button type='button' class='btn btn-ghost' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -43,7 +43,7 @@
         {% if entityData.status_title %}
           <strong>{{ 'Status'|trans }}:</strong> {{ entityData.status_title }}<br>
         {% endif %}
-        <strong>{{ 'Created by'|trans }}:</strong> {{ entityData.fullname }}<br>
+        <strong>{{ 'Created by'|trans }}:</strong> {{ entityData.fullname }}{% if entityData.orcid %}<br>ORCID: <a href='https://orcid.org/{{ entityData.orcid }}' target='_blank' rel='noopener'>{{ entityData.orcid }}</a>{% endif %}<br>
         <strong>{{ 'Team'|trans }}:</strong> {{ entityData.team_name }}<br>
       </p>
     </div>

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -373,6 +373,7 @@ if (window.location.pathname === '/sysconfig.php') {
       (document.getElementById('idpModal_lname_attr') as HTMLInputElement).value = idp.lname_attr;
       (document.getElementById('idpModal_team_attr') as HTMLInputElement).value = idp.team_attr;
       (document.getElementById('idpModal_orgid_attr') as HTMLInputElement).value = idp.orgid_attr;
+      (document.getElementById('idpModal_orcid_attr') as HTMLInputElement).value = idp.orcid_attr;
       document.getElementById('idpModalSaveButton').dataset.id = idp.id;
       $('#idpModal').modal('show');
     });

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -61,6 +61,7 @@ class SamlTest extends \PHPUnit\Framework\TestCase
             'fname_attr' => 'User.FirstName',
             'lname_attr' => 'User.LastName',
             'orgid_attr' => 'internal_id',
+            'orcid_attr' => 'orcidAttr',
         ));
         $IdpsCerts = new IdpsCerts($requester, $this->idpId);
         $IdpsCerts->postAction(Action::Create, array('x509' => $cert));


### PR DESCRIPTION
* allow setting an attribute key for ORCID in IdP settings
* create new users with orcid from saml
* display orcid in pdf exports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for ORCID identifiers in IdP configuration and SAML authentication; ORCID now captured and stored for users.
  * Creator ORCID shown in exported PDFs when present.

* **User Interface**
  * IDP setup modal includes a new optional ORCID attribute field.

* **API/Schema**
  * IdP API/schema accepts an optional orcid attribute and marks several IdP attribute fields as nullable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->