### PR TITLE
perf: sql: improve entity read

### DIFF
--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -48,6 +48,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
         ?EntityType $relatedOrigin = null,
     ): string {
         $this->entitySelect($fullSelect);
+        $this->userTeamMembership();
         $this->compounds();
         $this->status();
         $this->category();
@@ -60,6 +61,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
         if ($relatedOrigin !== null) {
             $this->links($relatedOrigin);
         }
+
         $this->usersTeams();
 
         $sql = array(
@@ -341,6 +343,16 @@ final class EntitySqlBuilder implements SqlBuilderInterface
         return ":userid MEMBER OF (entity.$can->>'$.users')";
     }
 
+    private function userTeamMembership(): void
+    {
+        $this->joinsSql[] = sprintf(
+            'LEFT JOIN users2teams
+                ON (users2teams.users_id = entity.userid
+                    AND users2teams.teams_id = %d)',
+            $this->entity->Users->getTeam(),
+        );
+    }
+
     private function teamEvents(): void
     {
         if ($this->entity instanceof Experiments) {
@@ -380,11 +392,8 @@ final class EntitySqlBuilder implements SqlBuilderInterface
 
         $this->joinsSql[] = 'LEFT JOIN users
             ON (users.userid = entity.userid)';
-        $this->joinsSql[] = sprintf(
-            'LEFT JOIN users2teams
-                ON (users2teams.users_id = entity.userid and users2teams.teams_id = %d)
-            LEFT JOIN teams ON (entity.team = teams.id)',
-            $this->entity->Users->getTeam(),
-        );
+
+        $this->joinsSql[] = 'LEFT JOIN teams
+            ON (entity.team = teams.id)';
     }
 }


### PR DESCRIPTION
apply the users2teams join first to reduce number of rows considered

see #6958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved SQL query structure for team membership data retrieval, enhancing consistency and reliability in database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->