### PR TITLE
bug/medium: entities reload

### DIFF
--- a/src/ts/components/EntityList.svelte
+++ b/src/ts/components/EntityList.svelte
@@ -238,13 +238,7 @@
   }
 
   function bumpReloadVersionIfFiltersChanged(): void {
-    const nextSignature = getCurrentNonSearchFilterSignature();
-
-    if (nextSignature === nonSearchFilterSignature) {
-      return;
-    }
-
-    nonSearchFilterSignature = nextSignature;
+    nonSearchFilterSignature = getCurrentNonSearchFilterSignature();
     reloadVersion += 1;
   }
 

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -800,7 +800,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = collectForm(form);
       clearForm(form);
       checked.forEach(chk => {
-        const paramsCopy = Object.assign({notifOnSaved: 0}, params);
+        const paramsCopy = Object.assign({}, params, { notifOnSaved: 0 });
         // they do not have all the same endpoint: handle tags and links the generic patch method
         for (const key in paramsCopy) {
           if (key === 'tags') {

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -800,7 +800,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const params = collectForm(form);
       clearForm(form);
       checked.forEach(chk => {
-        const paramsCopy = Object.assign({}, params);
+        const paramsCopy = Object.assign({notifOnSaved: 0}, params);
         // they do not have all the same endpoint: handle tags and links the generic patch method
         for (const key in paramsCopy) {
           if (key === 'tags') {
@@ -990,7 +990,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         // perform deletes
         const deletes = checked.map(chk =>
-          ApiC.delete(`${entity.type}/${chk}`, { notifOnSaved:0 }),
+          ApiC.delete(`${entity.type}/${chk}`, { notifOnSaved: 0 }),
         );
         Promise.all(deletes).then(() => {
           notify.success();


### PR DESCRIPTION
fix entities not reloading after performing actions on selected entities

EntityList was only reloading when the URL filter signature changed. Actions such as deleting, archiving or restoring entities don't modify the URL, so the list remained stale until a manual refresh.

This change makes the reload unconditional when an entity-filters-changed event is received, ensuring the list is refreshed after entity actions while preserving the existing event flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list refreshing so filtered results update reliably, even when the filter settings haven’t changed.
  * Reduced notification noise during batch updates by suppressing per-entity save confirmations and consolidating feedback into fewer notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->