### PR TITLE
ci: use specific hook/url for doc

### DIFF
--- a/.github/workflows/trigger-documentation.yml
+++ b/.github/workflows/trigger-documentation.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Send request to webhook to trigger update of doc
         env:
-          HOOK_SECRET: ${{ secrets.HOOK_SECRET }}
-          HOOK_URL: ${{ secrets.HOOK_URL }}
+          HOOK_SECRET: ${{ secrets.DOC_HOOK_SECRET }}
+          HOOK_URL: ${{ secrets.DOC_HOOK_URL }}
         run: |
           curl --fail-with-body --silent --show-error --max-time 30 \
             -H "X-Hook-Secret: ${HOOK_SECRET}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation rebuild automation to use dedicated webhook configuration settings.
  * Documentation updates will continue triggering with the revised configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->