### PR TITLE
bump: nginx to 1.30.4

### DIFF
--- a/containers/elabimg/Dockerfile
+++ b/containers/elabimg/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCH=amd64; elif [ "$TARGETPL
 # Note: no need to chain the RUN commands here as it's a builder image and nothing will be kept
 FROM alpine:3.23 AS nginx-builder
 
-ENV NGINX_VERSION=1.30.3
+ENV NGINX_VERSION=1.30.4
 # pin nginx modules versions
 # see https://github.com/google/ngx_brotli/issues/120 for the lack of tags
 # BROKEN HASH: ENV NGX_BROTLI_COMMIT_HASH=63ca02abdcf79c9e788d2eedcc388d2335902e52


### PR DESCRIPTION
    *) Security: heap buffer overflow might occur in a worker process when
       using the map directive with regex matching if the map variable was
       included in a string expression after a capture affected by this map;
       a similar issue might happen when using a non-cacheable variable in a
       string expression (CVE-2026-42533).
       Thanks to Mufeed VH of Winfunc Research and Maxim Dounin.

    *) Security: uninitialized memory access might occur when using unnamed
       regex captures with the "slice" directive or background cache update,
       which could result in worker process memory disclosure or worker
       process termination (CVE-2026-60005).

    *) Security: use-after-free might occur when processing a specially
       crafted proxied backend response with the ngx_http_ssi_filter_module
       (CVE-2026-56434).
       Thanks to P4P3R-HAK.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled nginx version to 1.30.4 for improved maintenance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->