### PR TITLE
bug/major: fix experiments timestamp command

### DIFF
--- a/src/Commands/ExperimentsTimestamp.php
+++ b/src/Commands/ExperimentsTimestamp.php
@@ -87,7 +87,8 @@ final class ExperimentsTimestamp extends Command
             return 0;
         }
         $userid = (int) $input->getArgument('user');
-        $Experiments = new Experiments(new Users($userid), bypassReadPermission: true, bypassWritePermission: true);
+        // we set the team of Users() to 1 here so getTeam() doesn't explode, but it's not relevant
+        $Experiments = new Experiments(new Users($userid, 1), bypassReadPermission: true, bypassWritePermission: true);
         foreach ($expArr as $exp) {
             if ($output->isVerbose()) {
                 $output->writeln(sprintf('Timestamping experiment %d', $exp['id']));


### PR DESCRIPTION
the newly introduced getTeam() was problematic in the execution of the command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experiment timestamping reliability by ensuring the associated team context is available during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->