### PR TITLE
ui: idp modal: add missing hr

### DIFF
--- a/src/templates/idp-modal.html
+++ b/src/templates/idp-modal.html
@@ -55,6 +55,7 @@
             <input class='form-control col-md-4' type='text' data-allow-empty='1' id='idpModal_orgid_attr' name='orgid_attr' />
           </div>
           <p class='smallgray'>{{ 'Note: this attribute will not be synchronized from refresh action.'|trans }}</p>
+          <hr>
 
           <div class='d-flex justify-content-between'>
             <label for='idpModal_orcid_attr' class='col-form-label'>{{ 'Which attribute should be used for ORCID (optional)'|trans }}</label>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the IDP modal layout to add clearer visual separation between the “internal id (optional)” and “ORCID (optional)” fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->