### PR TITLE
bug/minor: dashboard: fix category links

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -69,7 +69,7 @@ components:
           value: experiments
 
     Category:
-      name: cat
+      name: category
       in: query
       schema:
         type: string

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -29,7 +29,7 @@
       <h4>{{ 'Browse by category'|trans }}</h4>
       <div class='d-flex my-2 flex-wrap lh-150'>
         {% for category in App.experimentsCategoryArr|filter(c => c.is_current_team == 1) -%}
-          <a href='experiments.php?mode=show&amp;cat={{ category.id }}' class='btn mr-2 catstat-btn category-btn mb-1' style='--bg: #{{ category.color }}'>{{ category.title }}</a>
+          <a href='experiments.php?mode=show&amp;category={{ category.id }}' class='btn mr-2 catstat-btn category-btn mb-1' style='--bg: #{{ category.color }}'>{{ category.title }}</a>
         {%- endfor %}
       </div>
       <hr>
@@ -78,7 +78,7 @@
     <h4>{{ 'Browse by category'|trans }}</h4>
     <div class='d-flex my-2 flex-wrap lh-150'>
       {% for category in App.itemsCategoryArr|filter(c => c.is_current_team == 1) -%}
-        <a href='database.php?mode=show&amp;cat={{ category.id }}' class='btn mr-2 catstat-btn category-btn lh-normal mb-1' style='--bg: #{{ category.color }}'>{{ category.title }}</a>
+        <a href='database.php?mode=show&amp;category={{ category.id }}' class='btn mr-2 catstat-btn category-btn lh-normal mb-1' style='--bg: #{{ category.color }}'>{{ category.title }}</a>
       {%- endfor %}
     </div>
     <hr>

--- a/src/ts/create-new.ts
+++ b/src/ts/create-new.ts
@@ -112,7 +112,7 @@ function onScopeChange(ev: Event) {
 function onCategoryChange(ev: Event) {
   const el = ev.currentTarget;
   if (!(el instanceof HTMLSelectElement)) return;
-  ApiC.getJson(`${el.dataset.endpoint}/?fastq&scope=${getScopeValue()}&cat=${el.selectedOptions[0].value}`).then(templates => {
+  ApiC.getJson(`${el.dataset.endpoint}/?fastq&scope=${getScopeValue()}&category=${el.selectedOptions[0].value}`).then(templates => {
     renderTemplates(templates);
   });
 }

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -485,7 +485,7 @@ export function addAutocompleteToLinkInputs(): void {
   [{
     selectElid: 'addLinkCatFilter',
     itemType: EntityType.Item,
-    filterFamily: 'cat',
+    filterFamily: 'category',
     inputElId: 'addLinkItemsInput',
   }, {
     selectElid: 'addLinkOwnerFilter',


### PR DESCRIPTION
query param is category not cat



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed category filtering across the dashboard so “Browse by category” and template loading use the correct `category` query parameter.
  * Updated category autocomplete to request results using the correct `category` parameter.
  * Link appearance and behavior remain unchanged.

* **Documentation**
  * Updated the API documentation for the category filter to reflect the `category` query parameter name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->