### PR TITLE
Apidoc: update patchuser2team

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6050,11 +6050,11 @@ paths:
                       description: Target userid
                     target:
                       type: string
-                      enum: ['group', 'is_owner']
+                      enum: ['is_admin', 'is_owner', 'is_archived']
                       description: The attribute to modify
                     content:
                       type: integer
-                      description: Binary value for `is_owner`, integer for `group` (2 for Admin, 4 for User)
+                      description: Binary value for the target attributes.
       responses:
         '200':
           description: Public properties of a user.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -6054,6 +6054,7 @@ paths:
                       description: The attribute to modify
                     content:
                       type: integer
+                      enum: [0, 1]
                       description: Binary value for the target attributes.
       responses:
         '200':

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -137,7 +137,7 @@ if (document.getElementById('users-table')) {
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
       const isAdminValue = el.dataset.promote === '1' ? 1 : 0;
-      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'iz_admin', content: isAdminValue, userid: userid}).then(() => document.dispatchEvent(new CustomEvent('dataReload')));
+      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'is_admin', content: isAdminValue, userid: userid}).then(() => document.dispatchEvent(new CustomEvent('dataReload')));
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -136,8 +136,8 @@ if (document.getElementById('users-table')) {
 
     // TOGGLE ADMIN STATUS
     } else if (el.matches('[data-action="toggle-admin-user"]')) {
-      const group = el.dataset.promote === '1' ? 2 : 4;
-      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'group', content: group, userid: userid}).then(() => document.dispatchEvent(new CustomEvent('dataReload')));
+      const isAdminValue = el.dataset.promote === '1' ? 1 : 0;
+      ApiC.patch(`${Model.User}/${userid}`, {action: Action.PatchUser2Team, team: el.dataset.team, target: 'iz_admin', content: isAdminValue, userid: userid}).then(() => document.dispatchEvent(new CustomEvent('dataReload')));
 
     // VALIDATE USER
     } else if (el.matches('[data-action="validate-user"]')) {


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [x] I have mentioned the related **issue** (if applicable).
https://github.com/elabftw/elabftw/issues/6944

- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation).
---

### Pull Request Description

Please provide **clear context** for your proposed change:

Updated apidocs spec for the `patchuser2team` with current `is_admin`, `is_owner` and `is_archived` attribs.

Also updated `editusers`, since it had the old parameters. The code otherwise seems dormant, since no template uses currently the `toggle-admin-user` value of `data-action`.

- What issue or need does this PR address?
- How did you approach the solution?
- If applicable, include **screenshots or examples** (especially for UI changes).

> ⚠️ We’re committed to reviewing your contributions, so in return, we ask that you take the time to present your work clearly.
> Pull requests without any description are frowned upon and will likely be closed immediately.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the team management “admin status” toggle to correctly update the intended user role attribute, and to submit the required binary value for the selected target.

* **Chores**
  * Updated the user team management API schema to support additional role attributes in the user patch action, including refreshed request documentation to clarify the binary nature of the submitted `content` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->