### PR TITLE
feat: ui: add navigation buttons to the right

### DIFF
--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -59,6 +59,7 @@ final class i18n4Js
             'archive-user-description' => _('Archiving a user means their account will be disabled. This action is reversible.'),
             'association-date' => _('Association date'),
             'background-color' => _('Background color'),
+            'back-to-top' => _('Back to top'),
             'can-manage-compounds' => _('Can manage compounds'),
             'can-manage-inventory-locations' => _('Can manage inventory locations'),
             'can-manage-users2teams' => _('Can manage users to teams'),

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1565,13 +1565,50 @@ input[type='color'] {
 
 /* SCROLL TO TOP OF PAGE BUTTON */
 .floating-middle-right {
+  align-items: flex-end;
+  gap: 0.5rem;
   position: fixed;
   right: 0.8%;
-  top: calc(100vh - 15rem);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20rem;
+  z-index: 1035;
 }
 
-#backToTopButton {
-  transition: all 0.5s ease;
+.scroll-button {
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+  white-space: nowrap;
+
+  .scroll-button-label {
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+      margin-right 0.2s ease,
+      max-width 0.3s ease,
+      opacity 0.2s ease;
+  }
+
+  &:hover,
+  &:focus-visible {
+    .scroll-button-label {
+      margin-right: 0.5rem;
+      max-width: 18rem;
+      opacity: 1;
+    }
+  }
+}
+
+[data-scroll-btn] {
+  scroll-margin-top:
+    calc(
+      var(--navbar-height)
+      + var(--toolbar-height)
+      + 1rem
+      + var(--scroll-btn-y, 0px)
+    );
 }
 
 #scrollTopBtnAnchor {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1567,6 +1567,7 @@ input[type='color'] {
 .floating-middle-right {
   align-items: flex-end;
   gap: 0.5rem;
+  pointer-events: none;
   position: fixed;
   right: 0.8%;
   top: 50%;
@@ -1579,6 +1580,7 @@ input[type='color'] {
   align-items: center;
   display: flex;
   justify-content: flex-end;
+  pointer-events: auto;
   white-space: nowrap;
 
   .scroll-button-label {

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -94,7 +94,7 @@
           <textarea aria-label='{{ 'Main content'|trans }}' id='body_area' class='mceditable invisible' name='body'>{{ Entity.entityData.body }}</textarea>
         {% endif %}
       </div>
-      <div class='d-flex ml-1'>
+      <div data-scroll-btn='fa-font' data-scroll-btn-label='{{ 'Main text end'|trans }}' data-scroll-btn-y='42' class='d-flex ml-1'>
         {# LAST SAVED #}
         <div>
           <span class='smallgray'>{{ 'Last saved:'|trans }}</span>
@@ -108,7 +108,7 @@
 <hr>
 {# EXTRA FIELDS #}
 {% include('field-builder-modal.html') %}
-<h3 data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Custom fields'|trans }}</h3>
+<h3 data-action='toggle-next' data-scroll-btn='fa-rectangle-list' data-scroll-btn-label='{{ 'Custom fields'|trans }}' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Custom fields'|trans }}</h3>
 <div data-save-hidden='metadataDiv' class='col-md-8 mt-4'>
   {# this div is filled in JS by Metadata.class.ts edit() #}
   <div id='metadataDiv'></div>
@@ -130,7 +130,7 @@
 {% include 'storage-view-edit.html' %}
 
 {# PERMISSIONS #}
-<h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='permissionsDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Permissions'|trans }}</h3>
+<h3 title='{{ 'Toggle visibility'|trans }}' data-scroll-btn='fa-user-lock' data-scroll-btn-label='{{ 'Permissions'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='permissionsDiv'><i class='fas fa-caret-down fa-fw mr-2'></i>{{ 'Permissions'|trans }}</h3>
 <div class='mt-2 ml-3' id='permissionsDiv' data-save-hidden='permissionsDiv'>
   {% if Entity.entityData.canread_target %}
     <h5>{{ 'Permissions for the template'|trans }}</h5>

--- a/src/templates/links.html
+++ b/src/templates/links.html
@@ -1,5 +1,5 @@
 {# LINKS #}
-<h3 data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Links'|trans }}</h3>
+<h3 data-action='toggle-next' data-scroll-btn='fa-link' data-scroll-btn-label='{{ 'Links'|trans }}' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='linksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Links'|trans }}</h3>
 <div class='mt-2' data-save-hidden='linksDiv' id='linksDiv'>
   {# EXPERIMENTS LINKS #}
   <h4 data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='ml-3 d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='experimentsLinksDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Experiment links'|trans }} (<span id='experimentsLinksCount'>{{ Entity.entityData.experiments_links|length }}</span>)</h4>

--- a/src/templates/spreadsheet-editor.html
+++ b/src/templates/spreadsheet-editor.html
@@ -1,6 +1,6 @@
 {% set text = 'Beta Notice: The spreadsheet editor is currently in beta (preview release) and should be used with caution. Please avoid storing important data in it. Additionally, files that include styling or advanced features such as graphics may not display as they originally appear. This editor is best suited for simple calculations and handling formulas. We welcome any feedback you may have.'|trans %}
 <section id='spreadsheetEditor' aria-label='{{ 'Spreadsheet Editor'|trans }}'>
-  <h3 data-action='toggle-next' data-toggle-target='spreadsheetEditorDiv' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title mt-2' tabindex='0' role='button' aria-expanded='false' aria-controls='spreadsheetEditorDiv'>
+  <h3 data-action='toggle-next' data-scroll-btn='fa-file-excel' data-scroll-btn-label='{{ 'Spreadsheet editor'|trans }}' data-toggle-target='spreadsheetEditorDiv' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title mt-2' tabindex='0' role='button' aria-expanded='false' aria-controls='spreadsheetEditorDiv'>
     <i id='sheetEditorIcon' class='fas fa-caret-right fa-fw mr-2'></i>{{ 'Spreadsheet Editor'|trans }}
   </h3>
   <span class='beta'>beta</span>

--- a/src/templates/steps-edit.html
+++ b/src/templates/steps-edit.html
@@ -1,5 +1,5 @@
 {# STEPS #}
-<h3 data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }} (<span id='stepsCount'>{{ Entity.entityData.steps|length }}</span>)</h3>
+<h3 data-action='toggle-next' data-scroll-btn='fa-list-check' data-scroll-btn-label='{{ 'Steps'|trans }}' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='stepsDiv'><i class='fas fa-caret-down mr-2 fa-fw'></i> {{ 'Steps'|trans }} (<span id='stepsCount'>{{ Entity.entityData.steps|length }}</span>)</h3>
 <div id='stepsDiv' class='mt-2' data-count-for='stepsCount' data-save-hidden='stepsDiv'>
   <div class='sortable' id='steps_div_{{ Entity.id }}' data-axis='y' data-table='{{ Entity.entityType.value }}_steps'>
     {# LOCK ALL STEPS #}

--- a/src/templates/storage-view-edit.html
+++ b/src/templates/storage-view-edit.html
@@ -2,7 +2,7 @@
 {% if Entity.entityType.value == 'experiments' or Entity.entityType.value == 'items' %}
 {% include 'add-container-modal.html' %}
 {% include 'move-container-modal.html' %}
-<h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='storageDivContent'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Storage'|trans }} (<span id='containersCount'>{{ Entity.entityData.containers|length }}</span>)</h3>
+<h3 title='{{ 'Toggle visibility'|trans }}' data-scroll-btn='fa-flask-vial' data-scroll-btn-label='{{ 'Storage'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title' tabindex='0' role='button' aria-expanded='true' aria-controls='storageDivContent'><i class='fas fa-caret-down mr-2 fa-fw'></i>{{ 'Storage'|trans }} (<span id='containersCount'>{{ Entity.entityData.containers|length }}</span>)</h3>
 <div class='row mt-2' id='storageDivContent' data-save-hidden='storageDivContent' data-count-for='containersCount'>
   <div class='ml-3 mt-3 col-md-12'>
       {% if Entity.entityData.containers %}

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -25,7 +25,7 @@
 <div id='filesDiv'>
   <div class='d-flex justify-content-between'>
     <div>{# necessary div for flex #}
-      <h3 title='{{ 'Toggle visibility'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' class='d-inline togglable-section-title' tabindex='0' role='button'>
+      <h3 title='{{ 'Toggle visibility'|trans }}' data-scroll-btn='fa-file-arrow-up' data-scroll-btn-label='{{ 'Attachments'|trans }}' data-action='toggle-next' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' data-toggle-target='uploadsDiv' class='d-inline togglable-section-title' tabindex='0' role='button'>
         <i class='fas fa-caret-down fa-fw mr-2'></i>{% trans %}Attached file
         {% plural Entity.entityData.uploads|length %}
         Attached files

--- a/src/templates/view.html
+++ b/src/templates/view.html
@@ -206,7 +206,7 @@
 <hr>
 <div class='d-flex flex-column align-items-end'>
   {# SHOW CREATED AT / LAST MOD #}
-  <div>{{ 'Created on %s'|trans|format(Entity.entityData.created_at ) }}</div>
+  <div>{{ 'Created on %s'|trans|format(Entity.entityData.created_at) }}</div>
   <div>{{ 'Last modified on %s'|trans|format(Entity.entityData.modified_at) }}</div>
   {# eLabID: add an if because templates don't have one #}
   {% if Entity.entityData.elabid %}

--- a/src/ts/ScrollButtons.class.ts
+++ b/src/ts/ScrollButtons.class.ts
@@ -5,6 +5,8 @@
  * @license AGPL-3.0
  * @package elabftw
  */
+import i18next from './i18n';
+
 export default class ScrollButtons {
   private readonly container: HTMLDivElement;
   private readonly backToTopButton: HTMLButtonElement;
@@ -19,7 +21,7 @@ export default class ScrollButtons {
       'flex-column',
     );
 
-    this.backToTopButton = this.createButton('fa-arrow-up', 'Back to top');
+    this.backToTopButton = this.createButton('fa-arrow-up', i18next.t('back-to-top'));
     this.backToTopButton.id = 'backToTopButton';
 
     this.backToTopButton.addEventListener('click', () => {

--- a/src/ts/ScrollButtons.class.ts
+++ b/src/ts/ScrollButtons.class.ts
@@ -1,0 +1,89 @@
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+export default class ScrollButtons {
+  private readonly container: HTMLDivElement;
+  private readonly backToTopButton: HTMLButtonElement;
+
+  public constructor() {
+    this.container = document.createElement('div');
+    this.container.id = 'scrollButtons';
+    this.container.classList.add(
+      'floating-middle-right',
+      'd-none',
+      'd-lg-flex',
+      'flex-column',
+    );
+
+    this.backToTopButton = this.createButton('fa-arrow-up', 'Back to top');
+    this.backToTopButton.id = 'backToTopButton';
+
+    this.backToTopButton.addEventListener('click', () => {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    });
+    this.container.prepend(this.backToTopButton);
+  }
+
+  public init(): void {
+    const root = document.getElementById('container');
+    if (!root) {
+      return;
+    }
+
+    this.registerSectionButtons();
+    root.append(this.container);
+  }
+
+  private registerSectionButtons(): void {
+    document.querySelectorAll<HTMLElement>('[data-scroll-btn]').forEach(target => {
+      const iconClass = target.dataset.scrollBtn?.trim();
+      if (!iconClass) {
+        return;
+      }
+
+      const extraOffset = Number.parseInt(target.dataset.scrollBtnY ?? '0', 10);
+      if (Number.isFinite(extraOffset) && extraOffset !== 0) {
+        target.style.setProperty('--scroll-btn-y', `${extraOffset}px`);
+      }
+
+      const label = target.dataset.scrollBtnLabel ?? target.innerText.trim();
+      const button = this.createButton(iconClass, label);
+
+      button.addEventListener('click', () => {
+        target.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      });
+
+      this.container.append(button);
+    });
+  }
+
+  private createButton(iconClass: string, label: string): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.classList.add('btn', 'btn-secondary', 'scroll-button');
+    button.setAttribute('aria-label', label);
+
+    const text = document.createElement('span');
+    text.classList.add('scroll-button-label');
+    text.textContent = label;
+
+    const icon = document.createElement('i');
+    icon.classList.add('fas', 'fa-fw', iconClass);
+    icon.setAttribute('aria-hidden', 'true');
+
+    // text first so the button expands towards the left
+    button.replaceChildren(text, icon);
+
+    return button;
+  }
+}

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -12,6 +12,7 @@ import type { SelectOptions } from '@deltablot/malle';
 import 'bootstrap/js/src/modal.js';
 import FavTag from './FavTag.class';
 import Heartbeat from './Heartbeat.class';
+import ScrollButtons from './ScrollButtons.class';
 import { clearLocalStorage, rememberLastSelected, selectLastSelected } from './localStorage';
 import {
   adjustHiddenState,
@@ -286,43 +287,7 @@ if (openedSidePanel === Model.Todolist) {
 document.querySelectorAll('[data-count-for]').forEach((container: HTMLElement) => new Counter(container));
 
 // BACK TO TOP BUTTON
-const btn = document.createElement('button');
-btn.type = 'button';
-btn.dataset.action = 'scroll-top';
-// make it look like a button, and on the right side of the screen, not too close from the bottom
-btn.classList.add('btn', 'btn-secondary', 'floating-middle-right');
-// element is invisible at first so we can make it visible so it triggers a css transition and appears progressively
-btn.style.opacity = '0';
-// will not be shown for small screens, only large ones
-btn.classList.add('d-none', 'd-xl-inline', 'd-lg-inline');
-// the button is an up arrow
-const icon = document.createElement('i');
-icon.classList.add('fas', 'fa-arrow-up');
-btn.replaceChildren(icon);
-// give it an id so we can remove it easily
-btn.id = 'backToTopButton';
-btn.setAttribute('aria-label', 'Back to top');
-btn.title = 'Back to top';
-
-// called when viewport approaches the footer
-const intersectionCallback = (entries): void => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting && document.getElementById('backToTopButton')) {
-      // we're near the top of the screen, remove the button if it's here
-      document.getElementById('backToTopButton').remove();
-    } else if (!entry.isIntersecting && !document.getElementById('backToTopButton')){ // user scrolled the trigger out AND button is not here
-      const addedBtn = document.getElementById('container').appendChild(btn);
-      // here we use requestAnimationFrame or the browser won't see the change and the css transition won't be triggered
-      requestAnimationFrame(() => {
-        addedBtn.style.opacity = '100';
-      });
-    }
-  });
-};
-
-const observer = new IntersectionObserver(intersectionCallback);
-observer.observe(document.getElementById('scrollTopBtnAnchor'));
-// END BACK TO TOP BUTTON
+new ScrollButtons().init();
 
 listenTrigger();
 adjustHiddenState();

--- a/src/ts/langs/ca_ES.ts
+++ b/src/ts/langs/ca_ES.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Arxivar un usuari significa que el seu compte es desactivarà. Aquesta acció és reversible.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Pot regitionar components",
     "can-manage-inventory-locations": "Pot gestionar ubicació d'inventari",
     "can-manage-users2teams": "Pot gestionar usuaris a equips",

--- a/src/ts/langs/cs_CZ.ts
+++ b/src/ts/langs/cs_CZ.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archivace uživatele znamená, že jeho účet bude deaktivován. Tato akce je vratná.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/de_DE.ts
+++ b/src/ts/langs/de_DE.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Die Archivierung eines Nutzers deaktiviert seinen Zugang. Diese Aktion ist umkehrbar.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Darf Substanzen verwalten",
     "can-manage-inventory-locations": "Darf Inventar-Standorte verwalten",
     "can-manage-users2teams": "Kann Nutzende Teams zuweisen",

--- a/src/ts/langs/el_GR.ts
+++ b/src/ts/langs/el_GR.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Η αρχειοθέτηση ενός χρήστη σημαίνει ότι ο λογαριασμός του θα απενεργοποιηθεί. Αυτή η ενέργεια είναι αναστρέψιμη.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/en_GB.ts
+++ b/src/ts/langs/en_GB.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/en_US.ts
+++ b/src/ts/langs/en_US.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archiving a user means their account will be disabled. This action is reversible.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/es_ES.ts
+++ b/src/ts/langs/es_ES.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archivar a un usuario significa que su cuenta se desactivará. Esta acción es reversible.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Puede gestionar compuestos",
     "can-manage-inventory-locations": "Puede gestionar ubicaciones de inventario",
     "can-manage-users2teams": "Puede administrar usuarios a equipos",

--- a/src/ts/langs/et_EE.ts
+++ b/src/ts/langs/et_EE.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Kasutaja arhiveerimine tähendab tema konto sulgemist. See toiming on tagasipööratav.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Saab ühendeid hallata",
     "can-manage-inventory-locations": "Saab laoseisu asukohti hallata",
     "can-manage-users2teams": "Saab kasutajaid meeskondadesse jagada",

--- a/src/ts/langs/fi_FI.ts
+++ b/src/ts/langs/fi_FI.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Käyttäjän arkistointi tarkoittaa, että hänen tilinsä poistetaan käytöstä. Tämä toiminto on peruutettava.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/fr_FR.ts
+++ b/src/ts/langs/fr_FR.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "L'archivage d'un utilisateur signifie que son compte sera désactivé. Cette action est réversible.",
     "association-date": "Date de création de l'association",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Peut gérer la base de composés chimiques",
     "can-manage-inventory-locations": "Peut gérer les emplacements des stocks",
     "can-manage-users2teams": "Peut gérer les utilisateurs en équipes",

--- a/src/ts/langs/id_ID.ts
+++ b/src/ts/langs/id_ID.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Mengarsipkan pengguna berarti akun mereka akan dinonaktifkan. Tindakan ini dapat dibatalkan.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Dapat mengelola senyawa",
     "can-manage-inventory-locations": "Dapat mengelola lokasi inventaris",
     "can-manage-users2teams": "Dapat mengelola pengguna hingga tim",

--- a/src/ts/langs/it_IT.ts
+++ b/src/ts/langs/it_IT.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archiviare un utente significa che il suo account verrà disabilitato. Questa azione è reversibile.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Può gestire i composti",
     "can-manage-inventory-locations": "Può gestire le posizioni dell'inventario",
     "can-manage-users2teams": "Può gestire gli utenti in team",

--- a/src/ts/langs/ja_JP.ts
+++ b/src/ts/langs/ja_JP.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "ユーザーをアーカイブすると、そのユーザーのアカウントは無効になります。この操作は元に戻すことができます。",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "化合物の管理が可能",
     "can-manage-inventory-locations": "在庫ロケーションの管理が可能",
     "can-manage-users2teams": "ユーザーをチーム単位で管理可能",

--- a/src/ts/langs/ko_KR.ts
+++ b/src/ts/langs/ko_KR.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "사용자를 보관처리하면 해당 사용자의 계정이 비활성화됩니다. 이 작업은 되돌릴 수 있습니다.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/nl_BE.ts
+++ b/src/ts/langs/nl_BE.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Het archiveren van een gebruiker betekent dat zijn/haar account wordt uitgeschakeld. Deze actie is omkeerbaar.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/pl_PL.ts
+++ b/src/ts/langs/pl_PL.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archiwizacja użytkownika oznacza dezaktywację jego konta. To działanie jest odwracalne.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Może zarządzaś związkami",
     "can-manage-inventory-locations": "Może zarządzać lokalizacją wyposażenia",
     "can-manage-users2teams": "Możliwość zarządzania użytkownikami w zespołach",

--- a/src/ts/langs/pt_BR.ts
+++ b/src/ts/langs/pt_BR.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "O arquivamento de um usuário significa que sua conta será desativada. Essa ação É reversível.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/pt_PT.ts
+++ b/src/ts/langs/pt_PT.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Arquivar um utilizador significa que a sua conta será desactivada. Esta ação é reversível.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/ru_RU.ts
+++ b/src/ts/langs/ru_RU.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Архивирование пользователя означает, что его учетная запись будет отключена. Это действие обратимо.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/sk_SK.ts
+++ b/src/ts/langs/sk_SK.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Archivácia používateľa znamená, že jeho účet bude deaktivovaný. Táto akcia je reverzibilná.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/sl_SI.ts
+++ b/src/ts/langs/sl_SI.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Arhiviranje uporabnika pomeni, da bo njegov račun onemogočen. To dejanje je reverzibilno.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/uz_UZ.ts
+++ b/src/ts/langs/uz_UZ.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "Foydalanuvchini arxivlash uning hisobi o'chirilishini anglatadi. Bu harakat qaytarilishi mumkin.",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "Can manage compounds",
     "can-manage-inventory-locations": "Can manage inventory locations",
     "can-manage-users2teams": "Can manage users to teams",

--- a/src/ts/langs/zh_CN.ts
+++ b/src/ts/langs/zh_CN.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "归档用户意味着他们的账户将被禁用。此操作是可逆的。",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "可以管理化合物",
     "can-manage-inventory-locations": "可以管理库存位置",
     "can-manage-users2teams": "可以管理团队中用户",

--- a/src/ts/langs/zh_TW.ts
+++ b/src/ts/langs/zh_TW.ts
@@ -16,6 +16,7 @@ const t = {
     "archive-user-description": "將使用者封存意味著其帳戶將被停用。此操作可撤銷。",
     "association-date": "Association date",
     "background-color": "Background color",
+    "back-to-top": "Back to top",
     "can-manage-compounds": "可管理化合物",
     "can-manage-inventory-locations": "可以管理庫存位置",
     "can-manage-users2teams": "可以管理團隊用戶",


### PR DESCRIPTION
fix #7206

@MoustaphaCamara in the end your suggestion to only have one at the time opened on hover was better than what I had in mind!

@eltouma @MoustaphaCamara thanks for the brainstorming on icons :rocket: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added floating scroll controls for quickly navigating to the top and key page sections.
  * Added smooth scrolling, configurable icons, labels, and vertical positioning.
  * Scroll controls support keyboard focus and reveal labels on hover or focus.
  * Added section navigation for editing, links, spreadsheet, steps, storage, and uploads.
  * Added “Back to top” translations across supported languages.

* **Bug Fixes**
  * Improved scroll-control alignment and positioning.
  * Removed extra whitespace in a displayed creation date expression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->