### PR TITLE
feat: categories/status: require Admin level to change is_private

### DIFF
--- a/src/Models/AbstractStatus.php
+++ b/src/Models/AbstractStatus.php
@@ -17,11 +17,13 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\Orderby;
 use Elabftw\Enums\Sort;
 use Elabftw\Enums\State;
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Params\BaseQueryParams;
 use Elabftw\Params\OrderingParams;
 use Elabftw\Params\StatusParams;
 use Elabftw\Services\Check;
 use Elabftw\Services\Filter;
+use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\RandomColorTrait;
 use Elabftw\Traits\SetIdTrait;
 use PDO;
@@ -140,6 +142,13 @@ abstract class AbstractStatus extends AbstractCategory
     {
         $this->canWriteOrExplode();
         foreach ($params as $key => $value) {
+            // special case for is_private: must be team Admin (see #6519)
+            if ($key === 'is_private') {
+                $helper = new TeamsHelper($this->Teams->id);
+                if ($helper->isAdminInTeam($this->Teams->Users->getUserid()) === false) {
+                    throw new IllegalActionException();
+                }
+            }
             $this->update(new StatusParams($key, (string) $value));
         }
         return $this->readOne();

--- a/src/Models/AbstractStatus.php
+++ b/src/Models/AbstractStatus.php
@@ -32,6 +32,7 @@ use Override;
 
 use function _;
 use function sprintf;
+use function array_key_exists;
 
 /**
  * Status for experiments or items
@@ -141,14 +142,14 @@ abstract class AbstractStatus extends AbstractCategory
     public function patch(Action $action, array $params): array
     {
         $this->canWriteOrExplode();
-        foreach ($params as $key => $value) {
-            // special case for is_private: must be team Admin (see #6519)
-            if ($key === 'is_private') {
-                $helper = new TeamsHelper($this->Teams->id);
-                if ($helper->isAdminInTeam($this->Teams->Users->getUserid()) === false) {
-                    throw new IllegalActionException();
-                }
+        // special case for is_private: must be team Admin (see #6519)
+        if (array_key_exists('is_private', $params)) {
+            $helper = new TeamsHelper($this->Teams->id ?? 0);
+            if ($helper->isAdminInTeam($this->Teams->Users->getUserid()) === false) {
+                throw new IllegalActionException(description: _('Only a team Admin can modify the visibility.'));
             }
+        }
+        foreach ($params as $key => $value) {
             $this->update(new StatusParams($key, (string) $value));
         }
         return $this->readOne();

--- a/tests/unit/models/AbstractCategoryTest.php
+++ b/tests/unit/models/AbstractCategoryTest.php
@@ -77,4 +77,18 @@ class AbstractCategoryTest extends \PHPUnit\Framework\TestCase
             'color' => '#29AEB9',
         ));
     }
+
+    public function testNormalUserCannotModifyIsPrivate(): void
+    {
+        $user = $this->getUserInTeam(1);
+        $Teams = new Teams($user, 1);
+        $Category = new ExperimentsCategories($Teams);
+
+        $this->expectException(IllegalActionException::class);
+
+        $Category->patch(Action::Update, array(
+            'title' => 'Secret category',
+            'is_private' => 0,
+        ));
+    }
 }


### PR DESCRIPTION
fix #6519


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a permission check when updating a status’s private visibility.
  * Team members who aren’t admins can no longer change the private setting; admins can continue to update it normally.
* **Tests**
  * Added a unit test to confirm non-admin users are blocked from modifying the private flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->