### PR TITLE
feat/ux: disable checkbox is_private if not admin

### DIFF
--- a/src/templates/categories-status-index.macro.html
+++ b/src/templates/categories-status-index.macro.html
@@ -1,4 +1,4 @@
-{% macro catstatidx(type, table, subtitle, infotip, sourceArr, emptyWarning, modalTitle, newNamePlaceholder, teamName) %}
+{% macro catstatidx(type, table, subtitle, infotip, sourceArr, emptyWarning, modalTitle, newNamePlaceholder, teamName, isAdmin) %}
 <h2>{{ teamName }}</h2>
 <div class='mb-5 d-flex justify-content-between'>
   <div class='d-flex'>
@@ -37,8 +37,8 @@
 
           <li class='list-inline-item'>
             <label for='expcatIsPrivate_{{ cat.id }}'>{{ 'Mark as private'|trans }}</label>
-            <label class='switch ucp-align'><span class='sr-only'>{{ 'Mark as private'|trans }}</span>
-              <input type='checkbox' autocomplete='off' data-trigger='change' data-model='teams/current/{{ type }}/{{ cat.id }}' data-target='is_private' {{ cat.is_private ? 'checked="checked"' }} id='expcatIsPrivate_{{ cat.id }}'>
+            <label class='switch ucp-align {{ not isAdmin ? 'disabled' }}'><span class='sr-only'>{{ 'Mark as private'|trans }}</span>
+              <input type='checkbox' autocomplete='off' data-trigger='change' data-model='teams/current/{{ type }}/{{ cat.id }}' data-target='is_private' {{ cat.is_private ? 'checked="checked"' }} {{ not isAdmin ? 'disabled="disabled"' }} id='expcatIsPrivate_{{ cat.id }}'>
               <span class='slider'></span>
             </label>
           </li>

--- a/src/templates/experiments-categories.html
+++ b/src/templates/experiments-categories.html
@@ -12,6 +12,7 @@
   'Create new experiments category'|trans,
   'Category name'|trans,
   App.Teams.teamArr.name,
+  App.Users.isAdmin,
   ) }}
 
 {% endblock body %}

--- a/src/templates/experiments-status.html
+++ b/src/templates/experiments-status.html
@@ -12,6 +12,7 @@
   'Create new experiments status'|trans,
   'Status name'|trans,
   App.Teams.teamArr.name,
+  App.Users.isAdmin,
   ) }}
 
 {% endblock body %}

--- a/src/templates/resources-categories.html
+++ b/src/templates/resources-categories.html
@@ -12,6 +12,7 @@
   'Create new resources category'|trans,
   'Category name'|trans,
   App.Teams.teamArr.name,
+  App.Users.isAdmin,
   ) }}
 
 {% endblock body %}

--- a/src/templates/resources-status.html
+++ b/src/templates/resources-status.html
@@ -12,6 +12,7 @@
   'Create new resources status'|trans,
   'Status name'|trans,
   App.Teams.teamArr.name,
+  App.Users.isAdmin,
   ) }}
 
 {% endblock body %}


### PR DESCRIPTION
following up on #7048, make the input disabled if we can't click it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Category and status pages now respect admin permissions more consistently.
  * The “Mark as private” option is disabled for non-admin users, preventing unauthorized changes.
  * Admin-specific controls in experiments and resources views now show only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->