### PR TITLE
bug/medium: refine users2teams permission checks

### DIFF
--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -143,21 +143,24 @@ final class Users2Teams
         return $Users->readOne();
     }
 
-    private function requesterCanModifyInTeamOrExplode(int $teamid): void
+    // Pass false for sensitive changes, such as is_admin, to exclude delegated user/team managers.
+    private function requesterCanModifyInTeamOrExplode(int $teamid, bool $allowUserTeamManager = true): void
     {
         $TeamsHelper = new TeamsHelper($teamid);
-        if (!(
-            $this->requester->isSysadmin()
-            || $this->requester->userData['can_manage_users2teams']
+        $isAllowed = $this->requester->isSysadmin()
             || $TeamsHelper->isAdminInTeam($this->requester->userData['userid'])
-        )) {
-            throw new IllegalActionException('User tried to modify a team where they are not admin');
+            || (
+                $allowUserTeamManager
+                && $this->requester->userData['can_manage_users2teams']
+            );
+        if (!$isAllowed) {
+            throw new IllegalActionException('User is not allowed to modify this team membership.');
         }
     }
 
     private function patchIsAdmin(int $userid, int $teamid, BinaryValue $isAdmin): int
     {
-        $this->requesterCanModifyInTeamOrExplode($teamid);
+        $this->requesterCanModifyInTeamOrExplode($teamid, allowUserTeamManager: false);
         $promoteToAdmin = $isAdmin->toBoolean() && !$this->wasAdminAlready($userid);
 
         $sql = 'UPDATE users2teams SET is_admin = :is_admin WHERE `users_id` = :userid AND `teams_id` = :team';

--- a/src/Models/Users2Teams.php
+++ b/src/Models/Users2Teams.php
@@ -209,7 +209,7 @@ final class Users2Teams
         }
         $sql = 'UPDATE users2teams SET ' . $what->value . ' = :content WHERE `users_id` = :userid AND `teams_id` = :team';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':content', $content, PDO::PARAM_INT);
+        $req->bindValue(':content', $content->value, PDO::PARAM_INT);
         $req->bindValue(':userid', $userid, PDO::PARAM_INT);
         $req->bindValue(':team', $teamid, PDO::PARAM_INT);
 

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -18,6 +18,9 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\UsersHelper;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function array_filter;
+use function array_values;
+
 class Users2TeamsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;
@@ -144,5 +147,40 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
         ), $newUser));
         // remove user again
         (new Users($newUser, 1))->destroy();
+    }
+
+    public function testUserTeamManagerCannotPromoteSelfToAdmin(): void
+    {
+        // non-admin user from team 2
+        $manager = $this->getUserInTeam(team: 2, admin: 0);
+        $manager->userData['can_manage_users2teams'] = 1;
+
+        // add user to team 1 as a regular member so an is_admin row exists
+        $this->Users2Teams->addUserToTeams($manager->userid, array(1));
+
+        // perform update as the delegated user/team manager
+        $Users2Teams = new Users2Teams($manager);
+        try {
+            // attempt promoting requester to admin in team 1
+            $Users2Teams->patchUser2Team(array(
+                'team' => 1,
+                'target' => 'is_admin',
+                'content' => 1,
+            ), $manager->userid);
+
+            $this->fail('A user/team manager should not be able to promote themselves to team admin.');
+        } catch (IllegalActionException) {
+            // expected: can_manage_users2teams does not allow admin changes
+        }
+
+        // Reload the user's team memberships from db
+        $teams = new UsersHelper($manager->userid)->getTeamsFromUserid();
+        // select membership entry for team 1 (from teams array)
+        $team = array_values(array_filter(
+            $teams,
+            static fn(array $team): bool => $team['id'] === 1,
+        ))[0];
+
+        $this->assertSame(0, $team['is_admin']);
     }
 }


### PR DESCRIPTION
Delegated users will be limited to adding/unreferencing users to/from teams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for sensitive team membership changes, including administrator status updates.
  * Prevented delegated team managers from promoting themselves to administrator.
  * Corrected membership update handling to ensure integer values are saved properly.
  * Updated the authorization error message for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->