### PR TITLE
bug/ui: tomselects: white bg

### DIFF
--- a/src/scss/_tom-select.scss
+++ b/src/scss/_tom-select.scss
@@ -12,7 +12,7 @@
 @include meta.load-css('tom-select/dist/css/tom-select.bootstrap4');
 
 .ts-control .item {
-  background-color: var(--superlight);
+  background-color: var(--firstlevel);
   border-radius: 0.18rem;
   color: var(--strongest);
   white-space: nowrap;
@@ -57,6 +57,11 @@
   color: var(--mediumstrong);
 }
 
+// background for ts inputs when active (e.g., selecting tags, team...)
+.ts-wrapper.single.input-active .ts-control {
+  background: var(--white);
+}
+
 .ts-dropdown {
   min-width: 200px;
 
@@ -85,7 +90,7 @@
 
       // when there's multiple items, e.g., tags filter in show page
       .item {
-        background-color: var(--superlight);
+        background-color: var(--firstlevel);
         color: var(--strongest);
       }
 


### PR DESCRIPTION
<img width="750" alt="Capture d’écran du 2026-08-05 17-25-45" src="https://github.com/user-attachments/assets/7388b6f4-5175-47b7-916d-a73234cdf540" />

<img width="450" alt="Capture d’écran du 2026-08-05 17-29-36" src="https://github.com/user-attachments/assets/134cbe6d-adb0-447a-8063-f3a9178098e6" />
<img width="750"  alt="Capture d’écran du 2026-08-05 17-30-27" src="https://github.com/user-attachments/assets/9ad97475-80dd-48a0-9c6d-3934cfc3e1de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Tom Select item backgrounds for improved visual consistency.
  * Added a white background to active single-select controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->