### PR TITLE
bug/minor: sysconfig: fix broken js on error

### DIFF
--- a/src/ts/sysconfig.ts
+++ b/src/ts/sysconfig.ts
@@ -144,6 +144,7 @@ function renderEndpoints(endpoints: Endpoint[]): void {
 function checkForUpdate() {
   const updateUrl = 'https://get.elabftw.net/updates.json';
   const currentVersionDiv = document.getElementById('currentVersion');
+  if (!currentVersionDiv) return;
   const latestVersionDiv = document.getElementById('latestVersion');
   const currentVersion = currentVersionDiv.innerText;
   // Note: this doesn't work on Chrome


### PR DESCRIPTION
if element is not in dom, js was broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checking stability when version information is unavailable.
  * Prevented errors caused by missing version display elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->