### PR TITLE
feat/ui: uploads: move delete action at bottom and refactor code

### DIFF
--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -47,7 +47,7 @@
 
       {# INSERT IN TEXT in edit mode #}
       {% set isInsertable = ext matches '/(jpg|jpeg|png|gif|svg|bmp|mkv|mp4|ogv|webm|aac|flac|mp3|ogg|opus|wav|txt)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isInsertable %}disabled{% endif %} data-action='insert-in-body' data-ext='{{ ext|e('html_attr') }}'data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-arrow-right-to-bracket mr-1'></i>{{ 'Insert in main text'|trans }}</button>
+      <button type='button' class='dropdown-item' {% if not isInsertable %}disabled{% endif %} data-action='insert-in-body' data-ext='{{ ext|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-arrow-right-to-bracket mr-1'></i>{{ 'Insert in main text'|trans }}</button>
 
       <div class='dropdown-divider'></div>
       {# Annotate image #}
@@ -71,10 +71,12 @@
     {% set isPreview = ext matches '/(txt|md|json)$/i' %}
     <button type='button' class='dropdown-item' {% if not isPreview %}disabled{% endif %} data-action='toggle-modal' data-target='plainTextModal' data-uploadid='{{ upload.id }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}' data-ext='{{ ext }}'><i class='fas fa-fw fa-eye mr-1'></i>{{ 'Preview'|trans }}</button>
 
-    {% if App.Users.userData.uploads_layout != 0 %}
+    {% if not isGrid %}
       <button type='button' class='dropdown-item' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}</button>
-      <div class='dropdown-divider'></div>
-      {{ ui.dropdown_item('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'text-danger') }}
+      {% if not upload.immutable and not Entity.isReadOnly %}
+        <div class='dropdown-divider'></div>
+        {{ ui.dropdown_item('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'text-danger') }}
+      {% endif %}
     {% endif %}
 
   </div>

--- a/src/templates/upload-dropdown-menu.html
+++ b/src/templates/upload-dropdown-menu.html
@@ -32,7 +32,6 @@
       {{ ui.dropdown_item('rename-upload', 'pencil-alt', 'Edit filename'|trans, upload.id) }}
       {% if not upload.immutable and not Entity.isReadOnly %}
         {{ ui.dropdown_item('archive-upload', 'box-archive', 'Archive/Unarchive'|trans, upload.id) }}
-        {{ ui.dropdown_item('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'text-danger') }}
       {% endif %}
 
       <div class='dropdown-divider'></div>
@@ -46,21 +45,9 @@
         <button type='button' class='dropdown-item' data-action='replace-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-sync-alt mr-1'></i>{{ 'Upload new version'|trans }}</button>
       {% endif %}
 
-      {# INSERT IN TEXT in edit mode for images #}
-      {% set isImage = ext matches '/(jpg|jpeg|png|gif|svg|bmp)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isImage %}disabled{% endif %} data-action='insert-image-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-image mr-1'></i>{{ 'Insert image'|trans }}</button>
-
-      {# INSERT VIDEO #}
-      {% set isVideo = ext matches '/(mkv|mp4|ogv|webm)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isVideo %}disabled{% endif %} data-action='insert-video-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-video mr-1'></i>{{ 'Insert video'|trans }}</button>
-
-      {# INSERT AUDIO #}
-      {% set isAudio = ext matches '/(aac|flac|mp3|ogg|opus|wav)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isAudio %}disabled{% endif %} data-action='insert-audio-in-body' data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-volume-low mr-1'></i>{{ 'Insert audio'|trans }}</button>
-
-      {# INSERT TEXT #}
-      {% set isTxt = ext matches '/txt$/i' %}
-      <button type='button' class='dropdown-item' {% if not isTxt %}disabled{% endif %} data-action='insert-plain-text' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}'><i class='fas fa-fw fa-file-import mr-1'></i>{{ 'Insert text'|trans }}</button>
+      {# INSERT IN TEXT in edit mode #}
+      {% set isInsertable = ext matches '/(jpg|jpeg|png|gif|svg|bmp|mkv|mp4|ogv|webm|aac|flac|mp3|ogg|opus|wav|txt)$/i' %}
+      <button type='button' class='dropdown-item' {% if not isInsertable %}disabled{% endif %} data-action='insert-in-body' data-ext='{{ ext|e('html_attr') }}'data-name='{{ upload.real_name|e('html_attr') }}' data-storage='{{ upload.storage }}' data-link='{{ upload.long_name|e('html_attr') }}' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-arrow-right-to-bracket mr-1'></i>{{ 'Insert in main text'|trans }}</button>
 
       <div class='dropdown-divider'></div>
       {# Annotate image #}
@@ -69,7 +56,7 @@
 
       {# JSON EDITOR #}
       {% set isJson = ext matches '/(json)$/i' %}
-      <button type='button' class='dropdown-item' {% if not isJson %}disabled{% endif %} data-action='json-load-file' data-uploadid='{{ upload.id }}' data-link='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-file-code mr-1'></i>{{ 'JSON editor'|trans }}</button>
+      <button type='button' class='dropdown-item' {% if not isJson %}disabled{% endif %} data-action='json-load-file' data-uploadid='{{ upload.id }}' data-link='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-file-code mr-1'></i>{{ 'Load in JSON editor'|trans }}</button>
       {# SHEET EDITOR #}
       {% set isSheet = ext in constant('Elabftw\\Elabftw\\Extensions::SPREADSHEET') %}
       <button type='button' class='dropdown-item' {% if not isSheet %}disabled{% endif %} data-action='xls-load-file' data-uploadid='{{ upload.id }}' data-storage='{{ upload.storage }}' data-path='{{ upload.long_name|e('html_attr') }}' data-name='{{ upload.real_name|e('html_attr') }}'><i class='fas fa-fw fa-file-excel mr-1'></i>{{ 'Spreadsheet editor'|trans }}</button>
@@ -86,6 +73,8 @@
 
     {% if App.Users.userData.uploads_layout != 0 %}
       <button type='button' class='dropdown-item' data-action='more-info-upload' data-uploadid='{{ upload.id }}'><i class='fas fa-fw fa-info-circle mr-1'></i>{{ 'More information'|trans }}</button>
+      <div class='dropdown-divider'></div>
+      {{ ui.dropdown_item('destroy-upload', 'trash-alt', 'Delete'|trans, upload.id, 'text-danger') }}
     {% endif %}
 
   </div>

--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -118,9 +118,9 @@ if (mode === 'edit') {
       return editor.setContent(content);
     });
   });
-  on('insert-image-in-body', (el: HTMLElement) => {
-    // link to the image file
-    const url = `app/download.php?name=${el.dataset.name}&f=${el.dataset.link}&storage=${el.dataset.storage}`;
+
+  // INSERT IN BODY
+  const insertImageInBody = (url: string): void => {
     // switch for markdown or tinymce editor
     let content: string;
     if (editor.type === 'md') {
@@ -131,10 +131,9 @@ if (mode === 'edit') {
     editor.setContent(content);
     // save to prevent destroy/archive actions on the uploads before they're considered part of the body
     updateEntityBody();
-  });
-  on('insert-video-in-body', (el: HTMLElement) => {
-    // link to the video file
-    const url = `app/download.php?name=${encodeURIComponent(el.dataset.name)}&f=${encodeURIComponent(el.dataset.link)}&storage=${encodeURIComponent(el.dataset.storage)}`;
+  };
+
+  const insertVideoInBody = (url: string): void => {
     // no syntax for video in markdown; use plain html in both cases
     const video = document.createElement('video');
     const source = document.createElement('source');
@@ -143,19 +142,18 @@ if (mode === 'edit') {
     video.controls = true;
     video.appendChild(source);
     editor.setContent(video.outerHTML);
-  });
-  on('insert-audio-in-body', (el: HTMLElement) => {
-    // link to the audio file
-    const url = `app/download.php?name=${encodeURIComponent(el.dataset.name)}&f=${encodeURIComponent(el.dataset.link)}&storage=${encodeURIComponent(el.dataset.storage)}`;
+  };
+
+  const insertAudioInBody = (url: string): void => {
     // no syntax for audio in markdown; use plain html in both cases
     const audio = document.createElement('audio');
     audio.src = url;
     audio.controls = true;
     editor.setContent(audio.outerHTML);
-  });
+  };
 
-  on('insert-plain-text', (el: HTMLElement) => {
-    fetch(`app/download.php?storage=${el.dataset.storage}&f=${el.dataset.path}`).then(response => {
+  const insertTextInBody = (url: string): void => {
+    fetch(url).then(response => {
       return response.text();
     }).then(fileContent => {
       const specialChars = {
@@ -165,7 +163,25 @@ if (mode === 'edit') {
       // wrap in pre element to retain whitespace, html encode '<' and '>'
       editor.setContent('<pre>' + fileContent.replace(/[<>]/g, char => specialChars[char]) + '</pre>');
     });
+  };
+
+  const imageExts = ['jpg', 'jpeg', 'png', 'gif', 'svg', 'bmp'];
+  const videoExts = ['mkv', 'mp4', 'ogv', 'webm'];
+  const audioExts = ['aac', 'flac', 'mp3', 'ogg', 'opus', 'wav'];
+
+  const insertHandlers = new Map<string, (url: string) => void>([
+    ...imageExts.map(ext => [ext, insertImageInBody] as const),
+    ...videoExts.map(ext => [ext, insertVideoInBody] as const),
+    ...audioExts.map(ext => [ext, insertAudioInBody] as const),
+    ['txt', insertTextInBody],
+  ]);
+
+  on('insert-in-body', (el: HTMLElement) => {
+    const url = `app/download.php?name=${encodeURIComponent(el.dataset.name)}&f=${encodeURIComponent(el.dataset.link)}&storage=${encodeURIComponent(el.dataset.storage)}`;
+    insertHandlers.get(el.dataset.ext.replace(/^\./, '').toLowerCase())?.(url);
   });
+  // END INSERT IN BODY
+
 
   // REPLACE UPLOADED FILE
   // this should be in uploads but there is no good way so far to interact with the two editors there


### PR DESCRIPTION
remove all the options for different file types: keep one for all also refactor the functions to avoid code duplication (such as for url) rename "Load in JSON editor" action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated edit-mode insertion controls into a single **“Insert in main text”** option that supports more file types based on the selected element.
  * Renamed the JSON editor dropdown entry to **“Load in JSON editor.”**

* **Bug Fixes**
  * Improved dropdown layout so the **Delete** action appears later and more consistently in the non-grid menu.
  * Refined insert-in-body behavior to select the correct insertion method using the file extension metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->