### PR TITLE
docs: update Addons page now that chem-plugin is only for fingerprinting

### DIFF
--- a/documentation/docs/install/addons.md
+++ b/documentation/docs/install/addons.md
@@ -11,19 +11,17 @@ Addons are services that can be deployed to provide extended functionality for e
 
 ## Description
 
-The `chem-plugin` addon is necessary for two things:
-
-- calculating fingerprint of chemical compounds (which subsequently allows for substructure search)
-- enabling all features of the chemical editor
+The `chem-plugin` addon is necessary for calculating fingerprint of chemical compounds (which subsequently allows for substructure search).
 
 ## How to install
 
-Deploy a `chem-plugin` container somewhere. It can be on the same server than eLabFTW or some other place. Adding a service to your `docker-compose.yml` file is the easiest. See the [example docker-compose.yml file](https://github.com/elabftw/elabimg/blob/e1e5a2da33db11ae8d54924c15a227d6abcd4e43/src/docker-compose.yml-EXAMPLE#L414-L419).
+Deploy a `chem-plugin` container somewhere. It can be on the same server than eLabFTW or some other place. Adding a service to your `docker-compose.yml` file is the easiest. See the [example docker-compose.yml file](https://github.com/elabftw/elabftw/blob/master/containers/elabimg/docker-compose.yml-EXAMPLE).
 
 The deployment is really straightforward, as there is nothing to configure. You just start the container and that's it.
 
 ~~~yaml
 chem-plugin:
+    # Note: it is recommended to either use the same version as eLabFTW like 5.6.8 or a sha256 pin
     image: elabftw/chem-plugin:latest
     container_name: chem-plugin
     restart: always
@@ -34,9 +32,6 @@ chem-plugin:
 Next, configure eLabFTW to use that service by adding four environment variables:
 
 ~~~yaml
-# This service is necessary for the Chemical structure editor (Ketcher)
-- USE_INDIGO=true
-- INDIGO_URL=http://chem-plugin:8080/
 # The fingerprinter is necessary to create a fingerprint of chemical compounds so we can do sub-structure search
 - USE_FINGERPRINTER=true
 - FINGERPRINTER_URL=http://chem-plugin:8000/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Chem Plugin Addon supports chemical fingerprint calculation for substructure searches.
  * Updated Docker Compose examples and recommended pinning the plugin version.
  * Removed outdated Ketcher configuration variables and retained fingerprinting setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->