### PR TITLE
documentation: add sbom doc

### DIFF
--- a/documentation/docs/usage/traceability-and-auditability.md
+++ b/documentation/docs/usage/traceability-and-auditability.md
@@ -244,3 +244,11 @@ An Audit Log recording sensitive actions in an immutable manner is available on 
 - SignatureKeysCreated
 - SignatureCreated
 - ActionRequested
+
+## Software Bill of Materials (SBOM)
+
+A SBOM in SPDX format is produced for each release. It can be fetched like this:
+
+~~~bash
+ docker buildx imagetools inspect docker.io/elabftw/elabimg:5.6.10 --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > elabftw-5.6.10-amd64.spdx.json
+~~~


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on accessing the SPDX-format Software Bill of Materials (SBOM) generated for each release.
  * Included a command example for extracting an SBOM from a release image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->