### PR TITLE
perf: show mode: don't load metakeys on page load

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -28,7 +28,6 @@ use Elabftw\Interfaces\ControllerInterface;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\Config;
 use Elabftw\Models\ExperimentsStatus;
-use Elabftw\Models\ExtraFieldsKeys;
 use Elabftw\Models\FavTags;
 use Elabftw\Models\ItemsStatus;
 use Elabftw\Models\ItemsTypes;
@@ -45,7 +44,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 
-use function array_column;
 use function sprintf;
 
 /**
@@ -109,7 +107,6 @@ abstract class AbstractEntityController implements ControllerInterface
     {
         // used to get all tags for top page tag filter
         $TeamTags = new TeamTags($this->App->Users, $this->App->Users->userData['team']);
-        $ExtraFieldsKeys = new ExtraFieldsKeys($this->App->Users, '', -1);
 
         // must be before the call to readShow
         if (($this->App->Users->userData['always_show_owned'] ?? null) === 1) {
@@ -146,7 +143,6 @@ abstract class AbstractEntityController implements ControllerInterface
             'statusArr' => $this->statusArr,
             'favTagsArr' => $favTagsArr,
             'pageTitle' => $this->getPageTitle(),
-            'metakeyArrForSelect' => array_column($ExtraFieldsKeys->readAll(), 'extra_fields_key'),
             'requestActionsArr' => $UserRequestActions->readAllFull(),
             'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
             // get all the tags for the top search bar

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -118,9 +118,6 @@
           >
             <option value='' disabled>{{ 'Name of field'|trans }}</option>
             <option value='**' {{- '**' == App.Request.query.get('metakey') ? ' selected' }}>{{ 'All fields'|trans }}</option>
-            {% for metakey in metakeyArrForSelect %}
-              <option value='{{ metakey }}' {{- metakey == App.Request.query.get('metakey') ? ' selected' }}>{{ metakey }}</option>
-            {% endfor %}
           </select>
           {% if App.devMode -%}
             <!-- [html-validate-enable prefer-native-element: suppress errors from tom-select] -->

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -314,6 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (metakeySelect) {
     let metakeyOptionsLoaded = false;
+    let metakeyOptionsLoading = false;
 
     new TomSelect('#metakey', {
       maxOptions: 512,
@@ -328,9 +329,14 @@ document.addEventListener('DOMContentLoaded', () => {
       ],
       preload: 'focus',
       shouldLoad() {
-        return !metakeyOptionsLoaded;
+        return !metakeyOptionsLoaded && !metakeyOptionsLoading;
       },
       load(query, callback) {
+        if (metakeyOptionsLoading || metakeyOptionsLoaded) {
+          callback();
+          return;
+        }
+        metakeyOptionsLoading = true;
         ApiC.getJson('extra_fields_keys')
           .then((extraFieldsKeys) => {
             const options = extraFieldsKeys
@@ -346,6 +352,9 @@ document.addEventListener('DOMContentLoaded', () => {
           })
           .catch(() => {
             callback();
+          })
+          .finally(() => {
+            metakeyOptionsLoading = false;
           });
       },
     });

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -310,13 +310,44 @@ document.addEventListener('DOMContentLoaded', () => {
   hydrateFilterAutoControlsFromUrl();
 
   // TomSelect for extra fields & owner search select
-  if (document.getElementById('metakey')) {
+  const metakeySelect = document.getElementById('metakey');
+
+  if (metakeySelect) {
+    let metakeyOptionsLoaded = false;
+
     new TomSelect('#metakey', {
       maxOptions: 512,
       plugins: [
         'dropdown_input',
         'remove_button',
       ],
+      valueField: 'value',
+      labelField: 'text',
+      searchField: [
+        'text',
+      ],
+      preload: 'focus',
+      shouldLoad() {
+        return !metakeyOptionsLoaded;
+      },
+      load(query, callback) {
+        ApiC.getJson('extra_fields_keys')
+          .then((extraFieldsKeys) => {
+            const options = extraFieldsKeys
+              .map((extraFieldKey) => ({
+                value: extraFieldKey.extra_fields_key,
+                text: extraFieldKey.extra_fields_key,
+                frequency: extraFieldKey.frequency,
+              }))
+              .filter((option) => option.value);
+
+            metakeyOptionsLoaded = true;
+            callback(options);
+          })
+          .catch(() => {
+            callback();
+          });
+      },
     });
   }
 


### PR DESCRIPTION
load them on demand. makes page load 6 times faster. fix #6956


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata field filter dropdown on the details view now loads available options on-demand (lazy loading) and initializes only when the control is present.
* **Chores**
  * Simplified the details-view payload by removing pre-computed metadata field options and reducing the rendered dropdown options to a placeholder plus the “all fields” choice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->