### PR TITLE
dev: remove bypasswrite in Teams class

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -95,7 +95,7 @@ final class Install extends Command
         (new Sql($sqlFs))->execFile('structure.sql');
         $output->writeln('<info>✓ Installation successful! Now creating the first team...</info>');
         // now create the default team
-        $Teams = new Teams(new Users(), bypassWritePermission: true);
+        $Teams = new Teams(new Users());
         $Teams->create($input->getOption('team') ?? 'Default team');
         $output->writeln('<info>✓ Team created successfully. Now populating branding table...</info>');
         new Branding(true)->populate();

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -53,8 +53,6 @@ abstract class AbstractImport implements ImportInterface
         protected LoggerInterface $logger,
     ) {
         $this->Db = Db::getConnection();
-        // yes, the bypassWritePermission opens it up to normal users that normally cannot create status and category,
-        // but user experience takes over this consideration here
         $this->Teams = new Teams($this->requester, $this->requester->team);
         if ($this->UploadedFile->getError()) {
             throw new ImproperActionException($this->UploadedFile->getErrorMessage());

--- a/src/Import/AbstractImport.php
+++ b/src/Import/AbstractImport.php
@@ -55,7 +55,7 @@ abstract class AbstractImport implements ImportInterface
         $this->Db = Db::getConnection();
         // yes, the bypassWritePermission opens it up to normal users that normally cannot create status and category,
         // but user experience takes over this consideration here
-        $this->Teams = new Teams($this->requester, $this->requester->team, bypassWritePermission: true);
+        $this->Teams = new Teams($this->requester, $this->requester->team);
         if ($this->UploadedFile->getError()) {
             throw new ImproperActionException($this->UploadedFile->getErrorMessage());
         }

--- a/src/Models/AbstractCategory.php
+++ b/src/Models/AbstractCategory.php
@@ -75,7 +75,7 @@ abstract class AbstractCategory extends AbstractRest
 
     protected function canWriteOrExplode(): void
     {
-        if ($this->Teams->bypassWritePermission) {
+        if ($this->Teams->canWrite()) {
             return;
         }
         $property = sprintf('users_canwrite_%s', $this->getUsersCanwriteName());

--- a/src/Models/AbstractStatus.php
+++ b/src/Models/AbstractStatus.php
@@ -57,6 +57,7 @@ abstract class AbstractStatus extends AbstractCategory
     #[Override]
     public function postAction(Action $action, array $reqBody): int
     {
+        $this->canWriteOrExplode();
         return $this->create(
             $reqBody['name'] ?? _('Untitled'),
             $reqBody['color'] ?? $this->getRandomDarkColor(),
@@ -156,7 +157,6 @@ abstract class AbstractStatus extends AbstractCategory
     #[Override]
     public function create(string $title = '', ?string $color = null, int $isDefault = 0): int
     {
-        $this->canWriteOrExplode();
         $title = Filter::title($title);
         $color ??= $this->getRandomDarkColor();
         $color = Check::color($color);

--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -45,7 +45,7 @@ final class Teams extends AbstractRest
 
     public array $teamArr = array();
 
-    public function __construct(public Users $Users, ?int $id = null, public bool $bypassWritePermission = false)
+    public function __construct(public Users $Users, ?int $id = null)
     {
         parent::__construct();
         $this->setId($id);
@@ -71,7 +71,6 @@ final class Teams extends AbstractRest
             $team = $req->fetch();
             // team was not found, we need to create it, but only if we're allowed to
             if ($team === false && $allowTeamCreation === true) {
-                $this->bypassWritePermission = true;
                 $freshTeam = new self($this->Users, $this->create($query));
                 $team = $freshTeam->selectOne();
             }
@@ -230,6 +229,8 @@ final class Teams extends AbstractRest
     #[Override]
     public function destroy(): bool
     {
+        $this->canWriteOrExplode();
+
         // check for stats, should be 0
         $count = $this->getStats($this->id ?? 0);
 
@@ -315,7 +316,7 @@ final class Teams extends AbstractRest
 
     public function canWrite(): bool
     {
-        if ($this->bypassWritePermission || $this->Users->isSysadmin()) {
+        if ($this->Users->isSysadmin()) {
             return true;
         }
         if ($this->id === null) {

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -98,7 +98,7 @@ final class Populate
 
         $this->output->writeln('┌ Creating teams, users, experiments, and resources...');
         $Users = new UltraAdmin(1, 1);
-        $Teams = new Teams($Users, bypassWritePermission: true);
+        $Teams = new Teams($Users);
 
         // main loop is on "teams" key
         foreach ($this->yaml['teams'] as $team) {
@@ -358,7 +358,7 @@ final class Populate
             return;
         }
         $iterations ??= $this->iterations;
-        $Teams = new Teams($Entity->Users, $Entity->Users->team, bypassWritePermission: true);
+        $Teams = new Teams($Entity->Users, $Entity->Users->team);
         if ($Entity instanceof Experiments) {
             $Category = new ExperimentsCategories($Teams);
             $Status = new ExperimentsStatus($Teams);

--- a/tests/unit/models/AbstractCategoryTest.php
+++ b/tests/unit/models/AbstractCategoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2012 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Models\Users\Users;
+use Elabftw\Traits\TestsUtilsTrait;
+
+use function bin2hex;
+use function random_bytes;
+
+class AbstractCategoryTest extends \PHPUnit\Framework\TestCase
+{
+    use TestsUtilsTrait;
+
+    private ExperimentsStatus $Category;
+
+    protected function setUp(): void
+    {
+        $this->Category = new ExperimentsStatus(new Teams(new Users(1, 1), 1));
+    }
+
+    public function testGetIdempotentIdFromTitleCreatesCategory(): void
+    {
+        $title = 'Idempotent category ' . bin2hex(random_bytes(8));
+
+        $id = $this->Category->getIdempotentIdFromTitle($title, '#29AEB9');
+
+        $this->assertIsInt($id);
+
+        $Category = new ExperimentsStatus(new Teams(new Users(1, 1), 1), $id);
+        $category = $Category->readOne();
+
+        $this->assertEquals($title, $category['title']);
+        $this->assertEquals('29AEB9', $category['color']);
+    }
+
+    public function testGetIdempotentIdFromTitleReturnsExistingCategory(): void
+    {
+        $title = 'Existing idempotent category ' . bin2hex(random_bytes(8));
+
+        $firstId = $this->Category->getIdempotentIdFromTitle($title, '#29AEB9');
+        $secondId = $this->Category->getIdempotentIdFromTitle($title, '#121212');
+
+        $this->assertSame($firstId, $secondId);
+
+        $Category = new ExperimentsStatus(new Teams(new Users(1, 1), 1), $firstId);
+        $category = $Category->readOne();
+
+        $this->assertEquals($title, $category['title']);
+        $this->assertEquals('29AEB9', $category['color']);
+    }
+
+    public function testNormalUserCannotCreateCategoryIfTeamSettingDisallowsIt(): void
+    {
+        $user = $this->getUserInTeam(1);
+        $Teams = new Teams($user, 1);
+        $Teams->teamArr['users_canwrite_experiments_categories'] = 0;
+
+        $Category = new ExperimentsCategories($Teams);
+
+        $this->expectException(IllegalActionException::class);
+
+        $Category->postAction(Action::Create, array(
+            'title' => 'Forbidden category',
+            'color' => '#29AEB9',
+        ));
+    }
+}

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -102,7 +102,6 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
     {
         $id = $this->Teams->postAction(Action::Create, array('name' => 'Destroy me'));
         $this->Teams->setId($id);
-        $this->Teams->bypassWritePermission = true;
         $this->assertTrue($this->Teams->destroy());
         // try to destroy a team with data
         $this->Teams->setId(1);


### PR DESCRIPTION
bad practice, not needed now that we have public create() and don't need to bypass permission check of postAction() for instance

also move the canWriteOrExplode() check in Status to the public api function, not the internal api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the special write-permission bypass used during installation, imports, and automated population, so team creation and related writes now follow standard authorization rules.
  * Ensured permission gating is consistently applied for status actions and category/status writes.
  * Updated team deletion to require proper authorization before changes are made.
* **Tests**
  * Added unit coverage for experiment category idempotency and authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->