### PR TITLE
bug/medium: entities reload

### DIFF
--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -236,6 +236,24 @@
 
     return normalized.toString();
   }
+  
+  function reloadEntityList(): void {
+    reloadVersion += 1;
+  }
+  
+  onMount(() => {
+    nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
+    
+    window.addEventListener('popstate', bumpUrlVersion);
+    window.addEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
+    window.addEventListener('entity-list-reload', reloadEntityList);
+    
+    return () => {
+      window.removeEventListener('popstate', bumpUrlVersion);
+      window.removeEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
+      window.removeEventListener('entity-list-reload', reloadEntityList);
+    };
+  });
 
   function bumpReloadVersionIfFiltersChanged(): void {
     const nextSignature = getCurrentNonSearchFilterSignature();

--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -241,18 +241,6 @@
     reloadVersion += 1;
   }
   
-  onMount(() => {
-    nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
-    window.addEventListener('popstate', bumpUrlVersion);
-    window.addEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
-    window.addEventListener('entity-list-reload', reloadEntityList);
-    return () => {
-      window.removeEventListener('popstate', bumpUrlVersion);
-      window.removeEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
-      window.removeEventListener('entity-list-reload', reloadEntityList);
-    };
-  });
-  
   function bumpReloadVersionIfFiltersChanged(): void {
     nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
     reloadVersion += 1;
@@ -576,13 +564,13 @@
 
   onMount(() => {
     nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
-
     window.addEventListener('popstate', bumpUrlVersion);
     window.addEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
-
+    window.addEventListener('entity-list-reload', reloadEntityList);
     return () => {
       window.removeEventListener('popstate', bumpUrlVersion);
       window.removeEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
+      window.removeEventListener('entity-list-reload', reloadEntityList);
     };
   });
 </script>

--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -243,11 +243,9 @@
   
   onMount(() => {
     nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
-    
     window.addEventListener('popstate', bumpUrlVersion);
     window.addEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);
     window.addEventListener('entity-list-reload', reloadEntityList);
-    
     return () => {
       window.removeEventListener('popstate', bumpUrlVersion);
       window.removeEventListener('entity-filters-changed', bumpReloadVersionIfFiltersChanged);

--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -254,15 +254,9 @@
       window.removeEventListener('entity-list-reload', reloadEntityList);
     };
   });
-
+  
   function bumpReloadVersionIfFiltersChanged(): void {
-    const nextSignature = getCurrentNonSearchFilterSignature();
-
-    if (nextSignature === nonSearchFilterSignature) {
-      return;
-    }
-
-    nonSearchFilterSignature = nextSignature;
+    nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
     reloadVersion += 1;
   }
 

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -406,18 +406,27 @@ export function getCheckedBoxes(): Array<CheckableItem> {
   return checkedBoxes;
 }
 
-// reload the entities in show mode
-export async function reloadEntitiesShow(): Promise<void | Response> {
-  window.dispatchEvent(new CustomEvent('entity-filters-changed'));
-  // ask mathjax to reparse the page
+// // reload the entities in show mode
+// export async function reloadEntitiesShow(): Promise<void | Response> {
+//   window.dispatchEvent(new CustomEvent('entity-filters-changed'));
+//   // ask mathjax to reparse the page
+//   MathJax.typeset();
+//   // rebind autocomplete for links input
+//   addAutocompleteToLinkInputs();
+//   // tags too
+//   addAutocompleteToTagInputs();
+//   // listen to data-trigger elements
+//   listenTrigger();
+//   // and set relative moments
+//   relativeMoment();
+// }
+
+export function reloadEntitiesShow(): void {
+  window.dispatchEvent(new CustomEvent('entity-list-reload'));
   MathJax.typeset();
-  // rebind autocomplete for links input
   addAutocompleteToLinkInputs();
-  // tags too
   addAutocompleteToTagInputs();
-  // listen to data-trigger elements
   listenTrigger();
-  // and set relative moments
   relativeMoment();
 }
 

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -406,27 +406,18 @@ export function getCheckedBoxes(): Array<CheckableItem> {
   return checkedBoxes;
 }
 
-// // reload the entities in show mode
-// export async function reloadEntitiesShow(): Promise<void | Response> {
-//   window.dispatchEvent(new CustomEvent('entity-filters-changed'));
-//   // ask mathjax to reparse the page
-//   MathJax.typeset();
-//   // rebind autocomplete for links input
-//   addAutocompleteToLinkInputs();
-//   // tags too
-//   addAutocompleteToTagInputs();
-//   // listen to data-trigger elements
-//   listenTrigger();
-//   // and set relative moments
-//   relativeMoment();
-// }
-
-export function reloadEntitiesShow(): void {
-  window.dispatchEvent(new CustomEvent('entity-list-reload'));
+// reload the entities in show mode
+export async function reloadEntitiesShow(): Promise<void | Response> {
+  window.dispatchEvent(new CustomEvent('entity-filters-changed'));
+  // ask mathjax to reparse the page
   MathJax.typeset();
+  // rebind autocomplete for links input
   addAutocompleteToLinkInputs();
+  // tags too
   addAutocompleteToTagInputs();
+  // listen to data-trigger elements
   listenTrigger();
+  // and set relative moments
   relativeMoment();
 }
 


### PR DESCRIPTION
fix entities not reloading after performing actions on selected entities

EntityList was only reloading when the URL filter signature changed. Actions such as deleting, archiving or restoring entities don't modify the URL, so the list remained stale until a manual refresh.

This change makes the reload unconditional when an `entity-filters-changed` event is received, ensuring the list is refreshed after entity actions while preserving the existing event flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Entity lists now refresh whenever filters change, including cases where the previous refresh signature would have prevented an update.
* **New Features**
  * Added support for reloading the entity list in response to reload/navigation-related events beyond the initial load.
  * Ensured the event listener is properly registered and cleaned up with the component lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->