### PR TITLE
bug/minor: fix autofocus happening on modals with tomSelect

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1077,8 +1077,8 @@ function focusFirstTextInputOnShown(modalSelector: string) {
   if (!modal) return;
   $(modal).one('shown.bs.modal', () => {
     modal.querySelector<HTMLElement>(
-      'input:is([type="text"], [type="search"], [type="email"], [type="url"], [type="tel"], [type="password"], [type="number"]):not([disabled]):not([readonly]),' +
-      'input:not([type]):not([disabled]):not([readonly]),' +
+      'input:is([type="text"], [type="search"], [type="email"], [type="url"], [type="tel"], [type="password"], [type="number"]):not([disabled]):not([readonly]):not(.ts-wrapper input), ' +
+      'input:not([type]):not([disabled]):not([readonly]):not(.ts-wrapper input), ' +
       'textarea:not([disabled]):not([readonly])',
     )?.focus();
   });


### PR DESCRIPTION
Autofocusing on tomselects hides the content because the select can be populated with many options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal autofocus behavior so it no longer targets TomSelect’s internal input field when a modal opens.
  * Reduced unintended focus shifts in forms that use custom select components, making modal interactions more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->