### PR TITLE
bug/minor: users: remove api keys when user is archived

### DIFF
--- a/src/Services/UserArchiver.php
+++ b/src/Services/UserArchiver.php
@@ -20,6 +20,7 @@ use Elabftw\Enums\Users2TeamsTargets;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnprocessableContentException;
+use Elabftw\Models\ApiKeys;
 use Elabftw\Models\AuditLogs;
 use Elabftw\Models\Config;
 use Elabftw\Models\Users\Users;
@@ -66,6 +67,9 @@ final class UserArchiver
             throw new UnprocessableContentException(_('A sysadmin account cannot be archived.'));
         }
         $this->target->invalidateToken();
+        // also remove any api key for that user in that team
+        $ApiKeys = new ApiKeys(new Users($this->target->getUserid(), $this->target->getTeam()));
+        $ApiKeys->destroyInTeam($this->target->getTeam());
         // if we are archiving a user, also lock all experiments (if asked)
         return $lockExp ? $this->lockAndArchiveExperiments() : true;
     }

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -280,12 +280,17 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         // tata in bravo
         $Admin = $this->getUserInTeam(team: 2, admin: 1);
         $user2 = $this->getUserInTeam(team: 2);
+        // create an api key
+        $ApiKeys = new ApiKeys($user2);
+        $ApiKeys->create('yep', 1);
         $Users2Teams = new Users2Teams($Admin);
         $this->assertEquals(1, $Users2Teams->patchUser2Team(array(
             'target' => Users2TeamsTargets::IsArchived->value,
             'content' => '1',
             'team' => '2',
         ), $user2->userid));
+        // make sure keys have been deleted after archival
+        $this->assertCount(0, $ApiKeys->readAll());
     }
 
     public function testCreateUser(): void


### PR DESCRIPTION
same as for team removal, apply it also to archival

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys associated with a user are now automatically removed when that user is archived from a team.
  * Improved account archiving behavior to prevent previously issued keys from remaining active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->