### PR TITLE
bug/minor: elabctl: remove dumps from mysql container after backup

### DIFF
--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -422,7 +422,7 @@ function mysql-backup
     # dump sql
     docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
     # copy it from the container to the host
-    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile"
+    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME} rm dump.sql"
     # compress it to the max
     gzip -f --best "$dumpfile"
     # delete old dumps


### PR DESCRIPTION
see #7121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary MySQL backup files are now removed from the database container after being copied, preventing unnecessary file buildup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->