### PR TITLE
Fix grep not capturating mysql warning message

### DIFF
--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -470,9 +470,6 @@ function mysql-backup
 {
     if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
         mkdir -pv "${BACKUP_DIR}"
-        if [ $? -eq 1 ]; then
-            sudo mkdir -pv ${BACKUP_DIR}
-        fi
     fi
 
     set -e
@@ -490,7 +487,7 @@ function mysql-backup
           --no-tablespaces \
           "$MYSQL_DATABASE" 2>&1 |
           grep -vF "[Warning] Using a password"
-  
+
       statuses=("${PIPESTATUS[@]}")
       (( statuses[0] == 0 && statuses[1] <= 1 ))
       '; then

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -466,28 +466,45 @@ function mysql
 }
 
 # create a mysqldump and remove old backups
-function mysql-backup
-{
-    if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
-        mkdir -pv "${BACKUP_DIR}"
+function mysql-backup {
+  if ! ls -A "${BACKUP_DIR}" >/dev/null 2>&1; then
+    mkdir -pv "${BACKUP_DIR}"
+    if [ $? -eq 1 ]; then
+      sudo mkdir -pv ${BACKUP_DIR}
     fi
+  fi
 
-    set -e
+  set -e
 
-    # get clean date
-    local -r date=$(date +%Y-%m-%d_%H-%M-%S) # 2016-02-10_20-12-45
-    local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
+  # get clean date
+  local -r date=$(date +%Y-%m-%d_%H-%M-%S) # 2016-02-10_20-12-45
+  local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
-    # dump sql
-    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -vF "[Warning] Using a password"' || echo ">> Containers must be running to do the backup!"
+  # dump sql
+  # only consider the exit code of mysqldump for the next step (docker cp) and not the grep
+  if docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c '
+      mysqldump \
+        -u"$MYSQL_USER" \
+        -p"$MYSQL_PASSWORD" \
+        -r dump.sql \
+        --no-tablespaces \
+        "$MYSQL_DATABASE" 2>&1 |
+        grep -vF "[Warning] Using a password"
+   
+    statuses=("${PIPESTATUS[@]}")
+    (( statuses[0] == 0 && statuses[1] <= 1 ))
+    '; then
     # copy it from the container to the host
-    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME} rm dump.sql"
-    # compress it to the max
-    gzip -f --best "$dumpfile"
-    # delete old dumps
-    if [[ "${DUMP_DELETE_DAYS}" != "disabled" ]]; then
-        find ${BACKUP_DIR} -mindepth 1 -name '*.sql.gz' -ctime ${DUMP_DELETE_DAYS} -delete
-    fi
+    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME}" rm dump.sql
+  else
+    echo ">> Containers must be running to do the backup!" >&2
+  fi
+  # compress it to the max
+  gzip -f --best "$dumpfile"
+  # delete old dumps
+  if [[ "${DUMP_DELETE_DAYS}" != "disabled" ]]; then
+    find ${BACKUP_DIR} -mindepth 1 -name '*.sql.gz' -ctime ${DUMP_DELETE_DAYS} -delete
+  fi
 }
 
 function refresh

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -466,45 +466,45 @@ function mysql
 }
 
 # create a mysqldump and remove old backups
-function mysql-backup {
-  if ! ls -A "${BACKUP_DIR}" >/dev/null 2>&1; then
-    mkdir -pv "${BACKUP_DIR}"
-    if [ $? -eq 1 ]; then
-      sudo mkdir -pv ${BACKUP_DIR}
+function mysql-backup
+{
+    if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
+        mkdir -pv "${BACKUP_DIR}"
+        if [ $? -eq 1 ]; then
+            sudo mkdir -pv ${BACKUP_DIR}
+        fi
     fi
-  fi
 
-  set -e
+    set -e
 
-  # get clean date
-  local -r date=$(date +%Y-%m-%d_%H-%M-%S) # 2016-02-10_20-12-45
-  local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
+    # get clean date
+    local -r date=$(date +%Y-%m-%d_%H-%M-%S) # 2016-02-10_20-12-45
+    local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
-  # dump sql
-  # only consider the exit code of mysqldump for the next step (docker cp) and not the grep
-  if docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c '
-      mysqldump \
-        -u"$MYSQL_USER" \
-        -p"$MYSQL_PASSWORD" \
-        -r dump.sql \
-        --no-tablespaces \
-        "$MYSQL_DATABASE" 2>&1 |
-        grep -vF "[Warning] Using a password"
-   
-    statuses=("${PIPESTATUS[@]}")
-    (( statuses[0] == 0 && statuses[1] <= 1 ))
-    '; then
-    # copy it from the container to the host
-    docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME}" rm dump.sql
-  else
-    echo ">> Containers must be running to do the backup!" >&2
-  fi
-  # compress it to the max
-  gzip -f --best "$dumpfile"
-  # delete old dumps
-  if [[ "${DUMP_DELETE_DAYS}" != "disabled" ]]; then
-    find ${BACKUP_DIR} -mindepth 1 -name '*.sql.gz' -ctime ${DUMP_DELETE_DAYS} -delete
-  fi
+    # dump sql
+    if docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c '
+        mysqldump \
+          -u"$MYSQL_USER" \
+          -p"$MYSQL_PASSWORD" \
+          -r dump.sql \
+          --no-tablespaces \
+          "$MYSQL_DATABASE" 2>&1 |
+          grep -vF "[Warning] Using a password"
+  
+      statuses=("${PIPESTATUS[@]}")
+      (( statuses[0] == 0 && statuses[1] <= 1 ))
+      '; then
+      # copy it from the container to the host
+      docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME}" rm dump.sql
+    else
+      echo ">> Containers must be running to do the backup!" >&2
+    fi
+    # compress it to the max
+    gzip -f --best "$dumpfile"
+    # delete old dumps
+    if [[ "${DUMP_DELETE_DAYS}" != "disabled" ]]; then
+        find ${BACKUP_DIR} -mindepth 1 -name '*.sql.gz' -ctime ${DUMP_DELETE_DAYS} -delete
+    fi
 }
 
 function refresh

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -479,7 +479,7 @@ function mysql-backup
     local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
     # dump sql
-    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
+    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -vF "[Warning] Using a password"' || echo ">> Containers must be running to do the backup!"
     # copy it from the container to the host
     docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile" && docker exec "${ELAB_MYSQL_CONTAINER_NAME} rm dump.sql"
     # compress it to the max

--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -479,6 +479,7 @@ function mysql-backup
     local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
     # dump sql
+    # only consider the exit code of mysqldump for the next step (docker cp) and not the grep
     if docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c '
         mysqldump \
           -u"$MYSQL_USER" \


### PR DESCRIPTION
Fixes #7207.

The `-F` flag makes sure grep doesn't treat the string `[Warning]` as a regex string.

Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [x] I have mentioned the related **issue** (if applicable).
- [x] I have updated or verified the relevant documentation (in documentation directory)
---

### Pull Request Description

Please provide **clear context** for your proposed change:

- What issue or need does this PR address?
- How did you approach the solution?
- If applicable, include **screenshots or examples** (especially for UI changes).

> ⚠️ We’re committed to reviewing your contributions, so in return, we ask that you take the time to present your work clearly.
> Pull requests without any description are frowned upon and will likely be closed immediately.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL backup output by removing only expected password warnings.
  * Backup failures are now detected and clearly reported.
  * Incomplete or invalid backups are no longer copied as successful backups.
  * Missing destination directories are created automatically when needed.
  * Compression and cleanup behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->