### PR TITLE
feat: api: support merging metadata during entity updates

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1249,6 +1249,9 @@ components:
           description: The main text content (HTML or Markdown)
           default: null
           example: "<h1>Section title</h1><p>Main text of resource</p>"
+        bodyappend:
+          type: string
+          description: Append content to the existing entity body instead of replacing it.
         canread_base:
           type: number
           nullable: true
@@ -1310,6 +1313,19 @@ components:
           nullable: true
         metadata:
           $ref: '#/components/schemas/metadata'
+        metadatamerge:
+          description: >
+            Merge incoming metadata into the existing entity metadata.
+            Existing extra fields keep their schema such as type, options, units and description;
+            only their value is updated. Incoming extra fields that do not already exist are added.
+          allOf:
+            - $ref: '#/components/schemas/metadata'
+          example:
+            extra_fields:
+              weight:
+                value: "12"
+              certified:
+                value: "X"
         rating:
           type: integer
           nullable: true

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -36,6 +36,9 @@ use function trim;
 use function count;
 use function explode;
 use function is_array;
+use function json_decode;
+use function json_encode;
+use function str_replace;
 
 /**
  * Import a CSV into compounds
@@ -130,7 +133,8 @@ final class CompoundsCsv extends AbstractCsv
                         $Tags = new Tags($this->Items);
                         $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
-                    $this->Items->update(new EntityParams('metadata', $this->collectMetadata($row)));
+                    //                    $this->Items->update(new EntityParams('metadata', $this->collectMetadata($row)));
+                    $this->Items->update(new EntityParams('metadata', $this->mergeMetadataValues($this->collectMetadata($row))));
                     foreach ($ids as $id) {
                         $Compounds2ItemsLinks = new Compounds2ItemsLinks($this->Items, $id);
                         $Compounds2ItemsLinks->create();
@@ -245,6 +249,50 @@ final class CompoundsCsv extends AbstractCsv
             'is_nano',
             'is_controlled',
         );
+    }
+
+    protected function mergeMetadataValues(string $incomingMetadata): string
+    {
+        $currentMetadata = $this->decodeMetadata($this->Items->readOne()['metadata'] ?? '');
+        $incomingMetadata = $this->decodeMetadata($incomingMetadata);
+
+        $currentMetadata['extra_fields'] ??= array();
+        $incomingMetadata['extra_fields'] ??= array();
+
+        foreach ($incomingMetadata['extra_fields'] as $name => $incomingField) {
+            $value = $incomingField['value'] ?? '';
+
+            if (isset($currentMetadata['extra_fields'][$name])) {
+                $currentMetadata['extra_fields'][$name]['value'] = $this->normalizeMetadataValue(
+                    $currentMetadata['extra_fields'][$name],
+                    $value,
+                );
+                continue;
+            }
+
+            $currentMetadata['extra_fields'][$name] = $incomingField;
+        }
+
+        return json_encode($currentMetadata, JSON_THROW_ON_ERROR);
+    }
+
+    protected function decodeMetadata(string $metadata): array
+    {
+        if ($metadata === '' || $metadata === '{}') {
+            return array('extra_fields' => array());
+        }
+        $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
+        return is_array($decoded) ? $decoded : array('extra_fields' => array());
+    }
+
+    protected function normalizeMetadataValue(array $field, mixed $value): string
+    {
+        $value = trim((string) $value);
+        return match ($field['type'] ?? 'text') {
+            'checkbox' => strcasecmp($value, 'X') === 0 ? 'on' : '',
+            'number' => str_replace(',', '.', $value),
+            default => $value,
+        };
     }
 
     private function createCompound(?string $casKey, array $row): int

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -36,9 +36,6 @@ use function trim;
 use function count;
 use function explode;
 use function is_array;
-use function json_decode;
-use function json_encode;
-use function str_replace;
 
 /**
  * Import a CSV into compounds
@@ -133,8 +130,7 @@ final class CompoundsCsv extends AbstractCsv
                         $Tags = new Tags($this->Items);
                         $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
-                    //                    $this->Items->update(new EntityParams('metadata', $this->collectMetadata($row)));
-                    $this->Items->update(new EntityParams('metadata', $this->mergeMetadataValues($this->collectMetadata($row))));
+                    $this->Items->update(new EntityParams('metadatamerge', $this->collectMetadata($row)));
                     foreach ($ids as $id) {
                         $Compounds2ItemsLinks = new Compounds2ItemsLinks($this->Items, $id);
                         $Compounds2ItemsLinks->create();
@@ -249,50 +245,6 @@ final class CompoundsCsv extends AbstractCsv
             'is_nano',
             'is_controlled',
         );
-    }
-
-    protected function mergeMetadataValues(string $incomingMetadata): string
-    {
-        $currentMetadata = $this->decodeMetadata($this->Items->readOne()['metadata'] ?? '');
-        $incomingMetadata = $this->decodeMetadata($incomingMetadata);
-
-        $currentMetadata['extra_fields'] ??= array();
-        $incomingMetadata['extra_fields'] ??= array();
-
-        foreach ($incomingMetadata['extra_fields'] as $name => $incomingField) {
-            $value = $incomingField['value'] ?? '';
-
-            if (isset($currentMetadata['extra_fields'][$name])) {
-                $currentMetadata['extra_fields'][$name]['value'] = $this->normalizeMetadataValue(
-                    $currentMetadata['extra_fields'][$name],
-                    $value,
-                );
-                continue;
-            }
-
-            $currentMetadata['extra_fields'][$name] = $incomingField;
-        }
-
-        return json_encode($currentMetadata, JSON_THROW_ON_ERROR);
-    }
-
-    protected function decodeMetadata(string $metadata): array
-    {
-        if ($metadata === '' || $metadata === '{}') {
-            return array('extra_fields' => array());
-        }
-        $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
-        return is_array($decoded) ? $decoded : array('extra_fields' => array());
-    }
-
-    protected function normalizeMetadataValue(array $field, mixed $value): string
-    {
-        $value = trim((string) $value);
-        return match ($field['type'] ?? 'text') {
-            'checkbox' => strcasecmp($value, 'X') === 0 ? 'on' : '',
-            'number' => str_replace(',', '.', $value),
-            default => $value,
-        };
     }
 
     private function createCompound(?string $casKey, array $row): int

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -106,6 +106,8 @@ use function array_fill;
 use function array_map;
 use function count;
 use function array_replace;
+use function strcasecmp;
+use function trim;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;
@@ -805,6 +807,12 @@ abstract class AbstractEntity extends AbstractRest
         if ($params->getTarget() === 'bodyappend') {
             $content = $this->readOne()['body'] . $content;
         }
+        if ($params->getTarget() === 'metadatamerge') {
+            $content = $this->mergeMetadataValues(
+                $this->readOne()['metadata'] ?? '',
+                (string) $content,
+            );
+        }
         // ensure no changes happen on entries with immutable permissions
         // admins can override the immutability of an entity's permissions. See #5800
         if ($params->getTarget() === 'canread' || $params->getTarget() === 'canwrite' || $params->getTarget() === 'canread_base' || $params->getTarget() === 'canwrite_base') {
@@ -1382,5 +1390,52 @@ abstract class AbstractEntity extends AbstractRest
         if ($this->getCreatePermissionFromTeam($teamConfigArr) === false) {
             throw new ForbiddenException();
         }
+    }
+
+    private function mergeMetadataValues(string $baseMetadata, string $incomingMetadata): string
+    {
+        $base = $this->decodeMetadata($baseMetadata);
+        $incoming = $this->decodeMetadata($incomingMetadata);
+
+        $base['extra_fields'] ??= array();
+        $incoming['extra_fields'] ??= array();
+
+        foreach ($incoming['extra_fields'] as $name => $incomingField) {
+            $value = $incomingField['value'] ?? '';
+
+            if (isset($base['extra_fields'][$name])) {
+                $base['extra_fields'][$name]['value'] = $this->normalizeMetadataValue(
+                    $base['extra_fields'][$name],
+                    $value,
+                );
+                continue;
+            }
+
+            $base['extra_fields'][$name] = $incomingField;
+        }
+
+        return json_encode($base, JSON_THROW_ON_ERROR);
+    }
+
+    private function decodeMetadata(string $metadata): array
+    {
+        if ($metadata === '' || $metadata === '{}') {
+            return array('extra_fields' => array());
+        }
+
+        $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : array('extra_fields' => array());
+    }
+
+    private function normalizeMetadataValue(array $field, mixed $value): string
+    {
+        $value = trim((string) $value);
+
+        return match ($field['type'] ?? 'text') {
+            'checkbox' => strcasecmp($value, 'X') === 0 ? 'on' : '',
+            'number' => str_replace(',', '.', $value),
+            default => $value,
+        };
     }
 }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -106,8 +106,8 @@ use function array_fill;
 use function array_map;
 use function count;
 use function array_replace;
-use function strcasecmp;
 use function trim;
+use function strtolower;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -808,10 +808,7 @@ abstract class AbstractEntity extends AbstractRest
             $content = $this->readOne()['body'] . $content;
         }
         if ($params->getTarget() === 'metadatamerge') {
-            $content = $this->mergeMetadataValues(
-                $this->readOne()['metadata'] ?? '',
-                (string) $content,
-            );
+            $content = $this->mergeMetadataValues($this->readOne()['metadata'] ?? '', $content);
         }
         // ensure no changes happen on entries with immutable permissions
         // admins can override the immutability of an entity's permissions. See #5800
@@ -1394,9 +1391,11 @@ abstract class AbstractEntity extends AbstractRest
 
     private function mergeMetadataValues(string $baseMetadata, string $incomingMetadata): string
     {
+        // base metadata comes from the template and contains the field schema
         $base = $this->decodeMetadata($baseMetadata);
+        // incoming metadata usually comes from CSV/API and contains the values to inject.
         $incoming = $this->decodeMetadata($incomingMetadata);
-
+        // ensure both metadata arrays have an extra_fields array.
         $base['extra_fields'] ??= array();
         $incoming['extra_fields'] ??= array();
 
@@ -1404,13 +1403,14 @@ abstract class AbstractEntity extends AbstractRest
             $value = $incomingField['value'] ?? '';
 
             if (isset($base['extra_fields'][$name])) {
+                // Preserve the existing field schema and only update its value
                 $base['extra_fields'][$name]['value'] = $this->normalizeMetadataValue(
                     $base['extra_fields'][$name],
                     $value,
                 );
                 continue;
             }
-
+            // Add unknown incoming fields as-is (create)
             $base['extra_fields'][$name] = $incomingField;
         }
 
@@ -1419,12 +1419,11 @@ abstract class AbstractEntity extends AbstractRest
 
     private function decodeMetadata(string $metadata): array
     {
+        // Treat empty metadata as valid metadata with no fields.
         if ($metadata === '' || $metadata === '{}') {
             return array('extra_fields' => array());
         }
-
         $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
-
         return is_array($decoded) ? $decoded : array('extra_fields' => array());
     }
 
@@ -1433,9 +1432,23 @@ abstract class AbstractEntity extends AbstractRest
         $value = trim((string) $value);
 
         return match ($field['type'] ?? 'text') {
-            'checkbox' => strcasecmp($value, 'X') === 0 ? 'on' : '',
+            // checkboxes use "on" when checked.
+            'checkbox' => $this->normalizeCheckboxValue($value),
+            // normalize decimal commas for number fields.
             'number' => str_replace(',', '.', $value),
+            // select/users/text/url/etc. keep the incoming string value.
             default => $value,
         };
+    }
+
+    private function normalizeCheckboxValue(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+        // Common truthy values accepted from CSV/API imports.
+        $truthyValues = array('1', 'true', 'yes', 'y', 'x', 'on', 'checked', 'oui');
+        return in_array(strtolower($value), $truthyValues, true) ? 'on' : '';
     }
 }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -81,6 +81,7 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use ZipArchive;
+use JsonException;
 
 use function array_column;
 use function array_merge;
@@ -808,7 +809,7 @@ abstract class AbstractEntity extends AbstractRest
             $content = $this->readOne()['body'] . $content;
         }
         if ($params->getTarget() === 'metadatamerge') {
-            $content = $this->mergeMetadataValues($this->readOne()['metadata'] ?? '', $content);
+            $content = $this->mergeMetadataValues($this->getCurrentMetadataColumn(), $content);
         }
         // ensure no changes happen on entries with immutable permissions
         // admins can override the immutability of an entity's permissions. See #5800
@@ -1265,6 +1266,15 @@ abstract class AbstractEntity extends AbstractRest
 
     protected function enforceTemplate(array $teamConfigArr): void {}
 
+    private function getCurrentMetadataColumn(): string
+    {
+        $sql = 'SELECT metadata FROM ' . $this->entityType->value . ' WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return (string) $req->fetchColumn();
+    }
+
     private function needsCompoundsJoin(string $displayFilterSql): bool
     {
         return $this->sqlReferencesCompounds($this->extendedFilter)
@@ -1410,7 +1420,8 @@ abstract class AbstractEntity extends AbstractRest
                 );
                 continue;
             }
-            // Add unknown incoming fields as-is (create)
+            // new fields: keep incoming schema, but normalize its value if it has a known type.
+            $incomingField['value'] = $this->normalizeMetadataValue($incomingField, $value);
             $base['extra_fields'][$name] = $incomingField;
         }
 
@@ -1423,7 +1434,11 @@ abstract class AbstractEntity extends AbstractRest
         if ($metadata === '' || $metadata === '{}') {
             return array('extra_fields' => array());
         }
-        $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new ImproperActionException(_('Invalid metadata JSON provided.'));
+        }
         return is_array($decoded) ? $decoded : array('extra_fields' => array());
     }
 

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -806,10 +806,10 @@ abstract class AbstractEntity extends AbstractRest
     {
         $content = $params->getContent();
         if ($params->getTarget() === 'bodyappend') {
-            $content = $this->readOne()['body'] . $content;
+            $content = $this->readColumn('body') . $content;
         }
         if ($params->getTarget() === 'metadatamerge') {
-            $content = $this->mergeMetadataValues($this->getCurrentMetadataColumn(), $content);
+            $content = $this->mergeMetadataValues($this->readColumn('metadata'), $content);
         }
         // ensure no changes happen on entries with immutable permissions
         // admins can override the immutability of an entity's permissions. See #5800
@@ -1266,9 +1266,10 @@ abstract class AbstractEntity extends AbstractRest
 
     protected function enforceTemplate(array $teamConfigArr): void {}
 
-    private function getCurrentMetadataColumn(): string
+    // read only one column from an entity without calling the full entity
+    private function readColumn(string $column): string
     {
-        $sql = 'SELECT metadata FROM ' . $this->entityType->value . ' WHERE id = :id';
+        $sql = 'SELECT ' . $column . ' FROM ' . $this->entityType->value . ' WHERE id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);

--- a/src/Params/EntityParams.php
+++ b/src/Params/EntityParams.php
@@ -27,7 +27,7 @@ final class EntityParams extends ContentParams implements ContentParamsInterface
         return match ($this->target) {
             'title' => Filter::title($this->asString()),
             // MySQL with throw an error if this param is incorrect
-            'date', 'metadata', 'proc_price_notax', 'proc_price_tax', 'booking_hourly_rate_notax', 'booking_hourly_rate_tax' => $this->getUnfilteredContent(),
+            'date', 'metadata', 'metadatamerge', 'proc_price_notax', 'proc_price_tax', 'booking_hourly_rate_notax', 'booking_hourly_rate_tax' => $this->getUnfilteredContent(),
             'proc_currency', 'booking_hourly_rate_currency' => Currency::from($this->asInt())->value,
             'body', 'bodyappend' => $this->getBody(),
             'canread', 'canwrite', 'canbook', 'canread_target', 'canwrite_target' => $this->getCanJson(),
@@ -47,6 +47,9 @@ final class EntityParams extends ContentParams implements ContentParamsInterface
     {
         if ($this->target === 'bodyappend') {
             return 'body';
+        }
+        if ($this->target === 'metadatamerge') {
+            return 'metadata';
         }
         return parent::getColumn();
     }

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -26,6 +26,8 @@ use Elabftw\Traits\TestsUtilsTrait;
 
 use function date;
 use function array_column;
+use function json_decode;
+use function json_encode;
 
 class ItemsTest extends \PHPUnit\Framework\TestCase
 {
@@ -212,6 +214,86 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         // unlock
         $item = $this->Items->toggleLock();
         $this->assertFalse((bool) $item['locked']);
+    }
+
+    // test metadata merge preserves existing fields on import
+    public function testMetadataMergePreservesExistingFieldSchema(): void
+    {
+        $new = $this->Items->create();
+        $this->Items->setId($new);
+
+        $baseMetadata = json_encode(array(
+            'extra_fields' => array(
+                'weight' => array(
+                    'type' => 'number',
+                    'value' => '0',
+                    'units' => array('g'),
+                    'unit' => 'g',
+                ),
+                'certified' => array(
+                    'type' => 'checkbox',
+                    'value' => '',
+                ),
+                'location' => array(
+                    'type' => 'select',
+                    'value' => '',
+                    'options' => array('Room A', 'Room B'),
+                ),
+            ),
+        ), JSON_THROW_ON_ERROR);
+
+        $incomingMetadata = json_encode(array(
+            'extra_fields' => array(
+                'weight' => array(
+                    'type' => 'text',
+                    'value' => '12,5',
+                ),
+                'certified' => array(
+                    'type' => 'text',
+                    'value' => 'X',
+                ),
+                'location' => array(
+                    'type' => 'text',
+                    'value' => 'Room B',
+                ),
+                'new checkbox' => array(
+                    'type' => 'checkbox',
+                    'value' => 'oui',
+                ),
+                'new text' => array(
+                    'type' => 'text',
+                    'value' => 'hello',
+                ),
+            ),
+        ), JSON_THROW_ON_ERROR);
+
+        // have the base Metadata on the item
+        $this->Items->patch(Action::Update, array('metadata' => $baseMetadata));
+        // now merge with some incoming data
+        $this->Items->patch(Action::Update, array('metadatamerge' => $incomingMetadata));
+
+        $metadata = json_decode($this->Items->readOne()['metadata'], true, 512, JSON_THROW_ON_ERROR);
+        $fields = $metadata['extra_fields'];
+
+        // weight keeps it's original "number" type, "g" unit, and the incoming "12.5" value
+        $this->assertSame('number', $fields['weight']['type']);
+        $this->assertSame('12.5', $fields['weight']['value']);
+        $this->assertSame(array('g'), $fields['weight']['units']);
+        $this->assertSame('g', $fields['weight']['unit']);
+
+        // checkbox receives truthy value "X" (or "oui") and becomes "on"
+        $this->assertSame('checkbox', $fields['certified']['type']);
+        $this->assertSame('on', $fields['certified']['value']);
+
+        $this->assertSame('select', $fields['location']['type']);
+        $this->assertSame('Room B', $fields['location']['value']);
+        $this->assertSame(array('Room A', 'Room B'), $fields['location']['options']);
+        // oui
+        $this->assertSame('checkbox', $fields['new checkbox']['type']);
+        $this->assertSame('on', $fields['new checkbox']['value']);
+
+        $this->assertSame('text', $fields['new text']['type']);
+        $this->assertSame('hello', $fields['new text']['value']);
     }
 
     private function makeItemFromImmutableTemplateFor(AuthenticatedUser $user): Items

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -234,10 +234,19 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
                     'type' => 'checkbox',
                     'value' => '',
                 ),
-                'location' => array(
+                'choice' => array(
                     'type' => 'select',
+                    'value' => 'A',
+                    'options' => array('A', 'B'),
+                ),
+                'person in charge' => array(
+                    'type' => 'users',
                     'value' => '',
-                    'options' => array('Room A', 'Room B'),
+                    'description' => 'Select the person responsible.',
+                ),
+                'website' => array(
+                    'type' => 'url',
+                    'value' => '',
                 ),
             ),
         ), JSON_THROW_ON_ERROR);
@@ -252,9 +261,17 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
                     'type' => 'text',
                     'value' => 'X',
                 ),
-                'location' => array(
+                'choice' => array(
                     'type' => 'text',
-                    'value' => 'Room B',
+                    'value' => 'C',
+                ),
+                'person in charge' => array(
+                    'type' => 'text',
+                    'value' => '42',
+                ),
+                'website' => array(
+                    'type' => 'text',
+                    'value' => 'https://example.org',
                 ),
                 'new checkbox' => array(
                     'type' => 'checkbox',
@@ -275,23 +292,33 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $metadata = json_decode($this->Items->readOne()['metadata'], true, 512, JSON_THROW_ON_ERROR);
         $fields = $metadata['extra_fields'];
 
-        // weight keeps it's original "number" type, "g" unit, and the incoming "12.5" value
+        // existing "weight" number keeps type/unit and receives normalized value.
         $this->assertSame('number', $fields['weight']['type']);
         $this->assertSame('12.5', $fields['weight']['value']);
         $this->assertSame(array('g'), $fields['weight']['units']);
         $this->assertSame('g', $fields['weight']['unit']);
 
-        // checkbox receives truthy value "X" (or "oui") and becomes "on"
+        // existing checkbox keeps type and receives normalized truthy value.
         $this->assertSame('checkbox', $fields['certified']['type']);
         $this->assertSame('on', $fields['certified']['value']);
 
-        $this->assertSame('select', $fields['location']['type']);
-        $this->assertSame('Room B', $fields['location']['value']);
-        $this->assertSame(array('Room A', 'Room B'), $fields['location']['options']);
-        // oui
+        // existing select keeps options even if incoming value is new.
+        $this->assertSame('select', $fields['choice']['type']);
+        $this->assertSame('C', $fields['choice']['value']);
+        $this->assertSame(array('A', 'B'), $fields['choice']['options']);
+
+        // existing user field keeps description/schema.
+        $this->assertSame('users', $fields['person in charge']['type']);
+        $this->assertSame('42', $fields['person in charge']['value']);
+        $this->assertSame('Select the person responsible.', $fields['person in charge']['description']);
+
+        // url keeps type.
+        $this->assertSame('url', $fields['website']['type']);
+        $this->assertSame('https://example.org', $fields['website']['value']);
+
+        // New fields are added and normalized according to their incoming type.
         $this->assertSame('checkbox', $fields['new checkbox']['type']);
         $this->assertSame('on', $fields['new checkbox']['value']);
-
         $this->assertSame('text', $fields['new text']['type']);
         $this->assertSame('hello', $fields['new text']['value']);
     }


### PR DESCRIPTION
- add a new `metadatamerge` update target to merge incoming metadata into an entity's existing metadata instead of
replacing it entirely.

This allows API clients and import workflows (_e.g.,_ compounds import command) to progressively populate metadata fields while preserving existing values and normalizing supported field types.

- also update the compounds CSV import to use the new merge behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **metadata merge** update option for entities, combining incoming metadata with existing metadata (preserving existing field schemas and updating values, while adding new fields when needed).
  * Added a **body append** update option to append to an existing entity body instead of replacing it.
  * Compound CSV imports now use the metadata merge behavior to better retain existing compound metadata.

* **Bug Fixes**
  * Improved metadata merge handling for empty or malformed metadata and normalized checkbox/numeric values for consistency.

* **Tests**
  * Added unit tests covering schema preservation and value updates during metadata merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->