### PR TITLE
dev: unify all cache folders into /var/cache/elabftw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
     steps:
       - run:
           name: Start container
-          command: docker compose -f containers/circleci/docker-compose.yml up -d --no-build
+          command: docker compose -f containers/circleci/docker-compose.yml up -d --no-build --wait --wait-timeout 120
 
   start_mysql:
     steps:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,7 +21,7 @@ $finder = Finder::create()
 ;
 
 return (new Config())
-    ->setCacheFile('/run/elabftw/cache/.php-cs-fixer.cache')
+    ->setCacheFile('/var/cache/elabftw/php/.php-cs-fixer.cache')
     ->setRules(array(
         '@PER-CS2x0' => true,
         '@PHP8x3Migration' => true,

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,10 +1,10 @@
 nodeLinker: pnp
 enableGlobalCache: false
-cacheFolder: /run/elabftw/yarn/cache
-globalFolder: /run/elabftw/yarn/global
-installStatePath: /run/elabftw/yarn/install-state.gz
-pnpUnpluggedFolder: /run/elabftw/yarn/unplugged
-virtualFolder: /run/elabftw/yarn/__virtual__
+cacheFolder: /var/cache/elabftw/yarn/cache
+globalFolder: /var/cache/elabftw/yarn/global
+installStatePath: /var/cache/elabftw/yarn/install-state.gz
+pnpUnpluggedFolder: /var/cache/elabftw/yarn/unplugged
+virtualFolder: /var/cache/elabftw/yarn/__virtual__
 approvedGitRepositories:
 npmMinimalAgeGate: 12d
 plugins:

--- a/builder.js
+++ b/builder.js
@@ -133,7 +133,7 @@ module.exports = (env, argv) => {
           {
             from: path.resolve(
               __dirname,
-              '/run/elabftw/yarn/unplugged/indigo-ketcher-npm-*/node_modules/indigo-ketcher/**/*.wasm',
+              '/var/cache/elabftw/yarn/unplugged/indigo-ketcher-npm-*/node_modules/indigo-ketcher/**/*.wasm',
             ),
             to: '[name][ext]',
             noErrorOnMissing: false,

--- a/containers/circleci/docker-compose.yml
+++ b/containers/circleci/docker-compose.yml
@@ -44,7 +44,8 @@ services:
     tmpfs:
       - /run/nginx:mode=1770,uid=1001,gid=1002
       - /run/php:mode=1770,uid=1001,gid=1002
-      - /var/cache/elabftw:mode=1770,uid=1001,gid=1002,exec,nosuid,nodev
+      - /var/cache/elabftw/php:mode=1770,uid=1001,gid=1002,exec,nosuid,nodev
+      - /var/cache/elabftw/nginx:mode=1770,uid=1001,gid=1002,noexec,nosuid,nodev
       - /elabftw/tests/_output:mode=1770,uid=1001,gid=1002
       - /elabftw/tests/_support/_generated:mode=1770,uid=1001,gid=1002
       - /var/lib/elabftw/exports:mode=755,uid=1001,gid=1002,noexec,nosuid,nodev

--- a/containers/circleci/docker-compose.yml
+++ b/containers/circleci/docker-compose.yml
@@ -44,9 +44,8 @@ services:
     tmpfs:
       - /run/nginx:mode=1770,uid=1001,gid=1002
       - /run/php:mode=1770,uid=1001,gid=1002
-      - /run/elabftw/cache:mode=1770,uid=1001,gid=1002,exec,nosuid,nodev
+      - /var/cache/elabftw:mode=1770,uid=1001,gid=1002,exec,nosuid,nodev
       - /elabftw/tests/_output:mode=1770,uid=1001,gid=1002
       - /elabftw/tests/_support/_generated:mode=1770,uid=1001,gid=1002
-      - /var/cache/nginx:mode=755,uid=1001,gid=1002,noexec,nosuid,nodev
       - /var/lib/elabftw/exports:mode=755,uid=1001,gid=1002,noexec,nosuid,nodev
       - /var/lib/elabftw/uploads:mode=755,uid=1001,gid=1002,noexec,nosuid,nodev

--- a/containers/elabimg/Dockerfile
+++ b/containers/elabimg/Dockerfile
@@ -316,6 +316,8 @@ COPY --from=composer@sha256:5946476338742b200bb9ff88f8be56275ddae4b3949c72305cb0
 RUN mkdir -p /run/elabftw \
     && chmod 1777 /run/elabftw
 
+RUN mkdir -p "$TMPDIR" "$COREPACK_HOME" "$COMPOSER_HOME"
+
 # this allows to skip the (long) build in dev mode where /elabftw will be bind-mounted anyway
 # pass it to build command with --build-arg BUILD_ALL=0
 ARG BUILD_ALL=1

--- a/containers/elabimg/Dockerfile
+++ b/containers/elabimg/Dockerfile
@@ -96,9 +96,9 @@ RUN ./configure \
         --error-log-path=/dev/stderr \
         --http-log-path=/dev/stdout \
         --lock-path=/run/nginx/nginx.lock \
-        --http-client-body-temp-path=/var/cache/nginx/client_body \
-        --http-fastcgi-temp-path=/var/cache/nginx/fastcgi \
-        --http-proxy-temp-path=/var/cache/nginx/proxy \
+        --http-client-body-temp-path=/var/cache/elabftw/nginx/client_body \
+        --http-fastcgi-temp-path=/var/cache/elabftw/nginx/fastcgi \
+        --http-proxy-temp-path=/var/cache/elabftw/nginx/proxy \
         --with-threads \
         --with-http_ssl_module \
         --with-http_v2_module \
@@ -195,8 +195,6 @@ COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=nginx-builder /etc/nginx/mime.types /etc/nginx/mime.types
 COPY --from=nginx-builder /etc/nginx/fastcgi.conf /etc/nginx/fastcgi.conf
 
-RUN mkdir /var/cache/nginx
-
 # END NGINX
 
 # OpenBabel
@@ -290,6 +288,10 @@ RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/php
 # ELABFTW
 RUN mkdir /elabftw
 WORKDIR /elabftw
+
+ENV TMPDIR=/var/cache/elabftw/php/tmp
+ENV COREPACK_HOME=/var/cache/elabftw/corepack
+
 # we only copy the strict necessary
 COPY ./bin /elabftw/bin
 COPY ./.babelrc /elabftw
@@ -306,7 +308,7 @@ COPY ./yarn.lock /elabftw
 COPY ./.yarnrc.yml /elabftw
 
 # COMPOSER
-ENV COMPOSER_HOME=/run/composer
+ENV COMPOSER_HOME=/var/cache/elabftw/composer
 # 2.10.2 https://github.com/composer/composer/releases/tag/2.10.2
 COPY --from=composer@sha256:5946476338742b200bb9ff88f8be56275ddae4b3949c72305cb0dbf10cfcb760 /usr/bin/composer /usr/local/bin/composer
 
@@ -324,13 +326,6 @@ ARG CI=0
 ENV CYPRESS_INSTALL_BINARY=0
 # avoid download prompt
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-# this is necessary for yarn install in dev mode, as /tmp is not writable
-ENV TMPDIR=/run/elabftw/cache
-RUN mkdir -p "$TMPDIR" && chmod 1777 "$TMPDIR"
-
-ENV COREPACK_HOME=/run/elabftw/cache/node/corepack
-RUN mkdir -p $COREPACK_HOME
-
 
 # enable new yarn
 RUN corepack enable
@@ -348,17 +343,13 @@ RUN if [ "$BUILD_ALL" = "1" ]; then \
             && yarn workspaces focus -A --production \
             && /usr/bin/php84 -d memory_limit=256M /usr/local/bin/composer install --prefer-dist --no-cache --no-progress --no-dev -a; \
         fi \
-        && rm -rf /run/elabftw/yarn /run/elabftw/cache /run/composer; \
+        && rm -rf /var/cache/elabftw; \
     fi
 # PHP: add php config after composer step so open_basedir is not an issue
 COPY ./containers/elabimg/php/php.ini /etc/php84/php.ini.tpl
 RUN rm -f /etc/php84/php.ini && ln -s /run/php/php.ini /etc/php84/php.ini
 COPY ./containers/elabimg/php/php-fpm.conf /etc/php84/php-fpm.conf
 COPY ./containers/elabimg/php/elabpool.conf /etc/php84/php-fpm.d/elabpool.conf.tpl
-
-# Make PHP write errors to stderr
-RUN mkdir -p /var/log/php84 && ln -sf /dev/stderr /var/log/php84/error.log
-
 # END PHP
 
 # create invoker service

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -31,7 +31,7 @@ services:
     user: <REPLACE WITH ELABFTW-WORKER UID>:<REPLACE WITH ELABFTW-WORKER GID>
 
     # this allows the container to run with a read-only filesystem
-    # you will need to bind-mount /var/cache/nginx to a writable directory if you set this to true
+    # you will need to bind-mount /var/cache/elabftw to a writable directory if you set this to true
     # default value: true
     read_only: true
 
@@ -64,7 +64,7 @@ services:
     # example:
     # - /run:mode=755,uid=1002,gid=1002,exec,nosuid,nodev
     tmpfs:
-      - /run:mode=755,uid=<REPLACE WITH ELABFTW-WORKER UID>,gid=<REPLACE WITH ELABFTW-WORKER GID>,exec,nosuid,nodev
+      - /run:mode=755,uid=<REPLACE WITH ELABFTW-WORKER UID>,gid=<REPLACE WITH ELABFTW-WORKER GID>,exec,nosuid,nodev,size=64m
 
     # restrict capabilities of the process to the strict minimum
     # not really necessary in user mode but defense in-depth
@@ -321,11 +321,11 @@ services:
         - '443:8080'
         # if you are running the container on the same network than a reverse proxy, you don't need to expose ports at all
     volumes:
-        # this volume is necessary for nginx to work (remember, we use a read-only filesystem)
+        # this volume is necessary for the application to work correctly (remember, we use a read-only filesystem)
         # make sure this folder is writable by the service user
-        # mkdir -p /var/elabftw/.cache/nginx
-        # chown elabftw-worker:elabftw-worker /var/elabftw/.cache/nginx
-        - /var/elabftw/.cache/nginx:/var/cache/nginx
+        # mkdir -p /var/cache/elabftw
+        # chown elabftw-worker:elabftw-worker /var/cache/elabftw
+        - /var/cache/elabftw/:/var/cache/elabftw
 
         # this is where you will keep the uploaded files persistently
         # for Windows users it might look like this

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -332,7 +332,7 @@ phpConf() {
     # production open_basedir conf value
     # /etc/ssl/cert.pem is for openssl and timestamp related functions
     # for /run/s6-rc... see elabftw/elabftw#5249
-    open_basedir="/.dockerenv:/elabftw/:/var/lib/elabftw/:/run/elabftw/tmp:/run/elabftw/cache:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner"
+    open_basedir="/.dockerenv:/elabftw/:/var/lib/elabftw/:/var/cache/elabftw/php:/var/cache/elabftw/nginx:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner"
     # DEV MODE
     if ($dev_mode); then
         # we don't want to use opcache as we want our changes to be immediately visible
@@ -347,9 +347,8 @@ phpConf() {
 }
 
 elabftwConf() {
-    mkdir -p /run/elabftw/cache/elab /run/elabftw/tmp /run/elabftw/cache/mpdf /run/elabftw/cache/twig /run/elabftw/cache/purifier/CSS /run/elabftw/cache/purifier/HTML /run/elabftw/cache/purifier/URI
-    # necessary so php user can write to it in podman rootless
-    chmod -R g+w /run/elabftw/cache
+    rm -rfv /var/cache/elabftw/*
+    mkdir -p /var/cache/elabftw/nginx/client_body /var/cache/elabftw/nginx/fastcgi /var/cache/elabftw/nginx/proxy /var/cache/elabftw/php/tmp /var/cache/elabftw/php/cache/elab /var/cache/elabftw/php/cache/mpdf /var/cache/elabftw/php/cache/twig /var/cache/elabftw/php/cache/purifier/CSS /var/cache/elabftw/php/cache/purifier/HTML /var/cache/elabftw/php/cache/purifier/URI
 }
 
 ldapConf() {

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -347,7 +347,7 @@ phpConf() {
 }
 
 elabftwConf() {
-    rm -rf /var/cache/elabftw/*
+    rm -rf /var/cache/elabftw/php/* /var/cache/elabftw/nginx/*
     mkdir -p /var/cache/elabftw/nginx/client_body /var/cache/elabftw/nginx/fastcgi /var/cache/elabftw/nginx/proxy /var/cache/elabftw/php/tmp /var/cache/elabftw/php/cache/elab /var/cache/elabftw/php/cache/mpdf /var/cache/elabftw/php/cache/twig /var/cache/elabftw/php/cache/purifier/CSS /var/cache/elabftw/php/cache/purifier/HTML /var/cache/elabftw/php/cache/purifier/URI
 }
 

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -332,7 +332,7 @@ phpConf() {
     # production open_basedir conf value
     # /etc/ssl/cert.pem is for openssl and timestamp related functions
     # for /run/s6-rc... see elabftw/elabftw#5249
-    open_basedir="/.dockerenv:/elabftw/:/var/lib/elabftw/:/var/cache/elabftw/php:/var/cache/elabftw/nginx:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner"
+    open_basedir="/.dockerenv:/elabftw/:/var/lib/elabftw/:/var/cache/elabftw/php:/run/elabftw:/var/cache/elabftw/nginx:/usr/bin/unzip:/etc/ssl/cert.pem:/run/s6-rc/servicedirs/s6rc-oneshot-runner"
     # DEV MODE
     if ($dev_mode); then
         # we don't want to use opcache as we want our changes to be immediately visible
@@ -347,7 +347,7 @@ phpConf() {
 }
 
 elabftwConf() {
-    rm -rfv /var/cache/elabftw/*
+    rm -rf /var/cache/elabftw/*
     mkdir -p /var/cache/elabftw/nginx/client_body /var/cache/elabftw/nginx/fastcgi /var/cache/elabftw/nginx/proxy /var/cache/elabftw/php/tmp /var/cache/elabftw/php/cache/elab /var/cache/elabftw/php/cache/mpdf /var/cache/elabftw/php/cache/twig /var/cache/elabftw/php/cache/purifier/CSS /var/cache/elabftw/php/cache/purifier/HTML /var/cache/elabftw/php/cache/purifier/URI
 }
 

--- a/containers/elabimg/php/php-fpm.conf
+++ b/containers/elabimg/php/php-fpm.conf
@@ -2,5 +2,6 @@
 ; FPM Configuration for eLabFTW ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 daemonize = no
+error_log = /dev/stderr
 ; only include our custom pool
 include=/run/php/elabpool.conf

--- a/containers/elabimg/php/php.ini
+++ b/containers/elabimg/php/php.ini
@@ -3,7 +3,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;
 
 [PHP]
-sys_temp_dir = /run/elabftw/tmp
+sys_temp_dir = /var/cache/elabftw/php/tmp
 ;;;;;;;;;;;;;;;;;;;;
 ; Language Options ;
 ;;;;;;;;;;;;;;;;;;;;
@@ -259,7 +259,7 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-upload_tmp_dir = /run/elabftw/tmp
+upload_tmp_dir = /var/cache/elabftw/php/tmp
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize

--- a/containers/elabtmp/docker-compose.yml
+++ b/containers/elabtmp/docker-compose.yml
@@ -44,6 +44,6 @@ services:
       retries: 3
     tmpfs:
       - /run:mode=755,uid=1000,gid=1000,exec,nosuid,nodev
-      - /var/cache/nginx:mode=755,uid=1000,gid=1000,exec,nosuid,nodev
+      - /var/cache/elabftw:mode=755,uid=1000,gid=1000,exec,nosuid,nodev
       - /var/lib/elabftw/exports:mode=755,uid=1000,gid=1000,noexec,nosuid,nodev
       - /var/lib/elabftw/uploads:mode=755,uid=1000,gid=1000,noexec,nosuid,nodev

--- a/documentation/config_examples/quadlet/elabftw.container
+++ b/documentation/config_examples/quadlet/elabftw.container
@@ -58,9 +58,9 @@ Secret=elabftw-s3-sk,type=env,target=ELAB_AWS_SECRET_KEY
 Volume=/mnt/data/elabftw_uploads:/var/lib/elabftw/uploads
 # this is necessary if you encrypt mysql connection and thus want the container to have access to the mysql cert
 Volume=/deltablot/mysql:/mysql-cert:z
-Volume=/var/elabftw/.cache/nginx:/var/cache/nginx:Z
+Volume=/var/cache/elabftw:/var/cache/elabftw:Z
 # Note the notmpcopyup option which is important
-Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
+Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup,tmpfs-size=64m
 
 # NETWORKS
 Network=elabftw.network

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -56,7 +56,7 @@ Next, add these lines below `image:`:
 user: <REPLACE WITH ELABFTW-WORKER UID>:<REPLACE WITH ELABFTW-WORKER GID>
 read_only: true
 tmpfs:
-  - /run:mode=755,uid=<REPLACE WITH ELABFTW-WORKER UID>,gid=<REPLACE WITH ELABFTW-WORKER GID>,exec,nosuid,nodev
+  - /run:mode=755,uid=<REPLACE WITH ELABFTW-WORKER UID>,gid=<REPLACE WITH ELABFTW-WORKER GID>,exec,nosuid,nodev,size=64m
 ~~~
 
 This will make the container start and run with `elabftw-worker` user, and a read-only filesystem.
@@ -82,22 +82,22 @@ See also sections below, adjust volumes accordingly.
 
 The `volumes:` section needs to be adjusted.
 
-#### Nginx cache folder
+#### Cache folder
 
-We will add a folder specific for nginx. First, we create it on the host and allow our `elabftw-worker` user to write to it:
+We will add a folder specific for cached files that the application will need to create. First, we create it on the host and allow our `elabftw-worker` user to write to it:
 
 ~~~bash
-mkdir -p /var/elabftw/.cache/nginx
-chown elabftw-worker:elabftw-worker /var/elabftw/.cache/nginx
+mkdir -p /var/cache/elabftw
+chown elabftw-worker:elabftw-worker /var/cache/elabftw
 ~~~
 
 Then in the configuration file, under `volumes:` section:
 
 ~~~yaml
 # docker
-  - /var/elabftw/.cache/nginx:/var/cache/nginx
+  - /var/cache/elabftw:/var/cache/elabftw
 # quadlet
-Volume=/var/elabftw/.cache/nginx:/var/cache/nginx:Z
+Volume=/var/cache/elabftw:/var/cache/elabftw:Z
 ~~~
 
 #### Uploads folder

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -71,7 +71,7 @@ Image=docker.io/elabftw/elabimg:6.0.0
 ReadOnly=true
 UserNS=keep-id
 HealthCmd=curl --fail --silent --show-error http://localhost:8080/healthcheck
-Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup
+Mount=type=tmpfs,destination=/run,U=true,tmpfs-mode=0755,notmpcopyup,tmpfs-size=64m
 ~~~
 
 Move the file into `${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd/` for your user.

--- a/src/Storage/Cache/NginxCache.php
+++ b/src/Storage/Cache/NginxCache.php
@@ -17,5 +17,5 @@ namespace Elabftw\Storage\Cache;
  */
 class NginxCache extends AbstractCache
 {
-    protected const string FOLDER = '/var/cache/nginx';
+    protected const string FOLDER = '/var/cache/elabftw/nginx';
 }

--- a/src/Storage/Cache/ParentCache.php
+++ b/src/Storage/Cache/ParentCache.php
@@ -19,7 +19,7 @@ use Override;
  */
 class ParentCache extends AbstractCache
 {
-    protected const string FOLDER = '/run/elabftw/cache';
+    protected const string FOLDER = '/var/cache/elabftw/php/cache';
 
     #[Override]
     public function clear(): bool

--- a/src/Storage/Cache/TwigCache.php
+++ b/src/Storage/Cache/TwigCache.php
@@ -17,11 +17,11 @@ use Override;
 use Symfony\Component\Console\Output\NullOutput;
 
 /**
- * For twig cached files
+ * For twig cached files. Do not inherit from ParentCache because of clear() override
  */
-class TwigCache extends ParentCache
+class TwigCache extends AbstractCache
 {
-    protected const string FOLDER = parent::FOLDER . '/twig';
+    protected const string FOLDER = '/var/cache/elabftw/php/cache/twig';
 
     #[Override]
     public function warm(): bool

--- a/src/Storage/Cache/TwigCache.php
+++ b/src/Storage/Cache/TwigCache.php
@@ -19,9 +19,9 @@ use Symfony\Component\Console\Output\NullOutput;
 /**
  * For twig cached files
  */
-class TwigCache extends AbstractCache
+class TwigCache extends ParentCache
 {
-    protected const string FOLDER = '/run/elabftw/cache/twig';
+    protected const string FOLDER = parent::FOLDER . '/twig';
 
     #[Override]
     public function warm(): bool

--- a/src/Storage/Tmp.php
+++ b/src/Storage/Tmp.php
@@ -17,5 +17,5 @@ namespace Elabftw\Storage;
  */
 final class Tmp extends AbstractStorage
 {
-    protected const string FOLDER = '/run/elabftw/tmp';
+    protected const string FOLDER = '/var/cache/elabftw/php/tmp';
 }

--- a/src/tools/psalm.xml
+++ b/src/tools/psalm.xml
@@ -5,7 +5,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     strictBinaryOperands="true"
-    cacheDirectory="/run/elabftw/psalm"
+    cacheDirectory="/var/cache/elabftw/php/cache"
     checkForThrowsInGlobalScope="true"
     ignoreInternalFunctionFalseReturn="true"
     ignoreInternalFunctionNullReturn="false"

--- a/tests/unit/models/UploadsTest.php
+++ b/tests/unit/models/UploadsTest.php
@@ -186,7 +186,7 @@ class UploadsTest extends \PHPUnit\Framework\TestCase
         $Uploads->setId($id);
         $fs = new Tmp()->getFs();
         $fs->write('a.file', 'yes');
-        $this->assertIsInt($Uploads->postAction(Action::Replace, array('real_name' => 'yep', 'filePath' => '/run/elabftw/tmp/a.file')));
+        $this->assertIsInt($Uploads->postAction(Action::Replace, array('real_name' => 'yep', 'filePath' => Tmp::getFolder() . '/a.file')));
     }
 
     public function testReplace(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated application, PHP, Nginx, build, and temporary-file caches under a dedicated cache location.
  * Improved container runtime configuration with clearer cache mounts and a 64 MB limit for runtime temporary storage.
  * PHP-FPM errors are now routed to standard error for easier container log collection.

* **Documentation**
  * Updated Docker, Quadlet, and upgrade guidance to reflect the new cache directory and mount requirements.

* **Tests**
  * Updated temporary-file handling to use the configured application directory consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->