### PR TITLE
reorg: merge elabctl in main repo

### DIFF
--- a/containers/elabctl/CHANGELOG.md
+++ b/containers/elabctl/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Version 5.0.3
 
-* Properly address #37 by only creating a tmp dir during install or sef-update
+* Properly address #37 by only creating a tmp dir during install or self-update
 
 ## Version 5.0.2
 
@@ -18,7 +18,7 @@
 
 ## Version 5.0.0
 
-The major version bump is simply to align with the rest of the elabftw related repositories, it has no other meaning.
+The major version bump is simply to align with the rest of the eLabFTW-related repositories, it has no other meaning.
 
 * Actually check for healthy state of MySQL container rather than wait 15 seconds before running db update. See elabftw/elabftw#4948.
 
@@ -83,7 +83,7 @@ The major version bump is simply to align with the rest of the elabftw related r
 ## Version 2.4.0
 
 * Add convenience function `initialize` to import the database structure
-* Populate SITE_URL in elabftw.yml form user input
+* Populate `SITE_URL` in elabftw.yml from user input
 * Use container names from elabctl.conf in elabftw.yml
 * `uninstall` also removes mysql:8.0
 
@@ -109,7 +109,7 @@ The major version bump is simply to align with the rest of the elabftw related r
 * Add a warning with a choice to continue update if the latest version is a beta version
 
 ## Version 2.2.4
-* Fix ENABLE_LETSENCRYPT being incorrectly set to true for self signed certs (#20)
+* Fix ENABLE_LETSENCRYPT being incorrectly set to true for self-signed certs (#20)
 * Drop "no domain name" support
 
 ## Version 2.2.3

--- a/containers/elabctl/CHANGELOG.md
+++ b/containers/elabctl/CHANGELOG.md
@@ -1,0 +1,180 @@
+# Changelog for elabctl
+
+## Version 5.0.4
+
+* Fix an issue where `elabctl update` could fail if no _healthcheck_ was configured for MySQL container. Fix #38 via #39.
+
+## Version 5.0.3
+
+* Properly address #37 by only creating a tmp dir during install or sef-update
+
+## Version 5.0.2
+
+* Cleanup tmp dir created during `self-update` function. fix #37
+
+## Version 5.0.1
+
+* Do a refresh (``docker compose up -d``) instead of a restart after update
+
+## Version 5.0.0
+
+The major version bump is simply to align with the rest of the elabftw related repositories, it has no other meaning.
+
+* Actually check for healthy state of MySQL container rather than wait 15 seconds before running db update. See elabftw/elabftw#4948.
+
+## Version 3.6.4
+
+* Use `mktemp` command to create temporary directory to write temporary files to, without another user being able to read or modify it.
+
+## Version 3.6.3
+
+* Add timeout before update command. See elabftw/elabftw#4948.
+
+## Version 3.6.2
+
+* Prevent issue with unset `BORG_REMOTE_PATH` env. Fix #36.
+
+## Version 3.6.1
+
+* Add `--default-character-set=utf8mb4` to `elabctl mysql` command
+
+## Version 3.6.0
+
+* Allow setting `BORG_REMOTE_PATH` env var for `borg` backup. (fix elabftw/elabftw#4798)
+
+## Version 3.5.0
+
+* Change `bin/console db:install` to new `bin/init db:install`
+* Reword the `update` help text
+
+## Version 3.4.0
+
+* Add `DUMP_DELETE_DAYS` variable (defaults to +0) to remove old mysql backup files after generating a dump (fix elabftw/elabftw#4285)
+
+## Version 3.3.0
+
+* Add convenience function `update-db-schema` which will update the MySQL database schema.
+* Use new function when running `update`.
+
+## Version 3.2.1
+
+* Improve detection of docker-compose/docker compose command.
+
+## Version 3.2.0
+
+* Remove check for beta version as it could never be true because latest release endpoint of github api doesn't include pre-releases.
+
+## Version 3.1.2
+
+* Don't check initially for docker-compose presence as we can use "docker compose". Instead check for "docker" command presence.
+
+## Version 3.1.1
+
+* Remove initial check for zip and git presence as they are not required
+
+## Version 3.1.0
+
+* Add hours, minutes and seconds to the mysql dump filename
+
+## Version 3.0.0
+
+* Use borg backup for the backup function -> requires change in configuration to work properly!
+
+## Version 2.4.0
+
+* Add convenience function `initialize` to import the database structure
+* Populate SITE_URL in elabftw.yml form user input
+* Use container names from elabctl.conf in elabftw.yml
+* `uninstall` also removes mysql:8.0
+
+## Version 2.3.4
+
+* Remove `--column-statistics=0` to mysqldump command. See https://github.com/elabftw/elabctl/issues/23
+
+## Version 2.3.3
+
+* Add `--column-statistics=0` to mysqldump command.
+
+## Version 2.3.2
+
+* Use `docker compose` for Docker version > 20.x and `docker-compose` otherwise.
+
+## Version 2.3.1
+
+* Use `docker compose` for Docker version > 19.x and `docker-compose` otherwise. (#22)
+
+## Version 2.3.0
+
+* Use `docker compose` instead of `docker-compose` command
+* Add a warning with a choice to continue update if the latest version is a beta version
+
+## Version 2.2.4
+* Fix ENABLE_LETSENCRYPT being incorrectly set to true for self signed certs (#20)
+* Drop "no domain name" support
+
+## Version 2.2.3
+* Fix permissions for uploaded files folder chown command
+
+## Version 2.2.2
+* Use correct mysql container name for backup
+
+## Version 2.2.1
+* Add link to latest version changelog after update
+
+## Version 2.2.0
+* Replace php-logs with access-logs and error-logs using docker logs command
+
+## Version 2.1.1
+* Fix wrongly committed local config
+
+## Version 2.1.0
+* Allow specifying the name of the containers in config file
+
+## Version 2.0.1
+* Add --no-tablespaces argument to mysqldump to avoid PROCESS privilege error
+
+## Version 2.0.0
+
+* Get a pre-processed config file from get.elabftw.net
+* Don't install certbot or try to get a certificate
+* Suppress the MySQL warning. Allow silent backup for cron with > /dev/null
+* Add mysql-backup command to just make a dump of the database, don't zip the files
+
+## Version 1.0.4
+
+* Use restart instead of refresh for update command (see elabftw/elabftw#1543)
+
+## Version 1.0.3
+
+* Use refresh instead of restart for update command
+* Use certbot instead of letsencrypt-auto
+
+## Version 1.0.2
+
+* Fix bugreport hanging on elabftw version
+* Add mysql command to spawn mysql shell in container
+* Check for disk space before update (#15)
+
+## Version 1.0.1
+
+* Download conf file to /tmp to avoid permissions issues
+* Add sudo for mkdir
+* Open port 80 for Let's Encrypt
+* Use sudo to remove data dir
+* Log file is gone
+* Don't try to install stuff, let user deal with it
+* Script can be used without being root
+
+## Version 0.6.4
+
+* Fix install on CentOS (thanks @M4aurice) (#14)
+* Ask before doing backup
+
+## Version 0.2.2
+
+* Fix install on RHEL (thanks @folf) (#7)
+* Fix running backup from cron (#6)
+* Use chmod 600 not 700 for config file
+* Allow traffic on port 443 with ufw
+* Add GPLv3 licence
+* Add CHANGELOG.md

--- a/containers/elabctl/LICENSE
+++ b/containers/elabctl/LICENSE
@@ -1,0 +1,674 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/containers/elabctl/README.md
+++ b/containers/elabctl/README.md
@@ -1,0 +1,29 @@
+# elabctl
+
+This script is used to manage an eLabFTW instance.
+
+#### See the main [documentation](https://doc.elabftw.net).
+
+## Install
+
+As root:
+
+With `curl`:
+
+~~~bash
+curl -sL https://get.elabftw.net -o /usr/local/bin/elabctl && chmod +x /usr/local/bin/elabctl
+~~~
+
+Or with `wget`:
+
+~~~bash
+wget -qO- https://get.elabftw.net > /usr/local/bin/elabctl && chmod +x /usr/local/bin/elabctl
+~~~
+
+## Use
+
+Make sure that `/usr/local/bin` is in your `$PATH`.
+
+~~~bash
+elabctl help
+~~~

--- a/containers/elabctl/README.md
+++ b/containers/elabctl/README.md
@@ -2,25 +2,15 @@
 
 This script is used to manage an eLabFTW instance.
 
-#### See the main [documentation](https://doc.elabftw.net).
+## Installation
 
-## Install
-
-As root:
-
-With `curl`:
+As `root` user:
 
 ~~~bash
-curl -sL https://get.elabftw.net -o /usr/local/bin/elabctl && chmod +x /usr/local/bin/elabctl
+curl --fail -sL https://get.elabftw.net -o /usr/local/bin/elabctl && chmod +x /usr/local/bin/elabctl
 ~~~
 
-Or with `wget`:
-
-~~~bash
-wget -qO- https://get.elabftw.net > /usr/local/bin/elabctl && chmod +x /usr/local/bin/elabctl
-~~~
-
-## Use
+## Usage
 
 Make sure that `/usr/local/bin` is in your `$PATH`.
 

--- a/containers/elabctl/elabctl.conf
+++ b/containers/elabctl/elabctl.conf
@@ -1,0 +1,59 @@
+# elabctl configuration file
+# see https://github.com/elabftw/elabctl
+# does nothing by default
+# uncomment and edit to customize your environment
+# ONLY ABSOLUTE PATHS HERE (start with a /)
+
+# where do you want your backups to end up?
+#declare BACKUP_DIR='/var/backups/elabftw'
+
+# where do we store the config file?
+#declare CONF_FILE='/etc/elabftw.yml'
+
+# where do we store the MySQL database and the uploaded files?
+#declare DATA_DIR='/var/elabftw'
+
+# optional, set a different path for uploaded files
+# default is DATA_DIR/web
+#declare UPLOAD_DIR=/path/to/uploaded_files
+
+# name of the web container (default: elabftw)
+#declare ELAB_WEB_CONTAINER_NAME='elabftw'
+
+# name of the mysql container (default: mysql)
+#declare ELAB_MYSQL_CONTAINER_NAME='mysql'
+
+# defines the time until older mysql dumps will be deleted (+0 = older than 24h, +1 = older than 48h and so on)
+# this value will be passed to the -ctime argument of find command
+# set to "disabled" to disable pruning
+#declare DUMP_DELETE_DAYS=+0
+
+
+#############################################################################################
+#                                                                                           #
+# BORG BACKUP CONFIGURATION                                                                 #
+#                                                                                           #
+# See: https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables #
+#                                                                                           #
+#############################################################################################
+
+# full path to the borg executable
+#declare BORG_PATH=/usr/local/bin/borg
+
+# borg passphrase
+#declare BORG_PASSPHRASE=
+
+# borg repository
+# remote example (with ssh): backupserver:/elabftw
+# local example: /mnt/data/big_drive/elabftw
+#declare BORG_REPO=
+
+# granularity of backups to keep
+declare BORG_KEEP_DAILY=14
+declare BORG_KEEP_MONTHLY=6
+
+# optional, only set if required (rsync.net)
+#declare BORG_REMOTE_PATH=borg1
+
+# optional, if you use gpg to store the borg password
+#declare BORG_PASSCOMMAND='/usr/bin/gpg --decrypt /path/to/encrypted-password.gpg'

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -22,7 +22,7 @@ declare UPLOAD_DIR="${DATA_DIR}/web"
 declare ELABCTL_CONF_FILE="using default values (no config file found)"
 
 # use the new compose command
-declare DC="docker compose"
+declare -a DC=(docker compose)
 
 function access-logs
 {
@@ -120,7 +120,7 @@ function get-user-conf
     if [ -f elabctl.conf ]; then
         mv -v elabctl.conf elabctl.conf.old
     fi
-    curl -Ls https://github.com/elabftw/elabctl/raw/master/elabctl.conf -o elabctl.conf
+    curl -Ls https://github.com/elabftw/elabftw/raw/master/containers/elabctl/elabctl.conf -o elabctl.conf
     echo "Downloaded elabctl.conf."
     echo "Edit it and move it in ~/.config or /etc."
     echo "Or leave it there and always use elabctl from this directory."
@@ -457,7 +457,7 @@ function self-update
     TMP_DIR=$(mktemp -d)
     tmp_filepath="${TMP_DIR}/elabctl"
     echo "Downloading new version to $tmp_filepath"
-    curl -sL https://raw.githubusercontent.com/elabftw/elabctl/master/elabctl.sh -o "$tmp_filepath"
+    curl -sL https://raw.githubusercontent.com/elabftw/elabftw/master/containers/elabctl/elabctl.sh -o "$tmp_filepath"
     chmod -v +x "$tmp_filepath"
     mv -v "$tmp_filepath" "$me"
     rmdir -v ${TMP_DIR}
@@ -466,19 +466,19 @@ function self-update
 function start
 {
     is-installed
-    eval "$DC" -f "$CONF_FILE" up -d
+    "${DC[@]}" -f "$CONF_FILE" up -d
 }
 
 function status
 {
     is-installed
-    eval "$DC" -f "$CONF_FILE" ps
+    "${DC[@]}" -f "$CONF_FILE" ps
 }
 
 function stop
 {
     is-installed
-    eval "$DC" -f "$CONF_FILE" down
+    "${DC[@]}" -f "$CONF_FILE" down
 }
 
 function uninstall
@@ -553,7 +553,7 @@ function update
         backup
         echo "Backup done, now updating."
     fi
-    eval "$DC" -f "$CONF_FILE" pull
+    "${DC[@]}" -f "$CONF_FILE" pull
     refresh
 
     echo "Do you want to update the MySQL database schema? (recommended) (y/N)"
@@ -665,6 +665,8 @@ if [ "${UPLOAD_DIR:0:1}" != "/" ]; then
     echo "Edit elabctl.conf and add a full path to the directory."
     exit 1
 fi
+
+UPLOAD_DIR="${UPLOAD_DIR:-${DATA_DIR}/web}"
 
 # available commands
 declare -A commands

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -1,0 +1,687 @@
+#!/usr/bin/env bash
+# https://www.elabftw.net
+# https://github.com/elabftw/elabctl/
+# © 2022 Nicolas CARPi @ Deltablot
+# License: GPLv3
+declare -r ELABCTL_VERSION='5.1.0'
+
+# default backup dir
+declare BACKUP_DIR='/var/backups/elabftw'
+
+# defines the time until older mysql dumps will be deleted (+0 = older than 24h, +1 = older than 48h and so on)
+declare DUMP_DELETE_DAYS=+0
+
+# default config file for docker compose
+declare CONF_FILE='/etc/elabftw.yml'
+# default data directory
+declare DATA_DIR='/var/elabftw'
+# allow override default web subfolder in data dir
+declare UPLOAD_DIR="${DATA_DIR}/web"
+
+# default conf file is no conf file
+declare ELABCTL_CONF_FILE="using default values (no config file found)"
+
+# use the new compose command
+declare DC="docker compose"
+
+function access-logs
+{
+    docker logs "${ELAB_WEB_CONTAINER_NAME}" 2>/dev/null
+}
+
+# display ascii logo
+function ascii
+{
+    echo ""
+    echo "      _          _     _____ _______        __"
+    echo "  ___| |    __ _| |__ |  ___|_   _\ \      / /"
+    echo " / _ \ |   / _| | '_ \| |_    | |  \ \ /\ / / "
+    echo "|  __/ |__| (_| | |_) |  _|   | |   \ V  V /  "
+    echo " \___|_____\__,_|_.__/|_|     |_|    \_/\_/   "
+    echo "                                              "
+    echo ""
+}
+
+# create a mysqldump and a borg snapshot of the uploaded files
+function backup
+{
+    mysql-backup
+    borg-backup
+}
+
+function borg-backup
+{
+    set -eu
+    # add these into env so it is picked up by borg
+    export BORG_REPO="${BORG_REPO}"
+    if [[ -v BORG_PASSPHRASE ]]; then
+        export BORG_PASSPHRASE="${BORG_PASSPHRASE}"
+    fi
+    if [[ -v BORG_PASSCOMMAND ]]; then
+        export BORG_PASSCOMMAND="${BORG_PASSCOMMAND}"
+    fi
+    if [[ -v BORG_REMOTE_PATH ]]; then
+        export BORG_REMOTE_PATH="${BORG_REMOTE_PATH}"
+    fi
+    # we add to the borg the uploaded files (web directory) and also the backup dir containing dumps of MySQL
+    "${BORG_PATH}" create "::$(hostname)-$(date +%F_%H-%M)" "${UPLOAD_DIR}" "${BACKUP_DIR}"
+    "${BORG_PATH}" prune --keep-daily="${BORG_KEEP_DAILY:-14}" --keep-monthly="${BORG_KEEP_MONTHLY:-6}"
+}
+
+# generate info for reporting a bug
+function bugreport
+{
+    echo "Collecting information for a bug report…"
+    echo "======================================================="
+    echo -n "Elabctl version: "
+    echo $ELABCTL_VERSION
+    echo -n "Elabftw version: see on sysconfig page"
+    echo "======================================================="
+    echo -n "Docker version: "
+    docker version | grep -m 1 Version | awk '{print $2}'
+    echo "======================================================="
+    echo "Operating system: "
+    uname -a
+    cat /etc/os-release
+    echo "======================================================="
+    echo "Memory:"
+    free -h
+    echo "======================================================="
+}
+
+function checkDeps
+{
+    need_to_quit=0
+
+    for bin in dialog docker curl sudo
+    do
+        if ! hash "$bin" 2>/dev/null; then
+            echo "Error: $bin not found in the \$PATH. Please install the program '$bin' or fix your \$PATH."
+            need_to_quit=1
+        fi
+    done
+
+    if [ $need_to_quit -eq 1 ]; then
+        exit 1
+    fi
+
+    require_docker_compose
+}
+
+function error-logs
+{
+    docker logs "${ELAB_WEB_CONTAINER_NAME}" 1>/dev/null
+}
+
+function get-user-conf
+{
+    # download the config file in the current directory
+    echo "Downloading the config file 'elabctl.conf' in current directory..."
+    if [ -f elabctl.conf ]; then
+        mv -v elabctl.conf elabctl.conf.old
+    fi
+    curl -Ls https://github.com/elabftw/elabctl/raw/master/elabctl.conf -o elabctl.conf
+    echo "Downloaded elabctl.conf."
+    echo "Edit it and move it in ~/.config or /etc."
+    echo "Or leave it there and always use elabctl from this directory."
+    echo "Then do 'elabctl install' again."
+}
+
+function has-disk-space
+{
+    # check if we have enough space on disk to update the docker image
+    docker_folder=$(docker info --format '{{.DockerRootDir}}')
+    # use default if previous command didn't work
+    safe_folder=${docker_folder:-/var/lib/docker}
+    space_test=$(($(stat -f --format="%a*%S" "$safe_folder")/1024**3 < 5))
+    if [[ $space_test -ne 0 ]]; then
+        echo "ERROR: There is less than 5 Gb of free space available on the disk where $safe_folder is located!"
+        df -h "$safe_folder"
+        echo ""
+        read -p "Remove old images and containers to free up some space? (y/N)" -n 1 -r
+        echo ""
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            docker system prune
+        fi
+        exit 1
+    fi
+}
+
+function help
+{
+    version
+    echo "
+    Usage: elabctl [OPTION] [COMMAND]
+           elabctl [ --help | --version ]
+           elabctl install
+           elabctl backup
+
+    Commands:
+
+        access-logs         Show last lines of webserver access log
+        backup              Backup your installation
+        borg-backup         Backup the files with borgbackup
+        bugreport           Gather information about the system for a bug report
+        error-logs          Show last lines of webserver error log
+        help                Show this text
+        info                Display the configuration variables and status
+        initialize          Initialize the MySQL database for eLabFTW
+        install             Configure and install required components
+        logs                Show logs of the containers
+        mysql               Open a MySQL prompt in the 'mysql' container
+        mysql-backup        Make a MySQL dump file for backup
+        refresh             Recreate the containers if they need to be
+        restart             Restart the containers
+        self-update         Update the elabctl script
+        status              Show status of running containers
+        start               Start the containers
+        stop                Stop the containers
+        uninstall           Uninstall eLabFTW and purge data
+        update              Pull the image defined, restart containers and update database schema
+        update-db-schema    Update the MySQL database schema
+        version             Display elabctl version
+    "
+}
+
+function info
+{
+    echo "Backup directory: ${BACKUP_DIR}"
+    echo "Data directory: ${DATA_DIR}"
+    echo "Upload directory: ${UPLOAD_DIR}"
+    echo "Web container name: ${ELAB_WEB_CONTAINER_NAME}"
+    echo "MySQL container name: ${ELAB_MYSQL_CONTAINER_NAME}"
+    echo ""
+    echo "Status:"
+    status
+}
+
+function initialize
+{
+    is-installed
+    docker exec -it "${ELAB_WEB_CONTAINER_NAME}" bin/init db:install
+}
+
+# get elabftw.yml and configure it with sed
+function install
+{
+    checkDeps
+
+    # do nothing if there are files in there
+    if [ "$(ls -A $DATA_DIR 2>/dev/null)" ]; then
+        echo "It looks like eLabFTW is already installed. Delete the ${DATA_DIR} folder to reinstall."
+        exit 1
+    fi
+
+    # init vars
+    # if you don't want any dialog
+    declare unattended=${ELAB_UNATTENDED:-0}
+    declare servername=${ELAB_SERVERNAME:-localhost}
+    declare hasdomain=${ELAB_HASDOMAIN:-0}
+    declare usehttps=${ELAB_USEHTTPS:-1}
+    declare useselfsigned=${ELAB_USESELFSIGNED:-0}
+
+    # exit on error
+    set -e
+
+    title="Install eLabFTW"
+    backtitle="eLabFTW installation"
+
+    # show welcome screen and ask if defaults are fine
+    if [ "$unattended" -eq 0 ]; then
+        # because answering No to dialog equals exit != 0
+        set +e
+
+        # welcome screen
+        dialog --backtitle "$backtitle" --title "$title" --msgbox "\nWelcome to the install of eLabFTW :)\n
+        This script will automatically install eLabFTW in a Docker container." 0 0
+
+        dialog --colors --backtitle "$backtitle" --title "$title" --yes-label "Looks good to me" --no-label "Download example conf and quit" --yesno "\nHere is what will happen:\n
+        The main configuration file will be created at: \Z4${CONF_FILE}\Zn\n
+        A directory holding elabftw MySQL data will be created at: \Z4${DATA_DIR}/mysql\Zn\n
+        A directory holding elabftw uploaded files will be created at: \Z4${UPLOAD_DIR}\Zn\n
+        The backups will be created at: \Z4${BACKUP_DIR}\Zn\n\n
+        If you wish to change these settings, quit now and edit the file \Z4elabctl.conf\Zn" 0 0
+        if [ $? -eq 1 ]; then
+            get-user-conf
+            exit 0
+        fi
+    fi
+
+    # create the data dir
+    mkdir -pv $DATA_DIR
+    if [ $? -eq 1 ]; then
+        sudo mkdir -pv $DATA_DIR
+    fi
+
+    declare TMP_DIR=$(mktemp -d)
+    declare TMP_CONF_FILE="${TMP_DIR}/elabftw.yml"
+
+    if [ "$unattended" -eq 0 ]; then
+        set +e
+        ########################################################################
+        # start asking questions                                               #
+        # what we want here is the domain name of the server or its IP address #
+        # and also if we want to use Let's Encrypt or not
+        ########################################################################
+
+        # ASK SERVER OR LOCAL?
+        dialog --backtitle "$backtitle" --title "$title" --yes-label "Server" --no-label "My computer" --yesno "\nAre you installing it on a Server or a personal computer?" 0 0
+        if [ $? -eq 1 ]; then
+            # local computer
+            servername="localhost"
+        else
+            # server
+
+            ## DOMAIN NAME OR IP BLOCK
+            dialog --backtitle "$backtitle" --title "$title" --yesno "\nIs a domain name pointing to this server?\n\nAnswer yes if this server can be reached using a domain name. Answer no if you can only reach it with an IP address.\n" 0 0
+            if [ $? -eq 0 ]; then
+                hasdomain=1
+                # ask for domain name
+                servername=$(dialog --backtitle "$backtitle" --title "$title" --inputbox "\nPlease enter your domain name below:\nExample: elabftw.example.org\n" 0 0 --output-fd 1)
+            else
+                # no domain is not supported, exit
+                dialog --backtitle "$backtitle" --title "$title" --msgbox "\nInstallation without a proper domain name is not supported.\n" 0 0
+                exit 1
+            fi
+            ## END DOMAIN NAME OR IP BLOCK
+
+            # ASK IF WE WANT HTTPS AT ALL FIRST
+            dialog --backtitle "$backtitle" --title "$title" --yes-label "Use HTTPS" --no-label "Disable HTTPS" --yesno "\nDo you want to run the HTTPS enabled container or a normal HTTP server? Note: disabling HTTPS means you will use another webserver as a proxy for TLS connections.\n\nChoose 'Disable HTTPS' if you already have a webserver capable of terminating TLS requests running (Apache/Nginx/HAProxy).\nChoose 'Use HTTPS' if unsure.\n" 0 0
+            if [ $? -eq 1 ]; then
+                # use HTTP
+                usehttps=0
+            else
+                if [ $hasdomain -eq 1 ]; then
+                    # ASK IF SELF-SIGNED OR PROPER CERT
+                    dialog --backtitle "$backtitle" --title "$title" --yes-label "Use correct certificate" --no-label "Use self-signed" --yesno "\nDo you want to use a proper TLS certificate (coming from Let's Encrypt or provided by you) or use a self-signed certificate? The self-signed certificate will be automatically generated for you, but browsers will display a warning when connecting.\n\nChoose 'Use self-signed' if you do not have a domain name.\n" 0 0
+                    if [ $? -eq 0 ]; then
+                        # want correct cert
+                        dialog --backtitle "$backtitle" --title "$title" --msgbox "\nSee the documentation on how to configure your TLS certificate before starting the containers.\n" 0 0
+                    else
+                        # use self signed
+                        useselfsigned=1
+                        dialog --backtitle "$backtitle" --title "$title" --msgbox "\nA self-signed certificate will be generated upon container start. But really you should try and use a domain name ;)\n" 0 0
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+
+
+    set -e
+
+    echo 40 | dialog --backtitle "$backtitle" --title "$title" --gauge "Creating folder structure. You will be asked for your password (bottom left of the screen)." 20 80
+    sudo mkdir -pv ${DATA_DIR}/mysql ${UPLOAD_DIR}
+    sudo chmod -Rv 700 ${DATA_DIR} ${UPLOAD_DIR}
+    echo "Executing: sudo chown -v 999:999 ${DATA_DIR}/mysql"
+    sudo chown -v 999:999 ${DATA_DIR}/mysql
+    echo "Executing: sudo chown -v 101:101 ${UPLOAD_DIR}"
+    sudo chown -v 101:101 ${UPLOAD_DIR}
+    sleep 2
+
+    echo 50 | dialog --backtitle "$backtitle" --title "$title" --gauge "Grabbing the docker compose configuration file" 20 80
+    # make a copy of an existing conf file
+    if [ -e $CONF_FILE ]; then
+        echo 55 | dialog --backtitle "$backtitle" --title "$title" --gauge "Making a copy of the existing configuration file." 20 80
+        \cp $CONF_FILE ${CONF_FILE}.old
+    fi
+
+    # get a config file already filled with random passwords/keys
+    curl --silent "https://get.elabftw.net/?config" -o "$TMP_CONF_FILE"
+    sleep 1
+
+    # elab config
+    echo 50 | dialog --backtitle "$backtitle" --title "$title" --gauge "Adjusting configuration" 20 80
+    sed -i -e "s/SERVER_NAME=localhost/SERVER_NAME=$servername/" $TMP_CONF_FILE
+    sed -i -e "s:/var/elabftw/web:${UPLOAD_DIR}:" $TMP_CONF_FILE
+    sed -i -e "s/container_name: elabftw/container_name: ${ELAB_WEB_CONTAINER_NAME}/" $TMP_CONF_FILE
+    sed -i -e "s/container_name: mysql/container_name: ${ELAB_MYSQL_CONTAINER_NAME}/" $TMP_CONF_FILE
+
+    # disable https
+    scheme="https://"
+    if [ $usehttps -eq 0 ]; then
+        sed -i -e "s/DISABLE_HTTPS=false/DISABLE_HTTPS=true/" $TMP_CONF_FILE
+        scheme="http://"
+    fi
+
+    # enable letsencrypt
+    if [ $hasdomain -eq 1 ] && [ $useselfsigned -eq 0 ]; then
+        # even if we don't use Let's Encrypt, for using TLS certs we need this to be true, and volume mounted
+        sed -i -e "s:ENABLE_LETSENCRYPT=false:ENABLE_LETSENCRYPT=true:" $TMP_CONF_FILE
+        sed -i -e "s:#- /etc/letsencrypt:- /etc/letsencrypt:" $TMP_CONF_FILE
+    fi
+
+    sed -i -e "s#SITE_URL=#SITE_URL=$scheme$servername#" $TMP_CONF_FILE
+
+    sleep 1
+
+    # setup restrictive permissions
+    chmod 600 "$TMP_CONF_FILE"
+
+    # now move conf file at proper location
+    # use sudo in case it's in /etc and we are not root
+    sudo mv "$TMP_CONF_FILE" "$CONF_FILE"
+
+    rmdir -v ${TMP_DIR}
+
+    # final screen
+    if [ "$unattended" -eq 0 ]; then
+        dialog --colors --backtitle "$backtitle" --title "Installation finished" --msgbox "\nCongratulations, eLabFTW was successfully installed! :)\n\n
+        \Z1====>\Zn Finish the installation by configuring TLS certificates.\n\n
+        \Z1====>\Zn Then start the containers with: \Zb\Z4elabctl start\Zn\n\n
+        \Z1====>\Zn Then import the database structure with: \Zb\Z4elabctl initialize\Zn\n\n
+        \Z1====>\Zn Go to https://$servername once started!\n\n
+        In the mean time, check out what to do after an install:\n
+        \Z1====>\Zn https://doc.elabftw.net/sysadmin-guide.html#setting-up-email\n\n
+        The configuration file for docker compose is here: \Z4$CONF_FILE\Zn\n
+        Your data folder is: \Z4${DATA_DIR}\Zn. It contains the MySQL database and uploaded files.\n
+        You can use 'docker logs -f ${ELAB_WEB_CONTAINER_NAME}' to follow the starting up of the container.\n" 20 80
+    fi
+
+}
+
+function is-installed
+{
+    if [ ! -f $CONF_FILE ]; then
+        echo "###### ERROR ##########################################################"
+        echo "Configuration file (${CONF_FILE}) could not be found!"
+        echo "Did you run the install command?"
+        echo "#######################################################################"
+        exit 1
+    fi
+}
+
+function logs
+{
+    docker logs "${ELAB_MYSQL_CONTAINER_NAME}"
+    docker logs "${ELAB_WEB_CONTAINER_NAME}"
+}
+
+function mysql
+{
+    docker exec -it "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --default-character-set=utf8mb4'
+}
+
+# create a mysqldump and remove old backups
+function mysql-backup
+{
+    if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
+        mkdir -pv "${BACKUP_DIR}"
+        if [ $? -eq 1 ]; then
+            sudo mkdir -pv ${BACKUP_DIR}
+        fi
+    fi
+
+    set -e
+
+    # get clean date
+    local -r date=$(date +%Y-%m-%d_%H-%M-%S) # 2016-02-10_20-12-45
+    local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
+
+    # dump sql
+    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
+    # copy it from the container to the host
+    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile"
+    # compress it to the max
+    gzip -f --best "$dumpfile"
+    # delete old dumps
+    if [[ "${DUMP_DELETE_DAYS}" != "disabled" ]]; then
+        find ${BACKUP_DIR} -mindepth 1 -name '*.sql.gz' -ctime ${DUMP_DELETE_DAYS} -delete
+    fi
+}
+
+function refresh
+{
+    start
+}
+
+function require_docker_compose {
+  if docker compose version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "ERROR: 'docker compose' is not available (or Docker is not running)." >&2
+  exit 1
+}
+
+function restart
+{
+    stop
+    start
+}
+
+function self-update
+{
+    me=$(command -v "$0")
+    TMP_DIR=$(mktemp -d)
+    tmp_filepath="${TMP_DIR}/elabctl"
+    echo "Downloading new version to $tmp_filepath"
+    curl -sL https://raw.githubusercontent.com/elabftw/elabctl/master/elabctl.sh -o "$tmp_filepath"
+    chmod -v +x "$tmp_filepath"
+    mv -v "$tmp_filepath" "$me"
+    rmdir -v ${TMP_DIR}
+}
+
+function start
+{
+    is-installed
+    eval "$DC" -f "$CONF_FILE" up -d
+}
+
+function status
+{
+    is-installed
+    eval "$DC" -f "$CONF_FILE" ps
+}
+
+function stop
+{
+    is-installed
+    eval "$DC" -f "$CONF_FILE" down
+}
+
+function uninstall
+{
+    stop
+
+    local -r backtitle="eLabFTW uninstall"
+    local title="Uninstall"
+
+    set +e
+
+    dialog --backtitle "$backtitle" --title "$title" --yesno "\nWarning! You are about to delete everything related to eLabFTW on this computer!\n\nThere is no 'go back' button. Are you sure you want to do this?\n" 0 0
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+
+    dialog --backtitle "$backtitle" --title "$title" --yesno "\nDo you want to delete the backups, too?" 0 0
+    if [ $? -eq 0 ]; then
+        rmbackup='y'
+    else
+        rmbackup='n'
+    fi
+
+    dialog --backtitle "$backtitle" --title "$title" --ok-label "Skip timer" --cancel-label "Cancel uninstall" --pause "\nRemoving everything in 10 seconds. Stop now you fool!\n" 20 40 10
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+
+    clear
+
+    # remove config file and eventual backup
+    if [ -f "${CONF_FILE}.old" ]; then
+        rm -vf "${CONF_FILE}.old"
+        echo "[x] Deleted ${CONF_FILE}.old"
+    fi
+    if [ -f "$CONF_FILE" ]; then
+        rm -vf "$CONF_FILE"
+        echo "[x] Deleted $CONF_FILE"
+    fi
+    # remove uploads directory
+    if [ -d "$UPLOAD_DIR" ]; then
+        sudo rm -rvf "$UPLOAD_DIR"
+        echo "[x] Deleted $UPLOAD_DIR"
+    fi
+    # remove data directory
+    if [ -d "$DATA_DIR" ]; then
+        sudo rm -rvf "$DATA_DIR"
+        echo "[x] Deleted $DATA_DIR"
+    fi
+    # remove backup dir
+    if [ $rmbackup == 'y' ] && [ -d "$BACKUP_DIR" ]; then
+        rm -rvf "$BACKUP_DIR"
+        echo "[x] Deleted $BACKUP_DIR"
+    fi
+
+    # remove docker images
+    docker rmi elabftw/elabimg || true
+    docker rmi mysql:5.7 || true
+    docker rmi mysql:8.0 || true
+
+    echo ""
+    echo "[✓] Everything has been obliterated. Have a nice day :)"
+}
+
+function update
+{
+    is-installed
+    has-disk-space
+    echo "Do you want to make a backup before updating? (y/N)"
+    read -r dobackup
+    if [ "$dobackup" = "y" ]; then
+        backup
+        echo "Backup done, now updating."
+    fi
+    eval "$DC" -f "$CONF_FILE" pull
+    refresh
+
+    echo "Do you want to update the MySQL database schema? (recommended) (y/N)"
+    read -r doDbUpdate
+    if [ "$doDbUpdate" = "y" ]; then
+        update-db-schema
+    fi
+
+    echo "You are now running the latest eLabFTW version."
+    echo "Make sure to read the CHANGELOG!"
+    echo "=> https://github.com/elabftw/elabftw/releases/latest"
+}
+
+function update-db-schema
+{
+    is-installed
+    # wait for mysql container to start, but only if there is one
+    if docker ps | grep -q "${ELAB_MYSQL_CONTAINER_NAME}"; then
+        echo -n "Waiting for the MySQL container to be ready before running update..."
+        while true; do
+            # check if healthcheck is available or else will crash (e.g. with older versions of elabFTW config files)
+            health_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "${ELAB_MYSQL_CONTAINER_NAME}")
+            if [ "$health_status" == "healthy" ]; then
+                break
+            fi
+            if [ "$health_status" == "no-healthcheck" ]; then
+                echo -e "\nNo healthcheck found. Waiting for 20 seconds as fallback..."
+                sleep 20
+                break
+            fi
+            # wait and retry while showing user activity
+            echo -n .
+            sleep 2
+        done
+    fi
+    echo "Running command 'bin/console db:update' in the eLabFTW container now"
+    docker exec -it "${ELAB_WEB_CONTAINER_NAME}" bin/console db:update
+}
+
+function upgrade
+{
+    update
+}
+
+function usage
+{
+    help
+}
+
+function version
+{
+    echo "elabctl © 2017 Nicolas CARPi - https://www.elabftw.net"
+    echo "elabctl version: $ELABCTL_VERSION"
+}
+
+# SCRIPT BEGIN
+
+# only one argument allowed
+if [ $# != 1 ]; then
+    help
+    exit 1
+fi
+
+# deal with --help and --version
+case "$1" in
+    -h|--help)
+    help
+    exit 0
+    ;;
+    -v|--version)
+    version
+    exit 0
+    ;;
+esac
+
+# default settings that could be overriden by config
+
+declare ELAB_WEB_CONTAINER_NAME='elabftw'
+declare ELAB_MYSQL_CONTAINER_NAME='mysql'
+
+# Now we load the configuration file for custom directories set by user
+if [ -f /etc/elabctl.conf ]; then
+    source /etc/elabctl.conf
+    ELABCTL_CONF_FILE="/etc/elabctl.conf"
+fi
+
+# elabctl.conf in ~/.config
+if [ -f "${HOME}/.config/elabctl.conf" ]; then
+    source "${HOME}/.config/elabctl.conf"
+    ELABCTL_CONF_FILE="${HOME}/.config/elabctl.conf"
+fi
+
+# if elabctl is in current dir it has top priority
+if [ -f elabctl.conf ]; then
+    source elabctl.conf
+    ELABCTL_CONF_FILE="elabctl.conf"
+fi
+
+# check that the path for the data dir is absolute
+if [ "${DATA_DIR:0:1}" != "/" ]; then
+    echo "Error in config file: DATA_DIR is not an absolute path!"
+    echo "Edit elabctl.conf and add a full path to the directory."
+    exit 1
+fi
+
+# check that the path for the upload dir is absolute
+if [ "${UPLOAD_DIR:0:1}" != "/" ]; then
+    echo "Error in config file: UPLOAD_DIR is not an absolute path!"
+    echo "Edit elabctl.conf and add a full path to the directory."
+    exit 1
+fi
+
+# available commands
+declare -A commands
+for valid in access-logs backup borg-backup bugreport error-logs help info infos initialize install logs mysql mysql-backup self-update start status stop refresh restart uninstall update update-db-schema upgrade usage version
+do
+    commands[$valid]=1
+done
+
+if [[ ${commands[$1]} ]]; then
+    # exit if variable isn't set
+    set -u
+    ascii
+    echo "Info: using elabctl configuration file: $ELABCTL_CONF_FILE"
+    echo "Info: using elabftw configuration file: $CONF_FILE"
+    echo "---------------------------------------------"
+    $1
+else
+    help
+    exit 1
+fi

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -629,7 +629,7 @@ case "$1" in
     ;;
 esac
 
-# default settings that could be overriden by config
+# default settings that could be overridden by config
 
 declare ELAB_WEB_CONTAINER_NAME='elabftw'
 declare ELAB_MYSQL_CONTAINER_NAME='mysql'


### PR DESCRIPTION
Reducing the number of repositories to maintain is a good move. It also makes it easier to have coherent changes into a single PR on a single repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete `elabctl` Bash CLI for installing, starting/stopping, updating, refreshing, backing up (MySQL dumps + Borg), and uninstalling eLabFTW deployments via Docker Compose.
  * Supports interactive or unattended installs, HTTPS/Let’s Encrypt configuration, optional database schema updates, self-updates, disk-space checks, and absolute path enforcement for data/upload directories.
* **Documentation**
  * Added `elabctl` README, license text, and versioned changelog.
  * Introduced an `elabctl` configuration template with Borg and deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->