### PR TITLE
bug/minor: ui: make button readable in dark mode

### DIFF
--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -143,7 +143,7 @@
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
         {% if not ucpPage and (rw == 'canread' or rw == 'canwrite') %}
-          <button type='button' class='btn btn-outline-primary' data-dismiss='modal' data-identifier='{{ identifier }}' data-action='save-permissions-both'>{{ 'Apply to Read & Write'|trans }}</button>
+          <button type='button' class='btn btn-ghost' data-dismiss='modal' data-identifier='{{ identifier }}' data-action='save-permissions-both'>{{ 'Apply to Read & Write'|trans }}</button>
         {% endif %}
         <button type='button' class='btn btn-primary' data-dismiss='modal' data-identifier='{{ identifier }}' data-rw='{{ rw }}' {{ ucpPage ? 'data-is-user-default="1"' }} data-action='save-permissions'>{{ 'Save'|trans }}</button>
       </div>


### PR DESCRIPTION
`apply to both read & write` permissions button isn't readable with outline-primary in dark mode. 
- Use ghost button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Apply to Read & Write” modal button styling for a more subtle, streamlined appearance.
  * Button behavior, label, and controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->