### PR TITLE
bug/minor: fix navbar tinymce

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -214,6 +214,8 @@ export function getTinymceBaseConfig(page: string): object {
   const templateEndpoint = (entity.type === EntityType.Experiment || entity.type === EntityType.Template)
     ? EntityType.Template
     : EntityType.ItemType;
+  const navbarHeight = document.querySelector<HTMLElement>('div > .navbar')?.offsetHeight ?? 0;
+  const stickyToolbarHeight = document.querySelector<HTMLElement>('.sticky-toolbar')?.offsetHeight ?? 0;
 
   return {
     selector: '.mceditable',
@@ -523,7 +525,7 @@ export function getTinymceBaseConfig(page: string): object {
       },
     ],
     toolbar_sticky: true,
-    toolbar_sticky_offset: document.querySelector<HTMLElement>('.sticky-toolbar')?.offsetHeight ?? 0,
+    toolbar_sticky_offset: navbarHeight + stickyToolbarHeight,
     // render MathJax for TinyMCE preview
     init_instance_callback: (editor) => {
       editor.on('ExecCommand', (e) => {


### PR DESCRIPTION
fix: #7079



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of the TinyMCE sticky toolbar by accounting for both the top navigation bar and existing sticky toolbar height.
  * Helps keep the editor toolbar correctly aligned when scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->