### PR TITLE
bug/minor: branding: use correct logo on 2fa page

### DIFF
--- a/src/templates/mfa.html
+++ b/src/templates/mfa.html
@@ -2,10 +2,15 @@
 
 {% block body %}
 
-<section class='text-center my-4'>
-  <img src='/assets/images/logo.png' alt='elabftw' title='elabftw' class='col-md-3' />
+<div class='text-center'>
+  <div class='logo logo-light'>
+     <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Light').value }}?format=binary' alt='eLabFTW'>
+  </div>
+  <div class='logo logo-dark'>
+     <img src='/api/v2/instance/branding/{{ constant('Elabftw\\Enums\\Branding::Dark').value }}?format=binary' alt='eLabFTW'>
+  </div>
   <h1 class='mt-4'><i class='mr-2 fas fa-mobile-screen'></i>{{ 'Two Factor Authentication'|trans }}</h1>
-</section>
+</div>
 
 <form method='post' action='app/controllers/LoginController.php' autocomplete='off'>
   <input type='hidden' name='auth_type' value='mfa'>


### PR DESCRIPTION
fix #7128



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the MFA page header branding to support separate light and dark theme logos.
  * Preserved the “Two Factor Authentication” title while refreshing its surrounding layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->