### PR TITLE
feat: remove hardcoded smtp2go.com server address

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1008,7 +1008,7 @@ components:
           smtp_address:
             type: string
             example: 'mail.smtp2go.com'
-            default: 'mail.smtp2go.com'
+            default: 'mail.example.com'
           smtp_encryption:
             type: string
             example: 'ssl'

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -78,7 +78,7 @@ final class Config extends AbstractRest
             ('mail_from', 'notconfigured@example.com'),
             ('proxy', ''),
             ('user_msg_need_local_account_created', ''),
-            ('smtp_address', 'mail.smtp2go.com'),
+            ('smtp_address', 'mail.example.com'),
             ('smtp_encryption', 'ssl'),
             ('smtp_password', ''),
             ('smtp_port', '587'),


### PR DESCRIPTION
It could cause issues when a misconfigured instance tries to send emails every minute for every user.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented default SMTP address to `mail.example.com`.

* **Configuration**
  * New configurations now use `mail.example.com` as the default SMTP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->