### PR TITLE
feat: compounds-import: add status to created resources

### DIFF
--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -131,11 +131,8 @@ final class CompoundsCsv extends AbstractCsv
                         $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
                     if (isset($row['status']) && trim($row['status']) !== '') {
-                        try {
-                            $this->Items->update(new EntityParams('status', (int) $row['status']));
-                        } catch (ImproperActionException $e) {
-                            $this->emitLog(sprintf('Status %s: %s', $row['status'], $e->getMessage()), LogLevel::ERROR);
-                        }
+                        $statusId = $this->getStatusId($this->Items->entityType, trim($row['status']));
+                        $this->Items->update(new EntityParams('status', $statusId));
                     }
                     $this->Items->update(new EntityParams('metadatamerge', $this->collectMetadata($row)));
                     foreach ($ids as $id) {

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -130,6 +130,13 @@ final class CompoundsCsv extends AbstractCsv
                         $Tags = new Tags($this->Items);
                         $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
+                    if (isset($row['status']) && trim($row['status']) !== '') {
+                        try {
+                            $this->Items->update(new EntityParams('status', (int) $row['status']));
+                        } catch (ImproperActionException $e) {
+                            $this->emitLog(sprintf('Status %s: %s', $row['status'], $e->getMessage()), LogLevel::ERROR);
+                        }
+                    }
                     $this->Items->update(new EntityParams('metadatamerge', $this->collectMetadata($row)));
                     foreach ($ids as $id) {
                         $Compounds2ItemsLinks = new Compounds2ItemsLinks($this->Items, $id);
@@ -208,6 +215,7 @@ final class CompoundsCsv extends AbstractCsv
             'comment',
             'custom_id',
             'tags',
+            'status',
             'chebi_id',
             'chembl_id',
             'dea_number',

--- a/src/Import/CompoundsCsv.php
+++ b/src/Import/CompoundsCsv.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Import;
 
 use Elabftw\Enums\Action;
+use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Compounds;
 use Elabftw\Models\Links\Compounds2ItemsLinks;
@@ -131,8 +132,12 @@ final class CompoundsCsv extends AbstractCsv
                         $Tags->postAction(Action::Create, array('tag' => trim($row['tags'])));
                     }
                     if (isset($row['status']) && trim($row['status']) !== '') {
-                        $statusId = $this->getStatusId($this->Items->entityType, trim($row['status']));
-                        $this->Items->update(new EntityParams('status', $statusId));
+                        try {
+                            $statusId = $this->getStatusId($this->Items->entityType, trim($row['status']));
+                            $this->Items->update(new EntityParams('status', $statusId));
+                        } catch (DatabaseErrorException | ImproperActionException $e) {
+                            $this->emitLog(sprintf('Status %s: %s', $row['status'], $e->getMessage()), LogLevel::ERROR);
+                        }
                     }
                     $this->Items->update(new EntityParams('metadatamerge', $this->collectMetadata($row)));
                     foreach ($ids as $id) {


### PR DESCRIPTION
When importing compounds with the import:compounds command, create status if they exist in the csv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV imports now recognize an additional `status` column when creating optional items from a resource template.
  * When `status` is provided and non-empty, it’s mapped to the corresponding status and applied to the created item.

* **Bug Fixes**
  * Updated the set of processed/accepted CSV columns so the `status` field is handled correctly during imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->