### PR TITLE
Show last name when first name is empty

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -234,7 +234,20 @@
         {# User dropdown #}
         <div class='nav-item dropdown'>
           <button class='btn nav-link border-0' id='navbarDropdown' type='button' aria-label='{{ 'User menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><span class='initials'>{{ App.Users.userData.initials }}</span></button>
-          <div class='dropdown-menu dropdown-menu-right'><div class='dropdown-header'>{{ 'Logged in as %s in:'|trans|format(App.Users.userData.firstname|default('Anonymous')) }}<br>{{ App.Teams.teamArr.name }}</div>
+          <div class='dropdown-menu dropdown-menu-right'>
+            <div class='dropdown-header'>
+                {% if App.Users.userData.firstname is not empty %}
+                    {% set displayName = App.Users.userData.firstname %}
+                {% elseif App.Users.userData.lastname is not empty %}
+                    {% set displayName = App.Users.userData.lastname %}
+                {% else %}
+                    {% set displayName = 'Anonymous'|trans %}
+                {% endif %}
+
+                {{ 'Logged in as %s in:'|trans|format(displayName) }}
+                <br>
+                {{ App.Teams.teamArr.name }}
+            </div>
             {% if App.Users.userData.teams|default([])|length > 1 %}
               <a href='login.php?switch_team=1' class='dropdown-item'><i class='fas fa-repeat fa-fw'></i> {{ 'Switch team'|trans }}</a>
             {% endif %}

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -235,19 +235,7 @@
         <div class='nav-item dropdown'>
           <button class='btn nav-link border-0' id='navbarDropdown' type='button' aria-label='{{ 'User menu'|trans }}' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'><span class='initials'>{{ App.Users.userData.initials }}</span></button>
           <div class='dropdown-menu dropdown-menu-right'>
-            <div class='dropdown-header'>
-                {% if App.Users.userData.firstname is not empty %}
-                    {% set displayName = App.Users.userData.firstname %}
-                {% elseif App.Users.userData.lastname is not empty %}
-                    {% set displayName = App.Users.userData.lastname %}
-                {% else %}
-                    {% set displayName = 'Anonymous'|trans %}
-                {% endif %}
-
-                {{ 'Logged in as %s in:'|trans|format(displayName) }}
-                <br>
-                {{ App.Teams.teamArr.name }}
-            </div>
+           <div class='dropdown-header'>{{ 'Logged in as %s in:'|trans|format(App.Users.userData.firstname|default(App.Users.userData.lastname|default('Anonymous'))) }}<br>{{ App.Teams.teamArr.name }}</div>
             {% if App.Users.userData.teams|default([])|length > 1 %}
               <a href='login.php?switch_team=1' class='dropdown-item'><i class='fas fa-repeat fa-fw'></i> {{ 'Switch team'|trans }}</a>
             {% endif %}


### PR DESCRIPTION
### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [x] I have mentioned the related **issue**.
- [ ] I have updated or verified the relevant documentation (documentation directory).

---

## Summary

This PR fixes the user dropdown display when a user's first name is empty.

Previously, the dropdown displayed **"Anonymous"** whenever `firstname` was empty, even if the user had a valid last name.

The updated fallback logic is:

- Show the first name if it is available.
- Otherwise, show the last name if it is available.
- Otherwise, show the translated **"Anonymous"** label.

This matches the expected behavior described in issue #7213.

## Related Issue

Closes #7213

## Approach

The change is limited to `src/templates/head.html`.

A temporary `displayName` variable is used to determine the appropriate name before rendering the existing translated `"Logged in as %s in:"` message. This keeps the change localized and preserves the existing behavior for users with a first name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the user dropdown header to display names in the correct order: first name, last name, or a translated “Anonymous” fallback.
  * Preserved the existing team name display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->