### PR TITLE
bug/minor: table header for view modes: duplicate header

### DIFF
--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -544,11 +544,7 @@ export class Metadata {
         }
         table.append(tbody);
         tableContainer.append(table);
-        const fieldsHeader = document.createElement('h5');
-        fieldsHeader.classList.add('mt-3', 'mb-2');
-        fieldsHeader.innerText = i18next.t('custom-fields');
 
-        groupWrapperDiv.append(fieldsHeader);
         groupWrapperDiv.append(tableContainer);
         groupWrapperDiv.append(document.createElement('hr'));
         this.metadataDiv.append(groupWrapperDiv);


### PR DESCRIPTION
<img width="464" height="479" alt="image" src="https://github.com/user-attachments/assets/0f6b280b-4f05-4fbd-9212-034b52bfa694" />

Introduced in #7044 :clown_face: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the extra-fields section by removing its redundant heading.
  * Preserved existing group headers, tables, containers, and dividers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->