### PR TITLE
bug/minor: populate: fix warning

### DIFF
--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -108,7 +108,8 @@ final class Populate
         foreach ($this->yaml['teams'] as $team) {
             $teamid = $Teams->create($team['name']);
             $this->output->writeln(sprintf('├ + team: %s (ID: %d)', $team['name'], $teamid));
-            $Teams->setId($teamid);
+            // init a new object so we populate teamArr
+            $Teams = new Teams($Users, $teamid);
 
             $columns = array(
                 'visible',


### PR DESCRIPTION
Create a fresh Teams object so teamArr is populated with data: setId() is not enough for Teams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team setup during initialization so each team’s data is handled independently, helping prevent cross-team mix-ups and ensuring related setup steps run with the correct team context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->