### PR TITLE
bug/ui: show mode: use correct terminology for custom fields search

### DIFF
--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -83,7 +83,7 @@
         <div class='show-more-filters-menu'>
           {# METADATA SEARCH #}
           <div class='filter-section filter-section-wide'>
-            <label class='font-weight-bold mb-1'>{{ 'Metadata'|trans }}</label>
+            <label class='font-weight-bold mb-1'>{{ 'Custom fields'|trans }}</label>
 
             <div class='input-group d-flex flex-nowrap'>
               {% if App.devMode -%}<!-- [html-validate-disable prefer-native-element: suppress errors from tom-select] -->{%- endif %}


### PR DESCRIPTION
metadata is the internal key for it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the filter section label from “Metadata” to “Custom fields” in the expanded filters area for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->