### PR TITLE
ui: dark: autocomplete style

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -219,6 +219,16 @@ select:not([multiple]) {
     background-color: var(--darkred);
     border-color: var(--lightred);
   }
+
+  /* autocomplete */
+  .ui-autocomplete {
+    background: var(--mainbackground);
+  }
+
+  .ui-menu-item-wrapper {
+    color: var(--strongest);
+  }
+
 }
 
 .logo-dark { display: none; }


### PR DESCRIPTION
fix #6512

autocomplete had light colors when in dark



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode appearance for autocomplete suggestions.
  * Updated the suggestion dropdown background and item text colors to better match the app’s theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->