### PR TITLE
bug/medium: search query: fix helpers

### DIFF
--- a/src/templates/select-state.html
+++ b/src/templates/select-state.html
@@ -10,7 +10,7 @@
   (State.Deleted.value): 'Deleted'|trans,
 } %}
 {# here we have filterHelper and filterAuto that are only meaningful on show mode #}
-<select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterHelper filterAuto' autocomplete='off'>
+<select name='state' aria-label='{{ 'State'|trans }}' class='form-control filterAuto' autocomplete='off'>
   {% for value, label in stateOptions %}
   <option data-action='{% if value == '' %}clear{% else %}insert-param-and-reload{% endif %}' data-target='state' value='{{ value }}' {% if dataReload %}data-reload='{{ dataReload }}'{% endif %} {{ reqState == value ? 'selected' }}>{{ label }}</option>
   {% endfor %}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -20,7 +20,6 @@
   <div class='d-flex'>
     {% set pageName = scriptName|replace({'.php': ''}) %}
     {% set searchTarget = pageName %}
-    {% set searchPlaceholder = 'Search in %s'|trans|format(pageTitle|lower) %}
     {% if pageName == 'database' %}
       {% set searchTarget = 'resources'|trans %}
     {% endif %}
@@ -35,8 +34,8 @@
         id='searchBar'
         data-name='q'
         data-value='{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim|e('html_attr') : '' }}'
-        data-placeholder='{{ searchPlaceholder|e('html_attr') }}'
-        data-aria-label='{{ searchPlaceholder|e('html_attr') }}'
+        data-placeholder='{{ 'Search'|trans }}'
+        data-aria-label='{{ 'Search'|trans }}'
         data-button-label='{{ 'Search'|trans|e('html_attr') }}'
       >
         <div class='input-group w-100 search-bar-input-group search-bar-fallback'>
@@ -45,8 +44,8 @@
             name='q'
             type='text'
             class='form-control'
-            placeholder='{{ searchPlaceholder|e('html_attr') }}'
-            aria-label='{{ searchPlaceholder|e('html_attr') }}'
+            placeholder='{{ 'Search'|trans }}'
+            aria-label='{{ 'Search'|trans }}'
             spellcheck='false'
             value='{{ App.Request.query.get('q') ? App.Request.query.get('q')|trim|e('html_attr') : '' }}'
           />

--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -102,6 +102,8 @@
     currentOwner: string;
     currentTags: string[];
     currentState: string;
+    currentScope: string;
+    currentBookable: string;
   };
 
   function handleFilterClick(
@@ -178,6 +180,8 @@
       currentOwner: getCurrentUrlParam('owner'),
       currentTags: getCurrentUrlTags(),
       currentState: getCurrentUrlParam('state'),
+      currentScope: getCurrentUrlParam('scope'),
+      currentBookable: getCurrentUrlParam('bookable'),
     };
   }
 
@@ -194,6 +198,8 @@
       context.currentOwner,
       context.currentTags,
       context.currentState,
+      context.currentScope,
+      context.currentBookable,
       currentReloadVersion,
     ]);
   }
@@ -261,6 +267,8 @@
     currentOwner,
     currentTags,
     currentState,
+    currentScope,
+    currentBookable,
   } = context;
     const seq = ++requestSeq;
     error = '';
@@ -299,6 +307,15 @@
         params['state'] = currentState;
       }
 
+      if (currentScope.length > 0) {
+        params['scope'] = currentScope;
+      }
+
+      if (currentBookable.length > 0) {
+        params['bookable'] = currentBookable;
+      }
+
+      // don't display errors
       params['notifOnError'] = 0;
 
       // fetch entries

--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -299,6 +299,8 @@
         params['state'] = currentState;
       }
 
+      params['notifOnError'] = 0;
+
       // fetch entries
       const payload = await ApiC.getJson(currentType, params) as EntityListItem[] | { items?: EntityListItem[] };
 

--- a/src/ts/entities-table.jsx
+++ b/src/ts/entities-table.jsx
@@ -18,7 +18,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { get } from 'svelte/store';
 import { createRoot } from 'react-dom/client';
 import { ApiC } from './api';
-import { notify } from './notify';
 import i18next from './i18n';
 import { DEFAULT_AG_GRID_PAGINATION, getEntityTypeFromPage } from './misc';
 
@@ -26,6 +25,7 @@ import { DEFAULT_AG_GRID_PAGINATION, getEntityTypeFromPage } from './misc';
 const yesNo = v => v === 1 ? i18next.t('yes') : i18next.t('no');
 const lastLoginText = v => v === null ? i18next.t('never') : v;
 let entitiesTableRoot = null;
+const isExtendedSearch = value => /(?:^|\s)\w+:[^\s]+/.test(value);
 
 const rowSelection = {
   mode: 'multiRow',
@@ -42,7 +42,12 @@ const EntitiesTable = ({ searchQuery, selectedEntities }) => {
     gridApiRef.current = params.api;
 
     if (searchQuery) {
-      params.api.setGridOption('quickFilterText', get(searchQuery));
+      const value = get(searchQuery);
+
+      params.api.setGridOption(
+        'quickFilterText',
+        isExtendedSearch(value) ? '' : value,
+      );
     }
 
     fetchData();
@@ -132,10 +137,9 @@ const EntitiesTable = ({ searchQuery, selectedEntities }) => {
 
     try {
       const endpoint = getEntityTypeFromPage(window.location);
-      const entities = await ApiC.getJson(`${endpoint}?${queryString ? `&${queryString}` : ''}`);
+      const entities = await ApiC.getJson(`${endpoint}?${queryString ? `&${queryString}` : ''}`, {notifOnError: 0});
       setRowData(entities);
     } catch (error) {
-      notify.error(error);
       console.error(`Could not load entities: ${error}`);
     }
   }, []);
@@ -161,7 +165,10 @@ const EntitiesTable = ({ searchQuery, selectedEntities }) => {
     }
 
     const unsubscribe = searchQuery.subscribe(value => {
-      gridApiRef.current?.setGridOption('quickFilterText', value);
+      gridApiRef.current?.setGridOption(
+        'quickFilterText',
+        isExtendedSearch(value) ? '' : value,
+      );
     });
 
     return unsubscribe;

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -124,8 +124,6 @@ async function displayEntities(mode: string) {
   mountEntityListSv(rootEl);
 }
 
-const params = new URLSearchParams(document.location.search.slice(1));
-
 const searchBar = document.getElementById('searchBar');
 if (searchBar) {
   // remove placeholder input
@@ -143,39 +141,22 @@ if (searchBar) {
   });
 }
 
-function removeHiddenInputsFromMainSearchForm(name: string): void
-{
-  const form = document.getElementById('mainSearchForm');
+function preventReactiveSearchFormSubmit(): void {
+  const form = document.getElementById('mainSearchForm') as HTMLFormElement | null;
+
   if (!form) {
     return;
   }
 
-  form.querySelectorAll<HTMLInputElement>('input[hidden]').forEach(input => {
-    if (input.name === name) {
-      input.remove();
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+
+    const input = form.elements.namedItem('q') as HTMLInputElement | null;
+
+    if (input) {
+      searchQuery.set(input.value);
     }
   });
-}
-
-function appendHiddenInputToMainSearchForm(name: string, value: string): void
-{
-  const form = document.getElementById('mainSearchForm');
-  if (!form) {
-    return;
-  }
-
-  const input = document.createElement('input');
-  input.hidden = true;
-  input.name = name;
-  input.setAttribute('aria-label', name);
-  input.value = value;
-  form.appendChild(input);
-}
-
-function addHiddenInputToMainSearchForm(name: string, value: string): void
-{
-  removeHiddenInputsFromMainSearchForm(name);
-  appendHiddenInputToMainSearchForm(name, value);
 }
 
 function syncSelectedEntitiesFromDom(): void {
@@ -257,13 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
     displayEntities(displayMode);
   })();
 
-
-  // Preserve filters from navbar dropdown (e.g., category, scope, bookable) when performing a search. #6284
-  ['category', 'scope', 'bookable'].forEach(param => {
-    if (params.has(param)) {
-      addHiddenInputToMainSearchForm(param, params.get(param));
-    }
-  });
+  preventReactiveSearchFormSubmit();
 
   // TomSelect for extra fields & owner search select
   if (document.getElementById('metakey')) {
@@ -548,10 +523,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (value === '') {
       url.searchParams.delete(param);
-      removeHiddenInputsFromMainSearchForm(param);
     } else {
       url.searchParams.set(param, value);
-      addHiddenInputToMainSearchForm(param, value);
     }
 
     window.history.replaceState({}, '', url.toString());
@@ -931,11 +904,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (selected.length === 0) {
       url.searchParams.delete(param);
-      removeHiddenInputsFromMainSearchForm(param);
     } else {
       const joined = selected.join(',');
       url.searchParams.set(param, joined); // param=1,2,5
-      addHiddenInputToMainSearchForm(param, joined);
     }
 
     window.history.replaceState({}, '', url.toString());
@@ -1178,11 +1149,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const url = new URL(window.location.href);
 
         url.searchParams.delete('tags[]');
-        removeHiddenInputsFromMainSearchForm('tags[]');
 
         selectedTags.forEach(tag => {
           url.searchParams.append('tags[]', tag);
-          appendHiddenInputToMainSearchForm('tags[]', tag);
         });
 
         window.history.replaceState({}, '', url.toString());

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -67,6 +67,7 @@ searchQuery.subscribe(value => {
     }
 
     window.history.replaceState({}, '', url.toString());
+    window.dispatchEvent(new CustomEvent('entity-filters-changed'));
   }, 250);
 });
 
@@ -362,7 +363,181 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function getFilterValueFromElement(elem: HTMLElement): string {
+    if (elem instanceof HTMLSelectElement) {
+      return elem.options[elem.selectedIndex]?.value ?? '';
+    }
+
+    if (elem instanceof HTMLInputElement) {
+      if (elem.type === 'checkbox') {
+        return elem.checked ? elem.value : '';
+      }
+
+      return elem.value.trim();
+    }
+
+    if (elem instanceof HTMLTextAreaElement) {
+      return elem.value.trim();
+    }
+
+    return '';
+  }
+
+  function getQuotes(value: string): string {
+    return /[\s:'"()&|!]/.test(value) ? '"' : '';
+  }
+
+  function escapeSearchToken(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  }
+
+  function buildFilterHelperRegex(filterName: string): RegExp {
+    const baseRegex = '(?:(?:"((?:\\\\"|(?:(?!")).)+)")|(?:\'((?:\\\\\'|(?:(?!\')).)+)\')|([^\\s:\'"()&|!]+))';
+    const operatorRegex = '(?:[<>]=?|!?=)?';
+    let valueRegex = baseRegex;
+
+    if (filterName === 'date') {
+      valueRegex = operatorRegex + baseRegex;
+    }
+
+    if (filterName === 'extrafield') {
+      valueRegex = `${baseRegex}:${baseRegex}`;
+    }
+
+    return new RegExp(`${filterName}:${valueRegex}\\s?`);
+  }
+
+  function getFilterHelperName(elem: HTMLElement): string {
+    return elem.dataset.filter || (elem as HTMLInputElement).name;
+  }
+
+  function buildFilterHelperToken(elem: HTMLElement): string {
+    let filterName = getFilterHelperName(elem);
+    let filterValue = getFilterValueFromElement(elem);
+
+    if (filterValue === '') {
+      return '';
+    }
+
+    if (filterName === '(?:author|group)') {
+      filterName = filterValue.split(':')[0];
+      filterValue = filterValue.substring(filterName.length + 1);
+    }
+
+    if (filterName === 'date') {
+      return `${filterName}:${filterValue}`;
+    }
+
+    if (filterName === 'extrafield') {
+      return `${filterName}:${filterValue}`;
+    }
+
+    const escapedValue = escapeSearchToken(filterValue);
+    const quotes = getQuotes(escapedValue);
+
+    return `${filterName}:${quotes}${escapedValue}${quotes}`;
+  }
+
+  function syncFilterHelperToSearchQuery(elem: HTMLElement): void {
+    const curVal = get(searchQuery);
+    const hasInput = curVal.length !== 0;
+    const hasSpace = curVal.endsWith(' ');
+    const addSpace = hasInput ? (hasSpace ? '' : ' ') : '';
+    const filterName = getFilterHelperName(elem);
+    const regex = buildFilterHelperRegex(filterName);
+    const filter = buildFilterHelperToken(elem);
+
+    if (curVal.match(regex)) {
+      searchQuery.set(curVal.replace(regex, filter === '' ? '' : `${filter} `).trimStart());
+      return;
+    }
+
+    if (filter !== '') {
+      searchQuery.set(`${curVal}${addSpace}${filter}`);
+    }
+  }
+
+  function getSearchTokenRegexPart(): string {
+    return '(?:(?:"(?:\\\\"|[^"])+")|(?:\'(?:\\\\\'|[^\'])*\')|[^\\s:\'"()&|!]+)';
+  }
+
+  function quoteSearchToken(value: string): string {
+    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+    if (/[\s:'"()&|!]/.test(escaped)) {
+      return `"${escaped}"`;
+    }
+
+    return escaped;
+  }
+
+  function buildExtrafieldFilter(): string {
+    const metakey = document.getElementById('metakey') as HTMLSelectElement | null;
+    const metavalue = document.getElementById('metavalue') as HTMLInputElement | null;
+
+    const key = metakey?.value.trim() ?? '';
+    const value = metavalue?.value.trim() ?? '';
+
+    if (key === '' && value === '') {
+      return '';
+    }
+
+    if (key === '' || value === '') {
+      return `extrafield:${quoteSearchToken(key || value)}`;
+    }
+
+    return `extrafield:${quoteSearchToken(key)}:${quoteSearchToken(value)}`;
+  }
+
+  function buildExtrafieldRegex(): RegExp {
+    const token = getSearchTokenRegexPart();
+
+    // Matches:
+    // extrafield:Manufacturer
+    // extrafield:Manufacturer:abc
+    // extrafield:Manufacturer:"abc"
+    // extrafield:"Some Field":"abc"
+    return new RegExp(`(^|\\s)extrafield:${token}(?::${token})?\\s?`);
+  }
+
+  function syncExtrafieldFilterToSearchQuery(): void {
+    const curVal = get(searchQuery);
+    const filter = buildExtrafieldFilter();
+    const regex = buildExtrafieldRegex();
+
+    if (regex.test(curVal)) {
+      const next = curVal.replace(regex, (_match, prefix: string) => {
+        return filter === '' ? prefix : `${prefix}${filter} `;
+      });
+
+      searchQuery.set(next.trim());
+      return;
+    }
+
+    if (filter === '') {
+      return;
+    }
+
+    searchQuery.set(`${curVal}${curVal.trim().length > 0 ? ' ' : ''}${filter}`);
+  }
+
   // FILTERS HANDLER FOR THE SHOW PAGE
+  document.querySelectorAll<HTMLElement>('.filterHelper').forEach(el => {
+    const eventName = el instanceof HTMLInputElement && el.type === 'text'
+      ? 'input'
+      : 'change';
+
+    el.addEventListener(eventName, event => {
+      const elem = event.currentTarget as HTMLElement;
+
+      if (elem.dataset.filter === 'extrafield') {
+        syncExtrafieldFilterToSearchQuery();
+        return;
+      }
+
+      syncFilterHelperToSearchQuery(elem);
+    });
+  });
   document.querySelectorAll('.filterAuto').forEach(el => {
     el.addEventListener('change', event => {
       // prevent this listener to be active when toggling archived users

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -48,26 +48,92 @@ type EntityFilterRequestedDetail = {
 const activeFilters = document.getElementById('activeFiltersDiv');
 let debounceTimer: number | undefined;
 let entityListSvComponent: Record<string, unknown> | null = null;
-const initialQ = new URL(window.location.href).searchParams.get('q') ?? '';
+const initialUrlParams = new URLSearchParams(window.location.search);
+const initialQ = initialUrlParams.get('q') ?? '';
+initialUrlParams.delete('q');
+
 const filterControls: ActiveFilterControl[] = [];
 const searchQuery = writable(initialQ);
+const entityFilters = writable(initialUrlParams);
 const selectedEntities = writable<string[]>([]);
+let searchQueryInitialized = false;
 
-searchQuery.subscribe(value => {
+function updateUrlFromStores(filters = get(entityFilters)): void {
+  const url = new URL(window.location.href);
+  const q = get(searchQuery).trim();
+
+  url.search = filters.toString();
+
+  if (q.length > 0) {
+    url.searchParams.set('q', q);
+  } else {
+    url.searchParams.delete('q');
+  }
+
+  window.history.replaceState({}, '', url.toString());
+  window.dispatchEvent(new CustomEvent('entity-filters-changed', {
+    detail: new URLSearchParams(url.search),
+  }));
+}
+
+function setEntityFilterParam(param: string, value: string): void {
+  entityFilters.update(currentParams => {
+    const nextParams = new URLSearchParams(currentParams);
+
+    nextParams.delete('offset');
+
+    if (value === '') {
+      nextParams.delete(param);
+    } else {
+      nextParams.set(param, value);
+    }
+
+    updateUrlFromStores(nextParams);
+
+    return nextParams;
+  });
+}
+
+function setEntityFilterParamValues(param: string, values: string[]): void {
+  entityFilters.update(currentParams => {
+    const nextParams = new URLSearchParams(currentParams);
+
+    nextParams.delete('offset');
+    nextParams.delete(param);
+
+    values.filter(Boolean).forEach(value => nextParams.append(param, value));
+    updateUrlFromStores(nextParams);
+
+    return nextParams;
+  });
+}
+
+function getEntityFilterParamValues(param: string): string[] {
+  const params = get(entityFilters);
+
+  if (param === 'tags[]') {
+    return params.getAll(param);
+  }
+
+  const value = params.get(param);
+
+  if (!value) {
+    return [];
+  }
+
+  return value.split(',').filter(Boolean);
+}
+
+searchQuery.subscribe(() => {
+  if (!searchQueryInitialized) {
+    searchQueryInitialized = true;
+    return;
+  }
+
   window.clearTimeout(debounceTimer);
 
   debounceTimer = window.setTimeout(() => {
-    const trimmedValue = value.trim();
-    const url = new URL(window.location.href);
-
-    if (trimmedValue.length > 0) {
-      url.searchParams.set('q', trimmedValue);
-    } else {
-      url.searchParams.delete('q');
-    }
-
-    window.history.replaceState({}, '', url.toString());
-    window.dispatchEvent(new CustomEvent('entity-filters-changed'));
+    updateUrlFromStores();
   }, 250);
 });
 
@@ -93,6 +159,7 @@ const mountEntityListSv = (target: HTMLElement): void => {
       entityType: entity.type,
       limit: 15,
       searchQuery,
+      entityFilters,
       selectedEntities,
       currentUserId: core.currentUserid,
       currentTeam: core.currentTeam,
@@ -239,6 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })();
 
   preventReactiveSearchFormSubmit();
+  hydrateFilterAutoControlsFromUrl();
 
   // TomSelect for extra fields & owner search select
   if (document.getElementById('metakey')) {
@@ -299,6 +367,7 @@ document.addEventListener('DOMContentLoaded', () => {
       param: 'owner',
       title: 'Owner',
     });
+    hydrateTomSelectFromUrl(control, 'owner');
     renderActiveFilters();
 
     bindExternalFilterRequest(control, 'owner');
@@ -356,6 +425,44 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     return '';
+  }
+
+  function hydrateFilterAutoControlsFromUrl(): void {
+    document.querySelectorAll<HTMLElement>('.filterAuto').forEach(elem => {
+      const param = elem.dataset.param || (elem as HTMLInputElement).name;
+      const values = getEntityFilterParamValues(param);
+
+      if (values.length === 0) {
+        return;
+      }
+
+      if (elem instanceof HTMLSelectElement || elem instanceof HTMLTextAreaElement) {
+        elem.value = values[0];
+        return;
+      }
+
+      if (elem instanceof HTMLInputElement) {
+        if (elem.type === 'checkbox') {
+          elem.checked = values.includes(elem.value);
+          return;
+        }
+
+        elem.value = values[0];
+      }
+    });
+  }
+
+  function hydrateTomSelectFromUrl(
+    control: TomSelectWithAllOptions,
+    param: string,
+  ): void {
+    getEntityFilterParamValues(param).forEach(value => {
+      ensureTomSelectOption(control, value, value);
+
+      if (!control.items.map(String).includes(value)) {
+        control.addItem(value, true);
+      }
+    });
   }
 
   function getQuotes(value: string): string {
@@ -517,18 +624,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function syncFilterAutoToUrl(elem: HTMLElement): void {
     const param = elem.dataset.param || (elem as HTMLInputElement).name;
     const value = getFilterValueFromElement(elem);
-    const url = new URL(window.location.href);
 
-    url.searchParams.delete('offset');
-
-    if (value === '') {
-      url.searchParams.delete(param);
-    } else {
-      url.searchParams.set(param, value);
-    }
-
-    window.history.replaceState({}, '', url.toString());
-    reloadEntitiesShow();
+    setEntityFilterParam(param, value);
   }
 
   document.querySelectorAll<HTMLElement>('.filterAuto').forEach(el => {
@@ -602,7 +699,6 @@ document.addEventListener('DOMContentLoaded', () => {
   /////////////////////////
   document.getElementById('container').addEventListener('click', async event => {
     const el = (event.target as HTMLElement);
-    const params = new URLSearchParams(document.location.search);
     // SAVE MULTI CHANGES
     if (el.matches('[data-action="save-multi-changes"]')) {
 
@@ -677,15 +773,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // a tag has been clicked/selected, add it in url and load the page
     } else if (el.matches('[data-action="add-tag-filter"]')) {
-      params.set('tags[]', el.dataset.tag);
-      // clear out any offset from a previous query
-      params.delete('offset');
-      history.replaceState(null, '', `?${params.toString()}`);
+      setEntityFilterParamValues('tags[]', [el.dataset.tag ?? '']);
       document.querySelectorAll('[data-action="add-tag-filter"]').forEach(el => {
         el.classList.remove('selected');
       });
       el.classList.add('selected');
-      reloadEntitiesShow();
 
     // SORT COLUMN IN TABULAR MODE
     } else if (el.matches('[data-action="reorder-entities"]')) {
@@ -897,20 +989,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function syncMultiSelectParam(param: string, value: string | string[] | null | undefined) {
-    const url = new URL(window.location.href);
-
     // Tom Select gives an array for multi-select; normalize just in case
     const selected = Array.isArray(value) ? value : value ? [value] : [];
 
-    if (selected.length === 0) {
-      url.searchParams.delete(param);
-    } else {
-      const joined = selected.join(',');
-      url.searchParams.set(param, joined); // param=1,2,5
-    }
-
-    window.history.replaceState({}, '', url.toString());
-    window.dispatchEvent(new CustomEvent('entity-filters-changed'));
+    setEntityFilterParam(param, selected.join(','));
   }
 
   function bindExternalFilterRequest(
@@ -1035,15 +1117,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function bindShowAllToggle(control: TeamScopedTomSelect) {
-    bindDropdownToggle(control, '.ts-toggle-show-all', '_showAll', (checked) => {
-      const url = new URL(window.location.href);
-      if (checked) url.searchParams.set('scope', '3');
-      else url.searchParams.delete('scope');
-      window.history.replaceState({}, '', url.toString());
+    bindDropdownToggle(control, '.ts-toggle-show-all', '_showAll', checked => {
+      setEntityFilterParam('scope', checked ? '3' : '');
 
       applyTeamFilter(control);
       control.open(); // keep it open after filtering
-      reloadEntitiesShow();
     });
   }
 
@@ -1073,7 +1151,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       onInitialize(this: TeamScopedTomSelect) {
         this._allOptions = Object.values(this.options) as TomSelectOptionLike[];
-        this._showAll = false;
+        this._showAll = get(entityFilters).get('scope') === '3';
 
         applyTeamFilter(this);
       },
@@ -1090,6 +1168,7 @@ document.addEventListener('DOMContentLoaded', () => {
       param: cfg.param,
       title: cfg.title,
     });
+    hydrateTomSelectFromUrl(control, cfg.param);
     renderActiveFilters();
 
     if (cfg.param === 'category' || cfg.param === 'status') {
@@ -1146,16 +1225,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       onChange: (value: unknown) => {
         const selectedTags = Array.isArray(value) ? value as string[] : [];
-        const url = new URL(window.location.href);
 
-        url.searchParams.delete('tags[]');
-
-        selectedTags.forEach(tag => {
-          url.searchParams.append('tags[]', tag);
-        });
-
-        window.history.replaceState({}, '', url.toString());
-        window.dispatchEvent(new CustomEvent('entity-filters-changed'));
+        setEntityFilterParamValues('tags[]', selectedTags);
       },
 
       onItemAdd() {
@@ -1168,7 +1239,9 @@ document.addEventListener('DOMContentLoaded', () => {
         no_active_items: {},
         remove_button: {},
       },
-    });
+    }) as TomSelectWithAllOptions;
+
+    hydrateTomSelectFromUrl(tsTagFilter, 'tags[]');
 
     if (dropdownRoot) {
       $(dropdownRoot).on('shown.bs.dropdown', function() {

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -538,19 +538,36 @@ document.addEventListener('DOMContentLoaded', () => {
       syncFilterHelperToSearchQuery(elem);
     });
   });
-  document.querySelectorAll('.filterAuto').forEach(el => {
-    el.addEventListener('change', event => {
-      // prevent this listener to be active when toggling archived users
-      if ((event.target as HTMLElement).classList.contains('ts-toggle-archived')) return;
-      const url = new URL(window.location.href);
-      const elem = event.target as HTMLSelectElement;
-      const elemValue = elem.options[elem.selectedIndex].value;
-      url.searchParams.set(elem.name, elemValue);
-      // also add it to the main input form
-      addHiddenInputToMainSearchForm(elem.name, elemValue);
 
-      window.history.replaceState({}, '', url.toString());
-      reloadEntitiesShow();
+  function syncFilterAutoToUrl(elem: HTMLElement): void {
+    const param = elem.dataset.param || (elem as HTMLInputElement).name;
+    const value = getFilterValueFromElement(elem);
+    const url = new URL(window.location.href);
+
+    url.searchParams.delete('offset');
+
+    if (value === '') {
+      url.searchParams.delete(param);
+      removeHiddenInputsFromMainSearchForm(param);
+    } else {
+      url.searchParams.set(param, value);
+      addHiddenInputToMainSearchForm(param, value);
+    }
+
+    window.history.replaceState({}, '', url.toString());
+    reloadEntitiesShow();
+  }
+
+  document.querySelectorAll<HTMLElement>('.filterAuto').forEach(el => {
+    el.addEventListener('change', event => {
+      const elem = event.target as HTMLElement;
+
+      // prevent this listener to be active when toggling archived users
+      if (elem.classList.contains('ts-toggle-archived')) {
+        return;
+      }
+
+      syncFilterAutoToUrl(elem);
     });
   });
   // END SEARCH RELATED CODE

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -63,6 +63,7 @@ function updateUrlFromStores(filters = get(entityFilters)): void {
   const q = get(searchQuery).trim();
 
   url.search = filters.toString();
+  url.searchParams.delete('offset');
 
   if (q.length > 0) {
     url.searchParams.set('q', q);
@@ -108,7 +109,7 @@ function setEntityFilterParamValues(param: string, values: string[]): void {
   });
 }
 
-function getEntityFilterParamValues(param: string): string[] {
+function getEntityFilterParamValues(param: string, splitComma = true): string[] {
   const params = get(entityFilters);
 
   if (param === 'tags[]') {
@@ -121,7 +122,7 @@ function getEntityFilterParamValues(param: string): string[] {
     return [];
   }
 
-  return value.split(',').filter(Boolean);
+  return splitComma ? value.split(',').filter(Boolean) : [value];
 }
 
 searchQuery.subscribe(() => {
@@ -430,7 +431,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function hydrateFilterAutoControlsFromUrl(): void {
     document.querySelectorAll<HTMLElement>('.filterAuto').forEach(elem => {
       const param = elem.dataset.param || (elem as HTMLInputElement).name;
-      const values = getEntityFilterParamValues(param);
+      const values = getEntityFilterParamValues(param, false);
 
       if (values.length === 0) {
         return;
@@ -443,7 +444,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (elem instanceof HTMLInputElement) {
         if (elem.type === 'checkbox') {
-          elem.checked = values.includes(elem.value);
+          const checkboxValues = getEntityFilterParamValues(param, true);
+          elem.checked = checkboxValues.includes(elem.value);
           return;
         }
 

--- a/src/ts/stores/searchQueryStore.ts
+++ b/src/ts/stores/searchQueryStore.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const searchQuery = writable('');


### PR DESCRIPTION
* use the same placeholder for all
* prevent extended search from spamming errors on screen
* make entity table display results with extended search
* bring back code for filterHelper
* delete unused searchQueryStore.ts



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended search syntax (key:value) for advanced filtering.
  * URL-driven filters for scope and bookable.
  * Filter controls auto-hydrate from URL on load.

* **Improvements**
  * Unified search bar placeholder text across the UI.
  * Filter state synced via centralized store (no reloads).
  * Search fetch errors no longer produce user notifications.

* **Refactor**
  * Store-driven URL sync for filters; internal store export removed.

* **Style**
  * Adjusted select control CSS classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->