### PR TITLE
bug/medium: fix experiments timestamp

### DIFF
--- a/src/Commands/ExperimentsTimestamp.php
+++ b/src/Commands/ExperimentsTimestamp.php
@@ -66,10 +66,12 @@ final class ExperimentsTimestamp extends Command
         }
         $Db = Db::getConnection();
         $sql = sprintf('SELECT id FROM experiments
-            WHERE timestamped_at IS NULL
+            WHERE (
+                timestamped_at IS NULL
                OR (
                    modified_at > :m
                    AND ABS(TIMESTAMPDIFF(SECOND, timestamped_at, modified_at)) > %d
+                   )
                  )', self::TOLERANCE);
         $teams = $input->getOption('teams');
         if ($teams) {


### PR DESCRIPTION
fix #6926

take into account the filters. Wrap the timestamp selection conditions in parentheses so the team filter applies to both branches of the WHERE clause. Previously the sql operator precedence caused `team IN (...)` to only be applied to the "modified after timestamp" condition, while experiments with `timestamped_at IS NULL` were always selected regardless of the requested team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected experiment selection conditions during timestamp processing to ensure filtering is applied consistently.
  * Preserved existing timestamp tolerance and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->