### PR TITLE
bug/minor: mfa: don't read mfa_secret from request

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -123,7 +123,11 @@ final class LoginController implements ControllerInterface
         $loggingInUser = $AuthResponse->getUser();
 
         // if we're receiving mfa_secret, it's because we just enabled MFA, so save it for that user
-        if ($this->Session->has('mfa_secret') && $loggingInUser->userData['mfa_secret'] === null) {
+        if (
+            $AuthResponse->hasVerifiedMfa()
+            && $this->Session->has('mfa_secret')
+            && $loggingInUser->userData['mfa_secret'] === null
+        ) {
             $loggingInUser->update(new UserParams('mfa_secret', $this->Session->get('mfa_secret')));
             $this->Session->remove('mfa_secret');
         }

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -123,8 +123,9 @@ final class LoginController implements ControllerInterface
         $loggingInUser = $AuthResponse->getUser();
 
         // if we're receiving mfa_secret, it's because we just enabled MFA, so save it for that user
-        if ($this->Request->request->has('mfa_secret') && $loggingInUser->userData['mfa_secret'] === null) {
-            $loggingInUser->update(new UserParams('mfa_secret', $this->Request->request->getString('mfa_secret')));
+        if ($this->Session->has('mfa_secret') && $loggingInUser->userData['mfa_secret'] === null) {
+            $loggingInUser->update(new UserParams('mfa_secret', $this->Session->get('mfa_secret')));
+            $this->Session->remove('mfa_secret');
         }
 
         /////////

--- a/src/templates/mfa.html
+++ b/src/templates/mfa.html
@@ -35,7 +35,6 @@
               <button title='{{ 'Copy to clipboard'|trans }}' class='btn btn-ghost' type='button' data-action='copy-to-clipboard' data-target='mfa_secret'><i class='fas fa-clone'></i></button>
             </div>
             <input class='form-control text-center' value='{{ mfaNewSecret|formatMfaSecret }}' id='mfa_secret' disabled readonly />
-            <input type='hidden' name='mfa_secret' value='{{ mfaNewSecret }}'>
           </div>
         </div>
       </div>


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MFA secret handling during login: the account is now updated with the MFA secret only after MFA is verified and when a secret exists in temporary session storage.
  * If the user’s stored MFA secret is empty, it’s populated from the session’s MFA secret and then removed from temporary storage to prevent reuse.
  * Updated the MFA enable/manual-setup form to stop submitting the MFA secret via a hidden input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->