### PR TITLE
ci: fix stale elabtmp image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,20 @@ commands:
     steps:
       - run:
           name: Build image
+          # we use the SHA1 as build tag to make sure we don't use stale images in the build cascade
           command: |
-            docker build -t elabftw/elabimg:ci --build-arg CI=1 -f containers/elabimg/Dockerfile .
-            docker build -t elabftw/elabtmp -f containers/elabtmp/Dockerfile .
-            docker build -t elabftw/circleci -f containers/circleci/Dockerfile .
+            docker build \
+              -t "elabftw/elabimg:ci-${CIRCLE_SHA1}" \
+              --build-arg CI=1 \
+              -f containers/elabimg/Dockerfile .
+            docker build \
+              -t "elabftw/elabtmp:${CIRCLE_SHA1}" \
+              --build-arg "ELABIMG_TAG=ci-${CIRCLE_SHA1}" \
+              -f containers/elabtmp/Dockerfile .
+            docker build \
+              -t elabftw/circleci \
+              --build-arg "ELABTMP_TAG=${CIRCLE_SHA1}" \
+              -f containers/circleci/Dockerfile .
 
   load_image:
     steps:

--- a/containers/circleci/Dockerfile
+++ b/containers/circleci/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.3
 # Dockerfile for CircleCI
-FROM elabftw/elabtmp
+ARG ELABTMP_TAG=latest
+FROM elabftw/elabtmp:${ELABTMP_TAG}
 
 # add tests related folders and files to the image
 COPY ./tests /elabftw/tests

--- a/containers/elabtmp/Dockerfile
+++ b/containers/elabtmp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.3
 # Dockerfile for CI image
-FROM elabftw/elabimg:ci
+ARG ELABIMG_TAG=ci
+FROM elabftw/elabimg:${ELABIMG_TAG}
 
 # Install xdebug for coverage
 RUN apk add --update php84-pecl-xdebug


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI image builds by ensuring each intermediate image uses the correct build-specific version.
  * Reduced the risk of dependent images using stale or mismatched layers during automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->