### PR TITLE
feat: move branding to dedicated table

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3362,6 +3362,141 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+ # INSTANCE
+  /instance:
+    summary: Instance level actions
+    post:
+      tags: ['Instance']
+      summary: Run an instance level action.
+      operationId: post-instance
+      requestBody:
+        description: Parameters for the instance action.
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: ['action']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['allowuntrusted']
+                      description: Allow all untrusted devices to access locked down user accounts. Requires Sysadmin permissions.
+                - type: object
+                  required: ['action']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['clearlockedoutdevices']
+                      description: Clear all locked out devices. Requires Sysadmin permissions.
+                - type: object
+                  required: ['action', 'email']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['test']
+                      description: Send a test email. Requires Sysadmin permissions.
+                    email:
+                      type: string
+                      format: email
+                      description: Email address that will receive the test email.
+                      example: sysadmin@example.org
+                - type: object
+                  required: ['action', 'target', 'subject', 'body']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['email']
+                      description: Send a mass email to instance users. Requires Sysadmin permissions.
+                    target:
+                      type: string
+                      enum: ['active_users', 'admins', 'sysadmins']
+                      description: Target recipients.
+                    subject:
+                      type: string
+                      description: Email subject.
+                      example: Planned maintenance
+                    body:
+                      type: string
+                      description: Email body.
+                      example: The instance will be unavailable tonight.
+                - type: object
+                  required: ['action', 'entity_id', 'subject', 'body']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['emailbookers']
+                      description: Email users who booked the item.
+                    entity_id:
+                      type: integer
+                      description: ID of the bookable item.
+                      example: 12
+                    subject:
+                      type: string
+                      description: Email subject.
+                      example: Booking update
+                    body:
+                      type: string
+                      description: Email body.
+                      example: The booked item will be unavailable tomorrow.
+                - type: object
+                  required: ['action', 'target', 'subject', 'body']
+                  properties:
+                    action:
+                      type: string
+                      enum: ['emailteam']
+                      description: Email the current team or one of its teamgroups.
+                    target:
+                      type: string
+                      description: Target recipients. Use "team" for the current team or "teamgroup_{id}" for a teamgroup.
+                      example: teamgroup_4
+                      pattern: '^(team|teamgroup_[0-9]+)$'
+                    subject:
+                      type: string
+                      description: Email subject.
+                      example: Team update
+                    body:
+                      type: string
+                      description: Email body.
+                      example: Please read the latest team announcement.
+          multipart/form-data:
+            schema:
+              type: object
+              required: ['action', 'id', 'file']
+              properties:
+                action:
+                  type: string
+                  enum: ['update']
+                  description: Update a branding asset.
+                id:
+                  type: integer
+                  description: Branding id.
+                  example: 1
+                file:
+                  type: string
+                  format: binary
+                  description: Branding file. Accepted types are SVG, PNG, JPEG, WebP and ICO. Maximum size is 1 MiB.
+                  minLength: 1
+                  maxLength: 1048576
+            encoding:
+              file:
+                contentType: image/svg+xml, image/png, image/jpeg, image/webp, image/x-icon, image/vnd.microsoft.icon
+      responses:
+        '201':
+          description: The action was successful.
+          headers:
+            location:
+              description: An URL ending with the integer returned by the action.
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   # ITEMS
   /items:
     summary: Actions on items

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3486,6 +3486,7 @@ paths:
         required: true
         schema:
           type: integer
+          enum: [1, 2, 3, 4]
     get:
       tags: ['Branding']
       summary: Read a branding asset as a binary file.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3362,7 +3362,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
- # INSTANCE
+  # INSTANCE
   /instance:
     summary: Instance level actions
     post:
@@ -3460,28 +3460,6 @@ paths:
                       type: string
                       description: Email body.
                       example: Please read the latest team announcement.
-          multipart/form-data:
-            schema:
-              type: object
-              required: ['action', 'id', 'file']
-              properties:
-                action:
-                  type: string
-                  enum: ['update']
-                  description: Update a branding asset.
-                id:
-                  type: integer
-                  description: Branding id.
-                  example: 1
-                file:
-                  type: string
-                  format: binary
-                  description: Branding file. Accepted types are SVG, PNG, JPEG, WebP and ICO. Maximum size is 1 MiB.
-                  minLength: 1
-                  maxLength: 1048576
-            encoding:
-              file:
-                contentType: image/svg+xml, image/png, image/jpeg, image/webp, image/x-icon, image/vnd.microsoft.icon
       responses:
         '201':
           description: The action was successful.
@@ -3496,6 +3474,108 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+
+  # INSTANCE BRANDING
+  /instance/branding/{id}:
+    summary: Instance branding
+    parameters:
+      - name: id
+        in: path
+        description: Branding id.
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: ['Branding']
+      summary: Read a branding asset as a binary file.
+      operationId: get-instance-branding
+      parameters:
+        - name: format
+          in: query
+          description: Use binary format to retrieve the branding asset.
+          required: true
+          schema:
+            type: string
+            enum: ['binary']
+      responses:
+        '200':
+          description: The branding asset binary file.
+          headers:
+            Content-Length:
+              description: Size of the branding asset in bytes.
+              schema:
+                type: integer
+            Cache-Control:
+              description: Cache policy for the branding asset.
+              schema:
+                type: string
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            image/x-icon:
+              schema:
+                type: string
+                format: binary
+            image/vnd.microsoft.icon:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    post:
+      tags: ['Branding']
+      summary: Update a branding asset.
+      operationId: post-instance-branding
+      requestBody:
+        required: true
+        description: Parameters for updating a branding asset.
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: ['file']
+              properties:
+                action:
+                  type: string
+                  enum: ['update']
+                  description: Update a branding asset. Requires Sysadmin permissions.
+                  default: update
+                file:
+                  type: string
+                  format: binary
+                  description: Branding file. Accepted types are SVG, PNG, JPEG, WebP and ICO. Maximum size is 1 MiB.
+            encoding:
+              file:
+                contentType: image/svg+xml, image/png, image/jpeg, image/webp, image/x-icon, image/vnd.microsoft.icon
+      responses:
+        '201':
+          description: The branding asset has been updated.
+          headers:
+            location:
+              description: An URL to the branding asset that was updated
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+           $ref: '#/components/responses/Forbidden'
 
   # ITEMS
   /items:

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -3511,6 +3511,10 @@ paths:
               description: Cache policy for the branding asset.
               schema:
                 type: string
+            ETag:
+              description: Entity tag used for cache revalidation.
+              schema:
+                type: string
           content:
             image/svg+xml:
               schema:
@@ -3536,6 +3540,8 @@ paths:
               schema:
                 type: string
                 format: binary
+        '304':
+          description: The branding asset has not changed.
         '400':
           $ref: '#/components/responses/BadRequest'
     post:

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -18,6 +18,7 @@ use Elabftw\Elabftw\FsTools;
 use Elabftw\Elabftw\Sql;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Models\ApiKeys;
+use Elabftw\Models\Branding;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\UserParams;
@@ -27,15 +28,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
-use PDO;
-use RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\Question;
 
 use function dirname;
 use function sprintf;
-use function file_get_contents;
-use function strlen;
 
 /**
  * Import database structure
@@ -101,7 +98,7 @@ final class Install extends Command
         $Teams = new Teams(new Users(), bypassWritePermission: true);
         $Teams->create($input->getOption('team') ?? 'Default team');
         $output->writeln('<info>✓ Team created successfully. Now populating branding table...</info>');
-        $this->populateBrandingTable();
+        new Branding(true)->populate();
 
         if ($input->getOption('email')) {
             $output->writeln('<info>→ Creating Sysadmin user...</info>');
@@ -143,41 +140,5 @@ final class Install extends Command
     private function hashPassword(string $password): string
     {
         return new UserParams('password', $password)->getStringContent();
-    }
-
-    private function populateBrandingTable(): void
-    {
-        $branding = array(
-            1 => 'logo-header.svg',
-            2 => 'logo-light.svg',
-            3 => 'logo-dark.svg',
-            4 => 'favicon.svg',
-        );
-
-        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
-            VALUES (:id, :content_type, :data, :filesize)
-            ON DUPLICATE KEY UPDATE
-                content_type = VALUES(content_type),
-                data = VALUES(data),
-                filesize = VALUES(filesize),
-                modified_at = CURRENT_TIMESTAMP';
-
-        $Db = Db::getConnection();
-        $req = $Db->prepare($sql);
-
-        foreach ($branding as $id => $filename) {
-            $path = dirname(__DIR__, 2) . '/web/assets/images/' . $filename;
-            $data = file_get_contents($path);
-
-            if ($data === false) {
-                throw new RuntimeException(sprintf('Could not read branding file: %s', $path));
-            }
-
-            $req->bindValue(':id', $id, PDO::PARAM_INT);
-            $req->bindValue(':content_type', 'image/svg+xml');
-            $req->bindValue(':data', $data, PDO::PARAM_LOB);
-            $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
-            $req->execute();
-        }
     }
 }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -27,11 +27,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Override;
+use PDO;
+use RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\Question;
 
 use function dirname;
 use function sprintf;
+use function file_get_contents;
+use function strlen;
 
 /**
  * Import database structure
@@ -61,7 +65,7 @@ final class Install extends Command
         $req = $Db->q('SELECT COUNT(*) AS cnt FROM information_schema.tables WHERE table_schema = "' . Env::asString('DB_NAME') . '"');
         $res = $req->fetch();
         if ((int) $res['cnt'] > 1 && !$input->getOption('reset')) {
-            $output->writeln('<info>→ Database structure already present. Skipping initialization.</info>');
+            $output->writeln('<info>→ Database structure already present. Skipping initialization. Use "-r" to override.</info>');
             return Command::SUCCESS;
         }
 
@@ -96,6 +100,9 @@ final class Install extends Command
         // now create the default team
         $Teams = new Teams(new Users(), bypassWritePermission: true);
         $Teams->create($input->getOption('team') ?? 'Default team');
+        $output->writeln('<info>✓ Team created successfully. Now populating branding table...</info>');
+        $this->populateBrandingTable();
+
         if ($input->getOption('email')) {
             $output->writeln('<info>→ Creating Sysadmin user...</info>');
             $Users = new Users();
@@ -136,5 +143,41 @@ final class Install extends Command
     private function hashPassword(string $password): string
     {
         return new UserParams('password', $password)->getStringContent();
+    }
+
+    private function populateBrandingTable(): void
+    {
+        $branding = array(
+            1 => 'logo-header.svg',
+            2 => 'logo-light.svg',
+            3 => 'logo-dark.svg',
+            4 => 'favicon.svg',
+        );
+
+        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
+            VALUES (:id, :content_type, :data, :filesize)
+            ON DUPLICATE KEY UPDATE
+                content_type = VALUES(content_type),
+                data = VALUES(data),
+                filesize = VALUES(filesize),
+                modified_at = CURRENT_TIMESTAMP';
+
+        $Db = Db::getConnection();
+        $req = $Db->prepare($sql);
+
+        foreach ($branding as $id => $filename) {
+            $path = dirname(__DIR__, 2) . '/web/assets/images/' . $filename;
+            $data = file_get_contents($path);
+
+            if ($data === false) {
+                throw new RuntimeException(sprintf('Could not read branding file: %s', $path));
+            }
+
+            $req->bindValue(':id', $id, PDO::PARAM_INT);
+            $req->bindValue(':content_type', 'image/svg+xml');
+            $req->bindValue(':data', $data, PDO::PARAM_LOB);
+            $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
+            $req->execute();
+        }
     }
 }

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -273,7 +273,7 @@ final class Apiv2Controller extends AbstractApiController
                         $response->isNotModified($this->Request);
                         return $response;
                     }
-                    throw new ImproperActionException('Incorrect format (binary): only available for uploads endpoint.');
+                    throw new ImproperActionException('Incorrect format (binary): only available for uploads/exports/branding endpoints.');
                 }
             )(),
             ExportFormat::Csv,

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -269,7 +269,9 @@ final class Apiv2Controller extends AbstractApiController
             ExportFormat::Binary => (
                 function () {
                     if ($this->Model instanceof Uploads || $this->Model instanceof Exports || $this->Model instanceof Branding) {
-                        return $this->Model->readBinary();
+                        $response = $this->Model->readBinary();
+                        $response->isNotModified($this->Request);
+                        return $response;
                     }
                     throw new ImproperActionException('Incorrect format (binary): only available for uploads endpoint.');
                 }

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -34,6 +34,7 @@ use Elabftw\Make\Exports;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\ApiKeys;
 use Elabftw\Models\Batch;
+use Elabftw\Models\Branding;
 use Elabftw\Models\Comments;
 use Elabftw\Models\Compounds;
 use Elabftw\Models\Config;
@@ -237,7 +238,7 @@ final class Apiv2Controller extends AbstractApiController
         }
 
         if (
-            $this->Model instanceof Instance &&
+            $this->Model instanceof Branding &&
             str_starts_with($this->Request->headers->get('content-type') ?? '', 'multipart/form-data')
         ) {
             $file = $this->Request->files->get('file');
@@ -246,7 +247,6 @@ final class Apiv2Controller extends AbstractApiController
                 throw new ImproperActionException('Error reading file!');
             }
 
-            $this->reqBody['id'] = $this->Request->request->getInt('id');
             $this->reqBody['file'] = $file;
             $this->action = Action::tryFrom($this->Request->request->getString('action')) ?? Action::Update;
         }
@@ -268,7 +268,7 @@ final class Apiv2Controller extends AbstractApiController
         return match ($this->format) {
             ExportFormat::Binary => (
                 function () {
-                    if ($this->Model instanceof Uploads || $this->Model instanceof Exports) {
+                    if ($this->Model instanceof Uploads || $this->Model instanceof Exports || $this->Model instanceof Branding) {
                         return $this->Model->readBinary();
                     }
                     throw new ImproperActionException('Incorrect format (binary): only available for uploads endpoint.');
@@ -450,6 +450,7 @@ final class Apiv2Controller extends AbstractApiController
         }
         if ($this->Model instanceof Instance) {
             return match ($submodel) {
+                ApiSubModels::Branding => new Branding($this->requester->isSysadmin(), $this->subId),
                 ApiSubModels::Rors => new Instance2Rors($this->requester->isSysadmin(), $this->subIdString),
                 default => throw new InvalidApiSubModelException(ApiEndpoint::Instance),
             };
@@ -467,14 +468,14 @@ final class Apiv2Controller extends AbstractApiController
 
         // allow multipart/form-data for:
         // - POST uploads/import
-        // - POST instance, for branding upload
+        // - POST branding
         // use str_starts_with because the actual header will also contain the boundary
         if (str_starts_with($contentType, 'multipart/form-data') &&
             $this->Request->getMethod() === Request::METHOD_POST &&
             (
                 $this->Model instanceof Uploads ||
                 $this->Model instanceof ImportHandler ||
-                $this->Model instanceof Instance
+                $this->Model instanceof Branding
             )) {
             return;
         }

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -196,7 +196,9 @@ final class Apiv2Controller extends AbstractApiController
                 $this->Request->query->set('id', $this->id);
             }
         }
-        if ($this->Request->getContent()) {
+
+        $contentType = $this->Request->headers->get('content-type') ?? '';
+        if ($this->Request->getContent() && !str_starts_with($contentType, 'multipart/form-data')) {
             try {
                 // SET REQBODY
                 $this->reqBody = json_decode($this->Request->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -232,6 +234,21 @@ final class Apiv2Controller extends AbstractApiController
             $this->reqBody['canread_base'] = (BasePermissions::tryFrom($this->Request->request->getInt('canread_base')) ?? BasePermissions::Team)->value;
             $this->reqBody['canwrite_base'] = (BasePermissions::tryFrom($this->Request->request->getInt('canwrite_base')) ?? BasePermissions::User)->value;
             $this->action = Action::tryFrom($this->Request->request->getString('action')) ?? Action::Create;
+        }
+
+        if (
+            $this->Model instanceof Instance &&
+            str_starts_with($this->Request->headers->get('content-type') ?? '', 'multipart/form-data')
+        ) {
+            $file = $this->Request->files->get('file');
+
+            if ($file === null) {
+                throw new ImproperActionException('Error reading file!');
+            }
+
+            $this->reqBody['id'] = $this->Request->request->getInt('id');
+            $this->reqBody['file'] = $file;
+            $this->action = Action::tryFrom($this->Request->request->getString('action')) ?? Action::Update;
         }
         $id = $this->Model->postAction($this->action, $this->reqBody);
         return new Response('', Response::HTTP_CREATED, array('Location' => sprintf('%s/%s%d', Env::asUrl('SITE_URL'), $this->Model->getApiPath(), $id)));
@@ -277,6 +294,7 @@ final class Apiv2Controller extends AbstractApiController
             // set default action for patch
             $this->action = Action::Update;
         }
+
         return $this->Model->patch($this->action, $this->reqBody);
     }
 
@@ -445,16 +463,24 @@ final class Apiv2Controller extends AbstractApiController
             throw new IllegalActionException('Non sysadmin user tried to use a restricted api endpoint.');
         }
 
-        // allow multipart/form-data for the POST/uploads and POST/import endpoints only,
+        $contentType = $this->Request->headers->get('content-type') ?? '';
+
+        // allow multipart/form-data for:
+        // - POST uploads/import
+        // - POST instance, for branding upload
         // use str_starts_with because the actual header will also contain the boundary
-        if (str_starts_with($this->Request->headers->get('content-type') ?? '', 'multipart/form-data') &&
-            ($this->Model instanceof Uploads || $this->Model instanceof ImportHandler) &&
-            $this->Request->getMethod() === Request::METHOD_POST) {
+        if (str_starts_with($contentType, 'multipart/form-data') &&
+            $this->Request->getMethod() === Request::METHOD_POST &&
+            (
+                $this->Model instanceof Uploads ||
+                $this->Model instanceof ImportHandler ||
+                $this->Model instanceof Instance
+            )) {
             return;
         }
 
         // only accept json content-type unless it's GET or DELETE (also prevents csrf!)
-        if (!in_array($this->Request->getMethod(), array(Request::METHOD_GET, Request::METHOD_DELETE), true) && $this->Request->headers->get('content-type') !== 'application/json') {
+        if (!in_array($this->Request->getMethod(), array(Request::METHOD_GET, Request::METHOD_DELETE), true) && $contentType !== 'application/json') {
             throw new ImproperActionException('Incorrect content-type header.');
         }
     }

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 213;
+    public const int REQUIRED_SCHEMA = 214;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Elabftw/Tools.php
+++ b/src/Elabftw/Tools.php
@@ -173,7 +173,7 @@ final class Tools
         }
 
         return preg_match(
-            '#(?:^|[=&?/])api/v2/instance/branding/[1-9][0-9]*(?:$|[&?])#',
+            '#/api/v2/instance/branding/[1-4]\?format=binary#',
             $request->getRequestUri(),
         ) === 1;
     }

--- a/src/Elabftw/Tools.php
+++ b/src/Elabftw/Tools.php
@@ -174,7 +174,7 @@ final class Tools
 
         return preg_match(
             '#(?:^|[=&?/])api/v2/instance/branding/[1-9][0-9]*(?:$|[&?])#',
-            $request->server->get('QUERY_STRING') ?? '',
+            $request->getRequestUri(),
         ) === 1;
     }
 }

--- a/src/Elabftw/Tools.php
+++ b/src/Elabftw/Tools.php
@@ -14,6 +14,7 @@ namespace Elabftw\Elabftw;
 
 use League\CommonMark\Exception\UnexpectedEncodingException;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
+use Symfony\Component\HttpFoundation\Request;
 
 use function bin2hex;
 use function date;
@@ -33,6 +34,7 @@ use function ord;
 use function sprintf;
 use function strlen;
 use function vsprintf;
+use function preg_match;
 
 /**
  * Toolbelt full of useful functions
@@ -158,5 +160,21 @@ final class Tools
     public static function eLabHtmlspecialchars(mixed $string): string
     {
         return htmlspecialchars((string) $string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+    }
+
+    public static function isPublicBrandingBinaryRequest(Request $request): bool
+    {
+        if ($request->getMethod() !== Request::METHOD_GET) {
+            return false;
+        }
+
+        if ($request->query->getAlpha('format') !== 'binary') {
+            return false;
+        }
+
+        return preg_match(
+            '#(?:^|[=&?/])api/v2/instance/branding/[1-9][0-9]*(?:$|[&?])#',
+            $request->server->get('QUERY_STRING') ?? '',
+        ) === 1;
     }
 }

--- a/src/Enums/ApiSubModels.php
+++ b/src/Enums/ApiSubModels.php
@@ -19,6 +19,7 @@ use function array_map;
 
 enum ApiSubModels: string
 {
+    case Branding = 'branding';
     case Comments = 'comments';
     case CompoundsLinks = 'compounds_links';
     case Containers = 'containers';
@@ -136,6 +137,7 @@ enum ApiSubModels: string
         return array_map(
             fn(self $case): string => $case->value,
             array(
+                self::Branding,
                 self::Rors,
             ),
         );

--- a/src/Enums/Branding.php
+++ b/src/Enums/Branding.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Enums;
+
+enum Branding: int
+{
+    case Header = 1;
+    case Light = 2;
+    case Dark = 3;
+    case Favicon = 4;
+}

--- a/src/Enums/Branding.php
+++ b/src/Enums/Branding.php
@@ -18,4 +18,14 @@ enum Branding: int
     case Light = 2;
     case Dark = 3;
     case Favicon = 4;
+
+    public static function toFile(self $case): string
+    {
+        return match ($case) {
+            self::Header => 'logo-header.svg',
+            self::Light => 'logo-light.svg',
+            self::Dark => 'logo-dark.svg',
+            self::Favicon => 'favicon.svg',
+        };
+    }
 }

--- a/src/Models/Branding.php
+++ b/src/Models/Branding.php
@@ -28,6 +28,7 @@ use function strlen;
 use function strtolower;
 use function dirname;
 use function sprintf;
+use function hash;
 
 /**
  * Operations on branding table
@@ -65,10 +66,20 @@ final class Branding extends AbstractRest
     public function readBinary(): Response
     {
         $branding = $this->selectOne();
+
         return new Response($branding['data'], Response::HTTP_OK, array(
             'Content-Type' => $branding['content_type'],
             'Content-Length' => (string) $branding['filesize'],
-            'Cache-Control' => 'public, max-age=3600',
+            'Cache-Control' => 'public, no-cache, must-revalidate',
+            'ETag' => sprintf(
+                '"%s"',
+                hash('xxh3', sprintf(
+                    '%d:%s:%d',
+                    $branding['id'],
+                    $branding['modified_at'],
+                    $branding['filesize'],
+                )),
+            ),
         ));
     }
 
@@ -120,7 +131,7 @@ final class Branding extends AbstractRest
     {
         $branding = BrandingEnum::tryFrom($this->id ?? 0) ?? throw new ImproperActionException('Invalid branding id.');
 
-        $sql = 'SELECT id, content_type, data, filesize FROM branding WHERE id = :id';
+        $sql = 'SELECT id, content_type, data, filesize, modified_at FROM branding WHERE id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -154,7 +165,10 @@ final class Branding extends AbstractRest
         $filesize = $file->getSize();
 
         if ($filesize < 1 || $filesize > self::BRANDING_MAX_FILESIZE) {
-            throw new ImproperActionException('Invalid branding file size.');
+            throw new ImproperActionException(sprintf(
+                'Invalid branding file size. Maximum allowed size is %.1f MiB.',
+                self::BRANDING_MAX_FILESIZE / 1024 / 1024,
+            ));
         }
 
         $data = file_get_contents($file->getPathname());

--- a/src/Models/Branding.php
+++ b/src/Models/Branding.php
@@ -46,7 +46,7 @@ final class Branding extends AbstractRest
         'image/vnd.microsoft.icon',
     );
 
-    public function __construct(private readonly bool $canwrite, private readonly ?int $id = null)
+    public function __construct(private readonly bool $canwrite = false, private readonly ?int $id = null)
     {
         parent::__construct();
     }

--- a/src/Models/Branding.php
+++ b/src/Models/Branding.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Enums\Branding as BrandingEnum;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+use Override;
+use PDO;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+
+use function in_array;
+use function file_get_contents;
+use function strlen;
+use function strtolower;
+use function dirname;
+use function sprintf;
+
+/**
+ * Operations on branding table
+ */
+final class Branding extends AbstractRest
+{
+    private const int BRANDING_MAX_FILESIZE = 1048576; // 1 MiB
+
+    private const array ALLOWED_BRANDING_CONTENT_TYPES = array(
+        'image/svg+xml',
+        'image/png',
+        'image/jpeg',
+        'image/webp',
+        'image/x-icon',
+        'image/vnd.microsoft.icon',
+    );
+
+    public function __construct(private readonly bool $canwrite, private readonly ?int $id = null)
+    {
+        parent::__construct();
+    }
+
+    #[Override]
+    public function getApiPath(): string
+    {
+        return 'api/v2/instance/branding/';
+    }
+
+    #[Override]
+    public function readOne(): array
+    {
+        throw new ImproperActionException("Use format=binary on this endpoint. No\u{a0}JSON response available.");
+    }
+
+    public function readBinary(): Response
+    {
+        $branding = $this->selectOne();
+        return new Response($branding['data'], Response::HTTP_OK, array(
+            'Content-Type' => $branding['content_type'],
+            'Content-Length' => (string) $branding['filesize'],
+            'Cache-Control' => 'public, max-age=3600',
+        ));
+    }
+
+    #[Override]
+    public function postAction(Action $action, array $reqBody): int
+    {
+        return match ($action) {
+            Action::Update => $this->update($reqBody),
+            default => throw new ImproperActionException('Invalid action parameter sent.'),
+        };
+    }
+
+    public function populate(): void
+    {
+        $branding = array(
+            1 => 'logo-header.svg',
+            2 => 'logo-light.svg',
+            3 => 'logo-dark.svg',
+            4 => 'favicon.svg',
+        );
+
+        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
+            VALUES (:id, :content_type, :data, :filesize)
+            ON DUPLICATE KEY UPDATE
+                content_type = VALUES(content_type),
+                data = VALUES(data),
+                filesize = VALUES(filesize),
+                modified_at = CURRENT_TIMESTAMP';
+
+        $req = $this->Db->prepare($sql);
+
+        foreach ($branding as $id => $filename) {
+            $path = dirname(__DIR__, 2) . '/web/assets/images/' . $filename;
+            $data = file_get_contents($path);
+
+            if ($data === false) {
+                throw new RuntimeException(sprintf('Could not read branding file: %s', $path));
+            }
+
+            $req->bindValue(':id', $id, PDO::PARAM_INT);
+            $req->bindValue(':content_type', 'image/svg+xml');
+            $req->bindValue(':data', $data, PDO::PARAM_LOB);
+            $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
+            $this->Db->execute($req);
+        }
+    }
+
+    private function selectOne(): array
+    {
+        $branding = BrandingEnum::tryFrom($this->id ?? 0) ?? throw new ImproperActionException('Invalid branding id.');
+
+        $sql = 'SELECT id, content_type, data, filesize FROM branding WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        return $this->Db->fetch($req);
+    }
+
+    private function update(array $params): int
+    {
+        if (!$this->canwrite) {
+            throw new IllegalActionException();
+        }
+        $branding = BrandingEnum::tryFrom($this->id ?? 0) ?? throw new ImproperActionException('Invalid branding id.');
+
+        $file = $params['file'] ?? null;
+
+        if (!$file instanceof UploadedFile) {
+            throw new ImproperActionException('Missing branding file.');
+        }
+
+        if (!$file->isValid()) {
+            throw new ImproperActionException('Could not upload branding file.');
+        }
+
+        $contentType = strtolower($file->getMimeType() ?? 'unknown');
+
+        if (!in_array($contentType, self::ALLOWED_BRANDING_CONTENT_TYPES, true)) {
+            throw new ImproperActionException('Unsupported branding file type.');
+        }
+
+        $filesize = $file->getSize();
+
+        if ($filesize < 1 || $filesize > self::BRANDING_MAX_FILESIZE) {
+            throw new ImproperActionException('Invalid branding file size.');
+        }
+
+        $data = file_get_contents($file->getPathname());
+
+        if ($data === false || $data === '') {
+            throw new ImproperActionException('Could not read branding file.');
+        }
+
+        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
+            VALUES (:id, :content_type, :data, :filesize)
+            ON DUPLICATE KEY UPDATE
+                content_type = VALUES(content_type),
+                data = VALUES(data),
+                filesize = VALUES(filesize),
+                modified_at = CURRENT_TIMESTAMP';
+
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
+        $req->bindValue(':content_type', $contentType);
+        $req->bindValue(':data', $data, PDO::PARAM_LOB);
+        $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        return $branding->value;
+    }
+}

--- a/src/Models/Branding.php
+++ b/src/Models/Branding.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Nicolas CARPi / Deltablot
  * @copyright 2026 Nicolas CARPi
  * @see https://www.elabftw.net Official website
  * @license AGPL-3.0
@@ -60,7 +60,7 @@ final class Branding extends AbstractRest
     #[Override]
     public function readOne(): array
     {
-        throw new ImproperActionException("Use format=binary on this endpoint. No\u{a0}JSON response available.");
+        throw new ImproperActionException('Use ?format=binary on this endpoint. No JSON response available.');
     }
 
     public function readBinary(): Response
@@ -94,13 +94,6 @@ final class Branding extends AbstractRest
 
     public function populate(): void
     {
-        $branding = array(
-            1 => 'logo-header.svg',
-            2 => 'logo-light.svg',
-            3 => 'logo-dark.svg',
-            4 => 'favicon.svg',
-        );
-
         $sql = 'INSERT INTO branding (id, content_type, data, filesize)
             VALUES (:id, :content_type, :data, :filesize)
             ON DUPLICATE KEY UPDATE
@@ -111,15 +104,15 @@ final class Branding extends AbstractRest
 
         $req = $this->Db->prepare($sql);
 
-        foreach ($branding as $id => $filename) {
-            $path = dirname(__DIR__, 2) . '/web/assets/images/' . $filename;
+        foreach (BrandingEnum::cases() as $branding) {
+            $path = dirname(__DIR__, 2) . '/web/assets/images/' . BrandingEnum::toFile($branding);
             $data = file_get_contents($path);
 
             if ($data === false) {
                 throw new RuntimeException(sprintf('Could not read branding file: %s', $path));
             }
 
-            $req->bindValue(':id', $id, PDO::PARAM_INT);
+            $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
             $req->bindValue(':content_type', 'image/svg+xml');
             $req->bindValue(':data', $data, PDO::PARAM_LOB);
             $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -33,8 +33,6 @@ use function urlencode;
 use function in_array;
 use function array_key_exists;
 use function count;
-use function dirname;
-use function file_get_contents;
 use function sprintf;
 use function str_starts_with;
 
@@ -68,14 +66,6 @@ final class Config extends AbstractRest
      */
     public function create(): bool
     {
-        $logoHeaderSvg = file_get_contents(dirname(__DIR__, 2) . '/web/assets/images/logo-header.svg');
-        $logoLightSvg = file_get_contents(dirname(__DIR__, 2) . '/web/assets/images/logo-light.svg');
-        $logoDarkSvg = file_get_contents(dirname(__DIR__, 2) . '/web/assets/images/logo-dark.svg');
-        $faviconSvg = file_get_contents(dirname(__DIR__, 2) . '/web/assets/images/favicon.svg');
-        if ($logoHeaderSvg === false || $logoLightSvg === false || $logoDarkSvg === false || $faviconSvg === false) {
-            throw new AppException('Could not load default branding SVG assets.', 500);
-        }
-
         $sql = "INSERT INTO `config` (`conf_name`, `conf_value`) VALUES
             ('admin_validate', '1'),
             ('admin_panel_custom_msg', ''),
@@ -224,18 +214,10 @@ final class Config extends AbstractRest
             ('users_validity_is_externally_managed', '0'),
             ('dspace_host', ''),
             ('dspace_user', ''),
-            ('dspace_password', ''),
-            ('logo_header_svg', :logo_header_svg),
-            ('logo_light_svg', :logo_light_svg),
-            ('logo_dark_svg', :logo_dark_svg),
-            ('favicon_svg', :favicon_svg)";
+            ('dspace_password', '')";
 
         $req = $this->Db->prepare($sql);
         $req->bindValue(':schema', SchemaVersionChecker::REQUIRED_SCHEMA);
-        $req->bindValue(':logo_header_svg', $logoHeaderSvg);
-        $req->bindValue(':logo_light_svg', $logoLightSvg);
-        $req->bindValue(':logo_dark_svg', $logoDarkSvg);
-        $req->bindValue(':favicon_svg', $faviconSvg);
 
         return $this->Db->execute($req);
     }

--- a/src/Models/Instance.php
+++ b/src/Models/Instance.php
@@ -13,40 +13,23 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
-use Elabftw\Enums\Branding;
 use Elabftw\Enums\EmailTarget;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Services\Email;
 use Elabftw\Services\Filter;
 use Override;
-use PDO;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\Address;
 
 use function explode;
 use function in_array;
 use function str_starts_with;
-use function file_get_contents;
-use function strlen;
-use function strtolower;
 
 /**
  * Instance level actions
  */
 final class Instance extends AbstractRest
 {
-    private const int BRANDING_MAX_FILESIZE = 1048576; // 1 MiB
-
-    private const array ALLOWED_BRANDING_CONTENT_TYPES = array(
-        'image/svg+xml',
-        'image/png',
-        'image/jpeg',
-        'image/webp',
-        'image/x-icon',
-        'image/vnd.microsoft.icon',
-    );
-
     public function __construct(private readonly Users $requester, private readonly Email $email, private bool $emailSendGrouped)
     {
         parent::__construct();
@@ -61,7 +44,7 @@ final class Instance extends AbstractRest
     #[Override]
     public function postAction(Action $action, array $reqBody): int
     {
-        if (!in_array($action, array(Action::EmailBookers, Action::EmailTeam, Action::Update), true)) {
+        if (!in_array($action, array(Action::EmailBookers, Action::EmailTeam), true)) {
             $this->requester->isSysadminOrExplode();
         }
         return match ($action) {
@@ -83,7 +66,6 @@ final class Instance extends AbstractRest
                 new Items($this->requester, (int) $reqBody['entity_id']),
             ),
             Action::EmailTeam => $this->emailTeam($reqBody),
-            Action::Update => $this->updateBranding($reqBody),
             default => throw new ImproperActionException('Invalid action parameter sent.'),
         };
     }
@@ -107,59 +89,5 @@ final class Instance extends AbstractRest
             $replyTo,
             $this->emailSendGrouped,
         );
-    }
-
-    private function updateBranding(array $params): int
-    {
-        $branding = Branding::tryFrom((int) ($params['id'] ?? 0));
-
-        if ($branding === null) {
-            throw new ImproperActionException('Invalid branding id.');
-        }
-
-        $file = $params['file'] ?? null;
-
-        if (!$file instanceof UploadedFile) {
-            throw new ImproperActionException('Missing branding file.');
-        }
-
-        if (!$file->isValid()) {
-            throw new ImproperActionException('Could not upload branding file.');
-        }
-
-        $contentType = strtolower($file->getClientMimeType());
-
-        if (!in_array($contentType, self::ALLOWED_BRANDING_CONTENT_TYPES, true)) {
-            throw new ImproperActionException('Unsupported branding file type.');
-        }
-
-        $filesize = $file->getSize();
-
-        if ($filesize < 1 || $filesize > self::BRANDING_MAX_FILESIZE) {
-            throw new ImproperActionException('Invalid branding file size.');
-        }
-
-        $data = file_get_contents($file->getPathname());
-
-        if ($data === false || $data === '') {
-            throw new ImproperActionException('Could not read branding file.');
-        }
-
-        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
-            VALUES (:id, :content_type, :data, :filesize)
-            ON DUPLICATE KEY UPDATE
-                content_type = VALUES(content_type),
-                data = VALUES(data),
-                filesize = VALUES(filesize),
-                modified_at = CURRENT_TIMESTAMP';
-
-        $req = $this->Db->prepare($sql);
-        $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
-        $req->bindValue(':content_type', $contentType);
-        $req->bindValue(':data', $data, PDO::PARAM_LOB);
-        $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
-        $req->execute();
-
-        return $branding->value;
     }
 }

--- a/src/Models/Instance.php
+++ b/src/Models/Instance.php
@@ -13,23 +13,40 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\Branding;
 use Elabftw\Enums\EmailTarget;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Services\Email;
 use Elabftw\Services\Filter;
 use Override;
+use PDO;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\Address;
 
 use function explode;
 use function in_array;
 use function str_starts_with;
+use function file_get_contents;
+use function strlen;
+use function strtolower;
 
 /**
  * Instance level actions
  */
 final class Instance extends AbstractRest
 {
+    private const int BRANDING_MAX_FILESIZE = 1048576; // 1 MiB
+
+    private const array ALLOWED_BRANDING_CONTENT_TYPES = array(
+        'image/svg+xml',
+        'image/png',
+        'image/jpeg',
+        'image/webp',
+        'image/x-icon',
+        'image/vnd.microsoft.icon',
+    );
+
     public function __construct(private readonly Users $requester, private readonly Email $email, private bool $emailSendGrouped)
     {
         parent::__construct();
@@ -44,7 +61,7 @@ final class Instance extends AbstractRest
     #[Override]
     public function postAction(Action $action, array $reqBody): int
     {
-        if (!in_array($action, array(Action::EmailBookers, Action::EmailTeam), true)) {
+        if (!in_array($action, array(Action::EmailBookers, Action::EmailTeam, Action::Update), true)) {
             $this->requester->isSysadminOrExplode();
         }
         return match ($action) {
@@ -66,6 +83,7 @@ final class Instance extends AbstractRest
                 new Items($this->requester, (int) $reqBody['entity_id']),
             ),
             Action::EmailTeam => $this->emailTeam($reqBody),
+            Action::Update => $this->updateBranding($reqBody),
             default => throw new ImproperActionException('Invalid action parameter sent.'),
         };
     }
@@ -89,5 +107,59 @@ final class Instance extends AbstractRest
             $replyTo,
             $this->emailSendGrouped,
         );
+    }
+
+    private function updateBranding(array $params): int
+    {
+        $branding = Branding::tryFrom((int) ($params['id'] ?? 0));
+
+        if ($branding === null) {
+            throw new ImproperActionException('Invalid branding id.');
+        }
+
+        $file = $params['file'] ?? null;
+
+        if (!$file instanceof UploadedFile) {
+            throw new ImproperActionException('Missing branding file.');
+        }
+
+        if (!$file->isValid()) {
+            throw new ImproperActionException('Could not upload branding file.');
+        }
+
+        $contentType = strtolower($file->getClientMimeType());
+
+        if (!in_array($contentType, self::ALLOWED_BRANDING_CONTENT_TYPES, true)) {
+            throw new ImproperActionException('Unsupported branding file type.');
+        }
+
+        $filesize = $file->getSize();
+
+        if ($filesize < 1 || $filesize > self::BRANDING_MAX_FILESIZE) {
+            throw new ImproperActionException('Invalid branding file size.');
+        }
+
+        $data = file_get_contents($file->getPathname());
+
+        if ($data === false || $data === '') {
+            throw new ImproperActionException('Could not read branding file.');
+        }
+
+        $sql = 'INSERT INTO branding (id, content_type, data, filesize)
+            VALUES (:id, :content_type, :data, :filesize)
+            ON DUPLICATE KEY UPDATE
+                content_type = VALUES(content_type),
+                data = VALUES(data),
+                filesize = VALUES(filesize),
+                modified_at = CURRENT_TIMESTAMP';
+
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $branding->value, PDO::PARAM_INT);
+        $req->bindValue(':content_type', $contentType);
+        $req->bindValue(':data', $data, PDO::PARAM_LOB);
+        $req->bindValue(':filesize', strlen($data), PDO::PARAM_INT);
+        $req->execute();
+
+        return $branding->value;
     }
 }

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -23,6 +23,7 @@ use Elabftw\Enums\FileFromString;
 use Elabftw\Enums\Usergroup;
 use Elabftw\Enums\UsersColumn;
 use Elabftw\Models\ApiKeys;
+use Elabftw\Models\Branding;
 use Elabftw\Models\Compounds;
 use Elabftw\Models\Config;
 use Elabftw\Models\Experiments;
@@ -549,5 +550,6 @@ final class Populate
         // load structure
         $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')));
         $Sql->execFile('structure.sql');
+        new Branding(true)->populate();
     }
 }

--- a/src/Traits/TwigTrait.php
+++ b/src/Traits/TwigTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Traits;
 
 use Elabftw\Elabftw\BuildInfo;
+use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\FsTools;
 use jblond\TwigTrans\Translation;
 use Twig\Environment;
@@ -23,6 +24,8 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 use function dirname;
+use function base64_encode;
+use function sprintf;
 
 /**
  * To get Twig
@@ -120,6 +123,28 @@ trait TwigTrait
         // this helps with busting the cache in browsers
         $TwigEnvironment->addGlobal('v', BuildInfo::ID);
 
+        $TwigEnvironment->addGlobal('branding', $this->getBranding());
+
         return $TwigEnvironment;
+    }
+
+    private function getBranding(): array
+    {
+        $sql = 'SELECT id, content_type, data FROM branding';
+        $Db = Db::getConnection();
+        $req = $Db->prepare($sql);
+        $req->execute();
+
+        $branding = array();
+
+        while ($row = $req->fetch()) {
+            $branding[$row['id']] = sprintf(
+                'data:%s;base64,%s',
+                $row['content_type'],
+                base64_encode($row['data']),
+            );
+        }
+
+        return $branding;
     }
 }

--- a/src/Traits/TwigTrait.php
+++ b/src/Traits/TwigTrait.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Elabftw\Traits;
 
 use Elabftw\Elabftw\BuildInfo;
-use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\FsTools;
 use jblond\TwigTrans\Translation;
 use Twig\Environment;
@@ -24,8 +23,6 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 use function dirname;
-use function base64_encode;
-use function sprintf;
 
 /**
  * To get Twig
@@ -123,28 +120,6 @@ trait TwigTrait
         // this helps with busting the cache in browsers
         $TwigEnvironment->addGlobal('v', BuildInfo::ID);
 
-        $TwigEnvironment->addGlobal('branding', $this->getBranding());
-
         return $TwigEnvironment;
-    }
-
-    private function getBranding(): array
-    {
-        $sql = 'SELECT id, content_type, data FROM branding';
-        $Db = Db::getConnection();
-        $req = $Db->prepare($sql);
-        $req->execute();
-
-        $branding = array();
-
-        while ($row = $req->fetch()) {
-            $branding[$row['id']] = sprintf(
-                'data:%s;base64,%s',
-                $row['content_type'],
-                base64_encode($row['data']),
-            );
-        }
-
-        return $branding;
     }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1921,3 +1921,13 @@ input:user-invalid {
     opacity: 1;
   }
 }
+
+.logo-header {
+  height: 40px;
+  width: 110px;
+}
+
+.display-favicon {
+  height: 128px;
+  width: 128px;
+}

--- a/src/sql/schema214-down.sql
+++ b/src/sql/schema214-down.sql
@@ -1,0 +1,18 @@
+-- revert schema 214
+INSERT INTO config (conf_name, conf_value)
+SELECT
+    branding_type.conf_name,
+    CONVERT(branding.data USING utf8mb4)
+FROM branding
+JOIN (
+    SELECT 1 AS id, 'logo_header_svg' AS conf_name
+    UNION ALL SELECT 2, 'logo_light_svg'
+    UNION ALL SELECT 3, 'logo_dark_svg'
+    UNION ALL SELECT 4, 'favicon_svg'
+) AS branding_type ON branding_type.id = branding.id
+ON DUPLICATE KEY UPDATE
+    conf_value = VALUES(conf_value);
+
+DROP TABLE IF EXISTS branding;
+
+UPDATE config SET conf_value = 213 WHERE conf_name = 'schema';

--- a/src/sql/schema214.sql
+++ b/src/sql/schema214.sql
@@ -1,0 +1,31 @@
+-- schema 214
+CREATE TABLE IF NOT EXISTS branding (
+    id TINYINT UNSIGNED NOT NULL,
+    content_type VARCHAR(127) NOT NULL,
+    data MEDIUMBLOB NOT NULL,
+    filesize INT UNSIGNED NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+INSERT INTO branding (id, content_type, data, filesize)
+SELECT
+    branding_type.id,
+    'image/svg+xml',
+    CAST(config.conf_value AS BINARY),
+    OCTET_LENGTH(config.conf_value)
+FROM config
+JOIN (
+    SELECT 1 AS id, 'logo_header_svg' AS conf_name
+    UNION ALL SELECT 2, 'logo_light_svg'
+    UNION ALL SELECT 3, 'logo_dark_svg'
+    UNION ALL SELECT 4, 'favicon_svg'
+) AS branding_type ON branding_type.conf_name = config.conf_name
+WHERE config.conf_value IS NOT NULL
+  AND config.conf_value != ''
+ON DUPLICATE KEY UPDATE
+    content_type = VALUES(content_type),
+    data = VALUES(data),
+    filesize = VALUES(filesize),
+    modified_at = CURRENT_TIMESTAMP;
+DELETE FROM config WHERE conf_name IN ('logo_header_svg', 'logo_light_svg', 'logo_dark_svg', 'favicon_svg');

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -2311,6 +2311,17 @@ CREATE TABLE `users2rors` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 -- end schema 212
 
+-- schema 214
+CREATE TABLE branding (
+    id TINYINT UNSIGNED NOT NULL,
+    content_type VARCHAR(127) NOT NULL,
+    data MEDIUMBLOB NOT NULL,
+    filesize INT UNSIGNED NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
 --
 -- Indexes and Constraints for table `experiments_templates_edit_mode`
 --

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -51,8 +51,8 @@
     </button>
     {% endif %}
     {# logo #}
-    <a href='dashboard.php' class='logo-header' title='{{ 'Go to dashboard'|trans }}' aria-label='{{ 'Go to dashboard'|trans }}'>
-       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Header').value }}?format=binary' alt='eLabFTW'>
+    <a href='dashboard.php' title='{{ 'Go to dashboard'|trans }}' aria-label='{{ 'Go to dashboard'|trans }}'>
+       <img class='logo-header' src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Header').value }}?format=binary' alt='eLabFTW'>
     </a>
     {% if App.Session.has('is_auth') %}
     {# everything in there will be part of the burger #}

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -18,7 +18,7 @@
   <meta name='csrf-token' content='{{ App.Session.get('csrf') }}'/>
   <link rel='manifest' href='/manifest.webmanifest' crossorigin='use-credentials'>
   <link rel='icon' href='/assets/images/favicon.ico' sizes='any'>{# 32×32 #}
-  <link rel='icon' href='data:image/svg+xml,{{ App.Config.configArr.favicon_svg|url_encode }}' type='image/svg+xml'>
+  <link rel='icon' href='{{ branding[constant('Elabftw\\Enums\\Branding::Favicon').value] }}'>
   <link rel='apple-touch-icon' href='/assets/images/apple-touch-icon.png'>{# 180×180 #}
 
   <title>{{ Entity.entityData.title|default(pageTitle) }} - eLabFTW</title>
@@ -52,7 +52,7 @@
     {% endif %}
     {# logo #}
     <a href='dashboard.php' class='logo-header' title='{{ 'Go to dashboard'|trans }}' aria-label='{{ 'Go to dashboard'|trans }}'>
-      {{ App.Config.configArr.logo_header_svg|raw }}
+       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Header').value] }}' alt='eLabFTW'>
     </a>
     {% if App.Session.has('is_auth') %}
     {# everything in there will be part of the burger #}

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -18,7 +18,7 @@
   <meta name='csrf-token' content='{{ App.Session.get('csrf') }}'/>
   <link rel='manifest' href='/manifest.webmanifest' crossorigin='use-credentials'>
   <link rel='icon' href='/assets/images/favicon.ico' sizes='any'>{# 32×32 #}
-  <link rel='icon' href='{{ branding[constant('Elabftw\\Enums\\Branding::Favicon').value] }}'>
+  <link rel='icon' href='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Favicon').value }}?format=binary'>
   <link rel='apple-touch-icon' href='/assets/images/apple-touch-icon.png'>{# 180×180 #}
 
   <title>{{ Entity.entityData.title|default(pageTitle) }} - eLabFTW</title>
@@ -52,7 +52,7 @@
     {% endif %}
     {# logo #}
     <a href='dashboard.php' class='logo-header' title='{{ 'Go to dashboard'|trans }}' aria-label='{{ 'Go to dashboard'|trans }}'>
-       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Header').value] }}' alt='eLabFTW'>
+       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Header').value }}?format=binary' alt='eLabFTW'>
     </a>
     {% if App.Session.has('is_auth') %}
     {# everything in there will be part of the burger #}

--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -5,10 +5,10 @@
 <div class='text-center'>
   <div class='col-md-3 mx-auto'>
     <div class='logo logo-light'>
-      {{ App.Config.configArr.logo_light_svg|raw }}
+       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Light').value] }}' alt='eLabFTW'>
     </div>
     <div class='logo logo-dark'>
-      {{ App.Config.configArr.logo_dark_svg|raw }}
+       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Dark').value] }}' alt='eLabFTW'>
     </div>
   </div>
 </div>

--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -3,13 +3,11 @@
 </div>
 
 <div class='text-center'>
-  <div class='col-md-3 mx-auto'>
-    <div class='logo logo-light'>
-       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Light').value }}?format=binary' alt='eLabFTW'>
-    </div>
-    <div class='logo logo-dark'>
-       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Dark').value }}?format=binary' alt='eLabFTW'>
-    </div>
+  <div class='logo logo-light'>
+     <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Light').value }}?format=binary' alt='eLabFTW'>
+  </div>
+  <div class='logo logo-dark'>
+     <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Dark').value }}?format=binary' alt='eLabFTW'>
   </div>
 </div>
 <div class='separator col-md-4 mx-auto'></div>

--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -5,10 +5,10 @@
 <div class='text-center'>
   <div class='col-md-3 mx-auto'>
     <div class='logo logo-light'>
-       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Light').value] }}' alt='eLabFTW'>
+       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Light').value }}?format=binary' alt='eLabFTW'>
     </div>
     <div class='logo logo-dark'>
-       <img src='{{ branding[constant('Elabftw\\Enums\\Branding::Dark').value] }}' alt='eLabFTW'>
+       <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Dark').value }}?format=binary' alt='eLabFTW'>
     </div>
   </div>
 </div>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -189,23 +189,32 @@
 
   <h2 class='mb-3 p-2 pl-3 section-title'>{{ 'Organization branding'|trans }}</h2>
 
-  {% macro logo_block(title, key, svg, darkPreview) %}
+  {% macro logo_block(title, brandingId, dataUri, darkPreview) %}
+    {% set inputId = 'branding-file-' ~ brandingId %}
+
     <h3>
       <span class='text-nowrap'>
-        <button
-          data-action='edit-logo'
-          data-target='{{ key }}'
-          type='button'
-          title='{{ 'Edit'|trans }}'
-          class='btn btn-secondary'
-          aria-label='{{ 'Edit'|trans }}'
+        <label
+          for='{{ inputId }}'
+          title='{{ 'Upload new file'|trans }}'
+          class='btn btn-secondary mb-0'
+          aria-label='{{ 'Upload new file'|trans }}'
         >
-          <i class='fas fa-pencil-alt'></i>
-        </button>
+          <i class='fas fa-upload'></i>
+        </label>
+
+        <input
+          id='{{ inputId }}'
+          data-action='upload-branding'
+          data-target='{{ brandingId }}'
+          type='file'
+          accept='image/svg+xml,image/png,image/jpeg,image/webp,image/x-icon'
+          class='d-none'
+        >
 
         <button
-          data-action='reset-logo'
-          data-target='{{ key }}'
+          data-action='reset-branding'
+          data-target='{{ brandingId }}'
           type='button'
           title='{{ 'Restore default'|trans }}'
           class='btn btn-danger-ghost'
@@ -217,17 +226,52 @@
     </h3>
 
     <div class='{{ darkPreview ? 'bg-dark' : '' }} col-md-6 p-3 logo-preview'>
-      {{ svg|raw }}
+      {% if dataUri %}
+        <img
+          data-branding-preview='{{ brandingId }}'
+          src='{{ dataUri }}'
+          alt='{{ title }}'
+          class='img-fluid'
+        >
+      {% endif %}
     </div>
 
     <hr>
   {% endmacro %}
 
+  {% set brandingHeader = constant('Elabftw\\Enums\\Branding::Header').value %}
+  {% set brandingLight = constant('Elabftw\\Enums\\Branding::Light').value %}
+  {% set brandingDark = constant('Elabftw\\Enums\\Branding::Dark').value %}
+  {% set brandingFavicon = constant('Elabftw\\Enums\\Branding::Favicon').value %}
+
   <div class='pl-3' id='brandingLogos'>
-    {{ _self.logo_block('Header logo (110x40px)'|trans, 'logo_header_svg', App.Config.configArr.logo_header_svg, true) }}
-    {{ _self.logo_block('Login page logo (light theme)'|trans, 'logo_light_svg', App.Config.configArr.logo_light_svg, false) }}
-    {{ _self.logo_block('Login page logo (dark theme)'|trans, 'logo_dark_svg', App.Config.configArr.logo_dark_svg, true) }}
-    {{ _self.logo_block('Favicon'|trans, 'favicon_svg', App.Config.configArr.favicon_svg, false) }}
+    {{ _self.logo_block(
+      'Header logo (110x40px)'|trans,
+      brandingHeader,
+      branding[brandingHeader] ?? null,
+      true
+    ) }}
+
+    {{ _self.logo_block(
+      'Login page logo (light theme)'|trans,
+      brandingLight,
+      branding[brandingLight] ?? null,
+      false
+    ) }}
+
+    {{ _self.logo_block(
+      'Login page logo (dark theme)'|trans,
+      brandingDark,
+      branding[brandingDark] ?? null,
+      true
+    ) }}
+
+    {{ _self.logo_block(
+      'Favicon'|trans,
+      brandingFavicon,
+      branding[brandingFavicon] ?? null,
+      false
+    ) }}
   </div>
 
   <h2 class='p-2 pl-3 section-title' id='existingRors'>{{ 'Research Organization Registry (ROR)'|trans }}</h2>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -189,7 +189,7 @@
 
   <h2 class='mb-3 p-2 pl-3 section-title'>{{ 'Organization branding'|trans }}</h2>
 
-  {% macro logo_block(title, brandingId, dataUri, darkPreview) %}
+  {% macro logo_block(title, brandingId, darkPreview) %}
     {% set inputId = 'branding-file-' ~ brandingId %}
 
     <h3>
@@ -226,14 +226,12 @@
     </h3>
 
     <div class='{{ darkPreview ? 'bg-dark' : '' }} col-md-6 p-3 logo-preview'>
-      {% if dataUri %}
-        <img
-          data-branding-preview='{{ brandingId }}'
-          src='{{ dataUri }}'
-          alt='{{ title }}'
-          class='img-fluid'
-        >
-      {% endif %}
+      <img
+        data-branding-preview='{{ brandingId }}'
+        src='/api/v2/instance/branding/{{ brandingId }}?format=binary'
+        alt='{{ title }}'
+          class='{{ brandingId == constant('Elabftw\\Enums\\Branding::Favicon').value ? 'display-favicon' : 'img-fluid' }}'
+      >
     </div>
 
     <hr>
@@ -248,28 +246,24 @@
     {{ _self.logo_block(
       'Header logo (110x40px)'|trans,
       brandingHeader,
-      branding[brandingHeader] ?? null,
       true
     ) }}
 
     {{ _self.logo_block(
       'Login page logo (light theme)'|trans,
       brandingLight,
-      branding[brandingLight] ?? null,
       false
     ) }}
 
     {{ _self.logo_block(
       'Login page logo (dark theme)'|trans,
       brandingDark,
-      branding[brandingDark] ?? null,
       true
     ) }}
 
     {{ _self.logo_block(
       'Favicon'|trans,
       brandingFavicon,
-      branding[brandingFavicon] ?? null,
       false
     ) }}
   </div>

--- a/src/templates/sysconfig.html
+++ b/src/templates/sysconfig.html
@@ -198,9 +198,9 @@
           for='{{ inputId }}'
           title='{{ 'Upload new file'|trans }}'
           class='btn btn-secondary mb-0'
-          aria-label='{{ 'Upload new file'|trans }}'
         >
-          <i class='fas fa-upload'></i>
+          <i class='fas fa-upload' aria-hidden='true'></i>
+          <span class='sr-only'>{{ 'Upload new file'|trans }}</span>
         </label>
 
         <input
@@ -209,7 +209,7 @@
           data-target='{{ brandingId }}'
           type='file'
           accept='image/svg+xml,image/png,image/jpeg,image/webp,image/x-icon'
-          class='d-none'
+          class='sr-only'
         >
 
         <button

--- a/src/ts/Apiv2.class.ts
+++ b/src/ts/Apiv2.class.ts
@@ -5,9 +5,11 @@
  * @license AGPL-3.0
  * @package elabftw
  */
-import { Method } from './interfaces';
+import { Method, Selected } from './interfaces';
 import { getNewIdFromPostRequest } from './misc';
 import { notify } from './notify';
+
+type ApiParams = Record<string, unknown> | FormData | object | Selected;
 
 export class Api {
   // allow forcing the browser to make the request even if page is closed − useful for clearing exclusive edit on window unload
@@ -51,11 +53,11 @@ export class Api {
     });
   }
 
-  patch(query: string, params = {}): Promise<Response> {
+  patch(query: string, params: ApiParams = {}): Promise<Response> {
     return this.send(Method.PATCH, query, params);
   }
 
-  post(query: string, params = {}): Promise<Response> {
+  post(query: string, params: ApiParams = {}): Promise<Response> {
     return this.send(Method.POST, query, params);
   }
 
@@ -69,35 +71,49 @@ export class Api {
   }
 
   // private method: use patch/post/delete instead
-  private async send(method: Method, query: string, params = {}): Promise<Response> {
+  private async send(method: Method, query: string, params: ApiParams = {}): Promise<Response> {
+    const isFormData = params instanceof FormData;
+
+
     // allow toggle notifs off by sending notifOn(Saved|Error)=0 as param
     let notifOnSaved = true;
-    if (params['notifOnSaved'] === 0) {
-      notifOnSaved = false;
-    }
-    delete params['notifOnSaved'];
     let notifOnError = true;
-    if (params['notifOnError'] === 0) {
-      notifOnError = false;
+    if (!isFormData) {
+      if (params['notifOnSaved'] === 0) {
+        notifOnSaved = false;
+      }
+      delete params['notifOnSaved'];
+
+      if (params['notifOnError'] === 0) {
+        notifOnError = false;
+      }
+      delete params['notifOnError'];
     }
-    delete params['notifOnError'];
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-    const options = {
+
+    const headers: HeadersInit = {
+      'X-CSRF-Token': csrfToken,
+      'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    if (!isFormData) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const options: RequestInit = {
       method: method,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': csrfToken,
-        'X-Requested-With': 'XMLHttpRequest',
-      },
+      headers: headers,
       keepalive: this.keepalive,
     };
+
     if ([Method.POST, Method.PATCH].includes(method)) {
-      options['body'] = JSON.stringify(params);
+      options.body = isFormData ? params : JSON.stringify(params);
     }
+
     let urlParams = '';
-    if (method === Method.GET && Object.keys(params).length > 0) {
-      urlParams = `?${new URLSearchParams(params).toString()}`;
+    if (method === Method.GET && !isFormData && Object.keys(params).length > 0) {
+      urlParams = `?${new URLSearchParams(params as Record<string, string>).toString()}`;
     }
 
     return fetch(`api/v2/${query}${urlParams}`, options).then(async response => {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -195,11 +195,10 @@ function checkForUpdate() {
 
 const uploadBranding = async (brandingId: string, file: Blob, filename: string): Promise<void> => {
   const formData = new FormData();
-  formData.append('id', brandingId);
   formData.append('action', 'update');
   formData.append('file', file, filename);
 
-  await ApiC.post('instance', formData);
+  await ApiC.post(`instance/branding/${brandingId}`, formData);
   reloadElements(['brandingLogos']);
 };
 
@@ -246,6 +245,9 @@ if (window.location.pathname === '/sysconfig.php') {
     }
 
     const res = await fetch(url, { cache: 'no-cache' });
+    if (!res.ok) {
+      throw new Error(`Could not load default branding asset: ${url}`);
+    }
     const blob = await res.blob();
     const filename = url.split('/').pop() ?? 'branding.svg';
 

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -193,13 +193,32 @@ function checkForUpdate() {
   }).catch(error => latestVersionDiv.append(error));
 }
 
+const updateBrandingPreview = (brandingId: string, file: Blob): void => {
+  const img = document.querySelector<HTMLImageElement>(`img[data-branding-preview="${brandingId}"]`);
+
+  if (!img) {
+    reloadElements(['brandingLogos']);
+    return;
+  }
+
+  const previousObjectUrl = img.dataset.objectUrl;
+  if (previousObjectUrl) {
+    URL.revokeObjectURL(previousObjectUrl);
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  img.dataset.objectUrl = objectUrl;
+  img.src = objectUrl;
+};
+
 const uploadBranding = async (brandingId: string, file: Blob, filename: string): Promise<void> => {
   const formData = new FormData();
   formData.append('action', 'update');
   formData.append('file', file, filename);
 
   await ApiC.post(`instance/branding/${brandingId}`, formData);
-  reloadElements(['brandingLogos']);
+
+  updateBrandingPreview(brandingId, file);
 };
 
 const defaultBrandingAssets: Record<string, string> = {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -246,8 +246,11 @@ if (window.location.pathname === '/sysconfig.php') {
       return;
     }
 
-    await uploadBranding(brandingId, file, file.name);
-    input.value = '';
+    try {
+      await uploadBranding(brandingId, file, file.name);
+    } finally {
+      input.value = '';
+    }
   });
 
   on('reset-branding', async (el: HTMLElement) => {

--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -15,7 +15,6 @@ import { ApiC } from './api';
 import $ from 'jquery';
 import { SemverCompare } from './SemverCompare.class';
 import { on } from './handlers';
-import DOMPurify from 'dompurify';
 
 function updateTsFieldsVisibility(select: HTMLSelectElement) {
   const noAccountTsa = ['dfn', 'digicert', 'sectigo', 'globalsign'];
@@ -139,33 +138,6 @@ function renderEndpoints(endpoints: Endpoint[]): void {
   });
 }
 
-function pickSvgText(): Promise<string | null> {
-  return new Promise((resolve, reject) => {
-    const i = document.createElement('input');
-    i.type = 'file';
-    i.accept = '.svg,image/svg+xml';
-
-    i.onchange = async () => {
-      const f = i.files?.[0];
-      if (!f) return resolve(null);
-      const isSvgExt = f.name.toLowerCase().endsWith('.svg');
-      const isSvgMime = f.type === 'image/svg+xml';
-      if (!isSvgExt && !isSvgMime) {
-        return reject(new Error('Please choose an SVG file.'));
-      }
-      const text = await f.text();
-      const sanitizedText = DOMPurify.sanitize(text, { USE_PROFILES: { svg: true, svgFilters: true } });
-      const xml = new DOMParser().parseFromString(sanitizedText, 'image/svg+xml');
-      if (xml.querySelector('parsererror') || xml.documentElement?.nodeName !== 'svg') {
-        return reject(new Error('Not valid SVG.'));
-      }
-      resolve(sanitizedText);
-    };
-
-    i.click();
-  });
-}
-
 // GET the latest version information
 function checkForUpdate() {
   const updateUrl = 'https://get.elabftw.net/updates.json';
@@ -221,28 +193,63 @@ function checkForUpdate() {
   }).catch(error => latestVersionDiv.append(error));
 }
 
+const uploadBranding = async (brandingId: string, file: Blob, filename: string): Promise<void> => {
+  const formData = new FormData();
+  formData.append('id', brandingId);
+  formData.append('action', 'update');
+  formData.append('file', file, filename);
+
+  await ApiC.post('instance', formData);
+  reloadElements(['brandingLogos']);
+};
+
+const defaultBrandingAssets: Record<string, string> = {
+  '1': '/assets/images/logo-header.svg',
+  '2': '/assets/images/logo-light.svg',
+  '3': '/assets/images/logo-dark.svg',
+  '4': '/assets/images/favicon.svg',
+};
+
 if (window.location.pathname === '/sysconfig.php') {
 
   checkForUpdate();
 
-  on('edit-logo', async (el: HTMLElement) => {
-    const picked = await pickSvgText();
-    if (!picked) return; // cancelled
-    ApiC.patch('config', {[el.dataset.target!]: picked}).then(() => reloadElements(['brandingLogos']));
+  document.addEventListener('change', async event => {
+    const input = event.target;
+
+    if (!(input instanceof HTMLInputElement) || input.dataset.action !== 'upload-branding') {
+      return;
+    }
+
+    const brandingId = input.dataset.target;
+    const file = input.files?.[0];
+
+    if (!brandingId || !file) {
+      return;
+    }
+
+    await uploadBranding(brandingId, file, file.name);
+    input.value = '';
   });
 
-  on('reset-logo', async (el: HTMLElement) => {
-    // map config key -> default asset path
-    const defaults: Record<string, string> = {
-      logo_header_svg: '/assets/images/logo-header.svg',
-      logo_light_svg: '/assets/images/logo-light.svg',
-      logo_dark_svg: '/assets/images/logo-dark.svg',
-      favicon_svg: '/assets/images/favicon.svg',
-    };
-    const url = defaults[el.dataset.target];
+  on('reset-branding', async (el: HTMLElement) => {
+    const brandingId = el.dataset.target;
+
+    if (!brandingId) {
+      return;
+    }
+
+    const url = defaultBrandingAssets[brandingId];
+
+    if (!url) {
+      return;
+    }
+
     const res = await fetch(url, { cache: 'no-cache' });
-    const defaultSvg = await res.text();
-    ApiC.patch('config', {[el.dataset.target!]: defaultSvg}).then(() => reloadElements(['brandingLogos']));
+    const blob = await res.blob();
+    const filename = url.split('/').pop() ?? 'branding.svg';
+
+    await uploadBranding(brandingId, blob, filename);
   });
 
   // TEST EMAIL

--- a/tests/unit/models/BrandingTest.php
+++ b/tests/unit/models/BrandingTest.php
@@ -65,7 +65,7 @@ class BrandingTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame('image/svg+xml', $response->headers->get('Content-Type'));
-        $this->assertSame('max-age=3600, public', $response->headers->get('Cache-Control'));
+        $this->assertSame('must-revalidate, no-cache, public', $response->headers->get('Cache-Control'));
         $this->assertIsString($content);
         $this->assertSame((string) strlen($content), $response->headers->get('Content-Length'));
     }
@@ -85,7 +85,7 @@ class BrandingTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame('image/png', $response->headers->get('Content-Type'));
         $this->assertSame((string) strlen($data), $response->headers->get('Content-Length'));
-        $this->assertSame('max-age=3600, public', $response->headers->get('Cache-Control'));
+        $this->assertSame('must-revalidate, no-cache, public', $response->headers->get('Cache-Control'));
         $this->assertSame($data, $response->getContent());
     }
 
@@ -108,15 +108,16 @@ class BrandingTest extends \PHPUnit\Framework\TestCase
         $Branding = new Branding(true, 42);
 
         $this->expectException(ImproperActionException::class);
-        $Branding->readOne();
+        $Branding->readBinary();
     }
 
     public function testInvalidBrandingIdUpdate(): void
     {
         $Branding = new Branding(true, 42);
+        $file = $this->getUploadedFile('not an image', 'branding.txt');
 
         $this->expectException(ImproperActionException::class);
-        $Branding->postAction(Action::Update, array());
+        $Branding->postAction(Action::Update, array('file' => $file));
     }
 
     public function testMissingFile(): void

--- a/tests/unit/models/BrandingTest.php
+++ b/tests/unit/models/BrandingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+
+use function base64_decode;
+use function file_put_contents;
+use function is_file;
+use function strlen;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class BrandingTest extends \PHPUnit\Framework\TestCase
+{
+    private Branding $Branding;
+
+    private array $tmpFiles = array();
+
+    protected function setUp(): void
+    {
+        $this->Branding = new Branding(true, 1);
+        $this->Branding->populate();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $tmpFile) {
+            if (is_file($tmpFile)) {
+                unlink($tmpFile);
+            }
+        }
+    }
+
+    public function testApiPath(): void
+    {
+        $this->assertEquals('api/v2/instance/branding/', $this->Branding->getApiPath());
+    }
+
+    public function testReadOne(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->Branding->readOne();
+    }
+
+    public function testReadBinary(): void
+    {
+        $response = $this->Branding->readBinary();
+        $content = $response->getContent();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('image/svg+xml', $response->headers->get('Content-Type'));
+        $this->assertSame('max-age=3600, public', $response->headers->get('Cache-Control'));
+        $this->assertIsString($content);
+        $this->assertSame((string) strlen($content), $response->headers->get('Content-Length'));
+    }
+
+    public function testUpdate(): void
+    {
+        // valid 1×1 pixel PNG
+        $data = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', true);
+        $this->assertIsString($data);
+
+        $file = $this->getUploadedFile($data, 'branding.png');
+
+        $this->assertSame(1, $this->Branding->postAction(Action::Update, array('file' => $file)));
+
+        $response = $this->Branding->readBinary();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('image/png', $response->headers->get('Content-Type'));
+        $this->assertSame((string) strlen($data), $response->headers->get('Content-Length'));
+        $this->assertSame('max-age=3600, public', $response->headers->get('Cache-Control'));
+        $this->assertSame($data, $response->getContent());
+    }
+
+    public function testCannotUpdateWithoutWriteAccess(): void
+    {
+        $Branding = new Branding(false, 1);
+
+        $this->expectException(IllegalActionException::class);
+        $Branding->postAction(Action::Update, array());
+    }
+
+    public function testInvalidAction(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->Branding->postAction(Action::Create, array());
+    }
+
+    public function testInvalidBrandingIdRead(): void
+    {
+        $Branding = new Branding(true, 42);
+
+        $this->expectException(ImproperActionException::class);
+        $Branding->readOne();
+    }
+
+    public function testInvalidBrandingIdUpdate(): void
+    {
+        $Branding = new Branding(true, 42);
+
+        $this->expectException(ImproperActionException::class);
+        $Branding->postAction(Action::Update, array());
+    }
+
+    public function testMissingFile(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->Branding->postAction(Action::Update, array());
+    }
+
+    public function testUnsupportedFileType(): void
+    {
+        $file = $this->getUploadedFile('not an image', 'branding.txt');
+
+        $this->expectException(ImproperActionException::class);
+        $this->Branding->postAction(Action::Update, array('file' => $file));
+    }
+
+    private function getUploadedFile(string $contents, string $clientName): UploadedFile
+    {
+        $path = tempnam(sys_get_temp_dir(), 'elabftw-branding-test-');
+        $this->assertIsString($path);
+        $this->assertNotFalse(file_put_contents($path, $contents));
+        $this->tmpFiles[] = $path;
+
+        return new UploadedFile($path, $clientName, null, null, true);
+    }
+}

--- a/tests/unit/models/InstanceTest.php
+++ b/tests/unit/models/InstanceTest.php
@@ -1,8 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
 /**
- * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @author Nicolas CARPi / Deltablot
  * @copyright 2025 Nicolas CARPi
  * @see https://www.elabftw.net Official website
  * @license AGPL-3.0

--- a/web/app/controllers/ApiController.php
+++ b/web/app/controllers/ApiController.php
@@ -37,8 +37,11 @@ try {
     if ($App->Request->getMethod() === Request::METHOD_OPTIONS) {
         return new JsonResponse();
     }
-    // check if the authorization header starts with Basic it means it's a basic auth header and we ignore it.
-    if ($App->Request->server->has('HTTP_AUTHORIZATION') && !str_starts_with($App->Request->server->get('HTTP_AUTHORIZATION'), 'Basic')) {
+
+    // allow requests to branding assets without auth
+    $isPublicBrandingBinaryRequest = Tools::isPublicBrandingBinaryRequest($App->Request);
+
+    if (!$isPublicBrandingBinaryRequest && $App->Request->server->has('HTTP_AUTHORIZATION') && !str_starts_with($App->Request->server->get('HTTP_AUTHORIZATION'), 'Basic')) {
         // verify the key and load user info
         $ApiKeys = new ApiKeys(new Users());
         $key = $ApiKeys->readFromApiKey($App->Request->server->get('HTTP_AUTHORIZATION') ?? '');
@@ -46,8 +49,12 @@ try {
         $App->Users = new ActiveUser($key['userid'], $key['team']);
         $canWrite = (bool) $key['can_write'];
     } else {
-        if ($App->Session->get('is_auth') !== 1) {
+        if (!$isPublicBrandingBinaryRequest && $App->Session->get('is_auth') !== 1) {
             throw new UnauthorizedException();
+        }
+
+        if ($isPublicBrandingBinaryRequest) {
+            $canWrite = false;
         }
     }
 


### PR DESCRIPTION
remove it from config
also document /instance endpoint

fix #6727 
fix #6785 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added instance branding assets with binary download, multipart upload, live preview, and reset to default branding.
  * Introduced `POST /instance` actions (allowuntrusted, device lockout clearing, and instance/email-related actions).
  * Added `GET/POST /instance/branding/{id}` endpoints for viewing and updating branding.
* **Bug Fixes**
  * Improved API request handling for multipart uploads and ensured branding binary downloads work correctly for public access.
* **Tests**
  * Added unit coverage for branding download and update validations.
* **Chores**
  * Added schema 214 with a dedicated branding store and migrated existing default assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->