### PR TITLE
ci: cypress: remove ignore error

### DIFF
--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -19,10 +19,3 @@ import './commands';
 // running import here doesn't work as we need to call it, so use require
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('cypress-terminal-report/src/installLogsCollector')();
-
-// fix sporadic issues that are not important
-Cypress.on('uncaught:exception', err => {
-  if (err.message.includes('ResizeObserver')) {
-    return false;
-  }
-});


### PR DESCRIPTION
it is fixed now with proper css/js stuff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cypress tests now surface previously suppressed `ResizeObserver` errors, improving error visibility during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->