### PR TITLE
perf: entity readall: only include compounds table join if necessary

### DIFF
--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -46,10 +46,13 @@ final class EntitySqlBuilder implements SqlBuilderInterface
     public function getReadSqlBeforeWhere(
         bool $fullSelect = false,
         ?EntityType $relatedOrigin = null,
+        bool $withCompounds = false,
     ): string {
         $this->entitySelect($fullSelect);
         $this->userTeamMembership();
-        $this->compounds();
+        if ($withCompounds) {
+            $this->compounds();
+        }
         $this->status();
         $this->category();
         $this->comments();

--- a/src/Interfaces/SqlBuilderInterface.php
+++ b/src/Interfaces/SqlBuilderInterface.php
@@ -19,6 +19,7 @@ interface SqlBuilderInterface
     public function getReadSqlBeforeWhere(
         bool $fullSelect = false,
         ?EntityType $relatedOrigin = null,
+        bool $withCompounds = false,
     ): string;
 
     public function getCanFilter(string $can): string;

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -400,11 +400,14 @@ abstract class AbstractEntity extends AbstractRest
             $this->processExtendedQuery($displayParams->getUserQuery());
             $extended = true;
         }
+        $displayFilterSql = $displayParams->getFilterSql();
+        $withCompounds = $this->needsCompoundsJoin($displayFilterSql);
 
         $EntitySqlBuilder = $this->getSqlBuilder();
         $sql = $EntitySqlBuilder->getReadSqlBeforeWhere(
             $extended,
             $displayParams->getRelatedOrigin(),
+            $withCompounds,
         );
 
         $sql .= ' WHERE 1=1 ';
@@ -413,7 +416,7 @@ abstract class AbstractEntity extends AbstractRest
         $sql .= $this->filterSql;
 
         // add filters like related, owner or category
-        $sql .= $displayParams->getFilterSql();
+        $sql .= $displayFilterSql;
 
         // add the json permissions
         $sql .= $EntitySqlBuilder->getCanFilter($can);
@@ -1244,6 +1247,19 @@ abstract class AbstractEntity extends AbstractRest
     }
 
     protected function enforceTemplate(array $teamConfigArr): void {}
+
+    private function needsCompoundsJoin(string $displayFilterSql): bool
+    {
+        return $this->sqlReferencesCompounds($this->extendedFilter)
+            || $this->sqlReferencesCompounds($this->filterSql)
+            || $this->sqlReferencesCompounds($displayFilterSql);
+    }
+
+    private function sqlReferencesCompounds(string $sql): bool
+    {
+        return str_contains($sql, 'compounds.')
+            || str_contains($sql, 'compoundslinks.');
+    }
 
     private function handleCanUpdate(array $params, AccessType $type): void
     {

--- a/src/tools/populate-compounds.sql
+++ b/src/tools/populate-compounds.sql
@@ -1,0 +1,57 @@
+-- this script populates compounds table with many rows
+-- copy it in docker container, execute it from mysql container
+-- docker cp src/tools/populate-compounds.sql mysql:/c.sql
+-- elabctl mysql
+-- source /c.sql;
+
+SET @created_by_userid := 1;
+SET @@cte_max_recursion_depth = 40000;
+SET @team_id := 1;
+SET @how_many := 40000;
+
+INSERT INTO compounds (
+    created_by,
+    modified_by,
+    userid,
+    team,
+    state,
+    name,
+    molecular_formula,
+    molecular_weight,
+    cas_number,
+    smiles,
+    inchi,
+    inchi_key,
+    iupac_name,
+    pubchem_cid
+)
+WITH RECURSIVE seq AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1
+    FROM seq
+    WHERE n < @how_many
+)
+SELECT
+    @created_by_userid AS created_by,
+    @created_by_userid AS modified_by,
+    @created_by_userid AS userid,
+    @team_id AS team,
+    1 AS state,
+    CONCAT('Fake Compound ', LPAD(n, 4, '0')) AS name,
+    CONCAT('C', 5 + MOD(n, 30), 'H', 8 + MOD(n, 50), 'N', MOD(n, 4), 'O', MOD(n, 8)) AS molecular_formula,
+    12 as molecular_weight,
+    CONCAT('FAKE-', LPAD(n, 6, '0')) AS cas_number,
+    CASE MOD(n, 6)
+        WHEN 0 THEN 'CCO'
+        WHEN 1 THEN 'CCN'
+        WHEN 2 THEN 'CC(=O)O'
+        WHEN 3 THEN 'c1ccccc1'
+        WHEN 4 THEN 'CCOC(=O)C'
+        ELSE 'CC(C)O'
+    END AS smiles,
+    CONCAT('InChI=1S/FAKE-', LPAD(n, 6, '0')) AS inchi,
+    CONCAT('FAKEINCHIKEY', LPAD(n, 13, '0')) AS inchi_key,
+    CONCAT('fake compound ', LPAD(n, 4, '0')) AS iupac_name,
+    900000000 + n AS pubchem_cid
+FROM seq;

--- a/src/tools/populate-compounds.sql
+++ b/src/tools/populate-compounds.sql
@@ -38,7 +38,7 @@ SELECT
     @created_by_userid AS userid,
     @team_id AS team,
     1 AS state,
-    CONCAT('Fake Compound ', LPAD(n, 4, '0')) AS name,
+    CONCAT('Fake Compound ', LPAD(n, 6, '0')) AS name,
     CONCAT('C', 5 + MOD(n, 30), 'H', 8 + MOD(n, 50), 'N', MOD(n, 4), 'O', MOD(n, 8)) AS molecular_formula,
     12 as molecular_weight,
     CONCAT('FAKE-', LPAD(n, 6, '0')) AS cas_number,
@@ -52,6 +52,6 @@ SELECT
     END AS smiles,
     CONCAT('InChI=1S/FAKE-', LPAD(n, 6, '0')) AS inchi,
     CONCAT('FAKEINCHIKEY', LPAD(n, 13, '0')) AS inchi_key,
-    CONCAT('fake compound ', LPAD(n, 4, '0')) AS iupac_name,
+    CONCAT('fake compound ', LPAD(n, 6, '0')) AS iupac_name,
     900000000 + n AS pubchem_cid
 FROM seq;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved read/display query generation by making compounds-related joins conditional, so they’re only included when the active filters require them.
  * Streamlined display filter SQL handling to reduce redundant work during entity “show” operations.
* **Chores**
  * Added a MySQL utility script to bulk-populate the compounds table with synthetic test data (40,000 rows), useful for local development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->