### PR TITLE
ux: close tags panel on outside click

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1192,8 +1192,8 @@ the form-control fails to do that so we do the border ourselves */
 }
 
 /* replace flex container with a responsive grid */
-.suggested-tags-menu,
-.show-more-filters-menu {
+.suggested-tags-popover,
+.show-more-filters-popover {
   background: var(--white);
   border-radius: 5px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
@@ -1209,7 +1209,7 @@ the form-control fails to do that so we do the border ourselves */
   z-index: 100;
 }
 
-.show-more-filters-menu {
+.show-more-filters-popover {
   gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   min-width: min(42rem, 90vw);

--- a/src/templates/edit-tags.html
+++ b/src/templates/edit-tags.html
@@ -13,7 +13,7 @@
   <div class='mathjax-ignore ml-auto d-sm-block d-none'>
     <details closed class='suggested-tags'>
       <summary>{{ 'Suggested tags'|trans }}</summary>
-      <div id='tags_div_suggestedtags_{{ Entity.id }}' class='suggested-tags-menu'>
+      <div id='tags_div_suggestedtags_{{ Entity.id }}' class='suggested-tags-popover'>
         {% set filteredTags = [] %}
         {% for tag in teamTagsArr %}
           {% set tagFound = false %}

--- a/src/templates/edit-tags.html
+++ b/src/templates/edit-tags.html
@@ -11,7 +11,7 @@
     <input type='text' id='createTagInput' data-autocomplete='tags' class='createTagInput form-control' placeholder='{{ 'Add a tag'|trans }}' />
   </div>
   <div class='mathjax-ignore ml-auto d-sm-block d-none'>
-    <details closed class='suggested-tags'>
+    <details closed class='suggested-tags' data-cy='tagsMenu'>
       <summary>{{ 'Suggested tags'|trans }}</summary>
       <div id='tags_div_suggestedtags_{{ Entity.id }}' class='suggested-tags-popover'>
         {% set filteredTags = [] %}

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -79,7 +79,7 @@
           <i class='fas fa-filter'></i>
         </summary>
 
-        <div class='show-more-filters-menu'>
+        <div class='show-more-filters-popover'>
           {# METADATA SEARCH #}
           <div class='filter-section filter-section-wide'>
             <label class='font-weight-bold mb-1'>{{ 'Custom fields'|trans }}</label>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -258,6 +258,7 @@ TableSortingC.init();
 (new Tab()).init(document.querySelector('.tabbed-menu'));
 
 makeSortableGreatAgain();
+bindMoreFiltersOutsideClick();
 mountRors();
 
 const userPrefs = document.getElementById('user-prefs').dataset;
@@ -1695,3 +1696,17 @@ container.addEventListener('click', (event: Event) => {
     }
   });
 });
+
+function bindMoreFiltersOutsideClick(): void {
+  document.querySelectorAll<HTMLElement>('[class*="-popover"]').forEach(popover => {
+    const details = popover.closest('details');
+    if (!details) return;
+
+    document.addEventListener('click', event => {
+      const target = event.target;
+      if (details.open && target instanceof Node && !details.contains(target)) {
+        details.open = false;
+      }
+    });
+  });
+}

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -264,23 +264,6 @@ function preventReactiveSearchFormSubmit(): void {
   });
 }
 
-function bindMoreFiltersOutsideClick(): void {
-  const menu = document.querySelector('.show-more-filters-menu');
-  const details = menu?.closest('details');
-
-  if (!details) {
-    return;
-  }
-
-  document.addEventListener('click', event => {
-    const target = event.target;
-
-    if (details.open && target instanceof Node && !details.contains(target)) {
-      details.open = false;
-    }
-  });
-}
-
 function syncSelectedEntitiesFromDom(): void {
   const selectedIds = Array.from(
     document.querySelectorAll<HTMLInputElement>('[data-action="checkbox-entity"]:checked'),
@@ -361,7 +344,6 @@ document.addEventListener('DOMContentLoaded', () => {
   })();
 
   preventReactiveSearchFormSubmit();
-  bindMoreFiltersOutsideClick();
   hydrateFilterAutoControlsFromUrl();
 
   // TomSelect for extra fields & owner search select

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -14,6 +14,13 @@ describe('Experiments', () => {
     cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
     cy.get('div.tags').contains('some tag').should('exist');
 
+    // open suggested tags
+    cy.get('[data-cy="tagsMenu"] > summary').click();
+    cy.get('[data-cy="tagsMenu"]').should('have.attr', 'open');
+    // click outside
+    cy.get('#createTagInput').click();
+    cy.get('[data-cy="tagsMenu"]').should('not.have.attr', 'open');
+
     // delete tag
     cy.on('window:confirm', () => { return true; });
     cy.contains('some tag').click();


### PR DESCRIPTION
fix https://github.com/elabftw/elabftw/issues/7162

Complementary https://github.com/elabftw/elabftw/pull/7185

- rename with -popover suffix for higher coverage of eventual future modals like those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Suggested tags and advanced search filters now close when users click outside the open popover.
  - Improved consistency in the behavior and presentation of filter and tag popovers.

- **Style**
  - Updated popover styling and layout for a clearer, more consistent interface.

- **Tests**
  - Added coverage to verify that the suggested-tags popover opens and closes as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->