### PR TITLE
feat: compounds-import: add tags to created resources

### DIFF
--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -207,6 +207,7 @@ final class CompoundsCsv extends AbstractCsv
             'title',
             'comment',
             'custom_id',
+            'tags',
             'chebi_id',
             'chembl_id',
             'dea_number',

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -19,6 +19,7 @@ use Elabftw\Models\Links\Compounds2ItemsLinks;
 use Elabftw\Models\Links\Containers2ItemsLinks;
 use Elabftw\Models\Items;
 use Elabftw\Models\StorageUnits;
+use Elabftw\Models\Tags;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Params\EntityParams;
 use Elabftw\Services\PubChemImporter;
@@ -124,6 +125,10 @@ final class CompoundsCsv extends AbstractCsv
                     $this->Items->setId($resource);
                     if (isset($row['comment'])) {
                         $this->Items->update(new EntityParams('body', $row['comment']));
+                    }
+                    if (isset($row['tags']) && trim($row['tags']) !== '') {
+                        $Tags = new Tags($this->Items);
+                        $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
                     $this->Items->update(new EntityParams('metadata', $this->collectMetadata($row)));
                     foreach ($ids as $id) {


### PR DESCRIPTION
When importing compounds with the import:compounds command, create tags if they exist in the csv.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV imports now support adding tags when creating compounds or resources.
  * If a `tags` value is provided in the import row, it will be applied automatically after trimming whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->