### PR TITLE
bug/minor: authfail: use correct value for userid column

### DIFF
--- a/src/Auth/Local.php
+++ b/src/Auth/Local.php
@@ -79,7 +79,7 @@ final class Local implements AuthInterface
 
         // verify password
         if (password_verify($this->password, $this->result['password_hash']) !== true) {
-            throw new InvalidCredentialsException();
+            throw new InvalidCredentialsException($this->userid);
         }
         // check if it needs rehash (new algo)
         if (password_needs_rehash($this->result['password_hash'], PASSWORD_DEFAULT)) {

--- a/src/Exceptions/InvalidCredentialsException.php
+++ b/src/Exceptions/InvalidCredentialsException.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Exceptions;
 
+use Exception;
 use Override;
 
 use function _;
@@ -21,6 +22,11 @@ use function _;
  */
 final class InvalidCredentialsException extends UnauthorizedException
 {
+    public function __construct(int $userid = 0, ?Exception $previous = null)
+    {
+        parent::__construct($this->getErrorMessage(), $userid, $previous);
+    }
+
     #[Override]
     protected function getErrorMessage(): string
     {


### PR DESCRIPTION
it was registering 401 instead of the userid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invalid-password handling during sign-in so authentication errors now carry the correct account context.
  * Kept existing security checks and successful login behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->