### PR TITLE
elabimg: dockerfile: don't try and create /var/lib/elabftw folders at

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ containers/elabtmp
 containers/mysqltmp
 containers/README.md
 CONTRIBUTING.md
+documentation/
 FUNDING.yml
 GOVERNANCE.md
 ideas

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -331,7 +331,7 @@ phpConf() {
 }
 
 elabftwConf() {
-    mkdir -p /var/lib/elabftw/uploads /run/elabftw/cache/elab /run/elabftw/tmp /run/elabftw/cache/mpdf /run/elabftw/cache/twig /run/elabftw/cache/purifier/CSS /run/elabftw/cache/purifier/HTML /run/elabftw/cache/purifier/URI /var/lib/elabftw/exports
+    mkdir -p /run/elabftw/cache/elab /run/elabftw/tmp /run/elabftw/cache/mpdf /run/elabftw/cache/twig /run/elabftw/cache/purifier/CSS /run/elabftw/cache/purifier/HTML /run/elabftw/cache/purifier/URI
     # necessary so php user can write to it in podman rootless
     chmod -R g+w /run/elabftw/cache
 }

--- a/documentation/docs/install/upgrade/update.md
+++ b/documentation/docs/install/upgrade/update.md
@@ -7,7 +7,7 @@ title: Upgrade your instance
 
 
 :::warning
-Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../install/backups).
+Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../../install/backups).
 :::
 
 :::note
@@ -21,7 +21,7 @@ Make sure to figure out what version you are running and **read the release note
 The current running version can be seen in the bottom right of every page.
 
 :::warning
-Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../install/backups).
+Be sure to read the [release notes](https://github.com/elabftw/elabftw/releases/latest), they might contain important information. And have a [backup](../../install/backups).
 :::
 
 ## STEP 1: Specify which version you want

--- a/documentation/docs/usage/sysadmin-guide.md
+++ b/documentation/docs/usage/sysadmin-guide.md
@@ -152,7 +152,7 @@ It is important to keep your install up to date with the latest bug fixes and ne
 
 Subscribe to [the newsletter](http://eepurl.com/bTjcMj) to be warned when a new release is out or select "Releases only" from GitHub's Watch button on the [repo page](https://github.com/elabftw/elabftw).
 
-See instructions on updating eLabFTW on [upgrade page](../install/update).
+See instructions on updating eLabFTW on [upgrade page](../install/upgrade/update).
 
 ## Sysadmin Panel
 


### PR DESCRIPTION
runtime



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined container setup by limiting the Docker build context to required files.
  * Improved container startup initialization by adjusting which cache-related directories are created and ensuring permissions remain consistent.
* **Documentation**
  * Fixed upgrade-page link paths in the upgrade guide and the sysadmin guide to point to the correct backups and upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->