### PR TITLE
feat/minor: allow ctrl+click on Windows and  ⌘ Command on macOS

### DIFF
--- a/src/ts/entities-table.jsx
+++ b/src/ts/entities-table.jsx
@@ -291,6 +291,7 @@ const EntitiesTable = ({
 
   const cellClicked = event => {
     const target = event.event?.target;
+    const url = `?mode=view&id=${encodeURIComponent(event.data.id)}`;
 
     if (
       target instanceof HTMLElement
@@ -298,8 +299,11 @@ const EntitiesTable = ({
     ) {
       return;
     }
-
-    window.location = `?mode=view&id=${encodeURIComponent(event.data.id)}`;
+    if (event.event.ctrlKey || event.event.metaKey) {
+        window.open(url, '_blank');
+        return;
+    }
+    window.location = url;
   };
 
   return (

--- a/src/ts/entities-table.jsx
+++ b/src/ts/entities-table.jsx
@@ -299,9 +299,9 @@ const EntitiesTable = ({
     ) {
       return;
     }
-    if (event.event.ctrlKey || event.event.metaKey) {
-        window.open(url, '_blank');
-        return;
+    if (event.event?.ctrlKey || event.event?.metaKey) {
+      window.open(url, '_blank');
+      return;
     }
     window.location = url;
   };


### PR DESCRIPTION
#7093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening an entity’s details in a new browser tab using Ctrl-click or Meta-click.
* **Bug Fixes**
  * Preserved standard navigation for regular clicks while continuing to ignore clicks on interactive controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->