### PR TITLE
bug/minor: category/status: fix issue where deleted public category

### DIFF
--- a/src/Models/AbstractStatus.php
+++ b/src/Models/AbstractStatus.php
@@ -112,11 +112,12 @@ abstract class AbstractStatus extends AbstractCategory
                 CASE WHEN entity.team = :team THEN 1 ELSE 0 END AS is_current_team
              FROM %s AS entity
              INNER JOIN teams ON teams.id = entity.team
-             WHERE entity.is_private = 0 OR entity.team = :team',
+             WHERE (entity.is_private = 0 OR entity.team = :team)',
             $this->table
         );
 
         $queryParams ??= $this->getQueryParams();
+        $sql .= $queryParams->getStatesSql('entity');
         $sql .= $queryParams->getSql();
 
         $req = $this->Db->prepare($sql);


### PR DESCRIPTION
would still appear. That was because the state was not handled. Add proper state handling in the query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status filtering so results consistently reflect the applicable states.
  * Preserved correct team and privacy filtering when retrieving statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->