### PR TITLE
bug/medium: restore save action after cancelled save dialog

### DIFF
--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -38,6 +38,7 @@ function SpreadsheetEditor() {
   const replaceIdRef = useRef(null);
   const replaceNameRef = useRef(null);
   const isDirtyRef = useRef(false);
+  const isSavingRef = useRef(false);
 
   useEffect(() => { replaceIdRef.current = currentUploadId; }, [currentUploadId]);
   useEffect(() => { replaceNameRef.current = replaceName; }, [replaceName]);
@@ -78,7 +79,8 @@ function SpreadsheetEditor() {
   };
 
   const onSaveOrReplace = async () => {
-    if (isSaving) return;
+    if (isSavingRef.current) return;
+    isSavingRef.current = true;
     setIsSaving(true);
     try {
       const aoa = getAOA();
@@ -96,6 +98,7 @@ function SpreadsheetEditor() {
       setUnsavedWarning(false);
     } finally {
       window.parent.postMessage('uploadsDiv', window.location.origin);
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   };
@@ -182,7 +185,7 @@ function SpreadsheetEditor() {
       type: 'icon',
       class: 'ml-2 fas fa-floppy-disk',
       tooltip: i18next.t('save-attachment'),
-      onclick: isSaving ? undefined : onSaveOrReplace,
+      onclick: onSaveOrReplace,
     });
 
     tb.items.push(fullscreenBtn, importBtn, exportBtn, clearBtn );

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -94,6 +94,7 @@ function SpreadsheetEditor() {
         // SAVE MODE
         res = await saveAsAttachment(aoa, entity.type, entity.id);
       }
+      if (!res) return;
       keepResult(res);
       setUnsavedWarning(false);
     } finally {


### PR DESCRIPTION
fix #6487

When cancelling the first save dialog, the save button became unusable because its callback was removed. Fix by using a ref correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate save/replace submissions by blocking concurrent operations when the toolbar save action is clicked repeatedly.
  * Improved save/replace behavior so in-progress actions don’t interfere with result handling and completion updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->