### PR TITLE
bug/fresh: elabimg: remove cache in built image

### DIFF
--- a/containers/circleci/Dockerfile
+++ b/containers/circleci/Dockerfile
@@ -3,6 +3,9 @@
 ARG ELABTMP_TAG=latest
 FROM elabftw/elabtmp:${ELABTMP_TAG}
 
+# run yarn install again because we removed yarn stuff on elabimg build
+RUN yarn install --immutable
+
 # add tests related folders and files to the image
 COPY ./tests /elabftw/tests
 COPY ./eslint.config.mjs /elabftw

--- a/containers/elabimg/Dockerfile
+++ b/containers/elabimg/Dockerfile
@@ -347,9 +347,9 @@ RUN if [ "$BUILD_ALL" = "1" ]; then \
         else \
             yarn run buildall:prod \
             && yarn workspaces focus -A --production \
-            && /usr/bin/php84 -d memory_limit=256M /usr/local/bin/composer install --prefer-dist --no-cache --no-progress --no-dev -a \
-            && yarn cache clean; \
-        fi; \
+            && /usr/bin/php84 -d memory_limit=256M /usr/local/bin/composer install --prefer-dist --no-cache --no-progress --no-dev -a; \
+        fi \
+        && rm -rf /run/elabftw/yarn /run/elabftw/cache /run/composer; \
     fi
 # PHP: add php config after composer step so open_basedir is not an issue
 COPY ./containers/elabimg/php/php.ini /etc/php84/php.ini.tpl


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production build cleanup by removing temporary package-manager caches after dependency installation.
  * Reduced unnecessary cache data in the resulting build environment.
  * Improved build environment consistency by enforcing immutable dependency installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->