### PR TITLE
dev: populate: remove welcome emails

### DIFF
--- a/src/tools/populate-config.yml.dist
+++ b/src/tools/populate-config.yml.dist
@@ -30,12 +30,6 @@ config:
   # increase this a bit
   login_tries: 10
   s3_region: fr-par-42
-  onboarding_email_subject: test email subject
-  onboarding_email_body: <p>Test email body for <strong>users</strong>.</p>
-  onboarding_email_active: 1
-  onboarding_email_different_for_admins: 1
-  onboarding_email_admins_subject: subject for admins
-  onboarding_email_admins_body: <p>Test email body for <strong>admins</strong>.</p>
   dspace_host: https://demo.dspace.org/
   dspace_user: dspacedemo+admin@gmail.com
 


### PR DESCRIPTION
problematic as it tries to send emails to all users as soon as we configure email in dev



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete onboarding email settings from the sample configuration.
  * Simplified the configuration by eliminating unused fake-data entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->