### PR TITLE
doc: remove path from url

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -59,7 +59,6 @@ const config: Config = {
             ...(versioningReady && {
               '5.6': {
                 label: '5.6',
-                path: '5.6',
                 banner: 'none',
               },
             }),


### PR DESCRIPTION
so we don't break existing ones


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated versioned documentation configuration for version 5.6.
  * Preserved the 5.6 label and removed the version banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->