### PR TITLE
bug/medium: compounds import: fix issue with wrong locations

### DIFF
--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -319,18 +319,21 @@ final class StorageUnits extends AbstractRest
     {
         $parent = null;
         $id = 0;
+
         foreach ($locations as $location) {
             $unitName = trim($location);
             if (empty($unitName)) {
                 continue;
             }
-            $res = $this->searchStorage($unitName);
+
+            $res = $this->searchStorage($unitName, $parent);
             if ($res) {
                 $id = $parent = $res['id'];
             } else {
                 $id = $parent = $this->create($unitName, $parent);
             }
         }
+
         return $id;
     }
 
@@ -568,12 +571,23 @@ final class StorageUnits extends AbstractRest
         return (bool) $req->fetchColumn();
     }
 
-    private function searchStorage(string $unitName): array|false
+    private function searchStorage(string $unitName, ?int $parentId): array|false
     {
-        $sql = 'SELECT id, parent_id FROM storage_units WHERE name = :name';
+        if ($parentId === null) {
+            $sql = 'SELECT id, parent_id FROM storage_units WHERE name = :name AND parent_id IS NULL';
+        } else {
+            $sql = 'SELECT id, parent_id FROM storage_units WHERE name = :name AND parent_id = :parent_id';
+        }
+
         $req = $this->Db->prepare($sql);
         $req->bindParam(':name', $unitName);
+
+        if ($parentId !== null) {
+            $req->bindValue(':parent_id', $parentId, PDO::PARAM_INT);
+        }
+
         $this->Db->execute($req);
+
         try {
             return $this->Db->fetch($req);
         } catch (ResourceNotFoundException) {

--- a/tests/unit/Import/CompoundsCsvTest.php
+++ b/tests/unit/Import/CompoundsCsvTest.php
@@ -12,10 +12,12 @@ declare(strict_types=1);
 
 namespace Elabftw\Import;
 
+use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Storage;
 use Elabftw\Models\Compounds;
 use Elabftw\Models\Items;
+use Elabftw\Models\StorageUnits;
 use Elabftw\Models\Users\Users;
 use Elabftw\Services\HttpGetter;
 use Elabftw\Services\NullFingerprinter;
@@ -27,6 +29,12 @@ use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use function dirname;
+use function file_put_contents;
+use function sprintf;
+use function sys_get_temp_dir;
+use function tempnam;
+use function uniqid;
+use function unlink;
 
 use const UPLOAD_ERR_OK;
 
@@ -57,5 +65,60 @@ class CompoundsCsvTest extends \PHPUnit\Framework\TestCase
         $Compounds->setId($compoundId);
         $Import = new CompoundsCsv(new NullLogger(), $Items, $uploadedFile, $Compounds, 1);
         $this->assertTrue($Import->import() > 1);
+    }
+
+    public function testImportUsesFullStoragePathWhenChildNamesAreDuplicated(): void
+    {
+        $requester = new Users(1, 1);
+        $Items = new Items($requester);
+        $StorageUnits = new StorageUnits($requester, requireEditRights: false);
+
+        $suffix = uniqid('', true);
+        $lab1 = sprintf('CSV duplicate lab 1 %s', $suffix);
+        $lab2 = sprintf('CSV duplicate lab 2 %s', $suffix);
+        $freezer = sprintf('CSV duplicate freezer %s', $suffix);
+
+        $lab1Id = $StorageUnits->create($lab1);
+        $StorageUnits->create($freezer, $lab1Id);
+
+        $lab2Id = $StorageUnits->create($lab2);
+        $targetFreezerId = $StorageUnits->create($freezer, $lab2Id);
+
+        $csv = sprintf(
+            "name,location,quantity,unit\nRegression compound,%s/%s,42,g\n",
+            $lab2,
+            $freezer,
+        );
+
+        $csvPath = tempnam(sys_get_temp_dir(), 'compounds-storage-path-');
+        file_put_contents($csvPath, $csv);
+
+        try {
+            $uploadedFile = new UploadedFile(
+                $csvPath,
+                'compounds-storage-path.csv',
+                'text/csv',
+                UPLOAD_ERR_OK,
+                true,
+            );
+
+            $httpGetter = new HttpGetter(new Client(), '', false);
+            $Compounds = new Compounds($httpGetter, $requester, new NullFingerprinter(), false);
+            $Import = new CompoundsCsv(new NullLogger(), $Items, $uploadedFile, $Compounds, 1);
+
+            $this->assertSame(1, $Import->import());
+            $this->assertSame($targetFreezerId, $this->latestImportedStorageId());
+        } finally {
+            unlink($csvPath);
+        }
+    }
+
+    private function latestImportedStorageId(): int
+    {
+        $Db = Db::getConnection();
+        $req = $Db->prepare('SELECT storage_id FROM containers2items ORDER BY id DESC LIMIT 1');
+        $Db->execute($req);
+
+        return (int) $req->fetchColumn();
     }
 }


### PR DESCRIPTION
if locations had same name than already existing one in different parent, it could not be found. fix #6666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage locations now respect the full parent path when looking up nested units, preventing incorrect matches when child names are duplicated.
  * Compound imports now resolve and use the correct storage location for hierarchical paths, improving consistency in imported records.

* **Tests**
  * Added coverage for importing compounds with duplicated child storage names to verify the correct nested location is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->