### PR TITLE
feat: ui: add creation date in view mode

### DIFF
--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -205,7 +205,8 @@
 {# STATIC INFO #}
 <hr>
 <div class='d-flex flex-column align-items-end'>
-  {# SHOW LAST MOD #}
+  {# SHOW CREATED AT / LAST MOD #}
+  <div>{{ 'Created on %s'|trans|format(Entity.entityData.created_at ) }}</div>
   <div>{{ 'Last modified on %s'|trans|format(Entity.entityData.modified_at) }}</div>
   {# eLabID: add an if because templates don't have one #}
   {% if Entity.entityData.elabid %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The static information section now shows the entity creation timestamp before the last-modified timestamp.
  * Updated the related labeling to cover both timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->