### PR TITLE
bug/critical: tsconfig.json: fix verbatimModuleSyntax causing CSP issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "lib": ["es2022", "es2022.intl", "dom"],
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "isolatedModules": true
   },
   "include": [


### PR DESCRIPTION
this option is not compatible with strict CSP, and if it is, I don't know how.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript module syntax handling to improve compatibility during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->