### PR TITLE
dev: use prod csp in dev

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -18,7 +18,9 @@ const webpack = require('webpack');
 const sveltePreprocess = require('svelte-preprocess');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = (env) => {
+module.exports = (env, argv) => {
+  const mode = argv.mode ?? 'production';
+  const isDevelopment = mode === 'development';
   return {
     entry: {
       main: [
@@ -89,10 +91,9 @@ module.exports = (env) => {
         './src/ts/spreadsheet-utils.ts',
       ],
     },
-    // uncomment this to find where the error is coming from
-    // makes the build slower
-    //devtool: 'inline-source-map',
-    mode: 'production',
+    // faster but less precise source map
+    devtool: isDevelopment ? 'cheap-module-source-map' : false,
+    mode,
     output: {
       filename: '[name].bundle.js',
       path: path.resolve(__dirname, 'web/assets')
@@ -102,7 +103,7 @@ module.exports = (env) => {
         chunks: 'all',
         name: 'vendor',
       },
-      minimize: true,
+      minimize: !isDevelopment,
       minimizer: [
         '...',
         new MinimizerPlugin({
@@ -157,7 +158,7 @@ module.exports = (env) => {
             loader: 'ts-loader',
             options: {
               // in prod, we don't have the types of some libs, use transpileOnly to avoid errors
-              transpileOnly: env.production
+              transpileOnly: !isDevelopment,
               }
           },
         },

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -189,20 +189,19 @@ nginxConf() {
     # SET WORKER PROCESSES (default is auto)
     sed -i -e "s/%WORKER_PROCESSES%/${nginx_work_proc}/" /run/nginx/nginx.conf
 
-    # no unsafe-eval in prod
-    unsafe_eval=""
     # DEV MODE
     # we don't want to serve brotli/gzip compressed assets in dev (or we would need to recompress them after every change!)
     if ($dev_mode); then
         rm -f /run/nginx/conf.d/brotli.conf /run/nginx/conf.d/gzip.conf
-        # to allow webpack in watch/dev mode we need to allow unsafe-eval for script-src
-        unsafe_eval="'unsafe-eval'"
     fi
-    # set unsafe-eval in CSP
-    sed -i -e "s/%UNSAFE-EVAL4DEV%/${unsafe_eval}/" /run/nginx/common.conf
     sed -i -e "s/%CUSTOM_CONNECT_SRC%/$(escape_sed_repl "${custom_connect_src}")/" /run/nginx/common.conf
     # put a random short string as the server header to prevent fingerprinting
-    server_header=$(openssl rand -hex 2 | cut -c1-3)
+    random=$(openssl rand -hex 2)
+    if (( 16#${random:0:2} % 64 == 0 )); then
+        server_header='<3'
+    else
+        server_header=${random:0:3}
+    fi
     sed -i -e "s/%SERVER_HEADER%/${server_header}/" /run/nginx/common.conf
     # add Access-Control-Allow-Origin header if enabled
     acao_header=""

--- a/containers/elabimg/nginx/common.conf
+++ b/containers/elabimg/nginx/common.conf
@@ -159,7 +159,7 @@ location = /chem-editor.php {
 # allow blob: in frame-src for OpenCloning (syc.php). see https://github.com/elabftw/elabimg/issues/55
 location = /syc.php {
     more_clear_headers "Content-Security-Policy";
-    more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' %UNSAFE-EVAL4DEV%; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
+    more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self'; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
     include        /etc/nginx/fastcgi.conf;
     fastcgi_pass   127.0.0.1:9000;
 }
@@ -174,7 +174,7 @@ more_set_headers "Strict-Transport-Security: max-age=63072000";
 more_set_headers "X-XSS-Protection: 0";
 more_set_headers "X-Content-Type-Options: nosniff";
 # Note: do NOT add form-action 'self' here as it blocks SAML under Chrome based browsers, see elabftw/elabftw#5903
-more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self' %UNSAFE-EVAL4DEV%; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov https://api.ror.org %CUSTOM_CONNECT_SRC%; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
+more_set_headers "Content-Security-Policy: default-src 'self' data:; script-src 'self'; connect-src 'self' blob: https://get.elabftw.net https://pubchem.ncbi.nlm.nih.gov https://api.ror.org %CUSTOM_CONNECT_SRC%; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'self'; base-uri 'none'; frame-src 'self' blob:; frame-ancestors 'self'";
 more_set_headers "Referrer-Policy: no-referrer";
 # Experimental header: https://caniuse.com/?search=permission-policy
 more_set_headers "Permissions-Policy: autoplay=(), camera=(self), encrypted-media=(), fullscreen=(self), geolocation=(), microphone=(self), midi=(), payment=(), xr-spatial-tracking=()";

--- a/documentation/docs/contributing/installation.md
+++ b/documentation/docs/contributing/installation.md
@@ -77,7 +77,7 @@ curl -so docker-compose.yml "https://get.elabftw.net/?config"
 * Set `DEV_MODE` to `true`
 
 :::note
-The `DEV_MODE` relaxes the content security policy slightly, and turns off the extra safety net of a somewhat restrictive [open_basedir](https://www.php.net/manual/en/ini.core.php#ini.open-basedir) directive (values found in [docker-entrypoint.sh](https://github.com/elabftw/elabimg/blob/master/src/entrypoint/docker-entrypoint.sh)). Avoid having this enabled in production systems.
+The `DEV_MODE` removes cache for twig templates, adds source-mapped js assets and turns off the extra safety net of a somewhat restrictive [open_basedir](https://www.php.net/manual/en/ini.core.php#ini.open-basedir) directive (values found in [docker-entrypoint.sh](https://github.com/elabftw/elabimg/blob/master/src/entrypoint/docker-entrypoint.sh)). Avoid having this enabled in production systems.
 :::
 
 * Change the `ports:` line so the container runs on port 3148 (you can choose whatever port you want, or leave it on 443). It should look like this:


### PR DESCRIPTION
change webpack config so we don't need unsafe-eval anymore for the js in dev. this will allow catching csp issues during dev! also don't minimize in dev: faster.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Development builds now provide improved debugging support through source maps.
  - Production builds retain optimized output for better performance.
  - TypeScript validation and compilation behavior adjust automatically for each build mode.

- **Security**
  - Content Security Policy settings no longer permit unsafe script evaluation.
  - Server security headers now use more varied values.

- **Documentation**
  - Clarified development-mode behavior, including template caching, source-mapped assets, and filesystem access safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->