### PR TITLE
bug/medium: metadata cst fields: fix the ux in edit mode

### DIFF
--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -493,7 +493,6 @@ export class Metadata {
     }
 
     // clear previous content
-    this.metadataDiv.textContent = '';
     return displayFunction.call(this).catch(e => {
       if (e instanceof ResourceNotFoundException) {
         // no metadata is associated but it's okay, it's not an error
@@ -620,10 +619,10 @@ export class Metadata {
       this.editor.refresh(json as ValidMetadata);
       // clean groups field if they're removed via json editor
       if (!Object.prototype.hasOwnProperty.call(json, 'extra_fields')) {
+        this.metadataDiv.replaceChildren();
         reloadElements(['newFieldGroupSelect', 'fieldsGroup']);
         return;
       }
-
       const [groups, groupedArr] = this.getGroups('edit', json as ValidMetadata);
       // the full content of extra fields
       const wrapperDiv = document.createElement('div');
@@ -777,7 +776,7 @@ export class Metadata {
         }
       });
 
-      this.metadataDiv.append(wrapperDiv);
+      this.metadataDiv.replaceChildren(wrapperDiv);
       reloadElements(['newFieldGroupSelect', 'fieldsGroup']);
     }).then(() => {
       makeSortableGreatAgain();

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -352,9 +352,9 @@ if (document.getElementById('metadataDiv') && entity.id) {
             $('#fieldBuilderModal').modal('toggle');
             // focus on the newly added element
             document.querySelector(`#metadataDiv [data-name="${CSS.escape(fieldKey)}"]`)?.scrollIntoView({
-                behavior: 'smooth',
-                block: 'center',
-              });
+              behavior: 'smooth',
+              block: 'center',
+            });
           });
         });
       // EDIT EXTRA FIELD
@@ -450,9 +450,9 @@ if (document.getElementById('metadataDiv') && entity.id) {
             $('#fieldBuilderModal').modal('toggle');
             // focus on the newly added element
             document.querySelector(`#metadataDiv [data-name="${CSS.escape(newFieldKey)}"]`)?.scrollIntoView({
-                behavior: 'smooth',
-                block: 'center',
-              });
+              behavior: 'smooth',
+              block: 'center',
+            });
           });
         });
       // ADD OPTION FOR SELECT OR RADIO

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -351,7 +351,10 @@ if (document.getElementById('metadataDiv') && entity.id) {
             // and finally close the modal
             $('#fieldBuilderModal').modal('toggle');
             // focus on the newly added element
-            document.querySelector(`[data-name="${fieldKey}"`).scrollIntoView({behavior: 'smooth'});
+            document.querySelector(`#metadataDiv [data-name="${CSS.escape(fieldKey)}"]`)?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+              });
           });
         });
       // EDIT EXTRA FIELD
@@ -446,7 +449,10 @@ if (document.getElementById('metadataDiv') && entity.id) {
           MetadataC.update(json as ValidMetadata).then(() => {
             $('#fieldBuilderModal').modal('toggle');
             // focus on the newly added element
-            document.querySelector(`[data-name="${newFieldKey}"]`).scrollIntoView({behavior: 'smooth'});
+            document.querySelector(`#metadataDiv [data-name="${CSS.escape(newFieldKey)}"]`)?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+              });
           });
         });
       // ADD OPTION FOR SELECT OR RADIO

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -433,8 +433,9 @@ if (document.getElementById('metadataDiv') && entity.id) {
             const el = document.getElementById(id) as HTMLInputElement | null;
             if (el?.checked) field[key] = true;
           }
-          // preserve readonly
+          // preserve properties that aren't editable in this modal
           if (prevField?.readonly === true) field['readonly'] = true;
+          if (typeof prevField?.position === 'number') field['position'] = prevField.position;
           // ensure the old extra field is replaced
           if (!json['extra_fields']) json['extra_fields'] = {};
           if (originalFieldKey && originalFieldKey !== newFieldKey) {


### PR DESCRIPTION
fix #6347 

- fix position not kept during update of custom fields
- fix flashy effect when deleting or adding new elements: we had a dom cleanup with `content=' '` before re-populating, but we have a `replaceChildren` function so this fixes it.
- fix scrollIntoView: adding `block: center` makes it that the focused element is centered at the center of the page, so no effect of "lost" happens to the user
- also use escapeCSS for the selectors in js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata views and edit forms to consistently display current content without stale entries.
  * Improved handling when no additional metadata fields are available.
  * Updated field navigation to reliably focus and center newly added or edited fields.
  * Preserved field ordering when editing existing additional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->