### PR TITLE
bug/medium: fix dfn cert cutoff date check

### DIFF
--- a/src/Make/MakeDfnTimestamp.php
+++ b/src/Make/MakeDfnTimestamp.php
@@ -29,7 +29,7 @@ final class MakeDfnTimestamp extends AbstractMakeTrustedTimestamp
     protected function getChain(): string
     {
         // cert change on this date: https://www.dfn.de/zertifikatswechsel-beim-zeitstempeldienst/
-        if (date('Y-m-d') < '2026-06-23') {
+        if (date('Y-m-d') <= '2026-06-23') {
             return dirname(__DIR__) . '/certs/dfn-chain.pem';
         }
         return dirname(__DIR__) . '/certs/dfn-chain-26.pem';


### PR DESCRIPTION
change has occured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date-based certificate chain selection to ensure the appropriate certificate is used from the specified date onward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->