### PR TITLE
bug/minor: saml auth: prevent users from changing first/lastname

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -537,15 +537,18 @@ final class LoginController implements ControllerInterface
             throw new UnauthorizedException();
         }
 
+        $firstname = $info['firstname'];
+        $lastname = $info['lastname'];
+        if ($this->config['allow_users_change_identity'] === '1') {
+            $firstname = $this->Request->request->getString('teaminit_firstname');
+            $lastname = $this->Request->request->getString('teaminit_lastname');
+        }
+
         $user = ExistingUser::fromScratch(
             $info['email'],
             array($teamId),
-            $this->Request->request->getString(
-                'teaminit_firstname',
-            ),
-            $this->Request->request->getString(
-                'teaminit_lastname',
-            ),
+            $firstname,
+            $lastname,
             orgid: $info['orgid'] ?? null,
             orcid: $info['orcid'] ?? null,
         );

--- a/src/templates/login-full.html
+++ b/src/templates/login-full.html
@@ -34,6 +34,7 @@
         class='form-control'
         id='teaminit_firstname_input'
         name='teaminit_firstname'
+        {{ App.Config.configArr.allow_users_change_identity == '0' ? 'disabled' }}
         value='{{ teaminitUserInfo.firstname }}'
       />
 
@@ -43,6 +44,7 @@
         class='form-control'
         id='teaminit_lastname_input'
         name='teaminit_lastname'
+        {{ App.Config.configArr.allow_users_change_identity == '0' ? 'disabled' }}
         value='{{ teaminitUserInfo.lastname }}'
       />
       <button class='btn btn-primary mt-2' type='submit' name='submit'>{{ 'Request access'|trans }}</button>

--- a/tests/unit/controllers/LoginControllerTest.php
+++ b/tests/unit/controllers/LoginControllerTest.php
@@ -64,6 +64,7 @@ final class LoginControllerTest extends \PHPUnit\Framework\TestCase
             'remember_me_allowed' => '1',
             'cookie_validity_time' => '300',
             'anon_users' => '1',
+            'allow_users_change_identity' => '1',
             'ldap_username' => 'admin',
             'ldap_password' => 'adm1n',
             'ldap_scheme' => 'http',
@@ -495,6 +496,46 @@ final class LoginControllerTest extends \PHPUnit\Framework\TestCase
         );
         self::assertSame(
             'Name',
+            $user->userData['lastname'],
+        );
+    }
+
+    public function testInitialTeamSelectionKeepsIdentityWhenChangesDisabled(): void
+    {
+        $email = 'login-controller-' . bin2hex(random_bytes(6)) . '@example.com';
+        $session = new Session();
+        $session->set('initial_team_selection_required', true);
+        $session->set('teaminit_user_info', array(
+            'email' => $email,
+            'firstname' => 'Login',
+            'lastname' => 'Controller',
+            'orgid' => null,
+            'orcid' => null,
+        ));
+
+        $request = Request::create('/login.php', 'POST', array(
+            'auth_type' => 'teaminit',
+            'team_id' => 1,
+            'teaminit_firstname' => 'Forged',
+            'teaminit_lastname' => 'Identity',
+        ));
+        $config = $this->config;
+        $config['allow_users_change_identity'] = '0';
+
+        $response = $this->createController(
+            $request,
+            session: $session,
+            config: $config,
+        )->getResponse();
+
+        self::assertRedirect($response, '/login.php');
+        $user = ExistingUser::fromEmail($email);
+        self::assertSame(
+            'Login',
+            $user->userData['firstname'],
+        );
+        self::assertSame(
+            'Controller',
             $user->userData['lastname'],
         );
     }


### PR DESCRIPTION
honor instance setting
fix #6397
fix #6563

