### PR TITLE
feat: add logging for all container link changes

### DIFF
--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -154,23 +154,27 @@ abstract class AbstractContainersLinks extends AbstractLinks
         if (isset($params['storage_id'])) {
             $this->moveToStorage((int) $params['storage_id']);
         }
-        // resolved lazily below (post-move, so it reflects the final location) only when we log
-        $storagePath = null;
-        if (array_key_exists('qty_stored', $params) && $params['qty_stored'] !== null && $params['qty_stored'] !== '') {
+        $qtyGiven = array_key_exists('qty_stored', $params) && $params['qty_stored'] !== null && $params['qty_stored'] !== '';
+        $unitGiven = array_key_exists('qty_unit', $params) && $params['qty_unit'] !== null && $params['qty_unit'] !== '';
+        if ($qtyGiven) {
             $this->update('qty_stored', $params['qty_stored']);
-            // skip logging a same-value patch
-            if ((float) $params['qty_stored'] !== (float) $before['qty_stored']) {
-                $storagePath ??= $this->getStoragePath((int) $this->readOne()['storage_id']);
+        }
+        if ($unitGiven) {
+            $this->update('qty_unit', $params['qty_unit']);
+        }
+
+        // log only real changes; resolve the (post-move) path once, and only when we log
+        $qtyChanged = $qtyGiven && (float) $params['qty_stored'] !== (float) $before['qty_stored'];
+        $unitChanged = $unitGiven && (string) $params['qty_unit'] !== (string) $before['qty_unit'];
+        if ($qtyChanged || $unitChanged) {
+            $storagePath = $this->getStoragePath((int) $this->readOne()['storage_id']);
+            if ($qtyChanged) {
                 new Changelog($this->Entity)->create(new ContentParams(
                     'container_qty_changed',
                     sprintf('Quantity changed from "%s" to "%s" at "%s"', number_format((float) $before['qty_stored'], 2), number_format((float) $params['qty_stored'], 2), $storagePath),
                 ));
             }
-        }
-        if (array_key_exists('qty_unit', $params) && $params['qty_unit'] !== null && $params['qty_unit'] !== '') {
-            $this->update('qty_unit', $params['qty_unit']);
-            if ((string) $params['qty_unit'] !== (string) $before['qty_unit']) {
-                $storagePath ??= $this->getStoragePath((int) $this->readOne()['storage_id']);
+            if ($unitChanged) {
                 new Changelog($this->Entity)->create(new ContentParams(
                     'container_unit_changed',
                     sprintf('Unit changed from "%s" to "%s" at "%s"', $before['qty_unit'], $params['qty_unit'], $storagePath),
@@ -305,7 +309,7 @@ abstract class AbstractContainersLinks extends AbstractLinks
             new Changelog($this->Entity)->create(new ContentParams(
                 'container_created',
                 // at creation $this->id is the storage_id
-                sprintf('Added container with %s %s at "%s"', number_format($qty, 2), $unit, $this->getStoragePath($this->id)),
+                sprintf('Added container with %s %s at "%s"', number_format((float) $qty, 2), $unit, $this->getStoragePath($this->id)),
             ));
         }
 

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -33,6 +33,7 @@ use PDO;
 use function array_key_exists;
 use function intval;
 use function json_encode;
+use function number_format;
 use function sprintf;
 
 /**
@@ -148,14 +149,32 @@ abstract class AbstractContainersLinks extends AbstractLinks
     public function patch(Action $action, array $params): array
     {
         $this->Entity->canOrExplode(AccessType::Write);
+        $before = $this->readOne();
         if (isset($params['storage_id'])) {
             $this->moveToStorage((int) $params['storage_id']);
         }
+        // resolved lazily below (post-move, so it reflects the final location) only when we log
+        $storagePath = null;
         if (array_key_exists('qty_stored', $params) && $params['qty_stored'] !== null && $params['qty_stored'] !== '') {
             $this->update('qty_stored', $params['qty_stored']);
+            // skip logging a same-value patch
+            if ((float) $params['qty_stored'] !== (float) $before['qty_stored']) {
+                $storagePath ??= $this->getStoragePath((int) $this->readOne()['storage_id']);
+                new Changelog($this->Entity)->create(new ContentParams(
+                    'container_qty_changed',
+                    sprintf('Quantity changed from "%s" to "%s" at "%s"', number_format((float) $before['qty_stored'], 2), number_format((float) $params['qty_stored'], 2), $storagePath),
+                ));
+            }
         }
         if (array_key_exists('qty_unit', $params) && $params['qty_unit'] !== null && $params['qty_unit'] !== '') {
             $this->update('qty_unit', $params['qty_unit']);
+            if ((string) $params['qty_unit'] !== (string) $before['qty_unit']) {
+                $storagePath ??= $this->getStoragePath((int) $this->readOne()['storage_id']);
+                new Changelog($this->Entity)->create(new ContentParams(
+                    'container_unit_changed',
+                    sprintf('Unit changed from "%s" to "%s" at "%s"', $before['qty_unit'], $params['qty_unit'], $storagePath),
+                ));
+            }
         }
         return $this->readOne();
     }
@@ -206,11 +225,24 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $this->Entity->canOrExplode(AccessType::Write);
         $this->Entity->touch();
 
+        // read details for the changelog before the row is deleted
+        $current = $this->readOne();
+        $storagePath = $this->getStoragePath((int) $current['storage_id']);
+
         $sql = 'DELETE FROM ' . $this->getTable() . ' WHERE id = :id AND item_id = :item_id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
-        return $this->Db->execute($req);
+        $result = $this->Db->execute($req);
+
+        if ($req->rowCount() > 0) {
+            new Changelog($this->Entity)->create(new ContentParams(
+                'container_deleted',
+                sprintf('Removed container with %s %s from "%s"', $current['qty_stored'], $current['qty_unit'], $storagePath),
+            ));
+        }
+
+        return $result;
     }
 
     public function destroyAll(): bool
@@ -260,6 +292,15 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $req->bindParam(':qty_unit', $unit);
 
         $this->Db->execute($req);
+
+        // INSERT IGNORE inserts nothing on a FK violation; only log a real insert
+        if ($req->rowCount() > 0) {
+            new Changelog($this->Entity)->create(new ContentParams(
+                'container_created',
+                // at creation $this->id is the storage_id
+                sprintf('Added container with %s %s at "%s"', number_format($qty, 2), $unit, $this->getStoragePath($this->id)),
+            ));
+        }
 
         return $this->id;
     }
@@ -327,10 +368,8 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $Destination->canWriteOrExplode();
         $destinationData = $Destination->readOne();
 
-        // resolve old full_path for the changelog (do not require edit rights here)
-        $Old = new StorageUnits($this->Entity->Users, false);
-        $Old->setId($oldStorageId);
-        $oldPath = $Old->readOne()['full_path'] ?? '';
+        // resolve old full_path for the changelog
+        $oldPath = $this->getStoragePath($oldStorageId);
 
         $this->update('storage_id', $newStorageId);
         $this->Entity->touch();
@@ -339,6 +378,14 @@ abstract class AbstractContainersLinks extends AbstractLinks
             'container_moved',
             sprintf('From "%s" to "%s"', $oldPath, $destinationData['full_path'] ?? ''),
         ));
+    }
+
+    // full_path for changelog messages; read-only, so no edit rights required
+    private function getStoragePath(int $storageId): string
+    {
+        $Storage = new StorageUnits($this->Entity->Users, false);
+        $Storage->setId($storageId);
+        return $Storage->readOne()['full_path'] ?? '';
     }
 
     /**

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -19,6 +19,7 @@ use Elabftw\Enums\AccessType;
 use Elabftw\Enums\State;
 use Elabftw\Enums\Units;
 use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\Changelog;
 use Elabftw\Models\Config;
@@ -226,8 +227,14 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $this->Entity->touch();
 
         // read details for the changelog before the row is deleted
-        $current = $this->readOne();
-        $storagePath = $this->getStoragePath((int) $current['storage_id']);
+        $current = null;
+        $storagePath = '';
+        try {
+            $current = $this->readOne();
+            $storagePath = $this->getStoragePath((int) $current['storage_id']);
+        } catch (ResourceNotFoundException) {
+            // already gone: still run the DELETE (idempotent), just skip the changelog
+        }
 
         $sql = 'DELETE FROM ' . $this->getTable() . ' WHERE id = :id AND item_id = :item_id';
         $req = $this->Db->prepare($sql);
@@ -235,7 +242,7 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
         $result = $this->Db->execute($req);
 
-        if ($req->rowCount() > 0) {
+        if ($current !== null && $req->rowCount() > 0) {
             new Changelog($this->Entity)->create(new ContentParams(
                 'container_deleted',
                 sprintf('Removed container with %s %s from "%s"', $current['qty_stored'], $current['qty_unit'], $storagePath),

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -163,25 +163,43 @@ abstract class AbstractContainersLinks extends AbstractLinks
             $this->update('qty_unit', $params['qty_unit']);
         }
 
-        // log only real changes; resolve the (post-move) path once, and only when we log
-        $qtyChanged = $qtyGiven && (float) $params['qty_stored'] !== (float) $before['qty_stored'];
-        $unitChanged = $unitGiven && (string) $params['qty_unit'] !== (string) $before['qty_unit'];
+        // Compare persisted values after database normalization, such as DECIMAL rounding.
+        $after = $this->readOne();
+        $beforeQty = number_format((float) $before['qty_stored'], 2, '.', '');
+        $afterQty = number_format((float) $after['qty_stored'], 2, '.', '');
+        $qtyChanged = $qtyGiven && $afterQty !== $beforeQty;
+        $unitChanged = $unitGiven
+            && (string) $after['qty_unit'] !== (string) $before['qty_unit'];
+
         if ($qtyChanged || $unitChanged) {
-            $storagePath = $this->getStoragePath((int) $this->readOne()['storage_id']);
+            $containerId = (int) $after['id'];
+            $storagePath = $this->getStoragePath((int) $after['storage_id']);
             if ($qtyChanged) {
                 new Changelog($this->Entity)->create(new ContentParams(
                     'container_qty_changed',
-                    sprintf('Quantity changed from "%s" to "%s" at "%s"', number_format((float) $before['qty_stored'], 2), number_format((float) $params['qty_stored'], 2), $storagePath),
+                    sprintf(
+                        'Quantity changed from "%s" to "%s" at "%s" (container #%d)',
+                        $beforeQty,
+                        $afterQty,
+                        $storagePath,
+                        $containerId,
+                    ),
                 ));
             }
             if ($unitChanged) {
                 new Changelog($this->Entity)->create(new ContentParams(
                     'container_unit_changed',
-                    sprintf('Unit changed from "%s" to "%s" at "%s"', $before['qty_unit'], $params['qty_unit'], $storagePath),
+                    sprintf(
+                        'Unit changed from "%s" to "%s" at "%s" (container #%d)',
+                        $before['qty_unit'],
+                        $after['qty_unit'],
+                        $storagePath,
+                        $containerId,
+                    ),
                 ));
             }
         }
-        return $this->readOne();
+        return $after;
     }
 
     #[Override]
@@ -249,7 +267,13 @@ abstract class AbstractContainersLinks extends AbstractLinks
         if ($current !== null && $req->rowCount() > 0) {
             new Changelog($this->Entity)->create(new ContentParams(
                 'container_deleted',
-                sprintf('Removed container with %s %s from "%s"', $current['qty_stored'], $current['qty_unit'], $storagePath),
+                sprintf(
+                    'Removed container with %s %s from "%s" (container #%d)',
+                    $current['qty_stored'],
+                    $current['qty_unit'],
+                    $storagePath,
+                    (int) $current['id'],
+                ),
             ));
         }
 
@@ -306,10 +330,16 @@ abstract class AbstractContainersLinks extends AbstractLinks
 
         // INSERT IGNORE inserts nothing on a FK violation; only log a real insert
         if ($req->rowCount() > 0) {
+            $containerId = $this->Db->lastInsertId();
             new Changelog($this->Entity)->create(new ContentParams(
                 'container_created',
-                // at creation $this->id is the storage_id
-                sprintf('Added container with %s %s at "%s"', number_format((float) $qty, 2), $unit, $this->getStoragePath($this->id)),
+                sprintf(
+                    'Added container with %s %s at "%s" (container #%d)',
+                    number_format((float) $qty, 2, '.', ''),
+                    $unit,
+                    $this->getStoragePath($this->id),
+                    $containerId,
+                ),
             ));
         }
 
@@ -387,7 +417,12 @@ abstract class AbstractContainersLinks extends AbstractLinks
 
         new Changelog($this->Entity)->create(new ContentParams(
             'container_moved',
-            sprintf('From "%s" to "%s"', $oldPath, $destinationData['full_path'] ?? ''),
+            sprintf(
+                'From "%s" to "%s" (container #%d)',
+                $oldPath,
+                $destinationData['full_path'] ?? '',
+                $this->id ?? -1,
+            ),
         ));
     }
 

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -152,6 +152,92 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2.0, $this->readContainerQty('containers2items', $rowB));
     }
 
+    public function testCreateLogsToChangelog(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for create changelog test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(5.0, 'mL');
+
+        $entry = $this->latestChangelogEntry($Item, 'container_created');
+        $this->assertNotNull($entry);
+        $this->assertStringContainsString('Added container with 5.00 mL', $entry['content']);
+    }
+
+    public function testQtyChangeLogsToChangelog(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for qty changelog test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(10.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $Links->patch(Action::Update, array('qty_stored' => 3.0));
+
+        $entry = $this->latestChangelogEntry($Item, 'container_qty_changed');
+        $this->assertNotNull($entry);
+        $this->assertStringContainsString('from "10.00" to "3.00"', $entry['content']);
+    }
+
+    public function testUnitChangeLogsToChangelog(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for unit changelog test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(10.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $Links->patch(Action::Update, array('qty_unit' => 'g'));
+
+        $entry = $this->latestChangelogEntry($Item, 'container_unit_changed');
+        $this->assertNotNull($entry);
+        $this->assertStringContainsString('from "mL" to "g"', $entry['content']);
+    }
+
+    public function testDeleteLogsToChangelog(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for delete changelog test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(7.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $Links->destroy();
+
+        $entry = $this->latestChangelogEntry($Item, 'container_deleted');
+        $this->assertNotNull($entry);
+        $this->assertStringContainsString('Removed container', $entry['content']);
+    }
+
+    public function testNoOpQtyDoesNotLog(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for no-op qty test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(10.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        // patching to identical values must not create qty/unit changelog entries
+        $Links->patch(Action::Update, array('qty_stored' => 10.0, 'qty_unit' => 'mL'));
+
+        $this->assertNull($this->latestChangelogEntry($Item, 'container_qty_changed'));
+        $this->assertNull($this->latestChangelogEntry($Item, 'container_unit_changed'));
+    }
+
+    private function latestChangelogEntry(Items $entity, string $target): ?array
+    {
+        foreach (new Changelog($entity)->readAll() as $row) {
+            if ($row['target'] === $target) {
+                return $row;
+            }
+        }
+        return null;
+    }
+
     private function latestContainerRowId(string $table, int $itemId): int
     {
         $Db = \Elabftw\Elabftw\Db::getConnection();

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -212,6 +212,15 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('Removed container', $entry['content']);
     }
 
+    public function testDeleteMissingRowIsTolerated(): void
+    {
+        $Item = $this->getFreshItem();
+        // no container row for this id: destroy must not throw and must not log
+        $Links = new Containers2ItemsLinks($Item, PHP_INT_MAX);
+        $this->assertTrue($Links->destroy());
+        $this->assertNull($this->latestChangelogEntry($Item, 'container_deleted'));
+    }
+
     public function testNoOpQtyDoesNotLog(): void
     {
         $Item = $this->getFreshItem();

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -21,6 +21,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use PDO;
 
+use function sprintf;
+
 class ContainersLinksTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;
@@ -45,6 +47,10 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $Links = new Containers2ItemsLinks($Item, $rowId);
         $result = $Links->patch(Action::Update, array('storage_id' => $boxB));
         $this->assertEquals($boxB, (int) $result['storage_id']);
+
+        $entry = $this->latestChangelogEntry($Item, 'container_moved');
+        $this->assertNotNull($entry);
+        $this->assertStringContainsString(sprintf('(container #%d)', $rowId), $entry['content']);
 
         // moving to the same destination is a no-op (no exception)
         $result = $Links->patch(Action::Update, array('storage_id' => $boxB));
@@ -158,10 +164,12 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $box = $this->StorageUnits->create('Box for create changelog test');
         $Links = new Containers2ItemsLinks($Item, $box);
         $Links->createWithQuantity(5.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
 
         $entry = $this->latestChangelogEntry($Item, 'container_created');
         $this->assertNotNull($entry);
         $this->assertStringContainsString('Added container with 5.00 mL', $entry['content']);
+        $this->assertStringContainsString(sprintf('(container #%d)', $rowId), $entry['content']);
     }
 
     public function testQtyChangeLogsToChangelog(): void
@@ -178,6 +186,7 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $entry = $this->latestChangelogEntry($Item, 'container_qty_changed');
         $this->assertNotNull($entry);
         $this->assertStringContainsString('from "10.00" to "3.00"', $entry['content']);
+        $this->assertStringContainsString(sprintf('(container #%d)', $rowId), $entry['content']);
     }
 
     public function testUnitChangeLogsToChangelog(): void
@@ -194,6 +203,7 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $entry = $this->latestChangelogEntry($Item, 'container_unit_changed');
         $this->assertNotNull($entry);
         $this->assertStringContainsString('from "mL" to "g"', $entry['content']);
+        $this->assertStringContainsString(sprintf('(container #%d)', $rowId), $entry['content']);
     }
 
     public function testDeleteLogsToChangelog(): void
@@ -210,6 +220,7 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $entry = $this->latestChangelogEntry($Item, 'container_deleted');
         $this->assertNotNull($entry);
         $this->assertStringContainsString('Removed container', $entry['content']);
+        $this->assertStringContainsString(sprintf('(container #%d)', $rowId), $entry['content']);
     }
 
     public function testDeleteMissingRowIsTolerated(): void
@@ -235,6 +246,21 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNull($this->latestChangelogEntry($Item, 'container_qty_changed'));
         $this->assertNull($this->latestChangelogEntry($Item, 'container_unit_changed'));
+    }
+
+    public function testDatabaseRoundedQtyDoesNotLogChange(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for rounded qty test');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(1.23, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $result = $Links->patch(Action::Update, array('qty_stored' => 1.231));
+
+        $this->assertEquals(1.23, (float) $result['qty_stored']);
+        $this->assertNull($this->latestChangelogEntry($Item, 'container_qty_changed'));
     }
 
     private function latestChangelogEntry(Items $entity, string $target): ?array


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [ ] I have mentioned the related **issue** (if applicable).
- [x] I have updated or verified the relevant documentation (in documentation directory)
---

### Pull Request Description

In #6806 we added logging to the parent item whenever any container was moved from one location to another. This is to ensure we have a thorough audit trail for containers, as we do for other types of item in elabftw.

However, this left a gap in container logging for the other types of change: creation, changes of quantity/unit, and deletion, record of each of which was not recorded.

This PR extends the changelog of #6806 to cover those changes.

It's a first step in developing discussion from #7123 as well

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container link history for creation, quantity and unit updates, storage moves, and deletions.
  - Quantity details are formatted clearly and recorded only when values actually change.
  - No-op updates no longer create unnecessary history entries, including database-rounded quantities.
  - Missing records can be deleted safely, with history recorded only after successful removal.
  - Storage details now reflect the container’s destination after a move.

- **Tests**
  - Added coverage for creation, updates, deletion, no-op changes, missing records, and storage moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->