### PR TITLE
bug/minor: ui/ux: dark mode tomselect inputs unreadable

### DIFF
--- a/src/scss/_tom-select.scss
+++ b/src/scss/_tom-select.scss
@@ -23,7 +23,7 @@
     border: 1px solid var(--secondary-muted);
   }
 
-  #filterOwner-ts-control {
+  .ts-control input {
     background-color: var(--mainbackground);
     color: var(--mediumstrong);
   }


### PR DESCRIPTION
The input was dark text over dark background
<img width="603" height="150" alt="image" src="https://github.com/user-attachments/assets/ebb1bc6d-552b-476d-a158-5c4e4e63ae68" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark-mode input styling for select controls so the appearance now applies more consistently across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->