### PR TITLE
api/fix: handle custom userid

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1355,6 +1355,7 @@ components:
           type: integer
           description: |
             User ID of the entity owner.
+            If omitted, the requester's ID is used by default.
             When transferring ownership, the `team` field should also be provided (optional).
         team:
           type: integer

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -251,7 +251,12 @@ abstract class AbstractEntity extends AbstractRest
                     $userid = isset($reqBody['userid'])
                         ? (int) $reqBody['userid']
                         : $this->Users->userid;
-
+                    if ($userid !== $this->Users->userid) {
+                        $teamsHelper = new TeamsHelper($this->Users->team);
+                        if (!$teamsHelper->isUserInTeam($userid)) {
+                            throw new UnprocessableContentException(_('The selected user does not exist or is not a member of your team.'));
+                        }
+                    }
                     return $this->create(
                         title: $reqBody['title'] ?? null,
                         body: $reqBody['body'] ?? null,

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -247,6 +247,11 @@ abstract class AbstractEntity extends AbstractRest
                     $contentType = isset($reqBody['content_type'])
                         ? BodyContentType::from($reqBody['content_type'])
                         : ($useMarkdown ? BodyContentType::Markdown : BodyContentType::Html);
+
+                    $userid = isset($reqBody['userid'])
+                        ? (int) $reqBody['userid']
+                        : $this->Users->userid;
+
                     return $this->create(
                         title: $reqBody['title'] ?? null,
                         body: $reqBody['body'] ?? null,
@@ -261,6 +266,7 @@ abstract class AbstractEntity extends AbstractRest
                         status: $status,
                         metadata: $metadata,
                         contentType: $contentType,
+                        userid: $userid,
                     );
                 }
             )(),

--- a/src/Models/Experiments.php
+++ b/src/Models/Experiments.php
@@ -60,6 +60,7 @@ final class Experiments extends AbstractConcreteEntity
         BodyContentType $contentType = BodyContentType::Html,
         ?EntityType $createdFromType = null,
         ?int $createdFromId = null,
+        ?int $userid = null,
     ): int {
         // defaults
         $title = Filter::title($title ?? _('Untitled'));
@@ -90,7 +91,7 @@ final class Experiments extends AbstractConcreteEntity
         $req->bindParam(':canwrite_is_immutable', $canwriteIsImmutable, PDO::PARAM_INT);
         $req->bindParam(':metadata', $metadata);
         $req->bindParam(':custom_id', $customId, PDO::PARAM_INT);
-        $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $req->bindValue(':content_type', $contentType->value, PDO::PARAM_INT);
         $req->bindParam(':rating', $rating, PDO::PARAM_INT);
         $req->bindValue(':hide_main_text', $hideMainText->value, PDO::PARAM_INT);

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -64,6 +64,7 @@ final class Items extends AbstractConcreteEntity
         BodyContentType $contentType = BodyContentType::Html,
         ?EntityType $createdFromType = null,
         ?int $createdFromId = null,
+        ?int $userid = null,
         // specific to Items
         string $canbook = self::EMPTY_CAN_JSON,
         BasePermissions $canbookBase = BasePermissions::Team,
@@ -86,7 +87,7 @@ final class Items extends AbstractConcreteEntity
         $req->bindValue(':date', $date->format('Y-m-d'));
         $req->bindParam(':status', $status);
         $req->bindParam(':body', $body);
-        $req->bindParam(':userid', $this->Users->userid, PDO::PARAM_INT);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $req->bindParam(':category', $category, PDO::PARAM_INT);
         $req->bindValue(':elabid', Tools::generateElabid());
         $req->bindValue(':canread_base', $canreadBase->value, PDO::PARAM_INT);


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [ ] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the [relevant documentation](https://github.com/elabftw/documentation).
---

### Pull Request Description

Please provide **clear context** for your proposed change:

Currently the API accepts the `userid` key, but the backend doesn't honour it: always the current user will be the `Owner` as it's hardcoded. Please see:
- items: https://github.com/elabftw/elabftw/blob/master/src/Models/Items.php#L89
- experiments: https://github.com/elabftw/elabftw/blob/master/src/Models/Experiments.php#L93

The called API endpoints were `/items` and `/experiments` with the `POST` method.


- What issue or need does this PR address?
- How did you approach the solution?
- If applicable, include **screenshots or examples** (especially for UI changes).

> ⚠️ We’re committed to reviewing your contributions, so in return, we ask that you take the time to present your work clearly.
> Pull requests without any description are frowned upon and will likely be closed immediately.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create and duplicate requests can now specify a target user ID.
  * When no user ID is provided, the requester’s ID is used automatically.
  * Created experiments and items are assigned to the selected user.

* **Documentation**
  * Updated API documentation to clarify the default user ID behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->