### PR TITLE
bug/minor: permissions: allow a sysadmin that is not admin to be admin

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -792,7 +792,7 @@ class Users extends AbstractRest
 
     public function isAdminOrExplode(): void
     {
-        if ($this->isAdmin() === false) {
+        if (!$this->isSysadmin() && !$this->isAdmin()) {
             throw new IllegalActionException(Messages::InsufficientPermissions->toHuman());
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sysadmins can now perform actions that require administrator-level permissions without receiving an insufficient permissions error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->