### PR TITLE
feat: add container deletion reason

### DIFF
--- a/src/AuditEvent/ResourceDeleted.php
+++ b/src/AuditEvent/ResourceDeleted.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2024 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\AuditEvent;
+
+use Elabftw\Enums\AuditCategory;
+use Elabftw\Enums\EntityType;
+use Override;
+
+use function array_merge;
+use function json_encode;
+use function sprintf;
+
+final class ResourceDeleted extends AbstractAuditEvent
+{
+    public function __construct(int $requesterUserid, private int $entityId, private EntityType $entityType, private string $reason)
+    {
+        parent::__construct($requesterUserid, 0);
+    }
+
+    #[Override]
+    public function getBody(): string
+    {
+        return sprintf('Resource deleted. Reason: %s', $this->reason);
+    }
+
+    #[Override]
+    public function getJsonBody(): string
+    {
+        $info = array_merge($this->getBaseInfo(), array(
+            'entity_id' => $this->entityId,
+            'entity_type' => $this->entityType->value,
+            'reason' => $this->reason,
+        ));
+        return json_encode($info, JSON_THROW_ON_ERROR);
+    }
+
+    #[Override]
+    public function getCategory(): AuditCategory
+    {
+        return AuditCategory::ResourceDeleted;
+    }
+}

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 216;
+    public const int REQUIRED_SCHEMA = 217;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Enums/AuditCategory.php
+++ b/src/Enums/AuditCategory.php
@@ -33,4 +33,5 @@ enum AuditCategory: int
     case SignatureKeysCreated = 100;
     case SignatureCreated = 101;
     case ActionRequested = 102;
+    case ResourceDeleted = 110;
 }

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -22,7 +22,9 @@ use Elabftw\Enums\BodyContentType;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\FilterableColumn;
 use Elabftw\Enums\AccessType;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Links\Items2ItemsLinks;
+use Elabftw\Params\ContentParams;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Services\Filter;
 use Elabftw\Traits\InsertTagsTrait;
@@ -31,6 +33,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Override;
 
 use function _;
+use function array_filter;
+use function array_intersect;
+use function array_map;
+use function explode;
+use function in_array;
+use function json_decode;
+use function ksort;
+use function trim;
 
 /**
  * All about the database items
@@ -200,8 +210,48 @@ final class Items extends AbstractConcreteEntity
     }
 
     #[Override]
+    public function readOne(): array
+    {
+        parent::readOne();
+        $Teams = new Teams($this->Users, $this->Users->team);
+        $this->entityData['deletion_reason_required'] = !empty($Teams->teamArr['deletion_reason_enabled'])
+            && $this->deletionReasonMatches($Teams);
+        $this->entityData['deletion_reason_options'] = json_decode((string) ($Teams->teamArr['deletion_reason_options'] ?? '[]'), true) ?: array();
+        ksort($this->entityData);
+        return $this->entityData;
+    }
+
+    #[Override]
+    public function destroy(): bool
+    {
+        if (empty($this->entityData)) {
+            $this->readOne();
+        }
+        if ($this->entityData['deletion_reason_required']) {
+            $deletionReason = trim(Request::createFromGlobals()->query->getString('deletion_reason'));
+            if ($deletionReason === '') {
+                throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
+            }
+            new Changelog($this)->create(new ContentParams('deletion_reason', $deletionReason));
+        }
+        return parent::destroy();
+    }
+
+    #[Override]
     protected function getCreatePermissionKey(): string
     {
         return 'users_canwrite_resources';
+    }
+
+    // an item needs a deletion reason if its category or one of its tags is watched by the team
+    private function deletionReasonMatches(Teams $Teams): bool
+    {
+        $categories = json_decode((string) ($Teams->teamArr['deletion_reason_categories'] ?? '[]'), true) ?: array();
+        if (in_array((int) $this->entityData['category'], array_map('intval', $categories), true)) {
+            return true;
+        }
+        $watchedTags = json_decode((string) ($Teams->teamArr['deletion_reason_tags'] ?? '[]'), true) ?: array();
+        $entityTags = array_filter(explode('|', (string) ($this->entityData['tags'] ?? '')));
+        return !empty(array_intersect($watchedTags, $entityTags));
     }
 }

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -178,6 +178,34 @@ final class Items extends AbstractConcreteEntity
     }
 
     #[Override]
+    public function readOne(): array
+    {
+        parent::readOne();
+        $Teams = new Teams($this->Users, $this->Users->team);
+        $this->entityData['deletion_reason_required'] = !empty($Teams->teamArr['deletion_reason_enabled'])
+            && $this->deletionReasonMatches($Teams);
+        $this->entityData['deletion_reason_options'] = json_decode((string) ($Teams->teamArr['deletion_reason_options'] ?? '[]'), true) ?: array();
+        ksort($this->entityData);
+        return $this->entityData;
+    }
+
+    #[Override]
+    public function destroy(): bool
+    {
+        if (empty($this->entityData)) {
+            $this->readOne();
+        }
+        if ($this->entityData['deletion_reason_required']) {
+            $deletionReason = trim(Request::createFromGlobals()->query->getString('deletion_reason'));
+            if ($deletionReason === '') {
+                throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
+            }
+            new Changelog($this)->create(new ContentParams('deletion_reason', $deletionReason));
+        }
+        return parent::destroy();
+    }
+
+    #[Override]
     // get users who booked current item in the 4 surrounding months
     protected function getSurroundingBookers(): array
     {
@@ -207,34 +235,6 @@ final class Items extends AbstractConcreteEntity
         $req->bindValue(':itemid', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->fetchAll();
-    }
-
-    #[Override]
-    public function readOne(): array
-    {
-        parent::readOne();
-        $Teams = new Teams($this->Users, $this->Users->team);
-        $this->entityData['deletion_reason_required'] = !empty($Teams->teamArr['deletion_reason_enabled'])
-            && $this->deletionReasonMatches($Teams);
-        $this->entityData['deletion_reason_options'] = json_decode((string) ($Teams->teamArr['deletion_reason_options'] ?? '[]'), true) ?: array();
-        ksort($this->entityData);
-        return $this->entityData;
-    }
-
-    #[Override]
-    public function destroy(): bool
-    {
-        if (empty($this->entityData)) {
-            $this->readOne();
-        }
-        if ($this->entityData['deletion_reason_required']) {
-            $deletionReason = trim(Request::createFromGlobals()->query->getString('deletion_reason'));
-            if ($deletionReason === '') {
-                throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
-            }
-            new Changelog($this)->create(new ContentParams('deletion_reason', $deletionReason));
-        }
-        return parent::destroy();
     }
 
     #[Override]

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use DateTimeImmutable;
+use Elabftw\AuditEvent\ResourceDeleted;
 use Elabftw\Elabftw\Permissions;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Action;
@@ -181,7 +182,8 @@ final class Items extends AbstractConcreteEntity
     public function readOne(): array
     {
         parent::readOne();
-        $Teams = new Teams($this->Users, $this->Users->team);
+        // resolve the settings from the team that owns the item, not the requester's current team
+        $Teams = new Teams($this->Users, (int) ($this->entityData['team'] ?? $this->Users->team));
         $this->entityData['deletion_reason_required'] = !empty($Teams->teamArr['deletion_reason_enabled'])
             && $this->deletionReasonMatches($Teams);
         $this->entityData['deletion_reason_options'] = json_decode((string) ($Teams->teamArr['deletion_reason_options'] ?? '[]'), true) ?: array();
@@ -195,7 +197,7 @@ final class Items extends AbstractConcreteEntity
         if (empty($this->entityData)) {
             $this->readOne();
         }
-        if ($this->entityData['deletion_reason_required']) {
+        if (!empty($this->entityData['deletion_reason_required'])) {
             // read the reason from the request body so it stays out of the server access logs
             $request = Request::createFromGlobals();
             $payload = json_decode($request->getContent(), true) ?: array();
@@ -204,6 +206,8 @@ final class Items extends AbstractConcreteEntity
                 throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
             }
             new Changelog($this)->create(new ContentParams('deletion_reason', $deletionReason));
+            // also record it in the audit log, which survives even if the item is later purged
+            AuditLogs::create(new ResourceDeleted($this->Users->userData['userid'], $this->id ?? 0, $this->entityType, $deletionReason));
         }
         return parent::destroy();
     }

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -197,6 +197,7 @@ final class Items extends AbstractConcreteEntity
         if (empty($this->entityData)) {
             $this->readOne();
         }
+        $deletionReason = null;
         if (!empty($this->entityData['deletion_reason_required'])) {
             // read the reason from the request body so it stays out of the server access logs
             $request = Request::createFromGlobals();
@@ -205,11 +206,15 @@ final class Items extends AbstractConcreteEntity
             if ($deletionReason === '') {
                 throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
             }
+        }
+        $destroyed = parent::destroy();
+        // only write the deletion logs once the item was actually destroyed
+        if ($destroyed && $deletionReason !== null) {
             new Changelog($this)->create(new ContentParams('deletion_reason', $deletionReason));
             // also record it in the audit log, which survives even if the item is later purged
             AuditLogs::create(new ResourceDeleted($this->Users->userData['userid'], $this->id ?? 0, $this->entityType, $deletionReason));
         }
-        return parent::destroy();
+        return $destroyed;
     }
 
     #[Override]

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -196,7 +196,10 @@ final class Items extends AbstractConcreteEntity
             $this->readOne();
         }
         if ($this->entityData['deletion_reason_required']) {
-            $deletionReason = trim(Request::createFromGlobals()->query->getString('deletion_reason'));
+            // read the reason from the request body so it stays out of the server access logs
+            $request = Request::createFromGlobals();
+            $payload = json_decode($request->getContent(), true) ?: array();
+            $deletionReason = trim((string) ($payload['deletion_reason'] ?? $request->request->get('deletion_reason', '')));
             if ($deletionReason === '') {
                 throw new ImproperActionException(_('A reason must be provided to delete this resource.'));
             }

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -254,7 +254,7 @@ final class Items extends AbstractConcreteEntity
     private function deletionReasonMatches(Teams $Teams): bool
     {
         $categories = json_decode((string) ($Teams->teamArr['deletion_reason_categories'] ?? '[]'), true) ?: array();
-        if (in_array((int) $this->entityData['category'], array_map('intval', $categories), true)) {
+        if (in_array((int) ($this->entityData['category'] ?? 0), array_map('intval', $categories), true)) {
             return true;
         }
         $watchedTags = json_decode((string) ($Teams->teamArr['deletion_reason_tags'] ?? '[]'), true) ?: array();

--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -35,6 +35,7 @@ use function array_intersect;
 use function array_map;
 use function implode;
 use function is_array;
+use function json_encode;
 
 /**
  * All about the teams
@@ -42,6 +43,15 @@ use function is_array;
 final class Teams extends AbstractRest
 {
     use SetIdTrait;
+
+    // default reasons offered to users when deleting an HTA regulated resource
+    public const array DEFAULT_DELETION_REASONS = array(
+        'Consent withdrawn',
+        'Retention period expired',
+        'Transferred to another establishment',
+        'Used in research',
+        'Disposed per SOP',
+    );
 
     public array $teamArr = array();
 
@@ -341,9 +351,10 @@ final class Teams extends AbstractRest
     {
         $name = Filter::title($name);
 
-        $sql = 'INSERT INTO teams (name) VALUES (:name)';
+        $sql = 'INSERT INTO teams (name, deletion_reason_options) VALUES (:name, :deletion_reason_options)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':name', $name);
+        $req->bindValue(':deletion_reason_options', json_encode(self::DEFAULT_DELETION_REASONS, JSON_THROW_ON_ERROR));
         $this->Db->execute($req);
         // grab the team ID
         $newId = $this->Db->lastInsertId();

--- a/src/Params/TeamParam.php
+++ b/src/Params/TeamParam.php
@@ -16,9 +16,12 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Services\Filter;
 use Override;
 
+use function array_is_list;
 use function is_array;
+use function is_scalar;
 use function json_decode;
 use function json_encode;
+use function trim;
 
 final class TeamParam extends ContentParams
 {
@@ -47,8 +50,8 @@ final class TeamParam extends ContentParams
             'onboarding_email_active' => $this->getBinary(),
             'newcomer_threshold' => $this->asInt(),
             'deletion_reason_options',
-            'deletion_reason_categories',
-            'deletion_reason_tags' => $this->getJsonArrayContent(),
+            'deletion_reason_tags' => $this->getStringListContent(),
+            'deletion_reason_categories' => $this->getIntListContent(),
             default => throw new ImproperActionException('Incorrect parameter for team.' . $this->target),
         };
     }
@@ -61,15 +64,47 @@ final class TeamParam extends ContentParams
         return Filter::body(parent::getContent());
     }
 
-    private function getJsonArrayContent(): ?string
+    private function decodeFlatList(): array
+    {
+        $decoded = json_decode((string) $this->content, true);
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new ImproperActionException('Incorrect value: a flat JSON list is expected.');
+        }
+        return $decoded;
+    }
+
+    // a list of trimmed, non-empty strings (deletion reasons, watched tags)
+    private function getStringListContent(): ?string
     {
         if (empty($this->content)) {
             return null;
         }
-        $decoded = json_decode((string) $this->content, true);
-        if (!is_array($decoded)) {
-            throw new ImproperActionException('Incorrect value: a JSON array is expected.');
+        $list = array();
+        foreach ($this->decodeFlatList() as $element) {
+            if (!is_scalar($element)) {
+                throw new ImproperActionException('Incorrect value: only text entries are allowed.');
+            }
+            $trimmed = trim((string) $element);
+            if ($trimmed !== '') {
+                $list[] = $trimmed;
+            }
         }
-        return json_encode($decoded, JSON_THROW_ON_ERROR);
+        return json_encode($list, JSON_THROW_ON_ERROR);
+    }
+
+    // a list of integer ids (watched categories)
+    private function getIntListContent(): ?string
+    {
+        if (empty($this->content)) {
+            return null;
+        }
+        $list = array();
+        foreach ($this->decodeFlatList() as $element) {
+            if (!is_scalar($element)) {
+                throw new ImproperActionException('Incorrect value: only numeric ids are allowed.');
+            }
+            $list[] = (int) $element;
+        }
+        return json_encode($list, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Params/TeamParam.php
+++ b/src/Params/TeamParam.php
@@ -16,6 +16,10 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Services\Filter;
 use Override;
 
+use function is_array;
+use function json_decode;
+use function json_encode;
+
 final class TeamParam extends ContentParams
 {
     #[Override]
@@ -39,8 +43,12 @@ final class TeamParam extends ContentParams
             'users_canwrite_resources_templates',
             'visible',
             'newcomer_banner_active',
+            'deletion_reason_enabled',
             'onboarding_email_active' => $this->getBinary(),
             'newcomer_threshold' => $this->asInt(),
+            'deletion_reason_options',
+            'deletion_reason_categories',
+            'deletion_reason_tags' => $this->getJsonArrayContent(),
             default => throw new ImproperActionException('Incorrect parameter for team.' . $this->target),
         };
     }
@@ -51,5 +59,17 @@ final class TeamParam extends ContentParams
             return null;
         }
         return Filter::body(parent::getContent());
+    }
+
+    private function getJsonArrayContent(): ?string
+    {
+        if (empty($this->content)) {
+            return null;
+        }
+        $decoded = json_decode((string) $this->content, true);
+        if (!is_array($decoded)) {
+            throw new ImproperActionException('Incorrect value: a JSON array is expected.');
+        }
+        return json_encode($decoded, JSON_THROW_ON_ERROR);
     }
 }

--- a/src/sql/schema217-down.sql
+++ b/src/sql/schema217-down.sql
@@ -1,0 +1,8 @@
+-- revert schema 217
+ALTER TABLE `teams`
+  DROP COLUMN `deletion_reason_enabled`,
+  DROP COLUMN `deletion_reason_options`,
+  DROP COLUMN `deletion_reason_categories`,
+  DROP COLUMN `deletion_reason_tags`;
+
+UPDATE config SET conf_value = 216 WHERE conf_name = 'schema';

--- a/src/sql/schema217.sql
+++ b/src/sql/schema217.sql
@@ -1,0 +1,9 @@
+-- schema 217
+-- Add team settings to force a reason when deleting a resource (HTA compliance)
+ALTER TABLE `teams`
+  ADD COLUMN `deletion_reason_enabled` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  ADD COLUMN `deletion_reason_options` TEXT NULL DEFAULT NULL,
+  ADD COLUMN `deletion_reason_categories` TEXT NULL DEFAULT NULL,
+  ADD COLUMN `deletion_reason_tags` TEXT NULL DEFAULT NULL;
+
+UPDATE `teams` SET `deletion_reason_options` = '["Consent withdrawn","Retention period expired","Transferred to another establishment","Used in research","Disposed per SOP"]' WHERE `deletion_reason_options` IS NULL;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1210,6 +1210,10 @@ CREATE TABLE `teams` (
   `newcomer_threshold` INT UNSIGNED NOT NULL DEFAULT 15,
   `newcomer_banner` TEXT NULL DEFAULT NULL,
   `newcomer_banner_active` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `deletion_reason_enabled` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `deletion_reason_options` TEXT NULL DEFAULT NULL,
+  `deletion_reason_categories` TEXT NULL DEFAULT NULL,
+  `deletion_reason_tags` TEXT NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -130,8 +130,7 @@
       'help': 'Users will have to pick a reason before they can delete a resource whose category or tag is watched below.'|trans} %}
 
     <label for='deletionReasonOptions' class='col-form-label'>{{ 'Reasons offered to users (one per line)'|trans }}</label>
-    <textarea class='form-control' id='deletionReasonOptions' rows='4'>{% for reason in App.Teams.teamArr.deletion_reason_options|default('[]')|jsonDecode %}{{ reason }}{% if not loop.last %}
-{% endif %}{% endfor %}</textarea>
+    <textarea class='form-control' id='deletionReasonOptions' rows='4'>{{ App.Teams.teamArr.deletion_reason_options|default('[]')|jsonDecode|join("\n") }}</textarea>
     <hr>
 
     <label for='deletionReasonCategories' class='col-form-label'>{{ 'Watched resource categories'|trans }}</label>

--- a/src/templates/admin.html
+++ b/src/templates/admin.html
@@ -120,6 +120,40 @@
 
   </div>
 
+  <h2 class='p-2 pl-3 section-title'>{{ 'Deletion reason (HTA compliance)'|trans }}</h2>
+  <div class='pl-3 mt-2'>
+    {% set catsSelected = App.Teams.teamArr.deletion_reason_categories|default('[]')|jsonDecode %}
+    {% set tagsSelected = App.Teams.teamArr.deletion_reason_tags|default('[]')|jsonDecode %}
+    {% include 'binary-setting.html' with {'model': model, 'src': src,
+      'slug': 'deletion_reason_enabled',
+      'label': 'Force a reason when deleting a watched resource'|trans,
+      'help': 'Users will have to pick a reason before they can delete a resource whose category or tag is watched below.'|trans} %}
+
+    <label for='deletionReasonOptions' class='col-form-label'>{{ 'Reasons offered to users (one per line)'|trans }}</label>
+    <textarea class='form-control' id='deletionReasonOptions' rows='4'>{% for reason in App.Teams.teamArr.deletion_reason_options|default('[]')|jsonDecode %}{{ reason }}{% if not loop.last %}
+{% endif %}{% endfor %}</textarea>
+    <hr>
+
+    <label for='deletionReasonCategories' class='col-form-label'>{{ 'Watched resource categories'|trans }}</label>
+    <select class='form-control' id='deletionReasonCategories' multiple autocomplete='off'>
+      {% for itemsType in App.itemsCategoryArr %}
+        <option value='{{ itemsType.id }}' {{ itemsType.id in catsSelected ? 'selected' }}>{{ itemsType.title }}</option>
+      {% endfor %}
+    </select>
+    <hr>
+
+    <label for='deletionReasonTags' class='col-form-label'>{{ 'Watched tags'|trans }}</label>
+    <select class='form-control' id='deletionReasonTags' multiple autocomplete='off'>
+      {% for tag in tagsArr %}
+        <option value='{{ tag.tag }}' {{ tag.tag in tagsSelected ? 'selected' }}>{{ tag.tag }}</option>
+      {% endfor %}
+    </select>
+
+    <div class='mt-2 text-center'>
+      <button type='button' data-action='save-deletion-reason-settings' class='btn btn-primary'>{{ 'Save'|trans }}</button>
+    </div>
+  </div>
+
   <h2 class='p-2 pl-3 section-title' id='existingRors'>{{ 'Research Organization Registry (ROR)'|trans }}</h2>
 
   <div class='mb-2' data-svelte-component='rors' data-endpoint='teams/current/rors'></div>

--- a/src/templates/deletion-reason-modal.html
+++ b/src/templates/deletion-reason-modal.html
@@ -1,0 +1,29 @@
+{# reason for deletion modal (HTA compliance). Set an "options" array and optionally a "confirmAction". #}
+{% set confirmAction = confirmAction|default('destroy-with-reason') %}
+<div class='modal fade' id='deletionReasonModal' tabindex='-1' role='dialog' aria-labelledby='deletionReasonModalLabel'>
+  <div class='modal-dialog' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='deletionReasonModalLabel'>{{ 'Reason for deletion'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body'>
+        <label class='col-form-label' for='deletionReasonSelect'>{{ 'A reason is required to delete this resource.'|trans }}</label>
+        <select id='deletionReasonSelect' class='form-control' required autocomplete='off'>
+          <option value='' disabled selected>{{ 'Select a reason'|trans }}</option>
+          {% for reason in options %}
+            <option value='{{ reason }}'>{{ reason }}</option>
+          {% endfor %}
+          <option value='_other'>{{ 'Other'|trans }}</option>
+        </select>
+        <input type='text' id='deletionReasonOther' class='form-control mt-2 d-none' placeholder='{{ 'Specify reason'|trans }}' aria-label='{{ 'Specify reason'|trans }}'>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-transparent' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
+        <button type='button' data-action='{{ confirmAction }}' class='btn btn-danger'>{{ 'Delete'|trans }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -13,6 +13,9 @@
   {% include 'search-help-modal.html' %}
   {% include 'show-view-edit.html' %}
   {% include 'request-actions-show.html' %}
+  {% if Entity.entityType.value == 'items' and App.Teams.teamArr.deletion_reason_enabled %}
+    {% include 'deletion-reason-modal.html' with {'options': App.Teams.teamArr.deletion_reason_options|default('[]')|jsonDecode, 'confirmAction': 'destroy-selected-with-reason'} %}
+  {% endif %}
 
   <hr>
 

--- a/src/templates/view-edit-toolbar.html
+++ b/src/templates/view-edit-toolbar.html
@@ -34,6 +34,9 @@
   </div>
 </div>
 {% include 'duplicate-modal.html' %}
+{% if Entity.entityData.deletion_reason_required %}
+  {% include 'deletion-reason-modal.html' with {'options': Entity.entityData.deletion_reason_options} %}
+{% endif %}
 {# Modal for timestamping #}
 <div class='modal fade' id='timestampModal' tabindex='-1' role='dialog' aria-labelledby='timestampModalLabel'>
   <div class='modal-dialog' role='document'>
@@ -341,7 +344,11 @@
           {# DELETE / RESTORE #}
           {% if Entity.entityData.state == enum('Elabftw\\Enums\\State').Normal.value %}
             <div class='dropdown-divider'></div>
-            <button type='button' class='dropdown-item hover-danger' data-action='destroy'><i class='fas fa-trash-alt fa-fw' title='{{ 'Delete'|trans }}'></i> {{ 'Delete'|trans }}</button>
+            {% if Entity.entityData.deletion_reason_required %}
+              <button type='button' class='dropdown-item hover-danger' data-action='toggle-modal' data-target='deletionReasonModal'><i class='fas fa-trash-alt fa-fw' title='{{ 'Delete'|trans }}'></i> {{ 'Delete'|trans }}</button>
+            {% else %}
+              <button type='button' class='dropdown-item hover-danger' data-action='destroy'><i class='fas fa-trash-alt fa-fw' title='{{ 'Delete'|trans }}'></i> {{ 'Delete'|trans }}</button>
+            {% endif %}
           {% elseif Entity.entityData.state == enum('Elabftw\\Enums\\State').Deleted.value %}
             <div class='dropdown-divider'></div>
             <button type='button' class='dropdown-item hover-danger' data-action='restore'><i class='fas fa-trash-can-arrow-up fa-fw' title='{{ 'Restore entry'|trans }}'></i> {{ 'Restore entry'|trans }}</button>

--- a/src/ts/Apiv2.class.ts
+++ b/src/ts/Apiv2.class.ts
@@ -108,7 +108,7 @@ export class Api {
       keepalive: this.keepalive,
     };
 
-    if ([Method.POST, Method.PATCH].includes(method)) {
+    if ([Method.POST, Method.PATCH, Method.DELETE].includes(method)) {
       options.body = isFormData ? params : JSON.stringify(params);
     }
 

--- a/src/ts/admin.ts
+++ b/src/ts/admin.ts
@@ -174,6 +174,20 @@ if (window.location.pathname === '/admin.php') {
     });
   });
 
+  on('save-deletion-reason-settings', () => {
+    const options = (document.getElementById('deletionReasonOptions') as HTMLTextAreaElement).value
+      .split('\n').map(line => line.trim()).filter(line => line !== '');
+    const categories = Array.from((document.getElementById('deletionReasonCategories') as HTMLSelectElement).selectedOptions)
+      .map(opt => parseInt(opt.value, 10));
+    const tags = Array.from((document.getElementById('deletionReasonTags') as HTMLSelectElement).selectedOptions)
+      .map(opt => opt.value);
+    ApiC.patch(`${Model.Team}/current`, {
+      deletion_reason_options: JSON.stringify(options),
+      deletion_reason_categories: JSON.stringify(categories),
+      deletion_reason_tags: JSON.stringify(tags),
+    });
+  });
+
   on('open-onboarding-email-modal', () => {
     // reload the modal in case the users of the team have changed
     reloadElements(['sendOnboardingEmailModal'])

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -1038,6 +1038,7 @@ document.addEventListener('DOMContentLoaded', () => {
       );
       Promise.all(deletes).then(() => {
         notify.success();
+      }).finally(() => {
         reloadEntitiesShow();
       });
     }

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -1034,7 +1034,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       $('#deletionReasonModal').modal('hide');
       const deletes = checked.map(chk =>
-        ApiC.delete(`${entity.type}/${chk}?deletion_reason=${encodeURIComponent(reason)}`, { notifOnSaved: 0 }),
+        ApiC.delete(`${entity.type}/${chk}`, { deletion_reason: reason, notifOnSaved: 0 }),
       );
       Promise.all(deletes).then(() => {
         notify.success();

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -770,6 +770,8 @@ document.addEventListener('DOMContentLoaded', () => {
         id: checked.join('+'),
       });
       window.location.href = `make.php?${params.toString()}`;
+    } else if (el.matches('#deletionReasonSelect')) {
+      document.getElementById('deletionReasonOther').classList.toggle('d-none', el.value !== '_other');
     }
   });
 
@@ -985,6 +987,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const action = <Action>el.dataset.what;
       // special case: DELETE request for confirmation & deletes div
       if (action === Action.Destroy) {
+        // HTA compliance: when the team requires it, collect one reason for the whole batch first
+        const reasonModal = document.getElementById('deletionReasonModal');
+        if (reasonModal) {
+          $(reasonModal).modal('show');
+          return;
+        }
         if (!confirm(i18next.t('generic-delete-warning'))) {
           return;
         }
@@ -1003,6 +1011,32 @@ document.addEventListener('DOMContentLoaded', () => {
         ApiC.patch(`${entity.type}/${chk}`, { notifOnSaved: 0, action }),
       );
       Promise.all(results).then(() => {
+        notify.success();
+        reloadEntitiesShow();
+      });
+    } else if (el.matches('[data-action="destroy-selected-with-reason"]')) {
+      const checked = get(selectedEntities);
+      if (checked.length === 0) {
+        notify.error('nothing-selected');
+        return;
+      }
+      const reasonSelect = document.getElementById('deletionReasonSelect') as HTMLSelectElement;
+      if (!reasonSelect) {
+        return;
+      }
+      let reason = reasonSelect.value;
+      if (reason === '_other') {
+        reason = (document.getElementById('deletionReasonOther') as HTMLInputElement).value.trim();
+      }
+      if (!reason) {
+        notify.error('invalid-info');
+        return;
+      }
+      $('#deletionReasonModal').modal('hide');
+      const deletes = checked.map(chk =>
+        ApiC.delete(`${entity.type}/${chk}?deletion_reason=${encodeURIComponent(reason)}`, { notifOnSaved: 0 }),
+      );
+      Promise.all(deletes).then(() => {
         notify.success();
         reloadEntitiesShow();
       });

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -176,7 +176,7 @@ if (document.getElementById('topToolbar')) {
       return;
     }
     const path = window.location.pathname;
-    ApiC.delete(`${entity.type}/${entity.id}?deletion_reason=${encodeURIComponent(reason)}`).then(
+    ApiC.delete(`${entity.type}/${entity.id}`, { deletion_reason: reason }).then(
       () => window.location.replace(path.split('/').pop()));
   });
 

--- a/src/ts/toolbar.ts
+++ b/src/ts/toolbar.ts
@@ -155,6 +155,31 @@ if (document.getElementById('topToolbar')) {
     }
   });
 
+  // deletion with a mandatory reason (HTA compliance), reason is sent as a query parameter
+  const reasonSelect = document.getElementById('deletionReasonSelect') as HTMLSelectElement;
+  if (reasonSelect) {
+    reasonSelect.addEventListener('change', () => {
+      document.getElementById('deletionReasonOther').classList.toggle('d-none', reasonSelect.value !== '_other');
+    });
+  }
+
+  on('destroy-with-reason', () => {
+    if (!reasonSelect) {
+      return;
+    }
+    let reason = reasonSelect.value;
+    if (reason === '_other') {
+      reason = (document.getElementById('deletionReasonOther') as HTMLInputElement).value.trim();
+    }
+    if (!reason) {
+      notify.error('invalid-info');
+      return;
+    }
+    const path = window.location.pathname;
+    ApiC.delete(`${entity.type}/${entity.id}?deletion_reason=${encodeURIComponent(reason)}`).then(
+      () => window.location.replace(path.split('/').pop()));
+  });
+
   on(Action.CreateProcurementRequest, () => {
     const input = (document.getElementById('procurementRequestQtyInput') as HTMLInputElement);
     const qty = parseInt(input.value, 10);

--- a/tests/unit/Params/TeamParamTest.php
+++ b/tests/unit/Params/TeamParamTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2025 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Params;
+
+use Elabftw\Exceptions\ImproperActionException;
+
+class TeamParamTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDeletionReasonOptionsAreTrimmedStrings(): void
+    {
+        $params = new TeamParam('deletion_reason_options', '["  Consent withdrawn  ", "", "Used in research"]');
+        $this->assertSame('["Consent withdrawn","Used in research"]', $params->getContent());
+    }
+
+    public function testDeletionReasonOptionsRejectNestedArrays(): void
+    {
+        $params = new TeamParam('deletion_reason_options', '["ok", ["nested"]]');
+        $this->expectException(ImproperActionException::class);
+        $params->getContent();
+    }
+
+    public function testDeletionReasonOptionsRejectNonList(): void
+    {
+        $params = new TeamParam('deletion_reason_options', '{"a": "b"}');
+        $this->expectException(ImproperActionException::class);
+        $params->getContent();
+    }
+
+    public function testDeletionReasonCategoriesAreCastToInts(): void
+    {
+        $params = new TeamParam('deletion_reason_categories', '["3", 5]');
+        $this->assertSame('[3,5]', $params->getContent());
+    }
+
+    public function testEmptyDeletionReasonListIsNull(): void
+    {
+        $params = new TeamParam('deletion_reason_tags', '');
+        $this->assertNull($params->getContent());
+    }
+}

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -47,7 +47,7 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $Teams->update(new TeamParam('deletion_reason_enabled', '0'));
         $Teams->update(new TeamParam('deletion_reason_categories', '[]'));
         $Teams->update(new TeamParam('deletion_reason_tags', '[]'));
-        unset($_GET['deletion_reason']);
+        unset($_POST['deletion_reason']);
     }
 
     public function testCreateAndDestroy(): void
@@ -65,7 +65,7 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $new = $this->Items->create(category: $categoryId);
         $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
         $Teams->update(new TeamParam('deletion_reason_categories', json_encode(array($categoryId))));
-        unset($_GET['deletion_reason']);
+        unset($_POST['deletion_reason']);
         $Item = new Items($this->Items->Users, $new);
         $this->expectException(ImproperActionException::class);
         $Item->destroy();
@@ -78,7 +78,7 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $new = $this->Items->create(category: $categoryId);
         $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
         $Teams->update(new TeamParam('deletion_reason_categories', json_encode(array($categoryId))));
-        $_GET['deletion_reason'] = 'Sample destroyed per HTA schedule';
+        $_POST['deletion_reason'] = 'Sample destroyed per HTA schedule';
         $Item = new Items($this->Items->Users, $new);
         $this->assertTrue($Item->destroy());
         $changelog = new Changelog($Item)->readAll();
@@ -97,7 +97,7 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $new = $this->Items->create(category: $categoryId);
         $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
         $Teams->update(new TeamParam('deletion_reason_categories', '[]'));
-        unset($_GET['deletion_reason']);
+        unset($_POST['deletion_reason']);
         $Item = new Items($this->Items->Users, $new);
         $this->assertTrue($Item->destroy());
     }

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -28,6 +28,7 @@ use function date;
 use function array_column;
 use function json_decode;
 use function json_encode;
+use function str_contains;
 
 class ItemsTest extends \PHPUnit\Framework\TestCase
 {
@@ -88,6 +89,14 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
                 $this->assertSame('Sample destroyed per HTA schedule', $change['content']);
             }
         }
+        // the reason is also written to the audit log so it survives an item purge
+        $audited = false;
+        foreach (AuditLogs::read() as $log) {
+            if (str_contains((string) $log['body'], 'Sample destroyed per HTA schedule')) {
+                $audited = true;
+            }
+        }
+        $this->assertTrue($audited);
     }
 
     public function testUnwatchedItemDeletesWithoutReason(): void

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -41,12 +41,65 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $this->Items = $this->getFreshItemWithGivenUser($admin);
     }
 
+    protected function tearDown(): void
+    {
+        $Teams = new Teams($this->Items->Users, 1);
+        $Teams->update(new TeamParam('deletion_reason_enabled', '0'));
+        $Teams->update(new TeamParam('deletion_reason_categories', '[]'));
+        $Teams->update(new TeamParam('deletion_reason_tags', '[]'));
+        unset($_GET['deletion_reason']);
+    }
+
     public function testCreateAndDestroy(): void
     {
         $new = $this->Items->create();
         $this->assertTrue((bool) Check::id($new));
         $this->Items->setId($new);
         $this->Items->destroy();
+    }
+
+    public function testCannotDeleteWatchedItemWithoutReason(): void
+    {
+        $Teams = new Teams($this->Items->Users, 1);
+        $categoryId = new ResourcesCategories($Teams)->create('HTA regulated');
+        $new = $this->Items->create(category: $categoryId);
+        $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
+        $Teams->update(new TeamParam('deletion_reason_categories', json_encode(array($categoryId))));
+        unset($_GET['deletion_reason']);
+        $Item = new Items($this->Items->Users, $new);
+        $this->expectException(ImproperActionException::class);
+        $Item->destroy();
+    }
+
+    public function testDeleteWatchedItemWithReasonIsRecorded(): void
+    {
+        $Teams = new Teams($this->Items->Users, 1);
+        $categoryId = new ResourcesCategories($Teams)->create('HTA regulated');
+        $new = $this->Items->create(category: $categoryId);
+        $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
+        $Teams->update(new TeamParam('deletion_reason_categories', json_encode(array($categoryId))));
+        $_GET['deletion_reason'] = 'Sample destroyed per HTA schedule';
+        $Item = new Items($this->Items->Users, $new);
+        $this->assertTrue($Item->destroy());
+        $changelog = new Changelog($Item)->readAll();
+        $this->assertContains('deletion_reason', array_column($changelog, 'target'));
+        foreach ($changelog as $change) {
+            if ($change['target'] === 'deletion_reason') {
+                $this->assertSame('Sample destroyed per HTA schedule', $change['content']);
+            }
+        }
+    }
+
+    public function testUnwatchedItemDeletesWithoutReason(): void
+    {
+        $Teams = new Teams($this->Items->Users, 1);
+        $categoryId = new ResourcesCategories($Teams)->create('Not regulated');
+        $new = $this->Items->create(category: $categoryId);
+        $Teams->update(new TeamParam('deletion_reason_enabled', '1'));
+        $Teams->update(new TeamParam('deletion_reason_categories', '[]'));
+        unset($_GET['deletion_reason']);
+        $Item = new Items($this->Items->Users, $new);
+        $this->assertTrue($Item->destroy());
     }
 
     public function testCreateFromTemplate(): void


### PR DESCRIPTION
# Require a reason when deleting a regulated resource container/item

## Pull Request Checklist

- [x] I have added tests for any new features. → `tests/unit/Models/ItemsTest.php` gains three cases covering the server-side enforcement (refused without a reason, recorded when given, unwatched items unaffected).
- [x] I have mentioned the related issue (if applicable). → No related issue; part of an ongoing series of contributions hardening item/container handling for HTA compliance.
- [x] I have updated or verified the relevant documentation. → No behavioural docs reference the delete flow; the new admin controls carry inline help text.

## Pull Request Description

Under the Human Tissue Authority (HTA) regime, every individual container of human tissue must be traceable through its whole lifecycle, and its eventual destruction has to be recorded with a documented reason — an unexplained deletion breaks that chain of custody. This PR covers the destruction-reason requirement and is necessary for compliance.

When a resource is in scope, deleting it now requires the user to pick a reason from an admin-configured dropdown (or choose **Other** and type one), and that reason is written to the resource's changelog before it is removed. Enforcement is server-side, so it also covers deletions made through the API, not just the web UI.

The whole feature is per-team and off by default. An admin turns it on and chooses which resources it applies to by **category or tag** — so a team can watch, say, the "Human tissue container" category without forcing a reason on every other resource. When enabled, the reason list is seeded with sensible HTA defaults (Consent withdrawn, Retention period expired, Transferred to another establishment, Used in research, Disposed per SOP) that the admin can freely edit.

This patch:

- adds four per-team settings behind schema 217: a `deletion_reason_enabled` toggle, and `deletion_reason_options` / `deletion_reason_categories` / `deletion_reason_tags` (JSON lists);
- enforces the requirement in `Items::destroy()`: if the resource's category or one of its tags is watched, a non-empty reason must be supplied or the deletion is refused with an `ImproperActionException`;
- records the reason via the existing changelog system (`target = 'deletion_reason'`), so it surfaces automatically on the resource's changelog page and in PDF exports — no new audit table;
- exposes `deletion_reason_required` and `deletion_reason_options` on the resource in `readOne()`, so the UI knows when to prompt and with which options;
- replaces the native confirm with a reason modal on the single-resource delete, and prompts once for one reason applied to the whole batch on the multi-select delete;
- seeds the default reason list for new teams (`Teams::create()`) and for existing teams (a migration `UPDATE`), leaving the admin free to trim or extend it;
- scopes enforcement to resources (items) only — experiments are untouched.

## Changes

- Added four columns to `teams`: `deletion_reason_enabled` (`TINYINT`) plus `deletion_reason_options`, `deletion_reason_categories` and `deletion_reason_tags` (`TEXT`, JSON), behind schema 217. Existing teams are seeded with the default reason list by the migration.
- Server-side validation in `TeamParam`: the toggle is treated as binary, and the three list columns are validated as JSON arrays (rejecting anything that is not an array).
- `Items::destroy()` computes scope from the owning team's settings — an item is in scope when a watched category matches **or** a watched tag matches — and blocks deletion of an in-scope item unless a reason is provided, recording it to the changelog first.
- The reason is sent as a `deletion_reason` query parameter on the `DELETE` request, so no interface signature or controller routing had to change.
- Admin panel: a "Deletion reason (HTA compliance)" section with the enable toggle, a reasons textarea (one per line), and watched-category / watched-tag multi-selects, saved via the existing `teams/current` PATCH mechanism.
- A shared `deletion-reason-modal.html` partial, reused by both the single-resource toolbar and the resources list, parametrised by its option list and confirm action.
- Seeded defaults via a new `Teams::DEFAULT_DELETION_REASONS` constant so new and existing teams start from a usable list.

## Files changed

- `src/sql/structure.sql` — the four new `teams` columns.
- `src/sql/schema217.sql` *(new)* — migration adding the columns and seeding existing teams with the default reasons.
- `src/sql/schema217-down.sql` *(new)* — reverts the columns and the schema bump.
- `src/Elabftw/SchemaVersionChecker.php` — `REQUIRED_SCHEMA` 216 → 217.
- `src/Params/TeamParam.php` — `deletion_reason_enabled` (binary) and the three JSON-array cases with a `getJsonArrayContent()` helper.
- `src/Models/Teams.php` — `DEFAULT_DELETION_REASONS` constant; `create()` seeds `deletion_reason_options` for new teams.
- `src/Models/Items.php` — `destroy()` enforcement, `readOne()` exposes `deletion_reason_required` / `deletion_reason_options`, and a private `deletionReasonMatches()` (category-or-tag scope).
- `src/templates/deletion-reason-modal.html` *(new)* — the shared reason modal.
- `src/templates/view-edit-toolbar.html` — conditional delete button + modal include for a watched single resource.
- `src/templates/show.html` — modal include on the resources list when the team has the feature enabled.
- `src/templates/admin.html` — the "Deletion reason (HTA compliance)" settings section.
- `src/ts/toolbar.ts` — single-resource reason modal handling and reason-carrying delete.
- `src/ts/show.ts` — multi-select delete opens the modal and applies one reason to the batch.
- `src/ts/admin.ts` — collects the reasons/categories/tags and saves them via `teams/current`.
- `tests/unit/Models/ItemsTest.php` — three new cases plus a `tearDown` that resets the team settings.

## Testing

- `tests/unit/Models/ItemsTest.php` — `testCannotDeleteWatchedItemWithoutReason` (in-scope delete with no reason throws `ImproperActionException`), `testDeleteWatchedItemWithReasonIsRecorded` (reason is stored as a `deletion_reason` changelog entry), and `testUnwatchedItemDeletesWithoutReason` (out-of-scope resources delete freely). Not executed in my environment (I couldn't get the CI stuff working).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable deletion reasons for teams (options, watched categories, and tags) with default values for new teams.
  * Introduced “reason for deletion” prompts for deletions that match watched rules, including an “Other” flow.
  * Deletion reasons are recorded in changelogs and audit logs.
* **Bug Fixes**
  * DELETE requests now correctly transmit provided data.
* **Chores**
  * Updated schema to support deletion-reason settings and advanced schema version.
* **Tests**
  * Added/extended unit tests covering required/optional deletion-reason behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->