### PR TITLE
bug/major: prevent templates from resolving incoming entity links

### DIFF
--- a/src/Models/Links/AbstractExperimentsLinks.php
+++ b/src/Models/Links/AbstractExperimentsLinks.php
@@ -65,9 +65,16 @@ abstract class AbstractExperimentsLinks extends AbstractLinks
     #[Override]
     protected function getRelatedTable(): string
     {
-        if ($this->Entity instanceof Experiments) {
-            return 'experiments2experiments';
-        }
-        return 'experiments2items';
+        return match (true) {
+            // be strict here: entity IDs are only unique within their own table.
+            // Falling back to another entity type would make templates inherit
+            // incoming links from an experiment or resource with the same ID.
+            $this->Entity instanceof Experiments => 'experiments2experiments',
+            $this->Entity instanceof Items => 'experiments2items',
+            default => throw new LogicException(sprintf(
+                'Entity type %s cannot have incoming experiment links.',
+                $this->Entity::class,
+            )),
+        };
     }
 }

--- a/src/Models/Links/AbstractExperimentsLinks.php
+++ b/src/Models/Links/AbstractExperimentsLinks.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 namespace Elabftw\Models\Links;
 
 use Elabftw\Enums\EntityType;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Items;
 use Elabftw\Models\ItemsTypes;
 use Override;
+
+use function sprintf;
 
 /**
  * For links pointing to experiments
@@ -71,7 +74,7 @@ abstract class AbstractExperimentsLinks extends AbstractLinks
             // incoming links from an experiment or resource with the same ID.
             $this->Entity instanceof Experiments => 'experiments2experiments',
             $this->Entity instanceof Items => 'experiments2items',
-            default => throw new LogicException(sprintf(
+            default => throw new ImproperActionException(sprintf(
                 'Entity type %s cannot have incoming experiment links.',
                 $this->Entity::class,
             )),

--- a/src/Models/Links/AbstractItemsLinks.php
+++ b/src/Models/Links/AbstractItemsLinks.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 namespace Elabftw\Models\Links;
 
 use Elabftw\Enums\EntityType;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Experiments;
 use Elabftw\Models\Items;
 use Elabftw\Models\Templates;
 use Override;
+
+use function sprintf;
 
 /**
  * For links pointing to items

--- a/src/Models/Links/AbstractItemsLinks.php
+++ b/src/Models/Links/AbstractItemsLinks.php
@@ -65,9 +65,14 @@ abstract class AbstractItemsLinks extends AbstractLinks
     #[Override]
     protected function getRelatedTable(): string
     {
-        if ($this->Entity instanceof Items) {
-            return 'items2items';
-        }
-        return 'items2experiments';
+        // be strict here: see comment on AbstractExperimentsLinks
+        return match (true) {
+            $this->Entity instanceof Items => 'items2items',
+            $this->Entity instanceof Experiments => 'items2experiments',
+            default => throw new ImproperActionException(sprintf(
+                'Entity type %s cannot have incoming resource links.',
+                $this->Entity::class,
+            )),
+        };
     }
 }

--- a/src/Models/Links/AbstractLinks.php
+++ b/src/Models/Links/AbstractLinks.php
@@ -26,6 +26,8 @@ use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\AbstractEntity;
 use Elabftw\Models\AbstractRest;
 use Elabftw\Models\Changelog;
+use Elabftw\Models\ItemsTypes;
+use Elabftw\Models\Templates;
 use Elabftw\Params\ContentParams;
 use Elabftw\Traits\SetIdTrait;
 use Override;
@@ -67,6 +69,12 @@ abstract class AbstractLinks extends AbstractRest
     // Get related entities
     public function readRelated(): array
     {
+        // Templates may contain outgoing links, but regular entities cannot link
+        // to templates. Therefore, templates cannot have incoming links.
+        if ($this->Entity instanceof Templates || $this->Entity instanceof ItemsTypes) {
+            return array();
+        }
+
         return $this->prepareBindExecuteFetch($this->getSqlQuery(related: true));
     }
 

--- a/tests/unit/models/LinksTest.php
+++ b/tests/unit/models/LinksTest.php
@@ -320,4 +320,62 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ForbiddenException::class);
         new Experiments2ExperimentsLinks($Experiments, $targetId)->postAction(Action::Create, array());
     }
+
+    public function testTemplatesDoNotInheritIncomingLinksFromEntitiesWithSameId(): void
+    {
+        $User = $this->getRandomUserInTeam(1);
+
+        /**
+         * Experiment template and experiment sharing the same ID. Create incoming links to the experiment from:
+         * - another experiment;
+         * - a resource.
+         */
+        $TargetExperiment = $this->getFreshExperimentWithGivenUser($User);
+        $SourceExperiment = $this->getFreshExperimentWithGivenUser($User);
+        $SourceExperiment->ExperimentsLinks->setId($TargetExperiment->id);
+        $SourceExperiment->ExperimentsLinks->postAction(Action::Create, array());
+
+        $SourceItem = $this->getFreshItemWithGivenUser($User);
+        $SourceItem->ExperimentsLinks->setId($TargetExperiment->id);
+        $SourceItem->ExperimentsLinks->postAction(Action::Create, array());
+
+        // Move a fresh experiment template onto the experiment's numeric ID.
+        // IDs may legitimately collide because they belong to different tables.
+        $Template = $this->getFreshTemplate();
+        $req = $this->Db->prepare('UPDATE experiments_templates SET id = :collision_id WHERE id = :template_id');
+        $req->bindValue(':collision_id', $TargetExperiment->id, PDO::PARAM_INT);
+        $req->bindValue(':template_id', $Template->id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $Template = new Templates($Template->Users, $TargetExperiment->id);
+        $this->assertNotEmpty($TargetExperiment->ExperimentsLinks->readRelated());
+        $this->assertNotEmpty($TargetExperiment->ItemsLinks->readRelated());
+        $this->assertSame(array(), $Template->ExperimentsLinks->readRelated());
+        $this->assertSame(array(), $Template->ItemsLinks->readRelated());
+
+        // same for resources & resources templates
+        $TargetItem = $this->getFreshItemWithGivenUser($User);
+
+        $SourceExperiment = $this->getFreshExperimentWithGivenUser($User);
+        $SourceExperiment->ItemsLinks->setId($TargetItem->id);
+        $SourceExperiment->ItemsLinks->postAction(Action::Create, array());
+
+        $SourceItem = $this->getFreshItemWithGivenUser($User);
+        $SourceItem->ItemsLinks->setId($TargetItem->id);
+        $SourceItem->ItemsLinks->postAction(Action::Create, array());
+
+        // Move a fresh resource template onto the resource's numeric ID.
+        $ItemsType = $this->getFreshItemType();
+        $req = $this->Db->prepare('UPDATE items_types SET id = :collision_id WHERE id = :template_id');
+        $req->bindValue(':collision_id', $TargetItem->id, PDO::PARAM_INT);
+        $req->bindValue(':template_id', $ItemsType->id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $ItemsType = new ItemsTypes($ItemsType->Users, $TargetItem->id);
+
+        $this->assertNotEmpty($TargetItem->ExperimentsLinks->readRelated());
+        $this->assertNotEmpty($TargetItem->ItemsLinks->readRelated());
+        $this->assertSame(array(), $ItemsType->ExperimentsLinks->readRelated());
+        $this->assertSame(array(), $ItemsType->ItemsLinks->readRelated());
+    }
 }

--- a/tests/unit/models/LinksTest.php
+++ b/tests/unit/models/LinksTest.php
@@ -321,6 +321,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         new Experiments2ExperimentsLinks($Experiments, $targetId)->postAction(Action::Create, array());
     }
 
+    // regression test for links prior to issue #6633
     public function testTemplatesDoNotInheritIncomingLinksFromEntitiesWithSameId(): void
     {
         $User = $this->getRandomUserInTeam(1);
@@ -328,8 +329,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         /**
          * Experiment template and experiment sharing the same ID. Create incoming links to the experiment from:
          * - another experiment;
-         * - a resource.
-         */
+         * - a resource. */
         $TargetExperiment = $this->getFreshExperimentWithGivenUser($User);
         $SourceExperiment = $this->getFreshExperimentWithGivenUser($User);
         $SourceExperiment->ExperimentsLinks->setId($TargetExperiment->id);
@@ -364,7 +364,6 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $SourceItem->ItemsLinks->setId($TargetItem->id);
         $SourceItem->ItemsLinks->postAction(Action::Create, array());
 
-        // Move a fresh resource template onto the resource's numeric ID.
         $ItemsType = $this->getFreshItemType();
         $req = $this->Db->prepare('UPDATE items_types SET id = :collision_id WHERE id = :template_id');
         $req->bindValue(':collision_id', $TargetItem->id, PDO::PARAM_INT);


### PR DESCRIPTION
fix #6633

Ensure templates do not expose incoming links from experiments or resources.

Link resolution is now restricted to supported entity types, while template entities always return an empty list of incoming links.

With previous "less strict" match, _e.g.,_ in `AbstractExperimentsLinks`, every entity that was not an `Experiments` instance automatically used: `'experiments2items'`. That included both `Items`, `Templates` and `ItemsTypes` !
This prevents incorrect link associations when different entity types share the same numeric identifier and adds regression tests covering both experiment and resource templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Templates and item types from showing related inbound links when their IDs overlap with other entity records.
  * Improved related-link resolution by applying stricter rules for supported entity types, avoiding unintended fallbacks.

* **Tests**
  * Added regression coverage to ensure link visibility remains isolated even when numeric IDs collide across different tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->