### PR TITLE
bug/minor: fix HTML rendering in ELN preview

### DIFF
--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -234,6 +234,8 @@ final class TwigFilters
             $depth ??= 0;
             if (is_array($value)) {
                 $value = self::array2String($value, $depth + 1);
+            } else {
+                $value = Tools::eLabHtmlspecialchars($value);
             }
             $str .= '<details style="--depth: ' . $depth . '"><summary>' . $key . '</summary>' . $value . '</details>';
         }
@@ -243,7 +245,7 @@ final class TwigFilters
     public static function any2string(string|array|null $input): string
     {
         if (is_string($input)) {
-            return $input;
+            return Tools::eLabHtmlspecialchars($input);
         }
         if (is_array($input)) {
             return self::array2String($input);

--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -235,7 +235,7 @@ final class TwigFilters
             if (is_array($value)) {
                 $value = self::array2String($value, $depth + 1);
             } else {
-                $value = Tools::eLabHtmlspecialchars($value);
+                $value = Tools::eLabHtmlspecialchars((string) $value);
             }
             $str .= '<details style="--depth: ' . $depth . '"><summary>' . $key . '</summary>' . $value . '</details>';
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping for text rendered in generated details/summary markup.
  * Non-array scalar values are now safely escaped before being embedded into the output.
  * Plain string inputs are now escaped consistently instead of being returned raw, reducing the chance of unsafe or unintended content being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->