### PR TITLE
bug/minor: anonymous: fix anon user being kicked out

### DIFF
--- a/tests/cypress/integration/login.cy.ts
+++ b/tests/cypress/integration/login.cy.ts
@@ -58,13 +58,26 @@ describe('Login page', () => {
     cy.get('div.alert.alert-success').should('contain', answer);
   });
 
-  it ('logs in as anonymous user', () => {
+  it ('keeps anonymous user logged in after denied page access', () => {
     cy.visit('/login.php');
     cy.get('#anon-login').should('exist');
     cy.get('#anon_login_select').select(0);
     cy.get('#anon-login button[type="submit"]').click();
     cy.location('pathname').should('eq', '/experiments.php');
     cy.htmlvalidate();
+
+    cy.request({
+      url: '/scheduler.php',
+      failOnStatusCode: false,
+      followRedirect: false,
+    }).its('status').should('eq', 403);
+    cy.getCookie('kickreason').should('not.exist');
+
+    cy.visit('/scheduler.php', { failOnStatusCode: false });
+    cy.location('pathname').should('eq', '/scheduler.php');
+    cy.contains('Authentication required');
+    cy.visit('/experiments.php');
+    cy.location('pathname').should('eq', '/experiments.php');
     cy.request('/app/logout.php');
   });
 });

--- a/web/app/init.inc.php
+++ b/web/app/init.inc.php
@@ -193,6 +193,19 @@ try {
 
 
 } catch (UnauthorizedException $e) {
+    if (isset($App) && $Session->get('is_anon') === 1) {
+        // Boot with an explicit user to initialize data required by the error template.
+        $App->boot(new AnonymousUser(
+            $Session->get('team'),
+            Language::tryFrom($App->getLang()) ?? Language::EnglishGB,
+        ));
+
+        $Response = $e->getResponseFromException($App);
+        $Response->setStatusCode(Response::HTTP_FORBIDDEN);
+        $Response->send();
+        exit;
+    }
+
     // KICK USER TO LOGOUT PAGE THAT WILL REDIRECT TO LOGIN PAGE
     $cookieOptions = array(
         'expires' => time() + 30,


### PR DESCRIPTION
fix #6862



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous users can remain logged in when accessing restricted pages.
  * Restricted-page requests now show an “Authentication required” message instead of unexpectedly redirecting.
  * Anonymous access to supported experiment pages remains available while unauthorized requests are handled with a forbidden response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->