### PR TITLE
ci: fix parallellism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
 
   cypress_e2e_tests:
     executor: elab-executor
-    parallelism: 3
+    parallelism: 4
     working_directory: ~/elabftw/elabftw
     shell: /bin/bash --login
     steps:
@@ -229,19 +229,19 @@ jobs:
       - run:
           name: Run Cypress e2e tests on Chrome
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq "0" ]; then
+            if [ "$CIRCLE_NODE_INDEX" -eq "1" ]; then
               docker exec elab-cypress cypress run --browser chrome
             fi
       - run:
           name: Run Cypress e2e tests on Electron
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq "1" ]; then
+            if [ "$CIRCLE_NODE_INDEX" -eq "2" ]; then
               docker exec elab-cypress cypress run --browser electron
             fi
       - run:
           name: Run Cypress e2e tests on Edge
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq "2" ]; then
+            if [ "$CIRCLE_NODE_INDEX" -eq "3" ]; then
               docker exec elab-cypress cypress run --browser edge
             fi
       - run:


### PR DESCRIPTION
firefox and chrome were not running in parallel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution by increasing parallel run capacity, which should help speed up test runs.
  * Updated browser-to-worker assignment for Cypress runs to better balance execution across containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->