### PR TITLE
bug/minor: tables: fix thead transparent

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -519,9 +519,9 @@ button:disabled {
   }
 
   thead {
+    background-color: var(--white);
     position: sticky;
     top: 0;
-    background-color: var(--white);
 
     /* thead with no filter on top need to have this class to have a top border */
     /* stylelint-disable-next-line selector-no-qualifying-type */

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -521,6 +521,7 @@ button:disabled {
   thead {
     position: sticky;
     top: 0;
+    background-color: var(--white);
 
     /* thead with no filter on top need to have this class to have a top border */
     /* stylelint-disable-next-line selector-no-qualifying-type */


### PR DESCRIPTION
fix #6942
inherits some transparency from the table, but this row needs to be colored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sticky table header appearance so it displays with a solid background instead of being transparent.
  * Ensures header remains readable and prevents page content from showing through while scrolling, improving table clarity and visual consistency across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->