### PR TITLE
docs: versioning should work

### DIFF
--- a/documentation/docs/install/addons.md
+++ b/documentation/docs/install/addons.md
@@ -50,7 +50,7 @@ Restart the `elabftw` container to take these changes into account (`elabctl ref
 
 ## Description
 
-[OpenCloning](https://opencloning.org/) is an application used to plan and document cloning. DNA data can be loaded from various sources, and the application is tightly integrated with eLabFTW. This means that you can easily use Resource entries in eLabFTW and their attached files to perform cloning operations. See [usage documentation](/docs/tutorials/opencloning).
+[OpenCloning](https://opencloning.org/) is an application used to plan and document cloning. DNA data can be loaded from various sources, and the application is tightly integrated with eLabFTW. This means that you can easily use Resource entries in eLabFTW and their attached files to perform cloning operations. See [usage documentation](../tutorials/opencloning).
 
 ## How to install
 

--- a/documentation/docs/install/update.md
+++ b/documentation/docs/install/update.md
@@ -7,7 +7,7 @@ title: Upgrade
 
 
 :::warning
-Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](/docs/install/backups).
+Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../install/backups).
 :::
 
 :::note
@@ -21,7 +21,7 @@ Make sure to figure out what version you are running and **read the release note
 The current running version can be seen in the bottom right of every page.
 
 :::warning
-Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](/docs/install/backups).
+Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../install/backups).
 :::
 
 ## STEP 1: Specify which version you want

--- a/documentation/docs/tutorials/opencloning.md
+++ b/documentation/docs/tutorials/opencloning.md
@@ -13,7 +13,7 @@ title: OpenCloning
   <figcaption>OpenCloning menu.</figcaption>
 </figure>
 
-If the menu is grayed out, ask your Sysadmin to enable it. If you're looking for information about how to enable it as a Sysadmin, see [installing OpenCloning](/docs/install/addons) section.
+If the menu is grayed out, ask your Sysadmin to enable it. If you're looking for information about how to enable it as a Sysadmin, see [installing OpenCloning](../install/addons) section.
 
 ## How to use
 

--- a/documentation/docs/usage/fair.md
+++ b/documentation/docs/usage/fair.md
@@ -50,4 +50,4 @@ ROR are exported in `.eln` exports, and also visible in PDF exports.
 
 ### ELN
 
-The `.eln` file format, based on **RO-Crate** allows you to export and import data to and from your eLabFTW instance. See [Import/Export page](/docs/usage/import-export).
+The `.eln` file format, based on **RO-Crate** allows you to export and import data to and from your eLabFTW instance. See [Import/Export page](../usage/import-export).

--- a/documentation/docs/usage/import-export.md
+++ b/documentation/docs/usage/import-export.md
@@ -9,7 +9,7 @@ title: Import / Export
 
 When users add information into systems like eLabFTW, that information can get trapped in this system. We do not want that. We want information to flow freely.
 
-As such, eLabFTW allows users to freely export and import data, in different file formats, as well as accessing it through a [public API](/docs/usage/api), for automation tools.
+As such, eLabFTW allows users to freely export and import data, in different file formats, as well as accessing it through a [public API](../usage/api), for automation tools.
 
 This page describes the Import and Export features available in eLabFTW.
 
@@ -155,7 +155,7 @@ If the import looks good, you can now delete these newly imported items and impo
 
 ### Using the API to control how things are imported
 
-If you want to have complete control over the import process, you can use a few lines of python to do the import. Follow our [tutorial to import data from spreadsheet files](/docs/tutorials/import-csv).
+If you want to have complete control over the import process, you can use a few lines of python to do the import. Follow our [tutorial to import data from spreadsheet files](../tutorials/import-csv).
 
 
 ### Importing compounds through CLI (csv file)

--- a/documentation/docs/usage/intro.md
+++ b/documentation/docs/usage/intro.md
@@ -11,11 +11,11 @@ Let's define a few terms first:
 
 * **Instance**: a running eLabFTW service, for example: https://eln.example.org
 * **Team**: the main unit for a group of users
-* **Sysadmin**: technical role: a user with Sysadmin rights can modify the Instance configuration and create Teams, it is generally the same person that installed the Instance and manages the server.  See the [Sysadmin guide](/docs/usage/sysadmin-guide).
-* **Admin**: a user with Admin rights for a given team has access to the Admin Panel and can manage settings related to their Team. A given user can be Admin in Team A and User in Team B. See the [Admin guide](/docs/usage/admin-guide). Some Admins can also have the right to affect users from other teams.
-* **User**: a user with an account on the Instance, belonging to at least one Team. See the [User guide](/docs/category/user-guide).
+* **Sysadmin**: technical role: a user with Sysadmin rights can modify the Instance configuration and create Teams, it is generally the same person that installed the Instance and manages the server.  See the [Sysadmin guide](../usage/sysadmin-guide).
+* **Admin**: a user with Admin rights for a given team has access to the Admin Panel and can manage settings related to their Team. A given user can be Admin in Team A and User in Team B. See the [Admin guide](../usage/admin-guide). Some Admins can also have the right to affect users from other teams.
+* **User**: a user with an account on the Instance, belonging to at least one Team. See the [User guide](../category/user-guide).
 
-We could also mention the role of **Instance Coordinator**, someone identified by the Users as the person to go to for all things eLab in the institution. It might be Research Data Managers, or a designated Researcher or Engineer that is very familiar with eLabFTW. This person could have access to managing the relationship between users and teams. They could animate the internal chat room related to eLabFTW usage. See the [Instance Coordinator documentation page](/docs/usage/coordinator-guide).
+We could also mention the role of **Instance Coordinator**, someone identified by the Users as the person to go to for all things eLab in the institution. It might be Research Data Managers, or a designated Researcher or Engineer that is very familiar with eLabFTW. This person could have access to managing the relationship between users and teams. They could animate the internal chat room related to eLabFTW usage. See the [Instance Coordinator documentation page](../usage/coordinator-guide).
 
 ## General principles
 
@@ -53,7 +53,7 @@ A Team generally correspond to a real life research group or service. It is not 
 
 Every Team has one or several Admin, who can change many settings affecting users in the team, such as the default experimental template, categories for database items (Items Types), experiments Status, Tags, etc...
 
-Teams are created by the Sysadmin from the Sysconfig page ([see documentation](/docs/usage/sysadmin-guide#configure-teams-optional)).
+Teams are created by the Sysadmin from the Sysconfig page ([see documentation](../usage/sysadmin-guide#configure-teams-optional)).
 
 ## Experiments and Resources
 

--- a/documentation/docs/usage/sysadmin-guide.md
+++ b/documentation/docs/usage/sysadmin-guide.md
@@ -43,7 +43,7 @@ Register an account using this link: [SMTP2GO](https://get.smtp2go.com/xj1zy4rvl
 
 ## Set up backup
 
-See the dedicated [backup page](/docs/install/backups).
+See the dedicated [backup page](../install/backups).
 
 
 ## Configure teams `(optional)`
@@ -63,8 +63,8 @@ The "Visible" attribute allows you to hide a team from the "Register" page. Use 
 eLabFTW currently supports four authentication mechanisms:
 
 * Local authentication: email + password stored locally (in the eLabFTW database), this is the default
-* SAML authentication: use one or several Identity Provider (IDP) to authenticate users. See dedicated [SAML documentation page](/docs/install/post-install/authentication/saml).
-* LDAP authentication: verify the login with an LDAP service. See dedicated [LDAP documentation page](/docs/install/post-install/authentication/ldap).
+* SAML authentication: use one or several Identity Provider (IDP) to authenticate users. See dedicated [SAML documentation page](../install/post-install/authentication/saml).
+* LDAP authentication: verify the login with an LDAP service. See dedicated [LDAP documentation page](../install/post-install/authentication/ldap).
 * External authentication: use request headers added by your own middleware to authenticate the user (_e.g._ Apache's auth_mellon)
 
 It is possible to have several mechanisms at the same time but recommended to only leave one visible to users. So if you configure LDAP or SAML, disable the Local login so Users are not confused.
@@ -152,7 +152,7 @@ It is important to keep your install up to date with the latest bug fixes and ne
 
 Subscribe to [the newsletter](http://eepurl.com/bTjcMj) to be warned when a new release is out or select "Releases only" from GitHub's Watch button on the [repo page](https://github.com/elabftw/elabftw).
 
-See instructions on updating eLabFTW on [upgrade page](/docs/install/update).
+See instructions on updating eLabFTW on [upgrade page](../install/update).
 
 ## Sysadmin Panel
 
@@ -285,7 +285,7 @@ Of course, adjust these instructions relative to your setup. Try and have the mo
 
 Start your staging instance with: `docker compose up -d`. Make sure to adjust DNS, certificates, load balancers, reverse proxies accordingly.
 
-Use the [Restore backup](/docs/install/backups#how-to-restore-a-backup) instructions to copy your production data into the staging instance. It is recommended to do that regularly, especially before updates, so the staging data is the same as production data and you will not have surprises. It's also a good opportunity to test your backups, if this has not been automated.
+Use the [Restore backup](../install/backups#how-to-restore-a-backup) instructions to copy your production data into the staging instance. It is recommended to do that regularly, especially before updates, so the staging data is the same as production data and you will not have surprises. It's also a good opportunity to test your backups, if this has not been automated.
 
 Before a major release, update the staging instance, optionally asking users if everything looks good on this instance, and once everything is validated, you can upgrade the production instance.
 

--- a/documentation/docs/usage/user-guide/compounds.md
+++ b/documentation/docs/usage/user-guide/compounds.md
@@ -54,7 +54,7 @@ Maybe you've just created an never-seen before chemical compound, which means yo
 
 ## Importing compounds manually
 
-Look at the [Import compounds through CLI](/docs/tutorials/import-compounds) section to learn how to import your compounds from a spreadsheet file or through the API.
+Look at the [Import compounds through CLI](../../tutorials/import-compounds) section to learn how to import your compounds from a spreadsheet file or through the API.
 
 ## Fingerprints
 

--- a/documentation/docs/usage/user-guide/experiments.md
+++ b/documentation/docs/usage/user-guide/experiments.md
@@ -114,11 +114,11 @@ For both Experiment and Resource entries, the top part of the page displays a to
   <figcaption>Duplicate modal</figcaption>
 </figure>
 
-4. **Signature**: Add a signature to prove that this entry has been approved by a referenced human. See [Signatures documentation](/docs/usage/traceability-and-auditability#electronic-signatures).
+4. **Signature**: Add a signature to prove that this entry has been approved by a referenced human. See [Signatures documentation](../traceability-and-auditability#electronic-signatures).
 
-5. **RFC3161 Timestamping**: See [RFC 3161 Timestamping section](/docs/usage/traceability-and-auditability#trusted-timestamps)
+5. **RFC3161 Timestamping**: See [RFC 3161 Timestamping section](../traceability-and-auditability#trusted-timestamps)
 
-6. **Blockchain timestamping**: See [Blockchain Timestamping section](/docs/usage/traceability-and-auditability#blockchain-timestamps)
+6. **Blockchain timestamping**: See [Blockchain Timestamping section](../traceability-and-auditability#blockchain-timestamps)
 
 7. **Export**: Export your entry into different file formats, or to external repositories.
 <figure>

--- a/documentation/docs/usage/user-guide/intro.md
+++ b/documentation/docs/usage/user-guide/intro.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Concepts
 ---
 
-This guide is for Users. See also the guides for [Admins](/docs/usage/admin-guide) and for [Sysadmins](/docs/usage/sysadmin-guide).
+This guide is for Users. See also the guides for [Admins](../admin-guide) and for [Sysadmins](../sysadmin-guide).
 
 # Concepts
 

--- a/documentation/docs/usage/user-guide/settings.md
+++ b/documentation/docs/usage/user-guide/settings.md
@@ -26,4 +26,4 @@ Once this application is installed, on the eLabFTW page, select YES to "Use two-
 **Note**: it is highly recommended to enable 2FA wherever you can.
 
 ## Api keys tab
-Create an API key for your account from this page. An API key is like a Username+password for your account. It allows you to interact with eLabFTW programmatically, through the REST API. See [API documentation](/docs/usage/api).
+Create an API key for your account from this page. An API key is like a Username+password for your account. It allows you to interact with eLabFTW programmatically, through the REST API. See [API documentation](../api).

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -47,8 +47,8 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          // Make master/Edge the default documentation version.
-          lastVersion: 'current',
+           // Use current while creating the version, then make 5.6 the default.
+          lastVersion: versioningReady ? '5.6' : 'current',
 
           versions: {
             current: {
@@ -64,7 +64,6 @@ const config: Config = {
               },
             }),
           },
-
 
           // Point "Edit this page" to the correct Git branch.
           editUrl: ({version, docPath}) => {

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -1,6 +1,10 @@
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import {
+  useDocsPreferredVersion,
+  useLatestVersion,
+} from '@docusaurus/plugin-content-docs/client';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
@@ -8,24 +12,44 @@ import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
-function HomepageHeader() {
+function HomepageHeader(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
+  const latestVersion = useLatestVersion(undefined);
+  const {preferredVersion} = useDocsPreferredVersion();
+
+  const version = preferredVersion ?? latestVersion;
+
+  const getDocPath = (id: string): string => {
+    const doc = version.docs.find(candidate => candidate.id === id);
+
+    if (!doc) {
+      throw new Error(
+        `Documentation page "${id}" does not exist in version "${version.name}".`,
+      );
+    }
+
+    return doc.path;
+  };
+
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>
+
         <p className="hero__subtitle">{siteConfig.tagline}</p>
+
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/install/intro">
+            to={getDocPath('install/intro')}>
             Install it
           </Link>
+
           <Link
             className="button button--secondary button--lg"
-            to="/docs/usage/intro">
+            to={getDocPath('usage/intro')}>
             Use it
           </Link>
         </div>
@@ -36,11 +60,13 @@ function HomepageHeader() {
 
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
+
   return (
     <Layout
       title={siteConfig.title}
       description="Official eLabFTW documentation">
       <HomepageHeader />
+
       <main>
         <HomepageFeatures />
       </main>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated internal documentation links to use reliable relative paths across installation, usage, tutorials, and user guides.
  - Improved navigation between guides, API references, backup instructions, addons, and import/export tutorials.

- **New Features**
  - Homepage documentation links now respect the selected documentation version.
  - Documentation versioning now selects the appropriate default version when versioned builds are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->