### PR TITLE
bump: elabctl version

### DIFF
--- a/containers/elabctl/CHANGELOG.md
+++ b/containers/elabctl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for elabctl
 
+## Version 5.1.1
+
+* Remove raw dump from mysql container with `mysql-backup` command (#7122)
+
 ## Version 5.0.4
 
 * Fix an issue where `elabctl update` could fail if no _healthcheck_ was configured for MySQL container. Fix #38 via #39.

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # https://www.elabftw.net
-# https://github.com/elabftw/elabctl/
+# https://github.com/elabftw/elabftw
 # © 2022 Nicolas CARPi @ Deltablot
 # License: GPLv3
-declare -r ELABCTL_VERSION='5.1.0'
+declare -r ELABCTL_VERSION='5.1.1'
 
 # default backup dir
 declare BACKUP_DIR='/var/backups/elabftw'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the elabctl version to 5.1.1.
  * The MySQL backup command no longer includes a raw database dump.
* **Documentation**
  * Added release notes documenting the 5.1.1 changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->