### PR TITLE
feat: tables: caption at the top

### DIFF
--- a/src/scss/_tinymce.scss
+++ b/src/scss/_tinymce.scss
@@ -13,7 +13,3 @@ figure {
   top: calc(var(--navbar-height) + var(--toolbar-height)) !important;
   transition: top 0.2s ease;
 }
-
-table > caption {
-  caption-side: top;
-}

--- a/src/scss/_tinymce.scss
+++ b/src/scss/_tinymce.scss
@@ -13,3 +13,7 @@ figure {
   top: calc(var(--navbar-height) + var(--toolbar-height)) !important;
   transition: top 0.2s ease;
 }
+
+table > caption {
+  caption-side: top;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1414,7 +1414,6 @@ the form-control fails to do that so we do the border ourselves */
   color: var(--primary);
 }
 
-/* caption for tinymce */
 .image {
   background: var(--superlight);
   border: 1px solid var(--medium);
@@ -1424,6 +1423,12 @@ the form-control fails to do that so we do the border ourselves */
 
 .image img {
   margin: 8px 8px 0;
+}
+
+/* captions for tables and images */
+table > caption {
+  caption-side: top;
+  text-align: center;
 }
 
 .image figcaption,


### PR DESCRIPTION
fix #7137

Place captions at the top to stick to edit mode's display style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed an obsolete editor-related caption comment.
  * Updated table captions to appear centered above their tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->