### PR TITLE
bug/medium: metadata: type mismatch on metadatamerge

### DIFF
--- a/src/Elabftw/MetadataHelpers.php
+++ b/src/Elabftw/MetadataHelpers.php
@@ -118,25 +118,6 @@ final class MetadataHelpers
                 $baseField = &$base['extra_fields'][$name];
                 self::guardMetadataSchemaCompatibility($name, $baseField, $incomingField);
                 self::guardMetadataValueCompatibility($name, $baseField, $value);
-                $type = $baseField['type'] ?? '';
-
-                // Add imported values to the field's options if they don't already exist.
-                $values = match ($type) {
-                    'select-multi' => is_array($value)
-                        ? $value
-                        : array_map('trim', explode(',', (string) $value)),
-                    'select', 'select-one', 'radio' => array($value),
-                    default => array(),
-                };
-
-                if (!empty($values)) {
-                    $baseField['options'] ??= array();
-                    foreach ($values as $option) {
-                        if ($option !== '' && !in_array($option, $baseField['options'], true)) {
-                            $baseField['options'][] = $option;
-                        }
-                    }
-                }
                 // Preserve the existing field schema and only update its value
                 $baseField['value'] = self::normalizeMetadataValue($baseField, $value);
                 unset($baseField);

--- a/src/Elabftw/MetadataHelpers.php
+++ b/src/Elabftw/MetadataHelpers.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Exceptions\ImproperActionException;
+use JsonException;
+
+use function _;
+use function array_key_exists;
+use function array_map;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function is_scalar;
+use function json_decode;
+use function json_encode;
+use function sprintf;
+use function str_replace;
+use function trim;
+use function mb_strtolower;
+
+final class MetadataHelpers
+{
+    public static function mergeMetadata(?string $source, string $incoming): string
+    {
+        $sourceMetadata = self::decodeMetadata($source);
+        $incomingMetadata = self::decodeMetadata($incoming);
+
+        $sourceFields = $sourceMetadata['extra_fields'] ?? array();
+        $incomingFields = $incomingMetadata['extra_fields'] ?? array();
+
+        if (!is_array($sourceFields) || !is_array($incomingFields)) {
+            throw new ImproperActionException(_('Invalid metadata extra_fields provided.'));
+        }
+
+        foreach ($incomingFields as $name => $incomingField) {
+            if (!is_array($incomingField)) {
+                throw new ImproperActionException(
+                    sprintf(_('Invalid metadata field %s.'), $name)
+                );
+            }
+
+            // New field: there is no source schema, so keep the complete
+            // incoming field definition.
+            if (!array_key_exists($name, $sourceFields)) {
+                if (array_key_exists('value', $incomingField)) {
+                    self::guardMetadataValueCompatibility(
+                        $name,
+                        $incomingField,
+                        $incomingField['value'],
+                    );
+                    $incomingField['value'] = self::normalizeMetadataValue(
+                        $incomingField,
+                        $incomingField['value'],
+                    );
+                }
+
+                $sourceFields[$name] = $incomingField;
+                continue;
+            }
+
+            if (!is_array($sourceFields[$name])) {
+                throw new ImproperActionException(
+                    sprintf(_('Invalid metadata field %s.'), $name)
+                );
+            }
+
+            // Existing field: the source/template owns the schema.
+            // Incoming metadata only supplies the value.
+            if (!array_key_exists('value', $incomingField)) {
+                continue;
+            }
+
+            $value = $incomingField['value'];
+
+            self::guardMetadataValueCompatibility(
+                $name,
+                $sourceFields[$name],
+                $value,
+            );
+
+            $sourceFields[$name]['value'] = self::normalizeMetadataValue(
+                $sourceFields[$name],
+                $value,
+            );
+        }
+
+        $sourceMetadata['extra_fields'] = $sourceFields;
+
+        return json_encode($sourceMetadata, JSON_THROW_ON_ERROR);
+    }
+
+    public static function mergeMetadataValues(string $baseMetadata, string $incomingMetadata): string
+    {
+        // base metadata comes from the template and contains the field schema
+        $base = self::decodeMetadata($baseMetadata);
+        // incoming metadata usually comes from CSV/API and contains the values to inject.
+        $incoming = self::decodeMetadata($incomingMetadata);
+        // ensure both metadata arrays have an extra_fields array.
+        $base['extra_fields'] ??= array();
+        $incoming['extra_fields'] ??= array();
+
+        foreach ($incoming['extra_fields'] as $name => $incomingField) {
+            $value = $incomingField['value'] ?? '';
+
+            if (isset($base['extra_fields'][$name])) {
+                $baseField = &$base['extra_fields'][$name];
+                self::guardMetadataSchemaCompatibility($name, $baseField, $incomingField);
+                self::guardMetadataValueCompatibility($name, $baseField, $value);
+                $type = $baseField['type'] ?? '';
+
+                // Add imported values to the field's options if they don't already exist.
+                $values = match ($type) {
+                    'select-multi' => is_array($value)
+                        ? $value
+                        : array_map('trim', explode(',', (string) $value)),
+                    'select', 'select-one', 'radio' => array($value),
+                    default => array(),
+                };
+
+                if (!empty($values)) {
+                    $baseField['options'] ??= array();
+                    foreach ($values as $option) {
+                        if ($option !== '' && !in_array($option, $baseField['options'], true)) {
+                            $baseField['options'][] = $option;
+                        }
+                    }
+                }
+                // Preserve the existing field schema and only update its value
+                $baseField['value'] = self::normalizeMetadataValue($baseField, $value);
+                unset($baseField);
+                continue;
+            }
+            // new fields: keep incoming schema, but normalize its value if it has a known type.
+            $incomingField['value'] = self::normalizeMetadataValue($incomingField, $value);
+            $base['extra_fields'][$name] = $incomingField;
+        }
+
+        return json_encode($base, JSON_THROW_ON_ERROR);
+    }
+
+    private static function decodeMetadata(?string $metadata): array
+    {
+        if ($metadata === null || $metadata === '' || $metadata === '{}') {
+            return array('extra_fields' => array());
+        }
+
+        try {
+            $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new ImproperActionException(_('Invalid metadata JSON provided.'));
+        }
+
+        if (!is_array($decoded)) {
+            throw new ImproperActionException(_('Invalid metadata JSON provided.'));
+        }
+
+        return $decoded;
+    }
+
+    private static function normalizeMetadataValue(array $field, mixed $value): string|array
+    {
+        $type = $field['type'] ?? 'text';
+
+        if (
+            $type === 'select-multi'
+            || ($type === 'select' && ($field['allow_multi_values'] ?? false) === true)
+        ) {
+            if (is_array($value)) {
+                return array_map(
+                    static fn(mixed $option): string => trim((string) $option),
+                    $value,
+                );
+            }
+
+            return array_map('trim', explode(',', (string) $value));
+        }
+
+        $value = trim((string) $value);
+
+        return match ($type) {
+            'checkbox' => self::normalizeCheckboxValue($value),
+            'number' => str_replace(',', '.', $value),
+            default => $value,
+        };
+    }
+
+    private static function guardMetadataSchemaCompatibility(string $name, array $baseField, array $incomingField): void
+    {
+        // existing fields keep their original schema. If the incoming metadata explicitly specifies
+        // a schema (currently type or unit), it must match the stored one. Value-only updates are still allowed.
+        foreach (array('type', 'unit') as $key) {
+            // The incoming metadata does not specify this schema key, so keep the existing definition
+            if (!array_key_exists($key, $incomingField)) {
+                continue;
+            }
+
+            // reject attempts to merge an incompatible schema into an existing field
+            if (!array_key_exists($key, $baseField) || $incomingField[$key] !== $baseField[$key]) {
+                throw new ImproperActionException(sprintf(_('Metadata field %s has incompatible %s.'), $name, $key));
+            }
+        }
+    }
+
+    private static function guardMetadataValueCompatibility(
+        string $name,
+        array $field,
+        mixed $value,
+    ): void {
+        if ($value === '' || $value === null || $value === array()) {
+            return;
+        }
+
+        $type = $field['type'] ?? 'text';
+
+        if ($type === 'number') {
+            if (
+                !is_scalar($value)
+                || !is_numeric(str_replace(',', '.', trim((string) $value)))
+            ) {
+                throw new ImproperActionException(
+                    sprintf(_('Metadata field %s expects a number.'), $name)
+                );
+            }
+
+            return;
+        }
+
+        if (!in_array($type, array('select', 'select-one', 'select-multi', 'radio'), true)) {
+            return;
+        }
+
+        $options = $field['options'] ?? array();
+
+        if (!is_array($options)) {
+            throw new ImproperActionException(
+                sprintf(_('Metadata field %s has invalid options.'), $name)
+            );
+        }
+
+        $isMulti = $type === 'select-multi'
+            || ($type === 'select' && ($field['allow_multi_values'] ?? false) === true);
+
+        if (is_array($value)) {
+            if (!$isMulti) {
+                throw new ImproperActionException(
+                    sprintf(_('Metadata field %s expects a single value.'), $name)
+                );
+            }
+
+            $values = $value;
+        } elseif ($isMulti) {
+            $values = array_map('trim', explode(',', (string) $value));
+        } else {
+            $values = array(trim((string) $value));
+        }
+
+        foreach ($values as $option) {
+            if ($option !== '' && !in_array($option, $options, true)) {
+                throw new ImproperActionException(
+                    sprintf(
+                        _('Metadata field %s contains an invalid option.'),
+                        $name,
+                    )
+                );
+            }
+        }
+    }
+
+    private static function normalizeCheckboxValue(string $value): string
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $truthyValues = array(
+            // machine-ish
+            '1',
+            'true',
+            'on',
+            'checked',
+            'x',
+
+            // English
+            'yes',
+            'y',
+            'yeah',
+            'yep',
+            'yup',
+            'sure',
+            'okay',
+            'ok',
+            'aye',
+
+            // French
+            'oui',
+            'ouais',
+            'ouaip',
+            'grave',
+            'putain mais carrément quoi',
+
+            // Spanish
+            'sí',
+            'si',
+            'claro',
+
+            // Portuguese
+            'sim',
+
+            // German / Dutch
+            'ja',
+            'jawohl',
+
+            // Italian
+            'sì',
+
+            // Slavic
+            'da',
+            'tak',
+            'ano',
+
+            // Nordic
+            'joo',
+            'kyllä',
+            'ja',
+            'jep',
+
+            // Hungarian
+            'igen',
+
+            // Turkish
+            'evet',
+
+            // Japanese
+            'hai',
+            'はい',
+
+            // symbols
+            '+',
+            '✓',
+            '✔',
+        );
+
+        return in_array(mb_strtolower(trim($value)), $truthyValues, true) ? 'on' : '';
+    }
+}

--- a/src/Elabftw/MetadataHelpers.php
+++ b/src/Elabftw/MetadataHelpers.php
@@ -37,19 +37,10 @@ final class MetadataHelpers
         $sourceMetadata = self::decodeMetadata($source);
         $incomingMetadata = self::decodeMetadata($incoming);
 
-        $sourceFields = $sourceMetadata['extra_fields'] ?? array();
-        $incomingFields = $incomingMetadata['extra_fields'] ?? array();
-
-        if (!is_array($sourceFields) || !is_array($incomingFields)) {
-            throw new ImproperActionException(_('Invalid metadata extra_fields provided.'));
-        }
+        $sourceFields = self::getExtraFields($sourceMetadata);
+        $incomingFields = self::getExtraFields($incomingMetadata);
 
         foreach ($incomingFields as $name => $incomingField) {
-            if (!is_array($incomingField)) {
-                throw new ImproperActionException(
-                    sprintf(_('Invalid metadata field %s.'), $name)
-                );
-            }
 
             // New field: there is no source schema, so keep the complete
             // incoming field definition.
@@ -68,12 +59,6 @@ final class MetadataHelpers
 
                 $sourceFields[$name] = $incomingField;
                 continue;
-            }
-
-            if (!is_array($sourceFields[$name])) {
-                throw new ImproperActionException(
-                    sprintf(_('Invalid metadata field %s.'), $name)
-                );
             }
 
             // Existing field: the source/template owns the schema.
@@ -107,9 +92,8 @@ final class MetadataHelpers
         $base = self::decodeMetadata($baseMetadata);
         // incoming metadata usually comes from CSV/API and contains the values to inject.
         $incoming = self::decodeMetadata($incomingMetadata);
-        // ensure both metadata arrays have an extra_fields array.
-        $base['extra_fields'] ??= array();
-        $incoming['extra_fields'] ??= array();
+        $base['extra_fields'] = self::getExtraFields($base);
+        $incoming['extra_fields'] = self::getExtraFields($incoming);
 
         foreach ($incoming['extra_fields'] as $name => $incomingField) {
             $value = $incomingField['value'] ?? '';
@@ -129,6 +113,24 @@ final class MetadataHelpers
         }
 
         return json_encode($base, JSON_THROW_ON_ERROR);
+    }
+
+    private static function getExtraFields(array $metadata): array
+    {
+        $fields = $metadata['extra_fields'] ?? array();
+        if (!is_array($fields)) {
+            throw new ImproperActionException(_('Invalid metadata extra_fields provided.'));
+        }
+
+        foreach ($fields as $name => $field) {
+            if (!is_array($field)) {
+                throw new ImproperActionException(
+                    sprintf(_('Invalid metadata field %s.'), $name)
+                );
+            }
+        }
+
+        return $fields;
     }
 
     private static function decodeMetadata(?string $metadata): array
@@ -230,6 +232,11 @@ final class MetadataHelpers
             );
         }
 
+        $options = array_map(
+            static fn(mixed $option): mixed => is_scalar($option) ? (string) $option : $option,
+            $options,
+        );
+
         $isMulti = $type === 'select-multi'
             || ($type === 'select' && ($field['allow_multi_values'] ?? false) === true);
 
@@ -248,7 +255,7 @@ final class MetadataHelpers
         }
 
         foreach ($values as $option) {
-            if ($option !== '' && !in_array($option, $options, true)) {
+            if ($option !== '' && (!is_scalar($option) || !in_array((string) $option, $options, true))) {
                 throw new ImproperActionException(
                     sprintf(
                         _('Metadata field %s contains an invalid option.'),

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -88,7 +88,7 @@ abstract class AbstractCsv extends AbstractImport
 
     abstract protected function getProcessedColumns(): array;
 
-    protected function collectMetadata(array $row): string
+    protected function collectMetadata(array $row, bool $includeType = true): string
     {
         // we remove the columns present in compound to be left with the ones we want in metadata as extra fields
         $processedColumns = $this->getProcessedColumns();
@@ -103,7 +103,10 @@ abstract class AbstractCsv extends AbstractImport
             if (filter_var($value, FILTER_VALIDATE_URL)) {
                 $type = 'url';
             }
-            $metadata['extra_fields'][$key] = array('value' => $value, 'type' => $type);
+            $metadata['extra_fields'][$key] = array('value' => $value);
+            if ($includeType) {
+                $metadata['extra_fields'][$key]['type'] = $type;
+            }
         }
         return json_encode($metadata, JSON_THROW_ON_ERROR, 12);
 

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -88,28 +88,41 @@ abstract class AbstractCsv extends AbstractImport
 
     abstract protected function getProcessedColumns(): array;
 
-    protected function collectMetadata(array $row, bool $includeType = true): string
+    // we remove the columns processed as sql columns to be left with the ones we want in metadata as extra fields
+    protected function getColumnsImportableAsMetadata(array $row): array
     {
-        // we remove the columns present in compound to be left with the ones we want in metadata as extra fields
         $processedColumns = $this->getProcessedColumns();
-        $strippedRow = array_diff_key($row, array_flip($processedColumns));
+        return array_diff_key($row, array_flip($processedColumns));
+    }
+
+    protected function collectMetadata(array $row): string
+    {
+        $strippedRow = $this->getColumnsImportableAsMetadata($row);
         if (empty($strippedRow)) {
             return '{}';
         }
         $metadata = array();
         foreach ($strippedRow as $key => $value) {
             $type = 'text';
-            // translate urls into links
+            // detect a link-looking value to set type to url
             if (filter_var($value, FILTER_VALIDATE_URL)) {
                 $type = 'url';
             }
-            $metadata['extra_fields'][$key] = array('value' => $value);
-            if ($includeType) {
-                $metadata['extra_fields'][$key]['type'] = $type;
-            }
+            $metadata['extra_fields'][$key] = array(
+                'type' => $type,
+                'value' => $value,
+            );
         }
         return json_encode($metadata, JSON_THROW_ON_ERROR, 12);
+    }
 
+    protected function getMetadataFromRow(array $row): string
+    {
+        // if an explicit "metadata" column exists on the row, we directly use that and don't care about the rest
+        if (!empty($row['metadata'])) {
+            return $row['metadata'];
+        }
+        return $this->collectMetadata($row);
     }
 
     // collect tags

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Elabftw\Import;
 
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
+use JsonException;
 use League\Csv\Reader;
 use League\Csv\Info as CsvInfo;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -33,7 +35,9 @@ use function arsort;
 use function array_diff_key;
 use function array_flip;
 use function json_encode;
+use function json_decode;
 use function filter_var;
+use function is_array;
 use function key;
 
 /**
@@ -120,6 +124,14 @@ abstract class AbstractCsv extends AbstractImport
     {
         // if an explicit "metadata" column exists on the row, we directly use that and don't care about the rest
         if (!empty($row['metadata'])) {
+            try {
+                $metadata = json_decode($row['metadata'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                throw new ImproperActionException('Invalid metadata JSON provided.');
+            }
+            if (!is_array($metadata)) {
+                throw new ImproperActionException('Invalid metadata JSON provided.');
+            }
             return $row['metadata'];
         }
         return $this->collectMetadata($row);

--- a/src/Import/Csv.php
+++ b/src/Import/Csv.php
@@ -16,7 +16,6 @@ use DateTimeImmutable;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Enums\BodyContentType;
-use Elabftw\Params\EntityParams;
 use Elabftw\Enums\EntityType;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\AbstractEntity;
@@ -83,10 +82,8 @@ final class Csv extends AbstractCsv
             }
             $status = empty($row['status_title']) ? null : $this->getStatusId($this->entityType, $row['status_title']);
             $customId = empty($row['custom_id']) ? null : (int) $row['custom_id'];
-            // metadata can come from the dedicated metadata column or from extra CSV columns
-            $csvMetadata = empty($row['metadata']) ? null : (string) $row['metadata'];
-            $columnMetadata = $this->collectMetadata($row, $this->template === null);
-            $metadata = $csvMetadata ?? $columnMetadata;
+
+            $metadata = $this->getMetadataFromRow($row);
 
             $tags = empty($row['tags']) ? array() : explode(self::TAGS_SEPARATOR, $row['tags']);
             $canreadBase = empty($row['canread_base']) ? $this->canreadBase : $row['canread_base'];
@@ -100,16 +97,10 @@ final class Csv extends AbstractCsv
                 true
             )
             ) {
-                $entityId = $entity->postAction(Action::Create, array('template' => $this->template, 'title' => $row['title']));
+                $entityId = $entity->postAction(Action::Create, array('template' => $this->template, 'title' => $row['title'], 'metadata' => $metadata));
                 $entity->setId($entityId);
                 $this->processTags($entity, $tags);
                 $this->processLocation($entity, $row);
-                // preserve the template metadata schema while applying the explicit metadata payload first
-                if ($csvMetadata !== null) {
-                    $entity->update(new EntityParams('metadatamerge', $csvMetadata));
-                }
-                // merge remaining CSV columns as metadata, letting explicit columns override matching fields
-                $entity->update(new EntityParams('metadatamerge', $columnMetadata));
             } else {
                 $entityId = $entity->create(
                     title: $row['title'],
@@ -131,10 +122,6 @@ final class Csv extends AbstractCsv
                 // process inventory location after create because location links need the new resource id
                 if ($this->entityType === EntityType::Items) {
                     $this->processLocation($entity, $row);
-                }
-                // when a metadata column exists, create used it first, so merge extra CSV columns afterwards
-                if ($csvMetadata !== null) {
-                    $entity->update(new EntityParams('metadatamerge', $columnMetadata));
                 }
             }
 

--- a/src/Import/Csv.php
+++ b/src/Import/Csv.php
@@ -85,7 +85,7 @@ final class Csv extends AbstractCsv
             $customId = empty($row['custom_id']) ? null : (int) $row['custom_id'];
             // metadata can come from the dedicated metadata column or from extra CSV columns
             $csvMetadata = empty($row['metadata']) ? null : (string) $row['metadata'];
-            $columnMetadata = $this->collectMetadata($row);
+            $columnMetadata = $this->collectMetadata($row, $this->template === null);
             $metadata = $csvMetadata ?? $columnMetadata;
 
             $tags = empty($row['tags']) ? array() : explode(self::TAGS_SEPARATOR, $row['tags']);

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -114,6 +114,7 @@ use function array_filter;
 use function preg_replace;
 use function preg_match;
 use function strlen;
+use function is_numeric;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;
@@ -1558,6 +1559,7 @@ abstract class AbstractEntity extends AbstractRest
             if (isset($base['extra_fields'][$name])) {
                 $baseField = &$base['extra_fields'][$name];
                 $this->guardMetadataSchemaCompatibility($name, $baseField, $incomingField);
+                $this->guardMetadataValueCompatibility($name, $baseField, $value);
                 $type = $baseField['type'] ?? '';
 
                 // Add imported values to the field's options if they don't already exist.
@@ -1627,6 +1629,13 @@ abstract class AbstractEntity extends AbstractRest
             if (!array_key_exists($key, $baseField) || $incomingField[$key] !== $baseField[$key]) {
                 throw new ImproperActionException(sprintf(_('Metadata field %s has incompatible %s.'), $name, $key));
             }
+        }
+    }
+
+    private function guardMetadataValueCompatibility(string $name, array $field, mixed $value): void
+    {
+        if (($field['type'] ?? '') === 'number' && $value !== '' && !is_numeric(str_replace(',', '.', (string) $value))) {
+            throw new ImproperActionException(sprintf(_('Metadata field %s expects a number.'), $name));
         }
     }
 

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -1622,10 +1622,15 @@ abstract class AbstractEntity extends AbstractRest
 
     private function guardMetadataSchemaCompatibility(string $name, array $baseField, array $incomingField): void
     {
+        // existing fields keep their original schema. If the incoming metadata explicitly specifies
+        // a schema (currently type or unit), it must match the stored one. Value-only updates are still allowed.
         foreach (array('type', 'unit') as $key) {
+            // The incoming metadata does not specify this schema key, so keep the existing definition
             if (!array_key_exists($key, $incomingField)) {
                 continue;
             }
+
+            // reject attempts to merge an incompatible schema into an existing field
             if (!array_key_exists($key, $baseField) || $incomingField[$key] !== $baseField[$key]) {
                 throw new ImproperActionException(sprintf(_('Metadata field %s has incompatible %s.'), $name, $key));
             }
@@ -1634,6 +1639,8 @@ abstract class AbstractEntity extends AbstractRest
 
     private function guardMetadataValueCompatibility(string $name, array $field, mixed $value): void
     {
+        // Existing number fields must receive a valid numeric value
+        // Accept both '.' and ',' as decimal separators
         if (($field['type'] ?? '') === 'number' && $value !== '' && !is_numeric(str_replace(',', '.', (string) $value))) {
             throw new ImproperActionException(sprintf(_('Metadata field %s expects a number.'), $name));
         }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -1557,6 +1557,7 @@ abstract class AbstractEntity extends AbstractRest
 
             if (isset($base['extra_fields'][$name])) {
                 $baseField = &$base['extra_fields'][$name];
+                $this->guardMetadataSchemaCompatibility($name, $baseField, $incomingField);
                 $type = $baseField['type'] ?? '';
 
                 // Add imported values to the field's options if they don't already exist.
@@ -1615,6 +1616,18 @@ abstract class AbstractEntity extends AbstractRest
             // select/users/text/url/etc. keep the incoming string value.
             default => $value,
         };
+    }
+
+    private function guardMetadataSchemaCompatibility(string $name, array $baseField, array $incomingField): void
+    {
+        foreach (array('type', 'unit') as $key) {
+            if (!array_key_exists($key, $incomingField)) {
+                continue;
+            }
+            if (!array_key_exists($key, $baseField) || $incomingField[$key] !== $baseField[$key]) {
+                throw new ImproperActionException(sprintf(_('Metadata field %s has incompatible %s.'), $name, $key));
+            }
+        }
     }
 
     private function normalizeCheckboxValue(string $value): string

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -20,6 +20,7 @@ use Elabftw\Elabftw\CanSqlBuilder;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\EntitySqlBuilder;
 use Elabftw\Elabftw\Env;
+use Elabftw\Elabftw\MetadataHelpers as Mh;
 use Elabftw\Elabftw\FsTools;
 use Elabftw\Elabftw\Metadata;
 use Elabftw\Elabftw\Permissions;
@@ -82,7 +83,6 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use ZipArchive;
-use JsonException;
 
 use function array_column;
 use function array_merge;
@@ -109,12 +109,10 @@ use function array_map;
 use function count;
 use function array_replace;
 use function trim;
-use function strtolower;
 use function array_filter;
 use function preg_replace;
 use function preg_match;
 use function strlen;
-use function is_numeric;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;
@@ -199,12 +197,28 @@ abstract class AbstractEntity extends AbstractRest
         return match ($action) {
             Action::Create => (
                 function () use ($reqBody) {
+                    $metadata = null;
+                    if (!empty($reqBody['metadata'])) {
+                        $metadata = is_string($reqBody['metadata'])
+                            ? $reqBody['metadata'] ?? '{}'
+                            : json_encode($reqBody['metadata'], JSON_THROW_ON_ERROR);
+                    }
+
+
                     // create an entity from a template
                     if (isset($reqBody['template']) && ((int) $reqBody['template']) !== -1) {
-                        $entity = $this->entityType->toTemplateEntity($this->Users, (int) $reqBody['template']);
+                        $template = $this->entityType->toTemplateEntity($this->Users, (int) $reqBody['template']);
 
                         $title = $reqBody['title'] ?? null;
-                        return $this->copyEntityFrom(sourceEntity: $entity, title: $title, blankExtrafields: false);
+                        $overrideCreateParams = array();
+
+                        if ($metadata) {
+                            $overrideCreateParams['metadata'] = Mh::mergeMetadata(
+                                $template->entityData['metadata'],
+                                $metadata,
+                            );
+                        }
+                        return $this->copyEntityFrom(sourceEntity: $template, title: $title, blankExtrafields: false, overrideCreateParams: $overrideCreateParams);
                     }
                     // create a template from current entity
                     if (isset($reqBody['entity']) && ((int) $reqBody['entity']) !== -1) {
@@ -224,11 +238,7 @@ abstract class AbstractEntity extends AbstractRest
                     // convert to int only if not empty, otherwise send null: we don't want to convert a null to int, as it would send 0
                     $category = !empty($reqBody['category']) ? (int) $reqBody['category'] : null;
                     $status = !empty($reqBody['status']) ? (int) $reqBody['status'] : null;
-                    // force metadata to be a string
-                    $metadata = null;
-                    if (!empty($reqBody['metadata'])) {
-                        $metadata = json_encode($reqBody['metadata'], JSON_THROW_ON_ERROR);
-                    }
+
                     // force tags to be an array
                     $tags = $reqBody['tags'] ?? null;
                     if (is_string($tags)) {
@@ -834,7 +844,7 @@ abstract class AbstractEntity extends AbstractRest
             $content = $this->readColumn('body') . $content;
         }
         if ($params->getTarget() === 'metadatamerge') {
-            $content = $this->mergeMetadataValues($this->readColumn('metadata'), $content);
+            $content = Mh::mergeMetadataValues($this->readColumn('metadata'), $content);
         }
         // ensure no changes happen on entries with immutable permissions
         // admins can override the immutability of an entity's permissions. See #5800
@@ -1541,119 +1551,5 @@ abstract class AbstractEntity extends AbstractRest
         if ($this->getCreatePermissionFromTeam($teamConfigArr) === false) {
             throw new ForbiddenException();
         }
-    }
-
-    private function mergeMetadataValues(string $baseMetadata, string $incomingMetadata): string
-    {
-        // base metadata comes from the template and contains the field schema
-        $base = $this->decodeMetadata($baseMetadata);
-        // incoming metadata usually comes from CSV/API and contains the values to inject.
-        $incoming = $this->decodeMetadata($incomingMetadata);
-        // ensure both metadata arrays have an extra_fields array.
-        $base['extra_fields'] ??= array();
-        $incoming['extra_fields'] ??= array();
-
-        foreach ($incoming['extra_fields'] as $name => $incomingField) {
-            $value = $incomingField['value'] ?? '';
-
-            if (isset($base['extra_fields'][$name])) {
-                $baseField = &$base['extra_fields'][$name];
-                $this->guardMetadataSchemaCompatibility($name, $baseField, $incomingField);
-                $this->guardMetadataValueCompatibility($name, $baseField, $value);
-                $type = $baseField['type'] ?? '';
-
-                // Add imported values to the field's options if they don't already exist.
-                $values = match ($type) {
-                    'select-multi' => is_array($value)
-                        ? $value
-                        : array_map('trim', explode(',', (string) $value)),
-                    'select', 'select-one', 'radio' => array($value),
-                    default => array(),
-                };
-
-                if (!empty($values)) {
-                    $baseField['options'] ??= array();
-                    foreach ($values as $option) {
-                        if ($option !== '' && !in_array($option, $baseField['options'], true)) {
-                            $baseField['options'][] = $option;
-                        }
-                    }
-                }
-                // Preserve the existing field schema and only update its value
-                $baseField['value'] = $this->normalizeMetadataValue($baseField, $value);
-                unset($baseField);
-                continue;
-            }
-            // new fields: keep incoming schema, but normalize its value if it has a known type.
-            $incomingField['value'] = $this->normalizeMetadataValue($incomingField, $value);
-            $base['extra_fields'][$name] = $incomingField;
-        }
-
-        return json_encode($base, JSON_THROW_ON_ERROR);
-    }
-
-    private function decodeMetadata(string $metadata): array
-    {
-        // Treat empty metadata as valid metadata with no fields.
-        if ($metadata === '' || $metadata === '{}') {
-            return array('extra_fields' => array());
-        }
-        try {
-            $decoded = json_decode($metadata, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            throw new ImproperActionException(_('Invalid metadata JSON provided.'));
-        }
-        return is_array($decoded) ? $decoded : array('extra_fields' => array());
-    }
-
-    private function normalizeMetadataValue(array $field, mixed $value): string
-    {
-        $value = trim((string) $value);
-
-        return match ($field['type'] ?? 'text') {
-            // checkboxes use "on" when checked.
-            'checkbox' => $this->normalizeCheckboxValue($value),
-            // normalize decimal commas for number fields.
-            'number' => str_replace(',', '.', $value),
-            // select/users/text/url/etc. keep the incoming string value.
-            default => $value,
-        };
-    }
-
-    private function guardMetadataSchemaCompatibility(string $name, array $baseField, array $incomingField): void
-    {
-        // existing fields keep their original schema. If the incoming metadata explicitly specifies
-        // a schema (currently type or unit), it must match the stored one. Value-only updates are still allowed.
-        foreach (array('type', 'unit') as $key) {
-            // The incoming metadata does not specify this schema key, so keep the existing definition
-            if (!array_key_exists($key, $incomingField)) {
-                continue;
-            }
-
-            // reject attempts to merge an incompatible schema into an existing field
-            if (!array_key_exists($key, $baseField) || $incomingField[$key] !== $baseField[$key]) {
-                throw new ImproperActionException(sprintf(_('Metadata field %s has incompatible %s.'), $name, $key));
-            }
-        }
-    }
-
-    private function guardMetadataValueCompatibility(string $name, array $field, mixed $value): void
-    {
-        // Existing number fields must receive a valid numeric value
-        // Accept both '.' and ',' as decimal separators
-        if (($field['type'] ?? '') === 'number' && $value !== '' && !is_numeric(str_replace(',', '.', (string) $value))) {
-            throw new ImproperActionException(sprintf(_('Metadata field %s expects a number.'), $name));
-        }
-    }
-
-    private function normalizeCheckboxValue(string $value): string
-    {
-        $value = trim($value);
-        if ($value === '') {
-            return '';
-        }
-        // Common truthy values accepted from CSV/API imports.
-        $truthyValues = array('1', 'true', 'yes', 'y', 'x', 'on', 'checked', 'oui');
-        return in_array(strtolower($value), $truthyValues, true) ? 'on' : '';
     }
 }

--- a/tests/_data/invalid-metadata.csv
+++ b/tests/_data/invalid-metadata.csv
@@ -1,0 +1,2 @@
+title,metadata
+Test,{nope

--- a/tests/unit/Import/CsvTest.php
+++ b/tests/unit/Import/CsvTest.php
@@ -120,6 +120,29 @@ class CsvTest extends \PHPUnit\Framework\TestCase
         $Import->import();
     }
 
+    public function testImportRejectsInvalidExplicitMetadata(): void
+    {
+        $uploadedFile = new UploadedFile(
+            dirname(__DIR__, 2) . '/_data/invalid-metadata.csv',
+            'invalid-metadata.csv',
+            null,
+            UPLOAD_ERR_OK,
+            true,
+        );
+
+        $Import = new Csv(
+            new Users(1, 1),
+            $uploadedFile,
+            $this->logger,
+            EntityType::Items,
+            category: 1,
+        );
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata JSON provided.');
+        $Import->import();
+    }
+
     // import a file not produced by elabftw
     public function testImportCustom(): void
     {

--- a/tests/unit/classes/MetadataHelpersTest.php
+++ b/tests/unit/classes/MetadataHelpersTest.php
@@ -274,4 +274,67 @@ class MetadataHelpersTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Invalid metadata JSON provided.');
         MetadataHelpers::mergeMetadataValues('{}', '{nope');
     }
+
+    public function testMergeMetadataRejectsInvalidSourceField(): void
+    {
+        $source = '{"extra_fields":{"Nope":"not an array"}}';
+        $incoming = '{"extra_fields":{"Nope":{"value":"test"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata field Nope.');
+        MetadataHelpers::mergeMetadata($source, $incoming);
+    }
+
+    public function testMergeMetadataRejectsNonArrayJson(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata JSON provided.');
+        MetadataHelpers::mergeMetadata('null', '{}');
+    }
+
+    public function testMergeMetadataNormalizesMultiSelectArray(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","allow_multi_values":true,"options":["A","B","C"],"value":[]}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":["A","C"]}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select","allow_multi_values":true,"options":["A","B","C"],"value":["A","C"]}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataRejectsInvalidOptions(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","options":"nope","value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"A"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Choice has invalid options.');
+        MetadataHelpers::mergeMetadata($source, $incoming);
+    }
+
+    public function testMergeMetadataNormalizesEmptyCheckbox(): void
+    {
+        $source = '{"extra_fields":{"Certified":{"type":"checkbox","value":"on"}}}';
+        $incoming = '{"extra_fields":{"Certified":{"value":""}}}';
+        $expected = '{"extra_fields":{"Certified":{"type":"checkbox","value":""}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataValuesNormalizesSelectMultiArray(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"select-multi","options":["A","B"],"value":[]}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":["A","B"]}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select-multi","options":["A","B"],"value":["A","B"]}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesNormalizesSelectMultiString(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"select-multi","options":["A","B","C"],"value":[]}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"A, C"}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select-multi","options":["A","B","C"],"value":["A","C"]}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
 }

--- a/tests/unit/classes/MetadataHelpersTest.php
+++ b/tests/unit/classes/MetadataHelpersTest.php
@@ -337,4 +337,41 @@ class MetadataHelpersTest extends \PHPUnit\Framework\TestCase
 
         $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
     }
+
+    public function testMergeMetadataValuesRejectsInvalidExtraFields(): void
+    {
+        $base = '{"extra_fields":"nope"}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata extra_fields provided.');
+        MetadataHelpers::mergeMetadataValues($base, '{}');
+    }
+
+    public function testMergeMetadataValuesRejectsInvalidField(): void
+    {
+        $incoming = '{"extra_fields":{"Nope":"not an array"}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata field Nope.');
+        MetadataHelpers::mergeMetadataValues('{}', $incoming);
+    }
+
+    public function testMergeMetadataValuesAcceptsNumericOptions(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"select","options":[1,2],"value":"2"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"1"}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select","options":[1,2],"value":"1"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesRejectsNonScalarOption(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"select-multi","options":["A"],"value":[]}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":[["A"]]}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Choice contains an invalid option.');
+        MetadataHelpers::mergeMetadataValues($base, $incoming);
+    }
 }

--- a/tests/unit/classes/MetadataHelpersTest.php
+++ b/tests/unit/classes/MetadataHelpersTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Elabftw;
+
+use Elabftw\Exceptions\ImproperActionException;
+
+use function json_decode;
+use function json_encode;
+use function sprintf;
+
+class MetadataHelpersTest extends \PHPUnit\Framework\TestCase
+{
+    public function testMergeMetadataWithEmptySource(): void
+    {
+        $incoming = '{"extra_fields":{"Website":{"type":"url","value":"https://example.org"}}}';
+        $expected = '{"extra_fields":{"Website":{"type":"url","value":"https://example.org"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata(null, $incoming));
+    }
+
+    public function testMergeMetadataPreservesSourceSchema(): void
+    {
+        $source = '{"extra_fields":{"Weight":{"type":"number","unit":"g","units":["g","kg"],"description":"Mass","value":"1"}}}';
+        $incoming = '{"extra_fields":{"Weight":{"type":"text","unit":"kg","description":"Ignored","value":"12,5"}}}';
+        $expected = '{"extra_fields":{"Weight":{"type":"number","unit":"g","units":["g","kg"],"description":"Mass","value":"12.5"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataAddsNewFieldWithIncomingSchema(): void
+    {
+        $source = '{"extra_fields":{"Existing":{"type":"text","value":"old"}}}';
+        $incoming = '{"extra_fields":{"Website":{"type":"url","description":"Homepage","value":"https://example.org"}}}';
+        $expected = '{"extra_fields":{"Existing":{"type":"text","value":"old"},"Website":{"type":"url","description":"Homepage","value":"https://example.org"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataIgnoresExistingFieldWithoutValue(): void
+    {
+        $source = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"42"}}}';
+        $incoming = '{"extra_fields":{"Weight":{"type":"text","unit":"kg"}}}';
+
+        $this->assertJsonStringEqualsJsonString($source, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataNormalizesNumber(): void
+    {
+        $source = '{"extra_fields":{"Weight":{"type":"number","value":""}}}';
+        $incoming = '{"extra_fields":{"Weight":{"value":"12,5"}}}';
+        $expected = '{"extra_fields":{"Weight":{"type":"number","value":"12.5"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataRejectsInvalidNumber(): void
+    {
+        $source = '{"extra_fields":{"Weight":{"type":"number","value":""}}}';
+        $incoming = '{"extra_fields":{"Weight":{"value":"100X89"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Weight expects a number.');
+        MetadataHelpers::mergeMetadata($source, $incoming);
+    }
+
+    public function testMergeMetadataNormalizesCheckboxTruthyValues(): void
+    {
+        $source = '{"extra_fields":{"Certified":{"type":"checkbox","value":""}}}';
+        $truthyValues = array(
+            '1',
+            'TRUE',
+            'yes',
+            'YEP',
+            'oui',
+            'ouaip',
+            'grave',
+            'sí',
+            'sim',
+            'jawohl',
+            'sì',
+            'da',
+            'tak',
+            'kyllä',
+            'igen',
+            'evet',
+            'hai',
+            'はい',
+            '+',
+            '✓',
+            '✔',
+        );
+
+        foreach ($truthyValues as $value) {
+            $incoming = json_encode(array(
+                'extra_fields' => array(
+                    'Certified' => array('value' => $value),
+                ),
+            ), JSON_THROW_ON_ERROR);
+            $result = json_decode(MetadataHelpers::mergeMetadata($source, $incoming), true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame('on', $result['extra_fields']['Certified']['value'], sprintf('Expected "%s" to normalize to "on".', $value));
+        }
+    }
+
+    public function testMergeMetadataNormalizesCheckboxFalsyValues(): void
+    {
+        $source = '{"extra_fields":{"Certified":{"type":"checkbox","value":"on"}}}';
+        $falsyValues = array('0', 'false', 'no', 'off', 'non', 'いいえ', 'whatever');
+
+        foreach ($falsyValues as $value) {
+            $incoming = json_encode(array(
+                'extra_fields' => array(
+                    'Certified' => array('value' => $value),
+                ),
+            ), JSON_THROW_ON_ERROR);
+            $result = json_decode(MetadataHelpers::mergeMetadata($source, $incoming), true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame('', $result['extra_fields']['Certified']['value'], sprintf('Expected "%s" to normalize to an unchecked checkbox.', $value));
+        }
+    }
+
+    public function testMergeMetadataAcceptsValidSelectOption(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"B"}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"B"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataRejectsInvalidSelectOption(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"C"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Choice contains an invalid option.');
+        MetadataHelpers::mergeMetadata($source, $incoming);
+    }
+
+    public function testMergeMetadataNormalizesMultiSelect(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","allow_multi_values":true,"options":["A","B","C"],"value":[]}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"A, C"}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select","allow_multi_values":true,"options":["A","B","C"],"value":["A","C"]}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
+    public function testMergeMetadataRejectsMultipleValuesForSingleSelect(): void
+    {
+        $source = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":["A","B"]}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Choice expects a single value.');
+        MetadataHelpers::mergeMetadata($source, $incoming);
+    }
+
+    public function testMergeMetadataRejectsInvalidExtraFields(): void
+    {
+        $incoming = '{"extra_fields":"nope"}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata extra_fields provided.');
+        MetadataHelpers::mergeMetadata('{}', $incoming);
+    }
+
+    public function testMergeMetadataRejectsInvalidField(): void
+    {
+        $incoming = '{"extra_fields":{"Nope":"not an array"}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata field Nope.');
+        MetadataHelpers::mergeMetadata('{}', $incoming);
+    }
+
+    public function testMergeMetadataRejectsInvalidJson(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata JSON provided.');
+        MetadataHelpers::mergeMetadata('{}', '{nope');
+    }
+
+    public function testMergeMetadataValuesWithValueOnlyIncomingField(): void
+    {
+        $base = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"1"}}}';
+        $incoming = '{"extra_fields":{"Weight":{"value":"12,5"}}}';
+        $expected = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"12.5"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesWithCompatibleSchema(): void
+    {
+        $base = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"1"}}}';
+        $incoming = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"2"}}}';
+        $expected = '{"extra_fields":{"Weight":{"type":"number","unit":"g","value":"2"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesRejectsIncompatibleType(): void
+    {
+        $base = '{"extra_fields":{"Coffee":{"type":"number","unit":"liter","value":"100"}}}';
+        $incoming = '{"extra_fields":{"Coffee":{"type":"date","unit":"liter","value":"100"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Coffee has incompatible type.');
+        MetadataHelpers::mergeMetadataValues($base, $incoming);
+    }
+
+    public function testMergeMetadataValuesRejectsIncompatibleUnit(): void
+    {
+        $base = '{"extra_fields":{"Coffee":{"type":"number","unit":"liter","value":"100"}}}';
+        $incoming = '{"extra_fields":{"Coffee":{"type":"number","unit":"gram","value":"100"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Coffee has incompatible unit.');
+        MetadataHelpers::mergeMetadataValues($base, $incoming);
+    }
+
+    public function testMergeMetadataValuesRejectsInvalidNumber(): void
+    {
+        $base = '{"extra_fields":{"Coffee":{"type":"number","unit":"liter","value":"100"}}}';
+        $incoming = '{"extra_fields":{"Coffee":{"value":"100X89"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Coffee expects a number.');
+        MetadataHelpers::mergeMetadataValues($base, $incoming);
+    }
+
+    public function testMergeMetadataValuesRejectsInvalidSelectOption(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"radio","options":["A","B"],"value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"C"}}}';
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field Choice contains an invalid option.');
+        MetadataHelpers::mergeMetadataValues($base, $incoming);
+    }
+
+    public function testMergeMetadataValuesKeepsExistingSelectOptions(): void
+    {
+        $base = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"A"}}}';
+        $incoming = '{"extra_fields":{"Choice":{"value":"B"}}}';
+        $expected = '{"extra_fields":{"Choice":{"type":"select","options":["A","B"],"value":"B"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesAddsNewField(): void
+    {
+        $base = '{"extra_fields":{"Existing":{"type":"text","value":"old"}}}';
+        $incoming = '{"extra_fields":{"Website":{"type":"url","value":"https://example.org"}}}';
+        $expected = '{"extra_fields":{"Existing":{"type":"text","value":"old"},"Website":{"type":"url","value":"https://example.org"}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadataValues($base, $incoming));
+    }
+
+    public function testMergeMetadataValuesRejectsInvalidJson(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Invalid metadata JSON provided.');
+        MetadataHelpers::mergeMetadataValues('{}', '{nope');
+    }
+}

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -254,23 +254,18 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $incomingMetadata = json_encode(array(
             'extra_fields' => array(
                 'weight' => array(
-                    'type' => 'text',
                     'value' => '12,5',
                 ),
                 'certified' => array(
-                    'type' => 'text',
                     'value' => 'X',
                 ),
                 'choice' => array(
-                    'type' => 'text',
                     'value' => 'C',
                 ),
                 'person in charge' => array(
-                    'type' => 'text',
                     'value' => '42',
                 ),
                 'website' => array(
-                    'type' => 'text',
                     'value' => 'https://example.org',
                 ),
                 'new checkbox' => array(
@@ -321,6 +316,66 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('on', $fields['new checkbox']['value']);
         $this->assertSame('text', $fields['new text']['type']);
         $this->assertSame('hello', $fields['new text']['value']);
+    }
+
+    // prevent regression with conflicting metadata schema. #7148
+    public function testMetadataMergeRejectsSchemaMismatch(): void
+    {
+        $this->Items->patch(Action::Update, array(
+            'metadata' => json_encode(array(
+                'extra_fields' => array(
+                    'Coffee' => array(
+                        'type' => 'number',
+                        'unit' => 'liter',
+                        'value' => '1',
+                    ),
+                ),
+            ), JSON_THROW_ON_ERROR),
+        ));
+
+        $this->expectException(ImproperActionException::class);
+        $this->Items->patch(Action::Update, array(
+            'metadatamerge' => json_encode(array(
+                'extra_fields' => array(
+                    'Coffee' => array(
+                        'type' => 'date',
+                        'unit' => 'gram',
+                        'value' => '2',
+                    ),
+                ),
+            ), JSON_THROW_ON_ERROR),
+        ));
+    }
+
+    public function testMetadataMergeAllowsValueOnlyUpdate(): void
+    {
+        $this->Items->patch(Action::Update, array(
+            'metadata' => json_encode(array(
+                'extra_fields' => array(
+                    'Coffee' => array(
+                        'type' => 'number',
+                        'unit' => 'liter',
+                        'value' => '1',
+                    ),
+                ),
+            ), JSON_THROW_ON_ERROR),
+        ));
+
+        $metadata = $this->Items->patch(Action::Update, array(
+            'metadatamerge' => json_encode(array(
+                'extra_fields' => array(
+                    'Coffee' => array(
+                        'value' => '2',
+                    ),
+                ),
+            ), JSON_THROW_ON_ERROR),
+        ));
+
+        $fields = json_decode($metadata['metadata'], true, 512, JSON_THROW_ON_ERROR)['extra_fields'];
+
+        $this->assertSame('number', $fields['Coffee']['type']);
+        $this->assertSame('liter', $fields['Coffee']['unit']);
+        $this->assertSame('2', $fields['Coffee']['value']);
     }
 
     private function makeItemFromImmutableTemplateFor(AuthenticatedUser $user): Items

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -27,7 +27,6 @@ use Elabftw\Traits\TestsUtilsTrait;
 use function date;
 use function array_column;
 use function json_decode;
-use function json_encode;
 
 class ItemsTest extends \PHPUnit\Framework\TestCase
 {
@@ -216,151 +215,24 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse((bool) $item['locked']);
     }
 
-    // test metadata merge preserves existing fields on import
-    public function testMetadataMergePreservesExistingFieldSchema(): void
-    {
-        $new = $this->Items->create();
-        $this->Items->setId($new);
-
-        $baseMetadata = json_encode(array(
-            'extra_fields' => array(
-                'weight' => array(
-                    'type' => 'number',
-                    'value' => '0',
-                    'units' => array('g'),
-                    'unit' => 'g',
-                ),
-                'certified' => array(
-                    'type' => 'checkbox',
-                    'value' => '',
-                ),
-                'choice' => array(
-                    'type' => 'select',
-                    'value' => 'A',
-                    'options' => array('A', 'B'),
-                ),
-                'person in charge' => array(
-                    'type' => 'users',
-                    'value' => '',
-                    'description' => 'Select the person responsible.',
-                ),
-                'website' => array(
-                    'type' => 'url',
-                    'value' => '',
-                ),
-            ),
-        ), JSON_THROW_ON_ERROR);
-
-        $incomingMetadata = json_encode(array(
-            'extra_fields' => array(
-                'weight' => array(
-                    'value' => '12,5',
-                ),
-                'certified' => array(
-                    'value' => 'X',
-                ),
-                'choice' => array(
-                    'value' => 'C',
-                ),
-                'person in charge' => array(
-                    'value' => '42',
-                ),
-                'website' => array(
-                    'value' => 'https://example.org',
-                ),
-                'new checkbox' => array(
-                    'type' => 'checkbox',
-                    'value' => 'oui',
-                ),
-                'new text' => array(
-                    'type' => 'text',
-                    'value' => 'hello',
-                ),
-            ),
-        ), JSON_THROW_ON_ERROR);
-
-        // have the base Metadata on the item
-        $this->Items->patch(Action::Update, array('metadata' => $baseMetadata));
-        // now merge with some incoming data
-        $this->Items->patch(Action::Update, array('metadatamerge' => $incomingMetadata));
-
-        $metadata = json_decode($this->Items->readOne()['metadata'], true, 512, JSON_THROW_ON_ERROR);
-        $fields = $metadata['extra_fields'];
-
-        // existing "weight" number keeps type/unit and receives normalized value.
-        $this->assertSame('number', $fields['weight']['type']);
-        $this->assertSame('12.5', $fields['weight']['value']);
-        $this->assertSame(array('g'), $fields['weight']['units']);
-        $this->assertSame('g', $fields['weight']['unit']);
-
-        // existing checkbox keeps type and receives normalized truthy value.
-        $this->assertSame('checkbox', $fields['certified']['type']);
-        $this->assertSame('on', $fields['certified']['value']);
-
-        // existing select keeps type and adds new options automatically.
-        $this->assertSame('select', $fields['choice']['type']);
-        $this->assertSame('C', $fields['choice']['value']);
-        $this->assertSame(array('A', 'B', 'C'), $fields['choice']['options']);
-
-        // existing user field keeps description/schema.
-        $this->assertSame('users', $fields['person in charge']['type']);
-        $this->assertSame('42', $fields['person in charge']['value']);
-        $this->assertSame('Select the person responsible.', $fields['person in charge']['description']);
-
-        // url keeps type.
-        $this->assertSame('url', $fields['website']['type']);
-        $this->assertSame('https://example.org', $fields['website']['value']);
-
-        // New fields are added and normalized according to their incoming type.
-        $this->assertSame('checkbox', $fields['new checkbox']['type']);
-        $this->assertSame('on', $fields['new checkbox']['value']);
-        $this->assertSame('text', $fields['new text']['type']);
-        $this->assertSame('hello', $fields['new text']['value']);
-    }
-
-    // prevent regression with conflicting metadata schema. #7148
-    public function testMetadataMergeRejectsSchemaMismatch(): void
+    public function testMetadataMerge(): void
     {
         $this->Items->patch(Action::Update, array(
-            'metadata' => json_encode(
-                array(
-                    'extra_fields' => array(
-                        'Coffee' => array('type' => 'number', 'unit' => 'liter', 'value' => '1'))),
-                JSON_THROW_ON_ERROR
-            ),
+            'metadata' => '{"extra_fields":{"Coffee":{"type":"number","value":"1"}}}',
         ));
-
-        $this->expectException(ImproperActionException::class);
-        $this->expectExceptionMessageMatches('/Metadata field Coffee has incompatible type\./');
-        $this->Items->patch(Action::Update, array(
-            'metadatamerge' => json_encode(
-                array(
-                    'extra_fields' => array(
-                        'Coffee' => array('type' => 'date', 'unit' => 'gram', 'value' => '2'))),
-                JSON_THROW_ON_ERROR
-            ),
-        ));
-    }
-
-    public function testMetadataMergeRejectsInvalidNumber(): void
-    {
-        $this->Items->patch(Action::Update, array(
-            'metadata' => json_encode(
-                array(
-                    'extra_fields' => array(
-                        'Coffee' => array('type' => 'number', 'value' => '1'))),
-                JSON_THROW_ON_ERROR
-            ),
-        ));
-
-        $this->expectException(ImproperActionException::class);
-        $this->expectExceptionMessageMatches('/Metadata field Coffee expects a number\./');
 
         $this->Items->patch(Action::Update, array(
-            'metadatamerge' => json_encode(array(
-                'extra_fields' => array(
-                    'Coffee' => array('value' => '100X89'))), JSON_THROW_ON_ERROR),
+            'metadatamerge' => '{"extra_fields":{"Coffee":{"value":"2"}}}',
         ));
+
+        $metadata = json_decode(
+            $this->Items->readOne()['metadata'],
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertSame('2', $metadata['extra_fields']['Coffee']['value']);
     }
 
     private function makeItemFromImmutableTemplateFor(AuthenticatedUser $user): Items

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -347,35 +347,25 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
         ));
     }
 
-    public function testMetadataMergeAllowsValueOnlyUpdate(): void
+    public function testMetadataMergeRejectsInvalidNumber(): void
     {
         $this->Items->patch(Action::Update, array(
             'metadata' => json_encode(array(
                 'extra_fields' => array(
-                    'Coffee' => array(
-                        'type' => 'number',
-                        'unit' => 'liter',
-                        'value' => '1',
-                    ),
+                    'Coffee' => array('type' => 'number', 'value' => '1'),
                 ),
             ), JSON_THROW_ON_ERROR),
         ));
 
-        $metadata = $this->Items->patch(Action::Update, array(
+        $this->expectException(ImproperActionException::class);
+
+        $this->Items->patch(Action::Update, array(
             'metadatamerge' => json_encode(array(
                 'extra_fields' => array(
-                    'Coffee' => array(
-                        'value' => '2',
-                    ),
+                    'Coffee' => array('value' => '100X89'),
                 ),
             ), JSON_THROW_ON_ERROR),
         ));
-
-        $fields = json_decode($metadata['metadata'], true, 512, JSON_THROW_ON_ERROR)['extra_fields'];
-
-        $this->assertSame('number', $fields['Coffee']['type']);
-        $this->assertSame('liter', $fields['Coffee']['unit']);
-        $this->assertSame('2', $fields['Coffee']['value']);
     }
 
     private function makeItemFromImmutableTemplateFor(AuthenticatedUser $user): Items

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -322,49 +322,44 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
     public function testMetadataMergeRejectsSchemaMismatch(): void
     {
         $this->Items->patch(Action::Update, array(
-            'metadata' => json_encode(array(
-                'extra_fields' => array(
-                    'Coffee' => array(
-                        'type' => 'number',
-                        'unit' => 'liter',
-                        'value' => '1',
-                    ),
-                ),
-            ), JSON_THROW_ON_ERROR),
+            'metadata' => json_encode(
+                array(
+                    'extra_fields' => array(
+                        'Coffee' => array('type' => 'number', 'unit' => 'liter', 'value' => '1'))),
+                JSON_THROW_ON_ERROR
+            ),
         ));
 
         $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessageMatches('/Metadata field Coffee has incompatible type\./');
         $this->Items->patch(Action::Update, array(
-            'metadatamerge' => json_encode(array(
-                'extra_fields' => array(
-                    'Coffee' => array(
-                        'type' => 'date',
-                        'unit' => 'gram',
-                        'value' => '2',
-                    ),
-                ),
-            ), JSON_THROW_ON_ERROR),
+            'metadatamerge' => json_encode(
+                array(
+                    'extra_fields' => array(
+                        'Coffee' => array('type' => 'date', 'unit' => 'gram', 'value' => '2'))),
+                JSON_THROW_ON_ERROR
+            ),
         ));
     }
 
     public function testMetadataMergeRejectsInvalidNumber(): void
     {
         $this->Items->patch(Action::Update, array(
-            'metadata' => json_encode(array(
-                'extra_fields' => array(
-                    'Coffee' => array('type' => 'number', 'value' => '1'),
-                ),
-            ), JSON_THROW_ON_ERROR),
+            'metadata' => json_encode(
+                array(
+                    'extra_fields' => array(
+                        'Coffee' => array('type' => 'number', 'value' => '1'))),
+                JSON_THROW_ON_ERROR
+            ),
         ));
 
         $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessageMatches('/Metadata field Coffee expects a number\./');
 
         $this->Items->patch(Action::Update, array(
             'metadatamerge' => json_encode(array(
                 'extra_fields' => array(
-                    'Coffee' => array('value' => '100X89'),
-                ),
-            ), JSON_THROW_ON_ERROR),
+                    'Coffee' => array('value' => '100X89'))), JSON_THROW_ON_ERROR),
         ));
     }
 


### PR DESCRIPTION
fix #7148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata updates preserve existing field definitions when only values change.
  * Conflicting field types, units, or unsupported options are rejected with clear errors.
  * Invalid numeric, checkbox, and multi-select values are normalized or rejected appropriately.
  * CSV imports now handle metadata consistently with or without templates.

* **Tests**
  * Added coverage for metadata merging, schema preservation, value normalization, and invalid metadata validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->