### PR TITLE
(wip) add Archive action back: will archive user in all teams

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6003,7 +6003,7 @@ paths:
               oneOf:
                 - $ref: '#/components/schemas/users'
                 - type: object
-                  description: Archive or validate a user (will toggle the attribute)
+                  description: Archive or validate a user (will toggle the attribute). Archive will archive user in all teams and requires Sysadmin rights.
                   properties:
                     action:
                       type: string

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -489,6 +489,7 @@ class Users extends AbstractRest
                     new Users2Teams($this->requester)->create($this->userData['userid'], $team, isValidated: $this->userData['validated'] === 1);
                 }
             )(),
+            Action::Archive => (new Users2Teams($this->requester))->archive($this->getUserid()),
             Action::Disable2fa => $this->disable2fa(),
             Action::PatchUser2Team => (new Users2Teams($this->requester))->patchUser2Team($params, $this->getUserid()),
             Action::Unreference => (new Users2Teams($this->requester))->destroy($this->userData['userid'], (int) $params['team']),

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -70,10 +70,11 @@ final class Users2Teams
     // archive user in all teams
     public function archive(int $targetUserid): int
     {
+        $this->requester->isSysadminOrExplode();
         $UsersHelper = new UsersHelper($targetUserid);
         $teams = $UsersHelper->getTeamsFromUserid();
         foreach ($teams as $team) {
-            $this->patchIsArchived($targetUserid, $team['id'], BinaryValue::True);
+            $this->patchIsArchivedNoPermCheck($targetUserid, $team['id'], BinaryValue::True);
         }
         return count($teams);
     }
@@ -182,6 +183,11 @@ final class Users2Teams
     private function patchIsArchived(int $userid, int $teamid, BinaryValue $content): int
     {
         $this->requesterCanModifyInTeamOrExplode($teamid);
+        return $this->patchIsArchivedNoPermCheck($userid, $teamid, $content);
+    }
+
+    private function patchIsArchivedNoPermCheck(int $userid, int $teamid, BinaryValue $content): int
+    {
         return new UserArchiver($this->requester, new Users($userid, $teamid))
             ->setArchived($content)->value;
     }

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -67,6 +67,17 @@ final class Users2Teams
         return $wasInserted;
     }
 
+    // archive user in all teams
+    public function archive(int $targetUserid): int
+    {
+        $UsersHelper = new UsersHelper($targetUserid);
+        $teams = $UsersHelper->getTeamsFromUserid();
+        foreach ($teams as $team) {
+            $this->patchIsArchived($targetUserid, $team['id'], BinaryValue::True);
+        }
+        return count($teams);
+    }
+
     public function patchUser2Team(array $params, int $targetUserid): int
     {
         return $this->patchIsSomething(

--- a/src/Services/Email.php
+++ b/src/Services/Email.php
@@ -270,7 +270,7 @@ class Email
     private static function getAllEmailAddressesRawData(EmailTarget $target, ?int $targetId = null, ?array $range = null): array
     {
         $select = 'SELECT DISTINCT users.userid, email, CONCAT(firstname, " ", lastname) AS fullname FROM users
-            LEFT JOIN users2teams ON (users2teams.users_id = users.userid AND users2teams.is_archived = 0)
+            INNER JOIN users2teams ON (users2teams.users_id = users.userid AND users2teams.is_archived = 0)
             LEFT JOIN users2team_groups ON (users2team_groups.userid = users.userid)
             LEFT JOIN team_events ON (team_events.userid = users.userid)';
         switch ($target) {

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -48,6 +48,14 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testArchiveAsAdmin(): void
+    {
+        $admin = $this->getUserInTeam(2, admin: 1);
+        $Users2Teams = new Users2Teams($admin);
+        $this->expectException(IllegalActionException::class);
+        $Users2Teams->archive(2);
+    }
+
     public function testRmUserFromTeamButNotAdminInTeam(): void
     {
         // admin in team 2

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -15,6 +15,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
+use Elabftw\Services\UsersHelper;
 use Elabftw\Traits\TestsUtilsTrait;
 
 class Users2TeamsTest extends \PHPUnit\Framework\TestCase
@@ -34,6 +35,17 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
         $this->Users2Teams->rmUserFromTeams(4, array(3));
         $this->expectException(ImproperActionException::class);
         $this->Users2Teams->rmUserFromTeams(4, array(2));
+    }
+
+    public function testArchive(): void
+    {
+        $targetUserid = new Users(1, 1)->createOne('archiveme@example.com', array(1, 2, 3), automaticValidationEnabled: true);
+        $this->Users2Teams->archive($targetUserid);
+        $UsersHelper = new UsersHelper($targetUserid);
+        $teams = $UsersHelper->getTeamsFromUserid();
+        foreach ($teams as $team) {
+            $this->assertSame(1, $team['is_archived']);
+        }
     }
 
     public function testRmUserFromTeamButNotAdminInTeam(): void

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -32,10 +32,14 @@ class UsersTest extends \PHPUnit\Framework\TestCase
 
     private Users $Users;
 
+    private Config $Config;
+
     protected function setUp(): void
     {
         $requester = new Users(1, 1);
         $this->Users = new Users(1, 1, $requester);
+        $this->Config = Config::getConfig();
+        $this->Config->patch(Action::Update, array('admins_archive_users' => 1));
     }
 
     public function testPopulate(): void
@@ -287,10 +291,9 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     public function testCreateUser(): void
     {
         // force admin validation so we can run all code paths
-        $Config = Config::getConfig();
-        $Config->patch(Action::Update, array('admin_validate' => 1));
+        $this->Config->patch(Action::Update, array('admin_validate' => 1));
         $this->assertIsInt($this->Users->createOne('blahblah@yop.fr', array('Bravo'), 'blah', 'yop', 'somePassword!', Usergroup::Admin, false, false));
-        $Config->patch(Action::Update, array('admin_validate' => 0));
+        $this->Config->patch(Action::Update, array('admin_validate' => 0));
         $this->assertIsInt($this->Users->createOne('blahblah2@yop.fr', array('Bravo'), 'blah2', 'yop', 'somePassword!', Usergroup::Admin, true, false));
     }
 
@@ -299,12 +302,9 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $Admin = $this->getUserInTeam(team: 2, admin: 1);
         $user2 = $this->getUserInTeam(team: 2);
         $Users = new Users($user2->userid, 2, $Admin);
-        $Config = Config::getConfig();
-        $Config->patch(Action::Update, array('admins_archive_users' => 0));
-        $this->expectException(ImproperActionException::class);
+        $this->Config->patch(Action::Update, array('admins_archive_users' => 0));
+        $this->expectException(IllegalActionException::class);
         $Users->patch(Action::Archive, array());
-
-        $Config->patch(Action::Update, array('admins_archive_users' => 1));
     }
 
     public function testReadAllActiveFromTeam(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can be archived via PATCH; archiving applies across all teams and requires Sysadmin rights.

* **Bug Fixes / Behavior**
  * Email export now excludes users without active team memberships.

* **Tests**
  * Added unit tests for archive behavior.
  * Updated tests for archive permission handling and exception expectations.

* **Documentation**
  * API docs updated to clarify archive behavior and required permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->