### PR TITLE
doc: update upgrade doc with quadlet info

### DIFF
--- a/documentation/config_examples/quadlet/elabftw.container
+++ b/documentation/config_examples/quadlet/elabftw.container
@@ -1,5 +1,6 @@
 # This file is an example .container file for eLabFTW service running as user. Also place the .network file and possible configure HAProxy accordingly.
-# Place it in /etc/containers/systemd so a quadlet is generated and the service can be managed by systemd.
+# Place it in ${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd/ so a quadlet is generated and the service can be managed by systemd.
+# Use lingering for the user. Start the systemd service as user.
 # This is not an authoritative file, adapt it to your system.
 # Documentation: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
 
@@ -57,7 +58,7 @@ Secret=elabftw-s3-sk,type=env,target=ELAB_AWS_SECRET_KEY
 Volume=/mnt/data/elabftw_uploads:/var/lib/elabftw/uploads
 # this is necessary if you encrypt mysql connection and thus want the container to have access to the mysql cert
 Volume=/deltablot/mysql:/mysql-cert:z
-Volume=/var/cache/elabftw/nginx-cache:/var/cache/nginx:Z
+Volume=/var/elabftw/.cache/nginx:/var/cache/nginx:Z
 # Note the notmpcopyup option which is important
 Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
 

--- a/documentation/config_examples/quadlet/elabftw.container
+++ b/documentation/config_examples/quadlet/elabftw.container
@@ -1,5 +1,6 @@
-# This file is an example .container file for eLabFTW service. Also place the .network file and possible configure HAProxy accordingly.
+# This file is an example .container file for eLabFTW service running as user. Also place the .network file and possible configure HAProxy accordingly.
 # Place it in /etc/containers/systemd so a quadlet is generated and the service can be managed by systemd.
+# This is not an authoritative file, adapt it to your system.
 # Documentation: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
 
 [Unit]
@@ -10,20 +11,11 @@ After=network.target
 # Note: it is recommended to pin to a specific version instead of using the "stable" tag.
 Image=docker.io/elabftw/elabimg:stable
 ContainerName=elabftw
-
-# CAPABILITIES
-DropCapability=ALL
-AddCapability=CHOWN
-AddCapability=SETGID
-AddCapability=SETUID
-AddCapability=FOWNER
-AddCapability=DAC_OVERRIDE
-AddCapability=NET_BIND_SERVICE
-
-NoNewPrivileges=true
+ReadOnly=true
+UserNS=keep-id
 
 # HEALTHCHECK
-HealthCmd=curl --fail --silent --show-error http://localhost:443/healthcheck
+HealthCmd=curl --fail --silent --show-error http://localhost:8080/healthcheck
 HealthInterval=5s
 HealthTimeout=5s
 HealthRetries=20
@@ -52,12 +44,7 @@ Environment=REDIS_HOST=10.X.Y.Z
 Environment=REDIS_PORT=6379
 Environment=REDIS_USERNAME=elabftw_php_sessions
 Secret=redis-password,type=env,target=REDIS_PASSWORD
-Environment=ENABLE_IPV6=false
 Environment=SITE_URL=https://eln.example.org
-Environment=ELABFTW_USER=nobody
-Environment=ELABFTW_GROUP=nobody
-Environment=ELABFTW_USERID=65534
-Environment=ELABFTW_GROUPID=65534
 Secret=status-password,type=env,target=STATUS_PASSWORD
 # if using S3 storage
 Secret=elabftw-s3-ak,type=env,target=ELAB_AWS_ACCESS_KEY
@@ -67,33 +54,23 @@ Secret=elabftw-s3-sk,type=env,target=ELAB_AWS_SECRET_KEY
 # if not using s3, bind mount the uploads folder in the host
 # do NOT add :z here because NFS cause an issue #
 # host:container
-Volume=/mnt/data/elabftw_uploads:/elabftw/uploads
+Volume=/mnt/data/elabftw_uploads:/var/lib/elabftw/uploads
 # this is necessary if you encrypt mysql connection and thus want the container to have access to the mysql cert
 Volume=/deltablot/mysql:/mysql-cert:z
+Volume=/var/cache/elabftw/nginx-cache:/var/cache/nginx:Z
+# Note the notmpcopyup option which is important
+Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
 
 # NETWORKS
 Network=elabftw.network
 
 [Service]
-# see: https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
-LockPersonality=yes
-PrivateTmp=yes
-ProtectHome=yes
-ProtectKernelModules=yes
-Restart=unless-stopped
-RestrictAddressFamilies=AF_UNIX AF_INET AF_NETLINK
-RestrictRealtime=yes
+Restart=always
+MemoryHigh=4G
+MemoryMax=5G
+MemorySwapMax=0
+TasksMax=200
 
-# these ones break container execution
-#NoNewPrivileges=yes
-#PrivateDevices=yes
-#DevicePolicy=closed
-#ProtectSystem=strict
-#ProtectControlGroups=yes
-#ProtectKernelTunables=yes
-#RestrictNamespaces=yes
-#RestrictSUIDSGID=yes
-#MemoryDenyWriteExecute=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -70,9 +70,11 @@ Only changed/added lines are shown:
 Image=docker.io/elabftw/elabimg:6.0.0
 ReadOnly=true
 UserNS=keep-id
-HealthCmd=curl http://localhost:8080/healthcheck
+HealthCmd=curl --fail --silent --show-error http://localhost:8080/healthcheck
 Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
 ~~~
+
+Move the file into `${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd/` for your user.
 
 See also sections below, adjust volumes accordingly.
 
@@ -95,7 +97,7 @@ Then in the configuration file, under `volumes:` section:
 # docker
   - /var/elabftw/.cache/nginx:/var/cache/nginx
 # quadlet
-Volume=/var/lib/elabftw/nginx-cache:/var/cache/nginx:Z
+Volume=/var/elabftw/.cache/nginx:/var/cache/nginx:Z
 ~~~
 
 #### Uploads folder

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -15,13 +15,14 @@ Here are the main changes:
 - container volumes change
 - container user configuration change
 
-Note: this guide assumes usage of `docker compose`. For other deployments (`podman`/`quadlets`/k8s`, ...), you will need to adapt the changes to your context.
+Note: this guide assumes usage of `docker compose`, with hints related to `podman quadlets`. For other deployments, you will need to adapt the changes to your context.
 
 ## Making backups
 
 Make a backup of your configuration file:
 
 ~~~bash
+# docker
 cp /etc/elabftw.yml /etc/elabftw.yml.v5.bak
 ~~~
 
@@ -42,6 +43,8 @@ Note the user id and group id of that newly created user shown by the second com
 
 In your configuration file (by default `/etc/elabftw.yml`, start by setting the version of the image:
 
+### Docker
+
 ~~~yaml
 image: elabftw/elabimg:6.0.0
 ~~~
@@ -57,6 +60,21 @@ tmpfs:
 ~~~
 
 This will make the container start and run with `elabftw-worker` user, and a read-only filesystem.
+
+### Quadlet
+
+Only changed/added lines are shown:
+
+~~~conf
+[Container]
+Image=docker.io/elabftw/elabimg:6.0.0
+ReadOnly=true
+UserNS=keep-id
+HealthCmd=curl http://localhost:8080/healthcheck
+Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
+~~~
+
+See also sections below, adjust volumes accordingly.
 
 ### Volumes
 
@@ -74,7 +92,10 @@ chown elabftw-worker:elabftw-worker /var/elabftw/.cache/nginx
 Then in the configuration file, under `volumes:` section:
 
 ~~~yaml
+# docker
   - /var/elabftw/.cache/nginx:/var/cache/nginx
+# quadlet
+Volume=/var/lib/elabftw/nginx-cache:/var/cache/nginx:Z
 ~~~
 
 #### Uploads folder
@@ -134,6 +155,8 @@ ports:
 ~~~
 
 It is the right-hand side that needs to be modified: the listening port in the container.
+
+For quadlets, adjust PublishPort if you're using this, or adjust your reverse proxy to use port 8080.
 
 ### Environment
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running eLabFTW with Podman Quadlet alongside Docker Compose.
  * Documented read-only containers, user namespaces, health checks, temporary storage, resource limits, and restart behavior.
  * Updated volume and port configuration instructions, including health checks on port 8080.
  * Added separate nginx cache and upload mount examples for Docker and Quadlet deployments.
  * Documented running Quadlet containers as a user and configuring the default systemd target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->