### PR TITLE
bug/minor: api: fix teamgroups spec

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -5805,11 +5805,17 @@ paths:
             application/json:
               schema:
                 type: object
-                properties:
+                additionalProperties:
+                  $ref: '#/components/schemas/teamgroup'
+                example:
                   "1":
-                    $ref: '#/components/schemas/teamgroup'
+                    id: 1
+                    name: Super secret project
+                    users: [ ]
                   "2":
-                    $ref: '#/components/schemas/teamgroup'
+                    id: 2
+                    name: Advanced microscopy users
+                    users: [ ]
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -5800,13 +5800,16 @@ paths:
       operationId: read-team-teamgroups
       responses:
         '200':
-          description: A list of teamgroups for the team.
+          description: Teamgroups for the team, keyed by teamgroup ID.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/teamgroup'
+                type: object
+                properties:
+                  "1":
+                    $ref: '#/components/schemas/teamgroup'
+                  "2":
+                    $ref: '#/components/schemas/teamgroup'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':


### PR DESCRIPTION
fix #6945 teamgroups spec for GET

<img width="377" height="601" alt="image" src="https://github.com/user-attachments/assets/eac3ddb4-bec7-4ef8-82b7-1190acc2f644" />

<img width="336" height="475" alt="image" src="https://github.com/user-attachments/assets/274c78e8-722f-4d3d-98e2-fb862ea6f656" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Changes**
  - Updated the `GET /teams/{id}/teamgroups` `200` response format.
  - Team groups are now returned as an object keyed by team group ID, rather than a list/array.
  - Updated the API documentation and examples to match the new keyed response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->