### PR TITLE
bug/medium: tinymce insert template: fix loading templates

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -204,7 +204,6 @@ components:
       schema:
         type: integer
         enum: [0, 1]
-        default: 0
       description: |
         Return all columns of each entry when set to 1.
   # end query parameters for entity

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -197,6 +197,16 @@ components:
           value: "2,3"
       description: |
         Filter results based on their state: 1 (Normal), 2 (Archived), 3 (Deleted). Supports comma separated values.
+
+    Full:
+      name: full
+      in: query
+      schema:
+        type: integer
+        enum: [0, 1]
+        default: 0
+      description: |
+        Return all columns of each entry when set to 1.
   # end query parameters for entity
 
   requestBodies:
@@ -2281,6 +2291,7 @@ x-parameterGroups:
     - $ref: '#/components/parameters/Order'
     - $ref: '#/components/parameters/Sort'
     - $ref: '#/components/parameters/State'
+    - $ref: '#/components/parameters/Full'
 
 security:
   - token:

--- a/documentation/docs/contributing/devdoc.md
+++ b/documentation/docs/contributing/devdoc.md
@@ -256,10 +256,10 @@ Locally: current workaround:
 cd /tmp
 git clone https://github.com/elabftw/elabftw
 cd elabftw
-npm i --no-save --no-lockfile cypress cypress-terminal-report
+npm i --no-save --no-package-lock cypress cypress-terminal-report
+./node_modules/.bin/cypress install
 ./node_modules/.bin/cypress open
 # then once it's fixed
-git checkout -- yarn.lock
 rm -rf node_modules
 ~~~
 

--- a/src/Interfaces/QueryParamsInterface.php
+++ b/src/Interfaces/QueryParamsInterface.php
@@ -40,4 +40,6 @@ interface QueryParamsInterface
     public function getFilterSql(): string;
 
     public function setSkipOrderPinned(bool $value): void;
+
+    public function isFull(): bool;
 }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -378,6 +378,9 @@ abstract class AbstractEntity extends AbstractRest
             $this->processExtendedQuery($displayParams->getUserQuery());
             $extended = true;
         }
+        if ($displayParams->isFull()) {
+            $extended = true;
+        }
 
         $displayFilterSql = $displayParams->getFilterSql();
         $withCompounds = $this->needsCompoundsJoin($displayFilterSql);

--- a/src/Params/BaseQueryParams.php
+++ b/src/Params/BaseQueryParams.php
@@ -39,6 +39,7 @@ class BaseQueryParams implements QueryParamsInterface
         public int $limit = 0,
         public int $offset = 0,
         public array $states = array(State::Normal),
+        public bool $full = false,
     ) {
         if ($query !== null) {
             if ($query->has('limit')) {
@@ -146,5 +147,11 @@ class BaseQueryParams implements QueryParamsInterface
             return '';
         }
         return sprintf(' AND %s.state IN (%s)', $tableName, implode(', ', array_map(fn($state) => $state->value, $states)));
+    }
+
+    #[Override]
+    public function isFull(): bool
+    {
+        return $this->full;
     }
 }

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -150,6 +150,9 @@ final class DisplayParams extends BaseQueryParams
         if (!empty($query->get('extended'))) {
             $this->extendedQuery = trim($query->getString('extended'));
         }
+        if ($query->getInt('full') === 1) {
+            $this->full = true;
+        }
 
         // SCOPE FILTER
         // default scope is the user setting, but can be overridden by query param

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -251,7 +251,8 @@ export function getTinymceBaseConfig(page: string): object {
     // use undocumented callback function to asynchronously get the templates
     // see https://github.com/tinymce/tinymce/issues/5637#issuecomment-624982699
     templates: (callback): void => {
-      ApiC.getJson(templateEndpoint).then(json => {
+      // add full param to get the body
+      ApiC.getJson(`${templateEndpoint}?full=1`).then(json => {
         const res = [];
         json.forEach(tpl => {
           res.push({'title': tpl.title, 'description': '', 'content': tpl.body});

--- a/tests/cypress/integration/tinymceTemplates.cy.ts
+++ b/tests/cypress/integration/tinymceTemplates.cy.ts
@@ -1,0 +1,72 @@
+describe('TinyMCE templates', () => {
+  let templateId: number | null = null;
+
+  const templateTitle = `Cypress TinyMCE template ${Date.now()}`;
+  const templateText = 'Cypress TinyMCE template body inserted';
+  const templateBody = `<p>${templateText}</p>`;
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  afterEach(() => {
+    if (templateId !== null) {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v2/experiments_templates/${templateId}`,
+        failOnStatusCode: false,
+      });
+      templateId = null;
+    }
+  });
+
+  const getIframeBody = (selector: string) => cy
+    .get<HTMLIFrameElement>(selector)
+    .its('0.contentDocument.body')
+    .should('not.be.empty')
+    .then(cy.wrap);
+
+  it('displays and inserts an experiment template from TinyMCE', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/v2/experiments_templates',
+      body: {
+        title: templateTitle,
+        body: templateBody,
+      },
+    }).then(response => {
+      expect(response.status).to.eq(201);
+      cy.extractIdFromLocation(response).then(id => {
+        templateId = id;
+      });
+    });
+
+    cy.intercept('GET', '**/api/v2/experiments_templates*').as('getTemplates');
+
+    cy.createEntity('experiment', 'Cypress TinyMCE template experiment').then(() => {
+      cy.get('.tox-tinymce').should('be.visible');
+      getIframeBody('iframe.tox-edit-area__iframe')
+        .should('not.contain', templateText);
+
+      cy.get('.tox-dialog__footer').contains('.tox-button', 'Insert').click();
+      cy.get('.tox-collection__item').contains('Template').click();
+      cy.wait('@getTemplates');
+
+      cy.get('.tox-dialog').should('be.visible');
+      cy.get('.tox-dialog').find('.tox-listbox').click();
+      cy.get('.tox-collection__item').contains(templateTitle).click();
+
+      getIframeBody('.tox-dialog iframe')
+        .should('contain', templateText);
+
+      cy.get('.tox-dialog').contains('button', 'Insert').click();
+      cy.get('.tox-dialog').should('not.exist');
+
+      getIframeBody('iframe.tox-edit-area__iframe')
+        .should('contain', templateText);
+
+      cy.get('button[title="More options"]').click()
+        .get('button[data-action="destroy"]').click();
+    });
+  });
+});

--- a/tests/cypress/integration/tinymceTemplates.cy.ts
+++ b/tests/cypress/integration/tinymceTemplates.cy.ts
@@ -48,8 +48,8 @@ describe('TinyMCE templates', () => {
       getIframeBody('iframe.tox-edit-area__iframe')
         .should('not.contain', templateText);
 
-      cy.get('.tox-dialog__footer').contains('.tox-button', 'Insert').click();
-      cy.get('.tox-collection__item').contains('Template').click();
+      cy.get('.tox-mbtn__select-label').contains('Insert').click({force: true});
+      cy.get('.tox-collection__item-label').contains('Insert template').click({force: true});
       cy.wait('@getTemplates');
 
       cy.get('.tox-dialog').should('be.visible');
@@ -59,7 +59,7 @@ describe('TinyMCE templates', () => {
       getIframeBody('.tox-dialog iframe')
         .should('contain', templateText);
 
-      cy.get('.tox-dialog').contains('button', 'Insert').click();
+      cy.get('.tox-dialog').contains('button', 'Save').click();
       cy.get('.tox-dialog').should('not.exist');
 
       getIframeBody('iframe.tox-edit-area__iframe')

--- a/tests/unit/Params/DisplayParamsTest.php
+++ b/tests/unit/Params/DisplayParamsTest.php
@@ -23,12 +23,13 @@ class DisplayParamsTest extends \PHPUnit\Framework\TestCase
     public function testParams(): void
     {
         $user = $this->getRandomUserInTeam(1);
-        $params = new DisplayParams($user, EntityType::Experiments, new InputBag(array('scope' => 3, 'tags' => array('Yep'), 'cat' => '1,2,null', 'status' => 1, 'related' => 1, 'fastq' => 'a', 'extended' => 'b')));
+        $params = new DisplayParams($user, EntityType::Experiments, new InputBag(array('scope' => 3, 'tags' => array('Yep'), 'cat' => '1,2,null', 'status' => 1, 'related' => 1, 'fastq' => 'a', 'extended' => 'b', 'full' => '1')));
         $params->setSkipOrderPinned(true);
         $this->assertIsString($params->getSql());
         $this->assertTrue($params->skipOrderPinned);
         $this->assertSame('a', $params->getFastq());
         $this->assertEquals(0, $params->getLimit());
+        $this->assertTrue($params->isFull());
         // another one to get to the owner filter
         $params = new DisplayParams($user, EntityType::Experiments, new InputBag(array('scope' => 1, 'cat' => 'null')), skipOrderPinned: true);
         $this->assertStringContainsString('entity.userid', $params->filterSql);


### PR DESCRIPTION
The API response changed, so add a full=1 param to get extended columns.

* document it in apidoc
* fix devdoc incorrect npm flag and cypress instructions
* add a cypress test for it

fix #7083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `full=1` query option (documented in the OpenAPI spec) to return all columns for supported API results.
  - TinyMCE template selection now loads complete template details.
- **Bug Fixes**
  - Improved TinyMCE template insertion to ensure titles, descriptions, and content are correctly available.
- **Documentation**
  - Updated the local Cypress installation workaround with the latest setup steps.
- **Tests**
  - Added Cypress coverage for creating, selecting, inserting, and removing TinyMCE experiment templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->