### PR TITLE
bug/minor: view: always display uploads section

### DIFF
--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -145,9 +145,7 @@
 {% endif %}
 </section>
 
-{% if Entity.entityData.uploads %}
-  {% include 'uploads.html' %}
-{% endif %}
+{% include 'uploads.html' %}
 
 {% include 'steps-view.html' %}
 


### PR DESCRIPTION
to allow viewing archived entries. fix #7156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads are now consistently included in the relevant view, even when upload data is unavailable or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->