### PR TITLE
Feat/storage capacity

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2792,12 +2792,19 @@ paths:
                   description: ID of the parent storage unit. Set to null for a top-level unit.
                   example: null
                 capacity:
-                  type: integer
                   nullable: true
+                  oneOf:
+                    - type: integer
+                      minimum: 0
+                      maximum: 4294967295
+                    - type: string
+                      pattern: '^(0|[1-9][0-9]*)?$'
                   description: |
                     Maximum number of containers this unit should hold.
-                    Omit, or pass `null`, for unlimited (the default). Pass `0` for a unit
-                    that holds other units but never containers.
+                    Omit, or pass `null` or `""`, for unlimited (the default). Pass `0` for
+                    a unit that holds other units but never containers.
+                    Accepted as an integer or as its decimal string form, so that form
+                    submissions need no conversion. The upper bound is 4294967295.
                   example: 96
       responses:
         '201':
@@ -2867,12 +2874,19 @@ paths:
                     Cannot be the unit itself or any of its descendants.
                   example: 5
                 capacity:
-                  type: integer
                   nullable: true
+                  oneOf:
+                    - type: integer
+                      minimum: 0
+                      maximum: 4294967295
+                    - type: string
+                      pattern: '^(0|[1-9][0-9]*)?$'
                   description: |
                     Maximum number of containers this unit should hold.
-                    Pass `null` or an empty string for unlimited. Pass `0` for a unit that
+                    Pass `null` or `""` for unlimited. Pass `0` for a unit that
                     holds other units but never containers.
+                    Accepted as an integer or as its decimal string form, so that form
+                    submissions need no conversion. The upper bound is 4294967295.
                     May be set below the current occupancy, so that an over-filled
                     location can be declared and then drained.
                   example: 96

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1983,6 +1983,14 @@ components:
             0 means nothing may be stored directly in this unit, which suits a unit that
             exists to hold other units, such as a building or a room.
           example: 96
+        occupancy:
+          type: integer
+          description: |
+            Number of containers stored directly in this unit, never counting the contents
+            of units nested inside it. Deliberately unfiltered: a container occupies its
+            slot whether or not you can read the entity it belongs to, and whether or not
+            that entity is in the bin. This is the number compared against `capacity`.
+          example: 12
         level_depth:
           type: integer
           description: Depth level in the hierarchy (0 for root)
@@ -2504,7 +2512,7 @@ paths:
       description: |
         Without parameters, returns the full list of containers (assignments of experiments or resources to storage locations) that you have access to.
 
-        With `?hierarchy=true`, returns a flat list of all storage units (freezers, boxes, positions, etc.) with their hierarchy metadata (`id`, `name`, `parent_id`, `full_path`, `capacity`, `level_depth`, `children_count`). This allows clients to discover, traverse, or display the storage unit tree.
+        With `?hierarchy=true`, returns a flat list of all storage units (freezers, boxes, positions, etc.) with their hierarchy metadata (`id`, `name`, `parent_id`, `full_path`, `capacity`, `occupancy`, `level_depth`, `children_count`). This allows clients to discover, traverse, or display the storage unit tree.
       operationId: read-storage-units
       parameters:
         - name: hierarchy
@@ -2514,7 +2522,7 @@ paths:
             type: boolean
           description: |
             When true, returns a flat list of all storage units in the hierarchy
-            (id, name, parent_id, full_path, capacity, level_depth, children_count)
+            (id, name, parent_id, full_path, capacity, occupancy, level_depth, children_count)
             instead of the default container assignment list.
       responses:
         '200':
@@ -2742,6 +2750,13 @@ paths:
                             Maximum number of containers this unit should hold. Null means
                             unlimited; 0 means nothing may be stored directly in this unit.
                           example: 96
+                        occupancy:
+                          type: integer
+                          description: |
+                            Containers stored directly in this unit, not counting units
+                            nested inside it. Unfiltered by state or by your read access,
+                            so it is directly comparable to `capacity`.
+                          example: 12
                         level_depth:
                           type: integer
                           description: Depth in hierarchy (0 for root units).

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -2376,7 +2376,12 @@ paths:
     post:
       tags: ['Containers']
       summary: Create a container for this entity.
-      description: Store this entity in a storage unit with a specified quantity.
+      description: |
+        Store this entity in a storage unit with a specified quantity.
+
+        Rejected with `400` if the storage unit has a `capacity` and already holds
+        that many containers. Containers of binned entities still occupy their slot,
+        as binning a record does not empty a freezer.
       operationId: post-container
       requestBody:
         description: Parameters for creating a container.
@@ -2433,6 +2438,10 @@ paths:
         Update the quantity stored, the unit, or the storage location of a
         container. Setting `storage_id` moves the container to a different
         storage unit while preserving its `id` and `created_at`.
+
+        A move is rejected with `400` if the destination has a `capacity` and is
+        already full. Moving a container out of a full location is always allowed,
+        and moving it to where it already is remains a no-op.
       operationId: patch-container
       requestBody:
         description: Parameters for modifying a container.
@@ -2842,7 +2851,8 @@ paths:
                   description: |
                     Maximum number of containers this unit should hold.
                     Pass `null`, `0` or an empty string for unlimited.
-                    Not enforced when storing containers.
+                    May be set below the current occupancy, so that an over-filled
+                    location can be declared and then drained.
                   example: 96
       responses:
         '200':

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1975,6 +1975,11 @@ components:
           type: string
           description: Full hierarchical path from root to this unit
           example: "Building A > Room 101 > Freezer A"
+        capacity:
+          type: integer
+          nullable: true
+          description: Maximum number of containers this unit should hold. Null means unlimited.
+          example: 96
         level_depth:
           type: integer
           description: Depth level in the hierarchy (0 for root)
@@ -2487,7 +2492,7 @@ paths:
       description: |
         Without parameters, returns the full list of containers (assignments of experiments or resources to storage locations) that you have access to.
 
-        With `?hierarchy=true`, returns a flat list of all storage units (freezers, boxes, positions, etc.) with their hierarchy metadata (`id`, `name`, `parent_id`, `full_path`, `level_depth`, `children_count`). This allows clients to discover, traverse, or display the storage unit tree.
+        With `?hierarchy=true`, returns a flat list of all storage units (freezers, boxes, positions, etc.) with their hierarchy metadata (`id`, `name`, `parent_id`, `full_path`, `capacity`, `level_depth`, `children_count`). This allows clients to discover, traverse, or display the storage unit tree.
       operationId: read-storage-units
       parameters:
         - name: hierarchy
@@ -2497,7 +2502,7 @@ paths:
             type: boolean
           description: |
             When true, returns a flat list of all storage units in the hierarchy
-            (id, name, parent_id, full_path, level_depth, children_count)
+            (id, name, parent_id, full_path, capacity, level_depth, children_count)
             instead of the default container assignment list.
       responses:
         '200':
@@ -2718,6 +2723,11 @@ paths:
                           type: string
                           description: Full path from root to this unit, separated by " > ".
                           example: "Hospital > 4th floor > Freezer A"
+                        capacity:
+                          type: integer
+                          nullable: true
+                          description: Maximum number of containers this unit should hold. Null means unlimited.
+                          example: 96
                         level_depth:
                           type: integer
                           description: Depth in hierarchy (0 for root units).
@@ -2752,6 +2762,13 @@ paths:
                   nullable: true
                   description: ID of the parent storage unit. Set to null for a top-level unit.
                   example: null
+                capacity:
+                  type: integer
+                  nullable: true
+                  description: |
+                    Maximum number of containers this unit should hold.
+                    Omit, or pass `null` or `0`, for unlimited (the default).
+                  example: 96
       responses:
         '201':
           description: The storage unit has been created.
@@ -2795,7 +2812,7 @@ paths:
       tags: ['Storage units']
       summary: Modify a storage unit.
       description: |
-        Update the name and/or the parent of a storage unit. Setting
+        Update the name, the capacity and/or the parent of a storage unit. Setting
         `parent_id` reparents the unit (and everything under it) in place.
         Pass `parent_id: null` to move the unit to the root. Requires
         permission to manage inventory locations.
@@ -2819,6 +2836,14 @@ paths:
                     New parent storage unit id, or `null` to move to the root.
                     Cannot be the unit itself or any of its descendants.
                   example: 5
+                capacity:
+                  type: integer
+                  nullable: true
+                  description: |
+                    Maximum number of containers this unit should hold.
+                    Pass `null`, `0` or an empty string for unlimited.
+                    Not enforced when storing containers.
+                  example: 96
       responses:
         '200':
           description: The updated storage unit.

--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1978,7 +1978,10 @@ components:
         capacity:
           type: integer
           nullable: true
-          description: Maximum number of containers this unit should hold. Null means unlimited.
+          description: |
+            Maximum number of containers this unit should hold. Null means unlimited;
+            0 means nothing may be stored directly in this unit, which suits a unit that
+            exists to hold other units, such as a building or a room.
           example: 96
         level_depth:
           type: integer
@@ -2735,7 +2738,9 @@ paths:
                         capacity:
                           type: integer
                           nullable: true
-                          description: Maximum number of containers this unit should hold. Null means unlimited.
+                          description: |
+                            Maximum number of containers this unit should hold. Null means
+                            unlimited; 0 means nothing may be stored directly in this unit.
                           example: 96
                         level_depth:
                           type: integer
@@ -2776,7 +2781,8 @@ paths:
                   nullable: true
                   description: |
                     Maximum number of containers this unit should hold.
-                    Omit, or pass `null` or `0`, for unlimited (the default).
+                    Omit, or pass `null`, for unlimited (the default). Pass `0` for a unit
+                    that holds other units but never containers.
                   example: 96
       responses:
         '201':
@@ -2850,7 +2856,8 @@ paths:
                   nullable: true
                   description: |
                     Maximum number of containers this unit should hold.
-                    Pass `null`, `0` or an empty string for unlimited.
+                    Pass `null` or an empty string for unlimited. Pass `0` for a unit that
+                    holds other units but never containers.
                     May be set below the current occupancy, so that an over-filled
                     location can be declared and then drained.
                   example: 96

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 219;
+    public const int REQUIRED_SCHEMA = 220;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Import/AbstractCsv.php
+++ b/src/Import/AbstractCsv.php
@@ -169,9 +169,12 @@ abstract class AbstractCsv extends AbstractImport
         $storageUnitId = $StorageUnits->createImmutable($locationSplit);
         $Containers2ItemsLinks = new Containers2ItemsLinks($entity, $storageUnitId);
 
+        // capacity is not enforced here: one row is one container, and there is no channel to
+        // report a per-row rejection, so a full location would abort a part-committed import
         $Containers2ItemsLinks->createWithQuantity(
             (float) ($row['quantity'] ?? 1.0),
             $row['unit'] ?? '•',
+            enforceCapacity: false,
         );
     }
 }

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -325,7 +325,9 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $this->Db->beginTransaction();
         try {
             if ($enforceCapacity) {
-                new StorageUnits($this->Entity->Users, false)->assertHasRoom($this->id);
+                new StorageUnits($this->Entity->Users, false)->assertHasRoom(
+                    $this->id ?? throw new ImproperActionException('Missing storage unit id'),
+                );
             }
             $this->Entity->touch();
 

--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -30,6 +30,7 @@ use Elabftw\Models\StorageUnits;
 use Elabftw\Params\ContentParams;
 use Override;
 use PDO;
+use Throwable;
 
 use function array_key_exists;
 use function intval;
@@ -312,35 +313,51 @@ abstract class AbstractContainersLinks extends AbstractLinks
             && $this->Entity->id === intval($targetId);
     }
 
-    public function createWithQuantity(float $qty, string $unit): int
+    /**
+     * $enforceCapacity is only ever false for bulk importers, which turn one request into
+     * many containers and have no way to report a per-container rejection. See the CSV importer.
+     */
+    public function createWithQuantity(float $qty, string $unit, bool $enforceCapacity = true): int
     {
         $this->Entity->canOrExplode(AccessType::Write);
-        $this->Entity->touch();
 
-        // use IGNORE to avoid failure due to a key constraint violations
-        $sql = 'INSERT IGNORE INTO ' . $this->getTable() . ' (item_id, storage_id, qty_stored, qty_unit)
-            VALUES(:item_id, :storage, :qty_stored, :qty_unit)';
-        $req = $this->Db->prepare($sql);
-        $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
-        $req->bindParam(':storage', $this->id, PDO::PARAM_INT);
-        $req->bindParam(':qty_stored', $qty);
-        $req->bindParam(':qty_unit', $unit);
+        // the guard's row lock has to be held until this insert commits, so both live in one transaction
+        $this->Db->beginTransaction();
+        try {
+            if ($enforceCapacity) {
+                new StorageUnits($this->Entity->Users, false)->assertHasRoom($this->id);
+            }
+            $this->Entity->touch();
 
-        $this->Db->execute($req);
+            // use IGNORE to avoid failure due to a key constraint violations
+            $sql = 'INSERT IGNORE INTO ' . $this->getTable() . ' (item_id, storage_id, qty_stored, qty_unit)
+                VALUES(:item_id, :storage, :qty_stored, :qty_unit)';
+            $req = $this->Db->prepare($sql);
+            $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
+            $req->bindParam(':storage', $this->id, PDO::PARAM_INT);
+            $req->bindParam(':qty_stored', $qty);
+            $req->bindParam(':qty_unit', $unit);
 
-        // INSERT IGNORE inserts nothing on a FK violation; only log a real insert
-        if ($req->rowCount() > 0) {
-            $containerId = $this->Db->lastInsertId();
-            new Changelog($this->Entity)->create(new ContentParams(
-                'container_created',
-                sprintf(
-                    'Added container with %s %s at "%s" (container #%d)',
-                    number_format((float) $qty, 2, '.', ''),
-                    $unit,
-                    $this->getStoragePath($this->id),
-                    $containerId,
-                ),
-            ));
+            $this->Db->execute($req);
+
+            // INSERT IGNORE inserts nothing on a FK violation; only log a real insert
+            if ($req->rowCount() > 0) {
+                $containerId = $this->Db->lastInsertId();
+                new Changelog($this->Entity)->create(new ContentParams(
+                    'container_created',
+                    sprintf(
+                        'Added container with %s %s at "%s" (container #%d)',
+                        number_format((float) $qty, 2, '.', ''),
+                        $unit,
+                        $this->getStoragePath($this->id),
+                        $containerId,
+                    ),
+                ));
+            }
+            $this->Db->commit();
+        } catch (Throwable $e) {
+            $this->Db->rollBack();
+            throw $e;
         }
 
         return $this->id;
@@ -398,6 +415,9 @@ abstract class AbstractContainersLinks extends AbstractLinks
         }
         $current = $this->readOne();
         $oldStorageId = (int) $current['storage_id'];
+        // a no-op move must return before the capacity guard below, or the container
+        // would be counted as an occupant of its own destination and a full location
+        // would refuse to accept the container already sitting in it
         if ($oldStorageId === $newStorageId) {
             return;
         }
@@ -412,18 +432,27 @@ abstract class AbstractContainersLinks extends AbstractLinks
         // resolve old full_path for the changelog
         $oldPath = $this->getStoragePath($oldStorageId);
 
-        $this->update('storage_id', $newStorageId);
-        $this->Entity->touch();
+        // a move is an add to the destination; the source is never checked, as freeing a slot needs no permission
+        $this->Db->beginTransaction();
+        try {
+            $Destination->assertHasRoom($newStorageId);
+            $this->update('storage_id', $newStorageId);
+            $this->Entity->touch();
 
-        new Changelog($this->Entity)->create(new ContentParams(
-            'container_moved',
-            sprintf(
-                'From "%s" to "%s" (container #%d)',
-                $oldPath,
-                $destinationData['full_path'] ?? '',
-                $this->id ?? -1,
-            ),
-        ));
+            new Changelog($this->Entity)->create(new ContentParams(
+                'container_moved',
+                sprintf(
+                    'From "%s" to "%s" (container #%d)',
+                    $oldPath,
+                    $destinationData['full_path'] ?? '',
+                    $this->id ?? -1,
+                ),
+            ));
+            $this->Db->commit();
+        } catch (Throwable $e) {
+            $this->Db->rollBack();
+            throw $e;
+        }
     }
 
     // full_path for changelog messages; read-only, so no edit rights required

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -31,6 +31,7 @@ use function _;
 use function array_key_exists;
 use function array_map;
 use function filter_var;
+use function implode;
 use function in_array;
 use function is_int;
 use function is_string;
@@ -43,6 +44,13 @@ use function trim;
 final class StorageUnits extends AbstractRest
 {
     use SetIdTrait;
+
+    /**
+     * Tables holding real containers: a row in one of them occupies a slot. The template
+     * tables are absent on purpose, as their containers are defaults copied on creation
+     * rather than physical stock. Single source of truth for what "occupied" means.
+     */
+    private const array CONTAINER_TABLES = array('containers2items', 'containers2experiments');
 
     public function __construct(public Users $requester, private bool $requireEditRights, ?int $id = null)
     {
@@ -379,6 +387,52 @@ final class StorageUnits extends AbstractRest
         $req->bindValue(':name', $params->getContent());
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
+    }
+
+    /**
+     * How many containers sit directly in a unit. Deliberately unfiltered: a container
+     * occupies its slot whether or not the requester can read the entity, and whether or
+     * not that entity is in the bin. Binning a record does not empty a freezer.
+     */
+    public function countContainers(int $storageId): int
+    {
+        $sql = 'SELECT ' . implode(' + ', array_map(
+            static fn(string $table): string => sprintf('(SELECT COUNT(*) FROM %s WHERE storage_id = :storage_id)', $table),
+            self::CONTAINER_TABLES,
+        ));
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':storage_id', $storageId, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return (int) $req->fetchColumn();
+    }
+
+    /**
+     * Refuse if one more container in $storageId would exceed its capacity.
+     * Callers must already be in a transaction: the FOR UPDATE lock below is what
+     * serializes concurrent writers to the same unit, and it has to be held until
+     * their insert commits to be worth anything.
+     */
+    public function assertHasRoom(int $storageId): void
+    {
+        // lock only the row that declares the limit, so contention is exactly as wide as the constraint
+        $req = $this->Db->prepare('SELECT capacity FROM storage_units WHERE id = :id FOR UPDATE');
+        $req->bindValue(':id', $storageId, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $capacity = $req->fetchColumn();
+        // no such unit: leave it to the foreign key. NULL: unlimited, so never count
+        if ($capacity === false || $capacity === null) {
+            return;
+        }
+        $occupancy = $this->countContainers($storageId);
+        if ($occupancy < (int) $capacity) {
+            return;
+        }
+        throw new ImproperActionException(sprintf(
+            _('Cannot store in "%s": its capacity is %d and it already holds %d.'),
+            new self($this->requester, false, $storageId)->readOne()['full_path'] ?? '',
+            (int) $capacity,
+            $occupancy,
+        ));
     }
 
     public function updateCapacity(?int $capacity): bool

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -45,6 +45,9 @@ final class StorageUnits extends AbstractRest
 {
     use SetIdTrait;
 
+    // upper bound of the INT UNSIGNED capacity column
+    public const int MAX_CAPACITY = 4294967295;
+
     /**
      * Tables holding real containers: a row in one of them occupies a slot. The template
      * tables are absent on purpose, as their containers are defaults copied on creation
@@ -307,14 +310,23 @@ final class StorageUnits extends AbstractRest
         if ($hasCapacity) {
             $newCapacity = $this->normalizeCapacity($params['capacity']);
         }
-        if ($hasName) {
-            $this->update(new CommentParam($params['name']));
-        }
-        if ($hasCapacity) {
-            $this->updateCapacity($newCapacity);
-        }
-        if ($hasParent) {
-            $this->applyMove($newParentId);
+        // one transaction for the lot: a move that fails at the database level must not
+        // leave the name or capacity from the same request behind
+        $this->Db->beginTransaction();
+        try {
+            if ($hasName) {
+                $this->update(new CommentParam($params['name']));
+            }
+            if ($hasCapacity) {
+                $this->updateCapacity($newCapacity);
+            }
+            if ($hasParent) {
+                $this->writeMove($newParentId);
+            }
+            $this->Db->commit();
+        } catch (Throwable $e) {
+            $this->Db->rollBack();
+            throw $e;
         }
         return $this->readOne();
     }
@@ -525,6 +537,10 @@ final class StorageUnits extends AbstractRest
             if ($parsed < 0) {
                 throw new ImproperActionException('Capacity cannot be negative.');
             }
+            // the column is INT UNSIGNED: reject here rather than let MySQL truncate or error
+            if ($parsed > self::MAX_CAPACITY) {
+                throw new ImproperActionException(sprintf('Capacity cannot exceed %d.', self::MAX_CAPACITY));
+            }
             return $parsed;
         }
         throw new ImproperActionException('Invalid capacity: must be a whole number, or empty for unlimited.');
@@ -562,26 +578,37 @@ final class StorageUnits extends AbstractRest
         }
     }
 
+    /**
+     * Owns a transaction, so it is only for callers that have none. patch() writes a move
+     * alongside other columns and drives writeMove() from its own transaction instead.
+     */
     private function applyMove(?int $newParentId): bool
     {
-        $oldParentId = $this->readCurrentParentId();
-        if ($oldParentId === $newParentId) {
-            return true;
-        }
         $this->Db->beginTransaction();
         try {
-            $sql = 'UPDATE storage_units SET parent_id = :parent_id WHERE id = :id';
-            $req = $this->Db->prepare($sql);
-            $req->bindValue(':parent_id', $newParentId, $newParentId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
-            $req->bindParam(':id', $this->id, PDO::PARAM_INT);
-            $ok = $this->Db->execute($req);
-            $this->recordMove($oldParentId, $newParentId);
+            $ok = $this->writeMove($newParentId);
             $this->Db->commit();
             return $ok;
         } catch (Throwable $e) {
             $this->Db->rollBack();
             throw $e;
         }
+    }
+
+    // the move itself, with no transaction of its own: the caller must provide one
+    private function writeMove(?int $newParentId): bool
+    {
+        $oldParentId = $this->readCurrentParentId();
+        if ($oldParentId === $newParentId) {
+            return true;
+        }
+        $sql = 'UPDATE storage_units SET parent_id = :parent_id WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':parent_id', $newParentId, $newParentId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        $ok = $this->Db->execute($req);
+        $this->recordMove($oldParentId, $newParentId);
+        return $ok;
     }
 
     private function readCurrentParentId(): ?int

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -67,6 +67,9 @@ final class StorageUnits extends AbstractRest
     #[Override]
     public function readOne(): array
     {
+        // the CTE walks upwards, so occupancy has to be counted for the requested unit
+        // (original_id) rather than for the ancestor the current row happens to be on
+        $occupancy = self::occupancySql('storage_hierarchy.original_id');
         // Recursive CTE to find the full path of a specific id
         $sql = "
             WITH RECURSIVE storage_hierarchy AS (
@@ -110,6 +113,7 @@ final class StorageUnits extends AbstractRest
                 full_path,
                 original_parent_id AS parent_id,
                 capacity,
+                {$occupancy} AS occupancy,
                 level_depth
             FROM
                 storage_hierarchy
@@ -396,10 +400,7 @@ final class StorageUnits extends AbstractRest
      */
     public function countContainers(int $storageId): int
     {
-        $sql = 'SELECT ' . implode(' + ', array_map(
-            static fn(string $table): string => sprintf('(SELECT COUNT(*) FROM %s WHERE storage_id = :storage_id)', $table),
-            self::CONTAINER_TABLES,
-        ));
+        $sql = 'SELECT ' . self::occupancySql(':storage_id');
         $req = $this->Db->prepare($sql);
         $req->bindValue(':storage_id', $storageId, PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -480,6 +481,19 @@ final class StorageUnits extends AbstractRest
         if (!$this->canWrite()) {
             throw new IllegalActionException();
         }
+    }
+
+    /**
+     * SQL expression counting the containers stored directly in the unit designated by
+     * $idExpression. Shared so the occupancy displayed in the tree and the occupancy the
+     * capacity guard enforces are the same number by construction, not by coincidence.
+     */
+    private static function occupancySql(string $idExpression): string
+    {
+        return implode(' + ', array_map(
+            static fn(string $table): string => sprintf('(SELECT COUNT(*) FROM %s WHERE storage_id = %s)', $table, $idExpression),
+            self::CONTAINER_TABLES,
+        ));
     }
 
     private function normalizeParentId(mixed $raw): ?int
@@ -598,6 +612,9 @@ final class StorageUnits extends AbstractRest
 
     private function readHierarchyRows(): array
     {
+        // counted in the final projection, not in the CTE: the recursion does not need it,
+        // so this way it costs two indexed lookups per unit instead of two per branch
+        $occupancy = self::occupancySql('storage_hierarchy.id');
         $sql = "WITH RECURSIVE storage_hierarchy AS (
             -- Base case: Select all top-level units (those with no parent)
             SELECT
@@ -639,6 +656,7 @@ final class StorageUnits extends AbstractRest
             full_path,
             parent_id,
             capacity,
+            {$occupancy} AS occupancy,
             level_depth,
             children_count
         FROM

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -419,18 +419,27 @@ final class StorageUnits extends AbstractRest
         $req->bindValue(':id', $storageId, PDO::PARAM_INT);
         $this->Db->execute($req);
         $capacity = $req->fetchColumn();
-        // no such unit: leave it to the foreign key. NULL: unlimited, so never count
+        // no such unit: leave it to the foreign key. NULL: unlimited, so never count.
+        // a strict comparison matters here, as a capacity of 0 is meaningful and falsy
         if ($capacity === false || $capacity === null) {
             return;
         }
+        $capacity = (int) $capacity;
         $occupancy = $this->countContainers($storageId);
-        if ($occupancy < (int) $capacity) {
+        if ($occupancy < $capacity) {
             return;
+        }
+        $path = new self($this->requester, false, $storageId)->readOne()['full_path'] ?? '';
+        if ($capacity === 0) {
+            throw new ImproperActionException(sprintf(
+                _('Nothing can be stored directly in "%s": its capacity is zero. Pick one of the locations inside it.'),
+                $path,
+            ));
         }
         throw new ImproperActionException(sprintf(
             _('Cannot store in "%s": its capacity is %d and it already holds %d.'),
-            new self($this->requester, false, $storageId)->readOne()['full_path'] ?? '',
-            (int) $capacity,
+            $path,
+            $capacity,
             $occupancy,
         ));
     }
@@ -489,7 +498,8 @@ final class StorageUnits extends AbstractRest
     }
 
     /**
-     * null, an empty string or 0 all mean "unlimited"
+     * null or an empty string mean "unlimited". 0 is a real capacity: it marks a unit that
+     * exists to hold child units rather than containers, such as a building or a room.
      */
     private function normalizeCapacity(mixed $raw): ?int
     {
@@ -501,9 +511,9 @@ final class StorageUnits extends AbstractRest
             if ($parsed < 0) {
                 throw new ImproperActionException('Capacity cannot be negative.');
             }
-            return $parsed === 0 ? null : $parsed;
+            return $parsed;
         }
-        throw new ImproperActionException('Invalid capacity: must be a positive whole number.');
+        throw new ImproperActionException('Invalid capacity: must be a whole number, or empty for unlimited.');
     }
 
     private function validateMoveTarget(?int $newParentId): void

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -69,6 +69,7 @@ final class StorageUnits extends AbstractRest
                     name,
                     parent_id,
                     parent_id AS original_parent_id,
+                    capacity,
                     CAST(name AS CHAR(1000)) AS full_path,
                     0 AS level_depth
                 FROM
@@ -85,6 +86,7 @@ final class StorageUnits extends AbstractRest
                     child.name,
                     parent.parent_id,
                     child.original_parent_id,
+                    child.capacity,
                     CAST(CONCAT(parent.name, ' > ', child.full_path) AS CHAR(1000)) AS full_path,
                     child.level_depth + 1
                 FROM
@@ -99,6 +101,7 @@ final class StorageUnits extends AbstractRest
                 name,
                 full_path,
                 original_parent_id AS parent_id,
+                capacity,
                 level_depth
             FROM
                 storage_hierarchy
@@ -279,7 +282,8 @@ final class StorageUnits extends AbstractRest
         $this->canWriteOrExplode();
         $hasName = !empty($params['name']);
         $hasParent = array_key_exists('parent_id', $params);
-        if (!$hasName && !$hasParent) {
+        $hasCapacity = array_key_exists('capacity', $params);
+        if (!$hasName && !$hasParent && !$hasCapacity) {
             throw new ImproperActionException('No valid update target provided.');
         }
         $newParentId = null;
@@ -287,8 +291,15 @@ final class StorageUnits extends AbstractRest
             $newParentId = $this->normalizeParentId($params['parent_id']);
             $this->validateMoveTarget($newParentId);
         }
+        $newCapacity = null;
+        if ($hasCapacity) {
+            $newCapacity = $this->normalizeCapacity($params['capacity']);
+        }
         if ($hasName) {
             $this->update(new CommentParam($params['name']));
+        }
+        if ($hasCapacity) {
+            $this->updateCapacity($newCapacity);
         }
         if ($hasParent) {
             $this->applyMove($newParentId);
@@ -344,15 +355,17 @@ final class StorageUnits extends AbstractRest
         return $this->create(
             $reqBody['name'] ?? throw new ImproperActionException('Missing value for "name"'),
             Filter::intOrNull($reqBody['parent_id'] ?? 0),
+            $this->normalizeCapacity($reqBody['capacity'] ?? null),
         );
     }
 
-    public function create(string $unitName, ?int $parentId = null): int
+    public function create(string $unitName, ?int $parentId = null, ?int $capacity = null): int
     {
-        $sql = 'INSERT INTO storage_units(parent_id, name) VALUES(:parent_id, :name)';
+        $sql = 'INSERT INTO storage_units(parent_id, name, capacity) VALUES(:parent_id, :name, :capacity)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':parent_id', $parentId);
         $req->bindParam(':name', $unitName);
+        $req->bindValue(':capacity', $capacity, $capacity === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
         $this->Db->execute($req);
         return $this->Db->lastInsertId();
     }
@@ -364,6 +377,15 @@ final class StorageUnits extends AbstractRest
             WHERE id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':name', $params->getContent());
+        $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+        return $this->Db->execute($req);
+    }
+
+    public function updateCapacity(?int $capacity): bool
+    {
+        $sql = 'UPDATE storage_units SET capacity = :capacity WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':capacity', $capacity, $capacity === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }
@@ -410,6 +432,24 @@ final class StorageUnits extends AbstractRest
             return $parsed === 0 ? null : $parsed;
         }
         throw new ImproperActionException('Invalid parent_id');
+    }
+
+    /**
+     * null, an empty string or 0 all mean "unlimited"
+     */
+    private function normalizeCapacity(mixed $raw): ?int
+    {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        if (is_int($raw) || (is_string($raw) && filter_var($raw, FILTER_VALIDATE_INT) !== false)) {
+            $parsed = (int) $raw;
+            if ($parsed < 0) {
+                throw new ImproperActionException('Capacity cannot be negative.');
+            }
+            return $parsed === 0 ? null : $parsed;
+        }
+        throw new ImproperActionException('Invalid capacity: must be a positive whole number.');
     }
 
     private function validateMoveTarget(?int $newParentId): void
@@ -500,6 +540,7 @@ final class StorageUnits extends AbstractRest
                 id,
                 name,
                 parent_id,
+                capacity,
                 name AS full_path,
                 0 AS level_depth,
                 (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = storage_units.id) AS children_count
@@ -515,6 +556,7 @@ final class StorageUnits extends AbstractRest
                 child.id,
                 child.name,
                 child.parent_id,
+                child.capacity,
                 CONCAT(parent.full_path, ' > ', child.name) AS full_path,
                 parent.level_depth + 1,
                 (SELECT COUNT(*) FROM storage_units AS su WHERE su.parent_id = child.id) AS children_count
@@ -532,6 +574,7 @@ final class StorageUnits extends AbstractRest
             name,
             full_path,
             parent_id,
+            capacity,
             level_depth,
             children_count
         FROM

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1817,6 +1817,23 @@ input:user-invalid {
   }
 }
 
+/* how full a storage location is */
+.storage-occupancy {
+  background-color: var(--lightgold);
+  border-radius: 0.25rem;
+  color: var(--darkgold);
+  font-size: 80%;
+  font-weight: 600;
+  padding: 0.15em 0.45em;
+  white-space: nowrap;
+}
+
+/* no room left: the colour carries the limit, not the mere fact of being occupied */
+.storage-occupancy.storage-full {
+  background-color: var(--lightred);
+  color: var(--darkred);
+}
+
 /* top right button */
 .initials {
   color: var(--secondlevel);

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1809,7 +1809,8 @@ input:user-invalid {
   flex-shrink: 0; /* Ensure toolbars do not shrink */
 }
 
-#storageDiv {
+/* every storage tree, whatever its id: several coexist on a page */
+[data-storage-tree] {
   details,
   summary {
     margin: 10px 0;

--- a/src/sql/schema220-down.sql
+++ b/src/sql/schema220-down.sql
@@ -1,0 +1,3 @@
+-- revert schema 220
+ALTER TABLE `storage_units` DROP COLUMN `capacity`;
+UPDATE config SET conf_value = 219 WHERE conf_name = 'schema';

--- a/src/sql/schema220-down.sql
+++ b/src/sql/schema220-down.sql
@@ -1,3 +1,3 @@
 -- revert schema 220
-ALTER TABLE `storage_units` DROP COLUMN `capacity`;
+CALL DropColumn('storage_units', 'capacity');
 UPDATE config SET conf_value = 219 WHERE conf_name = 'schema';

--- a/src/sql/schema220.sql
+++ b/src/sql/schema220.sql
@@ -1,0 +1,2 @@
+-- schema 220
+ALTER TABLE `storage_units` ADD COLUMN `capacity` INT UNSIGNED NULL DEFAULT NULL;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -2214,6 +2214,8 @@ CREATE TABLE IF NOT EXISTS storage_units (
     id INT unsigned NOT NULL AUTO_INCREMENT,
     name VARCHAR(255),
     parent_id INT unsigned,
+    -- NULL means unlimited
+    capacity INT unsigned DEFAULT NULL,
     FOREIGN KEY (parent_id) REFERENCES storage_units(id) ON DELETE CASCADE,
     PRIMARY KEY(`id`)
 );

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -26,6 +26,8 @@
           <h5><label for='containerMultiplierInput'>{{ 'Total number of containers to distribute'|trans }}</label></h5>
           <input type='number' value='1' min='1' step='1' id='containerMultiplierInput' autocomplete='off' class='form-control' />
           <div class='sticky-top py-2 mb-2 mt-2' style='top:0; z-index:1'>
+            {# shown when the target can never be assigned because the locations are too full #}
+            <p class='smallgray' id='containerCapacityNotice' hidden>{{ 'There is not enough room left in these locations for that many containers.'|trans }}</p>
             <div class='d-flex align-items-center'>
               <span class='mr-auto'>
                 <span id='containerAssignedCount'>0</span> / <span id='containerTargetCount'>1</span> {{ 'assigned'|trans }}

--- a/src/templates/move-container-modal.html
+++ b/src/templates/move-container-modal.html
@@ -11,7 +11,7 @@
       <div class='modal-body'>
         <div class='mb-2'>
           <h5>{{ 'Pick a new storage location'|trans }}</h5>
-          {% include 'storage-list.html' with {'storage_editable': false, 'is_entity': true, 'is_move': true} %}
+          {% include 'storage-list.html' with {'storage_editable': false, 'is_entity': true, 'is_move': true, 'dom_id': 'moveContainerStorageDiv'} %}
         </div>
       </div>
       <div class='modal-footer'>

--- a/src/templates/move-storage-modal.html
+++ b/src/templates/move-storage-modal.html
@@ -14,7 +14,7 @@
           <div class='mb-2'>
             <button type='button' class='btn btn-ghost btn-sm' data-action='move-storage-to-root' data-dismiss='modal'><i class='fas fa-arrow-up mr-1'></i>{{ 'Move to root'|trans }}</button>
           </div>
-          {% include 'storage-list.html' with {'storage_editable': false, 'is_entity': false, 'is_move_storage': true} %}
+          {% include 'storage-list.html' with {'storage_editable': false, 'is_entity': false, 'is_move_storage': true, 'dom_id': 'moveStorageUnitStorageDiv'} %}
         </div>
       </div>
       <div class='modal-footer'>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -17,40 +17,55 @@
     <button type='button' class='btn btn-transparent' data-action='toggle-all-storage' data-expand='1'>{{ 'Expand all'|trans }}</button>
     <button type='button' class='btn btn-transparent' data-action='toggle-all-storage'>{{ 'Collapse all'|trans }}</button>
   </div>
-  {# stepper used in the entity-create flow to pick how many containers go in this location #}
-  {% macro render_stepper(storage_id, storage_name) %}
-    <div class='input-group input-group-sm mt-1' style='max-width:160px' data-storage-id='{{ storage_id }}'>
-      <div class='input-group-prepend'>
-        <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Decrease containers for %s'|trans|format(storage_name) }}'><i class='fas fa-minus'></i></button>
-      </div>
-      <input type='number' class='form-control text-center' min='0' step='1' value='0' inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ storage_id }}' aria-label='{{ 'Number of containers for %s'|trans|format(storage_name) }}' />
-      <div class='input-group-append'>
-        <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ storage_id }}' aria-label='{{ 'Increase containers for %s'|trans|format(storage_name) }}'><i class='fas fa-plus'></i></button>
-      </div>
-    </div>
+  {# how full this location is, against its limit when it declares one #}
+  {% macro render_occupancy(unit, is_full) %}
+    {% if unit.capacity is not null %}
+      <span class='storage-occupancy {{ is_full ? 'storage-full' }} ml-1' title='{{ 'Containers stored here, out of the maximum this location accepts'|trans }}'><i class='fas fa-box mr-1'></i>{{ unit.occupancy }} / {{ unit.capacity }}</span>
+    {% elseif unit.occupancy > 0 %}
+      <span class='storage-occupancy ml-1' title='{{ 'Containers already stored here'|trans }}'><i class='fas fa-box mr-1'></i>{{ unit.occupancy }}</span>
+    {% endif %}
   {% endmacro %}
-  {# max number of containers this location should hold; unset means unlimited #}
+  {# stepper used in the entity-create flow to pick how many containers go in this location #}
+  {% macro render_stepper(unit, is_full) %}
+    {% if is_full %}
+      {# no input at all: anything typed here would be refused on submit #}
+      <span class='smallgray'><i class='fas fa-ban mr-1'></i>{{ unit.capacity == 0 ? 'Holds no containers'|trans : 'Full'|trans }}</span>
+    {% else %}
+      <div class='input-group input-group-sm mt-1' style='max-width:160px' data-storage-id='{{ unit.id }}'>
+        <div class='input-group-prepend'>
+          <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ unit.id }}' aria-label='{{ 'Decrease containers for %s'|trans|format(unit.name) }}'><i class='fas fa-minus'></i></button>
+        </div>
+        {# max is the room left here, so the browser's own spinner and the js clamp alike #}
+        <input type='number' class='form-control text-center' min='0' step='1' value='0' {% if unit.capacity is not null %}max='{{ unit.capacity - unit.occupancy }}'{% endif %} inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ unit.id }}' aria-label='{{ 'Number of containers for %s'|trans|format(unit.name) }}' />
+        <div class='input-group-append'>
+          <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ unit.id }}' aria-label='{{ 'Increase containers for %s'|trans|format(unit.name) }}'><i class='fas fa-plus'></i></button>
+        </div>
+      </div>
+    {% endif %}
+  {% endmacro %}
+  {# the declared limit, editable on the inventory page only; elsewhere the badge carries it #}
   {% macro render_capacity(unit, storage_editable) %}
     {% if storage_editable %}
-      <span class='smallgray ml-2'>{{ 'Capacity'|trans }}: <span class='hl-hover p-1 rounded malleableColumn {{ not unit.capacity ? 'font-italic' }}' data-endpoint='storage_units' data-id='{{ unit.id }}' data-target='capacity' data-input-type='number'>{{ unit.capacity|default('unset'|trans) }}</span></span>
-    {% elseif unit.capacity %}
-      <span class='smallgray ml-2'>{{ 'Capacity: %s'|trans|format(unit.capacity) }}</span>
+      {# an explicit null test, as a capacity of 0 is a real limit and would read as unset #}
+      <span class='smallgray ml-2'>{{ 'Capacity'|trans }}: <span class='hl-hover p-1 rounded malleableColumn {{ unit.capacity is null ? 'font-italic' }}' data-endpoint='storage_units' data-id='{{ unit.id }}' data-target='capacity' data-input-type='number'>{{ unit.capacity is null ? ('unset'|trans) : unit.capacity }}</span></span>
     {% endif %}
   {% endmacro %}
   {% macro render_items(items, groupedItems, storage_editable, is_entity=true, is_move=false, is_move_storage=false) %}
     <ul class='list-group'>
       {% for item in items %}
+        {% set is_full = item.capacity is not null and item.occupancy >= item.capacity %}
         <li class='list-group-item py-1'>
           {# this data-id is used to open it up after adding children #}
           <details data-id='{{ item.id }}'>
-            <summary>{{ item.name }} {% if item.children_count > 0 %}({{ item.children_count }}){% endif %}</summary>
+            <summary>{{ item.name }} {% if item.children_count > 0 %}({{ item.children_count }}){% endif %}{{ _self.render_occupancy(item, is_full) }}</summary>
             <div class='mb-1'>
               {% if is_move_storage %}
                 <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' data-dismiss='modal' data-action='move-storage-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(item.name) }}</button>
               {% elseif is_entity and is_move %}
-                <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(item.name) }}</button>
+                {# the js disables full destinations on open, bar the container's own location #}
+                <button type='button' class='btn btn-primary btn-sm' data-id='{{ item.id }}' {% if is_full %}data-storage-full='1'{% endif %} data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(item.name) }}</button>
               {% elseif is_entity %}
-                {{ _self.render_stepper(item.id, item.name) }}
+                {{ _self.render_stepper(item, is_full) }}
               {% else %}
                 <a class='btn btn-secondary btn-sm' href='?storage_unit={{ item.id }}'><i class='fas fa-magnifying-glass mr-1'></i>{{ 'Display content'|trans }}</a>
               {% endif %}
@@ -74,11 +89,12 @@
 
   {# Start rendering from the root level, which has parent_id = null #}
   {% for root in storageUnitsArr[null] %}
+    {% set is_full = root.capacity is not null and root.occupancy >= root.capacity %}
     <div class='box' data-root-id='{{ root.id }}'>
       <p class='smallgray'>{{ 'Inventory location'|trans }}</p>
       <div class='d-flex'>
         <div>
-          <i class='fas fa-location-dot mr-2'></i><span class='{{ storage_editable ? 'malleableColumn hl-hover' }} p-1 rounded font-weight-bold' data-endpoint='storage_units' data-id='{{ root.id }}' data-target='name'>{{ root.name }}</span>
+          <i class='fas fa-location-dot mr-2'></i><span class='{{ storage_editable ? 'malleableColumn hl-hover' }} p-1 rounded font-weight-bold' data-endpoint='storage_units' data-id='{{ root.id }}' data-target='name'>{{ root.name }}</span>{{ _self.render_occupancy(root, is_full) }}
           {{ _self.render_capacity(root, storage_editable) }}
         </div>
         {% if storage_editable %}
@@ -95,11 +111,11 @@
           </div>
         {% elseif is_entity and is_move %}
           <div class='ml-auto'>
-            <button type='button' class='btn btn-primary btn-sm' data-id='{{ root.id }}' data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(root.name) }}</button>
+            <button type='button' class='btn btn-primary btn-sm' data-id='{{ root.id }}' {% if is_full %}data-storage-full='1'{% endif %} data-dismiss='modal' data-action='move-container-target'><i class='fas fa-location-dot mr-1'></i>{{ 'Move here: %s'|trans|format(root.name) }}</button>
           </div>
         {% elseif is_entity %}
           <div class='ml-auto'>
-            {{ _self.render_stepper(root.id, root.name) }}
+            {{ _self.render_stepper(root, is_full) }}
           </div>
         {% endif %}
       </div>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -3,16 +3,20 @@
 {# var: is_move bool — when true, render a "Move here" button targeting move-container-target instead of "Store in X" #}
 {# var: is_move_storage bool — when true, render a "Move here" button targeting move-storage-target (admin context) #}
 {# var: storageUnitsArr array #}
+{# var: dom_id string — id of the tree wrapper; must be unique per page as several trees can coexist #}
 {% set is_move = is_move|default(false) %}
 {% set is_move_storage = is_move_storage|default(false) %}
-<div class='mb-2'>
-  <button type='button' class='btn btn-transparent' data-action='toggle-all-storage' data-expand='1'>{{ 'Expand all'|trans }}</button>
-  <button type='button' class='btn btn-transparent' data-action='toggle-all-storage'>{{ 'Collapse all'|trans }}</button>
-</div>
+{% set dom_id = dom_id|default('storageDiv') %}
 {% if App.devMode and storage_editable -%}
   <!-- [html-validate-disable-block prefer-native-element: suppress errors] -->
 {%- endif %}
-<div id='storageDiv'>
+{# data-storage-tree lets the js find every tree on the page without knowing their ids #}
+<div id='{{ dom_id }}' data-storage-tree='1'>
+  {# inside the wrapper so these buttons act on their own tree, and so a reload brings them back #}
+  <div class='mb-2'>
+    <button type='button' class='btn btn-transparent' data-action='toggle-all-storage' data-expand='1'>{{ 'Expand all'|trans }}</button>
+    <button type='button' class='btn btn-transparent' data-action='toggle-all-storage'>{{ 'Collapse all'|trans }}</button>
+  </div>
   {# stepper used in the entity-create flow to pick how many containers go in this location #}
   {% macro render_stepper(storage_id, storage_name) %}
     <div class='input-group input-group-sm mt-1' style='max-width:160px' data-storage-id='{{ storage_id }}'>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -25,6 +25,14 @@
       </div>
     </div>
   {% endmacro %}
+  {# max number of containers this location should hold; unset means unlimited #}
+  {% macro render_capacity(unit, storage_editable) %}
+    {% if storage_editable %}
+      <span class='smallgray ml-2'>{{ 'Capacity'|trans }}: <span class='hl-hover p-1 rounded malleableColumn {{ not unit.capacity ? 'font-italic' }}' data-endpoint='storage_units' data-id='{{ unit.id }}' data-target='capacity' data-input-type='number'>{{ unit.capacity|default('unset'|trans) }}</span></span>
+    {% elseif unit.capacity %}
+      <span class='smallgray ml-2'>{{ 'Capacity: %s'|trans|format(unit.capacity) }}</span>
+    {% endif %}
+  {% endmacro %}
   {% macro render_items(items, groupedItems, storage_editable, is_entity=true, is_move=false, is_move_storage=false) %}
     <ul class='list-group'>
       {% for item in items %}
@@ -48,6 +56,7 @@
                 <button type='button' class='btn btn-ghost btn-sm' data-action='move-storage' data-id='{{ item.id }}'><i class='fas fa-arrows-up-down-left-right mr-1'></i>{{ 'Move'|trans }}</button>
                 <button type='button' class='btn btn-danger-ghost btn-sm' data-id='{{ item.id }}' data-action='destroy-storage'><i class='fas fa-minus-circle mr-1'></i>{{ 'Delete %s and its children'|trans|format(item.name) }}</button>
               {% endif %}
+              {{ _self.render_capacity(item, storage_editable) }}
             </div>
             {% if groupedItems[item.id] is defined %}
               {# Recursively render the children #}
@@ -66,6 +75,7 @@
       <div class='d-flex'>
         <div>
           <i class='fas fa-location-dot mr-2'></i><span class='{{ storage_editable ? 'malleableColumn hl-hover' }} p-1 rounded font-weight-bold' data-endpoint='storage_units' data-id='{{ root.id }}' data-target='name'>{{ root.name }}</span>
+          {{ _self.render_capacity(root, storage_editable) }}
         </div>
         {% if storage_editable %}
           <div class='ml-auto'>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -852,6 +852,10 @@ const storageTreeIds = (): string[] =>
 
 const reloadStorageTrees = (): Promise<void> => reloadElements(storageTreeIds());
 
+/** Refresh the trees along with the entity's own container list: both show occupancy. */
+const reloadStorageAndContainers = (): Promise<void> =>
+  reloadElements(['storageDivContent', ...storageTreeIds()]);
+
 /** Re-open a unit and its ancestors, in every tree that renders it. */
 function revealStorageUnit(storageId: string): void {
   document.querySelectorAll(`details[data-id="${storageId}"]`).forEach((details: HTMLDetailsElement) => {
@@ -920,6 +924,18 @@ const containerTarget = (): number =>
 const containerAssigned = (): number =>
   containerStepperInputs().reduce((sum, input) => sum + intFromInput(input), 0);
 
+/**
+ * Room left in a location, read from the max the server rendered for it. An unlimited
+ * location has no max, hence Infinity. Full locations render no stepper at all, so they
+ * never reach here.
+ */
+const slotsLeft = (input: HTMLInputElement): number =>
+  input.max === '' ? Infinity : Math.max(0, Number(input.max));
+
+/** Room left across every location that can still take containers. */
+const totalSlotsLeft = (): number =>
+  containerStepperInputs().reduce((sum, input) => sum + slotsLeft(input), 0);
+
 /** Update the assigned/target counter and enable submit only at an exact match. */
 function refreshContainerDistribution(): void {
   const target = containerTarget();
@@ -928,6 +944,10 @@ function refreshContainerDistribution(): void {
   const targetEl = document.getElementById('containerTargetCount');
   if (assignedEl) assignedEl.textContent = String(assigned);
   if (targetEl) targetEl.textContent = String(target);
+  // the steppers cannot be pushed to an unreachable target, so say why rather than leaving
+  // the submit button disabled with no explanation
+  const notice = document.getElementById('containerCapacityNotice');
+  if (notice) notice.toggleAttribute('hidden', target <= totalSlotsLeft());
   const submitBtn = document.getElementById('storeContainersBtn') as HTMLButtonElement | null;
   if (submitBtn) submitBtn.disabled = target === 0 || assigned !== target;
 }
@@ -941,10 +961,13 @@ const otherSteppersTotal = (except: HTMLInputElement): number =>
     .filter(input => input !== except)
     .reduce((sum, input) => sum + intFromInput(input), 0);
 
-/** Set a stepper to a value, clamped so the total assigned can never exceed the target. */
+/**
+ * Set a stepper to a value under two ceilings: what is left of the target to distribute,
+ * and what this particular location can still hold.
+ */
 function setStepperValue(input: HTMLInputElement, value: number): void {
-  const max = Math.max(0, containerTarget() - otherSteppersTotal(input));
-  input.value = String(Math.min(Math.max(0, value), max));
+  const max = Math.min(containerTarget() - otherSteppersTotal(input), slotsLeft(input));
+  input.value = String(Math.min(Math.max(0, value), Math.max(0, max)));
   refreshContainerDistribution();
 }
 
@@ -953,10 +976,7 @@ function reclampAllSteppers(): void {
   const target = containerTarget();
   let running = 0;
   containerStepperInputs().forEach(input => {
-    let value = intFromInput(input);
-    if (running + value > target) {
-      value = Math.max(0, target - running);
-    }
+    const value = Math.min(intFromInput(input), Math.max(0, target - running), slotsLeft(input));
     input.value = String(value);
     running += value;
   });
@@ -998,13 +1018,17 @@ on('store-containers-distributed', () => {
   }
   // lock the button while the batch runs so a second click cannot create a duplicate distribution
   if (submitBtn) submitBtn.disabled = true;
-  // Execute all POST calls and reload elements after all are resolved
-  Promise.all(postCalls)
-    .then(() => {
-      reloadElements(['storageDivContent']);
-      $('#storageModal').modal('hide');
+  // allSettled, not all: one location refusing on capacity must not hide the containers that
+  // did land elsewhere. Each request reports its own error, so nothing is notified here.
+  Promise.allSettled(postCalls)
+    .then(results => {
+      // the tree lives inside this modal, so reloading it resets the steppers to fresh counts
+      reloadStorageAndContainers().then(() => refreshContainerDistribution());
+      // stay open on a partial failure, so what was refused can be redistributed
+      if (!results.some(result => result.status === 'rejected')) {
+        $('#storageModal').modal('hide');
+      }
     })
-    .catch((error) => notify.error(error))
     .finally(() => {
       if (submitBtn) submitBtn.disabled = false;
     });
@@ -1036,7 +1060,7 @@ on('delete-storage-root', (el: HTMLElement) => ApiC.delete(`storage_units/${el.d
 
 on('destroy-container', (el: HTMLElement) => {
   if (confirm(i18next.t('generic-delete-warning'))) {
-    ApiC.delete(`${entity.type}/${entity.id}/containers/${el.dataset.id}`).then(() => reloadElements(['storageDivContent']));
+    ApiC.delete(`${entity.type}/${entity.id}/containers/${el.dataset.id}`).then(() => reloadStorageAndContainers());
   }
 });
 
@@ -1044,6 +1068,11 @@ on('move-container', (el: HTMLElement) => {
   const modal = document.getElementById('moveStorageModal');
   if (!modal) return;
   modal.dataset.containerId = el.dataset.id;
+  // a full destination would be refused by the server. The container's own location is exempt:
+  // moving it where it already sits is a no-op, and it is itself one of the occupants
+  modal.querySelectorAll('button[data-action="move-container-target"]').forEach((btn: HTMLButtonElement) => {
+    btn.disabled = btn.dataset.storageFull === '1' && btn.dataset.id !== el.dataset.currentStorageId;
+  });
   $('#moveStorageModal').modal('show');
 });
 
@@ -1097,7 +1126,7 @@ on('move-container-target', (el: HTMLElement) => {
   const newStorageId = el.dataset.id;
   if (!containerId || !newStorageId) return;
   ApiC.patch(`${entity.type}/${entity.id}/containers/${containerId}`, { storage_id: parseInt(newStorageId, 10) })
-    .then(() => reloadElements(['storageDivContent']))
+    .then(() => reloadStorageAndContainers())
     .catch((error) => notify.error(error));
 });
 

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -841,9 +841,28 @@ on('toggle-next', (el: HTMLElement) => {
 });
 
 // START STORAGE
+
+/**
+ * Ids of the storage trees currently on the page. Several coexist (inventory page + modals)
+ * and they render different action controls, so each has its own id and all of them must be
+ * reloaded together to stay in sync.
+ */
+const storageTreeIds = (): string[] =>
+  Array.from(document.querySelectorAll('[data-storage-tree]')).map(el => el.id);
+
+const reloadStorageTrees = (): Promise<void> => reloadElements(storageTreeIds());
+
+/** Re-open a unit and its ancestors, in every tree that renders it. */
+function revealStorageUnit(storageId: string): void {
+  document.querySelectorAll(`details[data-id="${storageId}"]`).forEach((details: HTMLDetailsElement) => {
+    details.open = true;
+    getAncestorDetails(details).forEach(ancestor => ancestor.open = true);
+  });
+}
+
 on('toggle-all-storage', (el: HTMLElement) => {
-  // expand or collapse all storage nodes
-  const root = document.getElementById('storageDiv');
+  // expand or collapse all storage nodes of the tree these buttons belong to
+  const root = el.closest('[data-storage-tree]');
   const state = el.dataset.expand === '1';
   if (root) {
     const detailsElements = root.querySelectorAll('details');
@@ -857,14 +876,7 @@ on('rename-storage', (el: HTMLElement) => {
   const name = prompt('Name')?.trim();
   if (!name) return;
   ApiC.patch(`storage_units/${el.dataset.id}`, {name: name}).then(() => {
-    reloadElements(['storageDiv']).then(() => {
-      const parent: HTMLDetailsElement = document.querySelector(`details[data-id="${el.dataset.id}"]`);
-      if (parent) {
-        parent.open = true;
-        // now open ancestors too
-        getAncestorDetails(parent).forEach(details => details.open = true);
-      }
-    });
+    reloadStorageTrees().then(() => revealStorageUnit(el.dataset.id));
   });
 });
 on('add-storage-children', (el: HTMLElement) => {
@@ -877,14 +889,7 @@ on('add-storage-children', (el: HTMLElement) => {
     name: unitName.trim(),
   };
   ApiC.post('storage_units', params).then(() => {
-    reloadElements(['storageDiv']).then(() => {
-      const parent: HTMLDetailsElement = document.querySelector(`details[data-id="${params.parent_id}"]`);
-      if (parent) {
-        parent.open = true;
-        // now open ancestors too
-        getAncestorDetails(parent).forEach(details => details.open = true);
-      }
-    });
+    reloadStorageTrees().then(() => revealStorageUnit(params.parent_id));
   });
 });
 // CONTAINER DISTRIBUTION across multiple storage locations
@@ -1027,7 +1032,7 @@ if (storageModalEl) {
   });
 }
 
-on('delete-storage-root', (el: HTMLElement) => ApiC.delete(`storage_units/${el.dataset.id}`).then(() => reloadElements(['storageDiv'])));
+on('delete-storage-root', (el: HTMLElement) => ApiC.delete(`storage_units/${el.dataset.id}`).then(() => reloadStorageTrees()));
 
 on('destroy-container', (el: HTMLElement) => {
   if (confirm(i18next.t('generic-delete-warning'))) {
@@ -1073,7 +1078,7 @@ on('move-storage-target', (el: HTMLElement) => {
   const newParentId = el.dataset.id;
   if (!storageId || !newParentId) return;
   ApiC.patch(`storage_units/${storageId}`, { parent_id: parseInt(newParentId, 10) })
-    .then(() => reloadElements(['storageDiv']))
+    .then(() => reloadStorageTrees())
     .catch((error) => notify.error(error));
 });
 
@@ -1082,7 +1087,7 @@ on('move-storage-to-root', () => {
   const storageId = modal?.dataset.storageId;
   if (!storageId) return;
   ApiC.patch(`storage_units/${storageId}`, { parent_id: null })
-    .then(() => reloadElements(['storageDiv']))
+    .then(() => reloadStorageTrees())
     .catch((error) => notify.error(error));
 });
 
@@ -1098,7 +1103,7 @@ on('move-container-target', (el: HTMLElement) => {
 
 on('destroy-storage', (el: HTMLElement) => {
   if (confirm(i18next.t('generic-delete-warning'))) {
-    ApiC.delete(`storage_units/${el.dataset.id}`).then(() => reloadElements(['storageDiv']));
+    ApiC.delete(`storage_units/${el.dataset.id}`).then(() => reloadStorageTrees());
   }
 });
 

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -263,6 +263,112 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->latestChangelogEntry($Item, 'container_qty_changed'));
     }
 
+    public function testCreateIsRejectedWhenLocationIsFull(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box with capacity 1');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(1.0, 'mL');
+        $this->setCapacity($box, 1);
+
+        try {
+            $Links->createWithQuantity(1.0, 'mL');
+            $this->fail('Expected ImproperActionException was not thrown.');
+        } catch (ImproperActionException $e) {
+            $this->assertStringContainsString('capacity is 1', $e->getMessage());
+            $this->assertStringContainsString('already holds 1', $e->getMessage());
+        }
+
+        // the transaction rolled back, so nothing was stored
+        $this->assertSame(1, $this->StorageUnits->countContainers($box));
+    }
+
+    public function testCreateIsAllowedWhileCapacityHasRoom(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box with capacity 2');
+        $this->setCapacity($box, 2);
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(1.0, 'mL');
+        $Links->createWithQuantity(1.0, 'mL');
+        $this->assertSame(2, $this->StorageUnits->countContainers($box));
+    }
+
+    public function testCreateWithCapacityEnforcementDisabledIgnoresFullLocation(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box for importer bypass');
+        $Links = new Containers2ItemsLinks($Item, $box);
+        $Links->createWithQuantity(1.0, 'mL');
+        $this->setCapacity($box, 1);
+
+        // the CSV importer stores unenforced rather than dropping the container silently
+        $Links->createWithQuantity(1.0, 'mL', enforceCapacity: false);
+        $this->assertSame(2, $this->StorageUnits->countContainers($box));
+    }
+
+    public function testMoveIsRejectedWhenDestinationIsFull(): void
+    {
+        $Item = $this->getFreshItem();
+        $source = $this->StorageUnits->create('Source box');
+        $full = $this->StorageUnits->create('Full destination box');
+
+        new Containers2ItemsLinks($Item, $full)->createWithQuantity(1.0, 'mL');
+        $this->setCapacity($full, 1);
+        new Containers2ItemsLinks($Item, $source)->createWithQuantity(2.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        try {
+            $Links->patch(Action::Update, array('storage_id' => $full));
+            $this->fail('Expected ImproperActionException was not thrown.');
+        } catch (ImproperActionException) {
+            $this->addToAssertionCount(1);
+        }
+
+        // rolled back: the container never left the source
+        $this->assertEquals($source, (int) $Links->readOne()['storage_id']);
+        $this->assertNull($this->latestChangelogEntry($Item, 'container_moved'));
+    }
+
+    public function testNoOpMoveIntoFullLocationIsAllowed(): void
+    {
+        $Item = $this->getFreshItem();
+        $box = $this->StorageUnits->create('Box at capacity for no-op move');
+        new Containers2ItemsLinks($Item, $box)->createWithQuantity(1.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+        $this->setCapacity($box, 1);
+
+        // moving a container to where it already is must not be counted against itself
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $result = $Links->patch(Action::Update, array('storage_id' => $box));
+        $this->assertEquals($box, (int) $result['storage_id']);
+    }
+
+    public function testMoveOutOfAFullLocationIsAllowed(): void
+    {
+        $Item = $this->getFreshItem();
+        $full = $this->StorageUnits->create('Full box to drain');
+        $elsewhere = $this->StorageUnits->create('Box to drain into');
+        $Links = new Containers2ItemsLinks($Item, $full);
+        $Links->createWithQuantity(1.0, 'mL');
+        $Links->createWithQuantity(1.0, 'mL');
+        $rowId = $this->latestContainerRowId('containers2items', $Item->id);
+        // capacity set below the current occupancy: the location must still be drainable
+        $this->setCapacity($full, 1);
+
+        $Links = new Containers2ItemsLinks($Item, $rowId);
+        $result = $Links->patch(Action::Update, array('storage_id' => $elsewhere));
+        $this->assertEquals($elsewhere, (int) $result['storage_id']);
+        $this->assertSame(1, $this->StorageUnits->countContainers($full));
+    }
+
+    private function setCapacity(int $storageId, int $capacity): void
+    {
+        $this->StorageUnits->setId($storageId);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => $capacity));
+    }
+
     private function latestChangelogEntry(Items $entity, string $target): ?array
     {
         foreach (new Changelog($entity)->readAll() as $row) {

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -307,6 +307,22 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(2, $this->StorageUnits->countContainers($box));
     }
 
+    public function testZeroCapacityBlocksStorageEntirely(): void
+    {
+        $Item = $this->getFreshItem();
+        $room = $this->StorageUnits->create('Room with capacity 0');
+        $this->setCapacity($room, 0);
+
+        $Links = new Containers2ItemsLinks($Item, $room);
+        try {
+            $Links->createWithQuantity(1.0, 'mL');
+            $this->fail('Expected ImproperActionException was not thrown.');
+        } catch (ImproperActionException $e) {
+            $this->assertStringContainsString('capacity is zero', $e->getMessage());
+        }
+        $this->assertSame(0, $this->StorageUnits->countContainers($room));
+    }
+
     public function testMoveIsRejectedWhenDestinationIsFull(): void
     {
         $Item = $this->getFreshItem();

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -90,6 +90,7 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertContains($childId, $ids);
         $this->assertArrayHasKey('parent_id', $result[0]);
         $this->assertArrayHasKey('children_count', $result[0]);
+        $this->assertArrayHasKey('occupancy', $result[0]);
         $this->assertArrayNotHasKey('entity_id', $result[0]);
     }
 
@@ -262,6 +263,47 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(1, $this->StorageUnits->countContainers($storageId));
     }
 
+    public function testHierarchyOccupancyCountsOnlyDirectContainers(): void
+    {
+        $Item = $this->getFreshItem();
+        $parentId = $this->StorageUnits->create('Freezer holding a box');
+        $childId = $this->StorageUnits->create('Box holding a tube', $parentId);
+        new Containers2ItemsLinks($Item, $childId)->createWithQuantity(1.0, 'mL');
+
+        $occupancy = $this->readOccupancyByUnitId();
+        // the container is inside the box, so the freezer around it stays empty: a capacity
+        // limits what a unit holds directly, never what its descendants hold
+        $this->assertEquals(0, $occupancy[$parentId]);
+        $this->assertEquals(1, $occupancy[$childId]);
+    }
+
+    public function testHierarchyOccupancyMatchesTheGuard(): void
+    {
+        $Item = $this->getFreshItem();
+        $storageId = $this->StorageUnits->create('Box the tree and the guard must agree on');
+        new Containers2ItemsLinks($Item, $storageId)->createWithQuantity(1.0, 'mL');
+        $Item->destroy();
+        // a displayed free slot the guard would then refuse is worse than showing nothing,
+        // so the tree has to count exactly what assertHasRoom() counts
+        $occupancy = $this->readOccupancyByUnitId();
+        $this->assertEquals($this->StorageUnits->countContainers($storageId), $occupancy[$storageId]);
+        $this->assertEquals(1, $occupancy[$storageId]);
+    }
+
+    public function testReadOneOccupancyIsThatOfTheRequestedUnit(): void
+    {
+        $Item = $this->getFreshItem();
+        $parentId = $this->StorageUnits->create('Parent walked through on the way up');
+        $childId = $this->StorageUnits->create('Child that holds the container', $parentId);
+        new Containers2ItemsLinks($Item, $childId)->createWithQuantity(1.0, 'mL');
+
+        // the cte climbs to the root, so this pins the count to the unit that was asked for
+        $this->StorageUnits->setId($childId);
+        $this->assertEquals(1, $this->StorageUnits->readOne()['occupancy']);
+        $this->StorageUnits->setId($parentId);
+        $this->assertEquals(0, $this->StorageUnits->readOne()['occupancy']);
+    }
+
     public function testAssertHasRoomWithoutCapacityNeverThrows(): void
     {
         $Item = $this->getFreshItem();
@@ -432,5 +474,14 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $history);
         $this->assertEquals($shelfA, (int) $history[0]['old_parent_id']);
         $this->assertEquals($shelfB, (int) $history[0]['new_parent_id']);
+    }
+
+    /**
+     * Occupancy of every unit, keyed by unit id, as the storage tree receives it.
+     */
+    private function readOccupancyByUnitId(): array
+    {
+        $queryParams = $this->StorageUnits->getQueryParams(new InputBag(array('hierarchy' => 'true')));
+        return array_column($this->StorageUnits->readAll($queryParams), 'occupancy', 'id');
     }
 }

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -206,6 +206,49 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->StorageUnits->patch(Action::Update, array('parent_id' => 'bogus'));
     }
 
+    public function testCapacityDefaultsToUnlimited(): void
+    {
+        $unitId = $this->StorageUnits->create('No capacity set');
+        $this->StorageUnits->setId($unitId);
+        $this->assertNull($this->StorageUnits->readOne()['capacity']);
+    }
+
+    public function testCreateWithCapacity(): void
+    {
+        $unitId = $this->StorageUnits->postAction(Action::Create, array('name' => 'Box of 96', 'capacity' => 96));
+        $this->StorageUnits->setId($unitId);
+        $this->assertEquals(96, $this->StorageUnits->readOne()['capacity']);
+    }
+
+    public function testPatchCapacity(): void
+    {
+        $unitId = $this->StorageUnits->create('Capacity patch test');
+        $this->StorageUnits->setId($unitId);
+        $this->assertEquals(1, $this->StorageUnits->patch(Action::Update, array('capacity' => 1))['capacity']);
+        // a string works too, as sent by the frontend
+        $this->assertEquals(12, $this->StorageUnits->patch(Action::Update, array('capacity' => '12'))['capacity']);
+        // 0, null and an empty string all mean unlimited
+        $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => 0))['capacity']);
+        $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => null))['capacity']);
+        $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => ''))['capacity']);
+    }
+
+    public function testPatchWithNegativeCapacityIsRejected(): void
+    {
+        $unitId = $this->StorageUnits->create('Negative capacity test');
+        $this->StorageUnits->setId($unitId);
+        $this->expectException(ImproperActionException::class);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => -1));
+    }
+
+    public function testPatchWithNonNumericCapacityIsRejected(): void
+    {
+        $unitId = $this->StorageUnits->create('Bogus capacity test');
+        $this->StorageUnits->setId($unitId);
+        $this->expectException(ImproperActionException::class);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => 'lots'));
+    }
+
     public function testPatchDoesNotPersistRenameWhenMoveFails(): void
     {
         $original = 'Atomicity test original';

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -22,10 +22,13 @@ use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function array_column;
+use function sprintf;
 
 class StorageUnitsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;
+
+    private const string BLOCK_MOVE_CONSTRAINT = 'block_move_history';
 
     private StorageUnits $StorageUnits;
 
@@ -276,7 +279,7 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
 
         // every move writes a history row, so blocking that insert fails the move at the
         // database level, after the name and capacity of the same request were written
-        $this->blockMoveHistoryInserts();
+        $this->blockMoveHistoryInserts($destinationId);
         try {
             $this->StorageUnits->patch(Action::Update, array(
                 'name' => 'Name that must not survive',
@@ -520,19 +523,29 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($shelfB, (int) $history[0]['new_parent_id']);
     }
 
-    private function blockMoveHistoryInserts(): void
+    /**
+     * Reject history rows pointing at $destinationId. A CHECK constraint rather than a
+     * trigger, as triggers need SUPER when binary logging is on. The destination is
+     * freshly created, so no existing row can violate the constraint as it is added.
+     */
+    private function blockMoveHistoryInserts(int $destinationId): void
     {
         $Db = Db::getConnection();
-        $Db->execute($Db->prepare(
-            "CREATE TRIGGER block_move_history BEFORE INSERT ON storage_units_history
-                FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'blocked by test'"
-        ));
+        $Db->execute($Db->prepare(sprintf(
+            'ALTER TABLE storage_units_history
+                ADD CONSTRAINT %s CHECK (new_parent_id <> %d)',
+            self::BLOCK_MOVE_CONSTRAINT,
+            $destinationId,
+        )));
     }
 
     private function unblockMoveHistoryInserts(): void
     {
         $Db = Db::getConnection();
-        $Db->execute($Db->prepare('DROP TRIGGER IF EXISTS block_move_history'));
+        // MySQL has no DROP CHECK IF EXISTS
+        $Db->execute($Db->prepare(
+            'ALTER TABLE storage_units_history DROP CHECK ' . self::BLOCK_MOVE_CONSTRAINT
+        ));
     }
 
     /**

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -227,9 +227,11 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $this->StorageUnits->patch(Action::Update, array('capacity' => 1))['capacity']);
         // a string works too, as sent by the frontend
         $this->assertEquals(12, $this->StorageUnits->patch(Action::Update, array('capacity' => '12'))['capacity']);
-        // 0, null and an empty string all mean unlimited
-        $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => 0))['capacity']);
+        // 0 is a real capacity: a unit that holds child units but never containers
+        $this->assertEquals(0, $this->StorageUnits->patch(Action::Update, array('capacity' => 0))['capacity']);
+        // only null and an empty string mean unlimited
         $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => null))['capacity']);
+        $this->assertEquals(0, $this->StorageUnits->patch(Action::Update, array('capacity' => '0'))['capacity']);
         $this->assertNull($this->StorageUnits->patch(Action::Update, array('capacity' => ''))['capacity']);
     }
 
@@ -280,6 +282,31 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->StorageUnits->patch(Action::Update, array('capacity' => 1));
         $this->expectException(ImproperActionException::class);
         $this->StorageUnits->assertHasRoom($storageId);
+    }
+
+    public function testAssertHasRoomRejectsAnEmptyUnitWithZeroCapacity(): void
+    {
+        $storageId = $this->StorageUnits->create('Room that holds freezers, not tubes');
+        $this->StorageUnits->setId($storageId);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => 0));
+        try {
+            $this->StorageUnits->assertHasRoom($storageId);
+            $this->fail('Expected ImproperActionException was not thrown.');
+        } catch (ImproperActionException $e) {
+            // an empty structural node must not report itself as merely full
+            $this->assertStringContainsString('capacity is zero', $e->getMessage());
+        }
+    }
+
+    public function testZeroCapacityStillAcceptsChildUnits(): void
+    {
+        $parentId = $this->StorageUnits->create('Building with no storage of its own');
+        $this->StorageUnits->setId($parentId);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => 0));
+        // capacity constrains containers, never child units
+        $childId = $this->StorageUnits->create('Freezer inside it', $parentId);
+        $this->StorageUnits->setId($childId);
+        $this->assertEquals($parentId, $this->StorageUnits->readOne()['parent_id']);
     }
 
     public function testAssertHasRoomOnMissingUnitIsTolerated(): void

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
+use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Links\Containers2ItemsLinks;
 use Elabftw\Models\Users\Users;
@@ -252,6 +254,48 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->StorageUnits->patch(Action::Update, array('capacity' => 'lots'));
     }
 
+    public function testCapacityIsCappedAtTheColumnMaximum(): void
+    {
+        $unitId = $this->StorageUnits->create('Huge capacity test');
+        $this->StorageUnits->setId($unitId);
+        // the column is INT UNSIGNED, so its ceiling is a rejection rather than a truncation
+        $this->assertEquals(
+            StorageUnits::MAX_CAPACITY,
+            $this->StorageUnits->patch(Action::Update, array('capacity' => StorageUnits::MAX_CAPACITY))['capacity'],
+        );
+        $this->expectException(ImproperActionException::class);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => StorageUnits::MAX_CAPACITY + 1));
+    }
+
+    public function testPatchIsRolledBackWhenTheMoveFails(): void
+    {
+        $destinationId = $this->StorageUnits->create('Rollback destination');
+        $unitId = $this->StorageUnits->create('Rollback source');
+        $this->StorageUnits->setId($unitId);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => 5));
+
+        // every move writes a history row, so blocking that insert fails the move at the
+        // database level, after the name and capacity of the same request were written
+        $this->blockMoveHistoryInserts();
+        try {
+            $this->StorageUnits->patch(Action::Update, array(
+                'name' => 'Name that must not survive',
+                'capacity' => 42,
+                'parent_id' => $destinationId,
+            ));
+            $this->fail('The move should have failed at the database level.');
+        } catch (DatabaseErrorException) {
+            // expected
+        } finally {
+            $this->unblockMoveHistoryInserts();
+        }
+
+        $unit = $this->StorageUnits->readOne();
+        $this->assertEquals('Rollback source', $unit['name']);
+        $this->assertEquals(5, $unit['capacity']);
+        $this->assertNull($unit['parent_id']);
+    }
+
     public function testCountContainersIsNotAffectedByBinning(): void
     {
         $Item = $this->getFreshItem();
@@ -474,6 +518,21 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $history);
         $this->assertEquals($shelfA, (int) $history[0]['old_parent_id']);
         $this->assertEquals($shelfB, (int) $history[0]['new_parent_id']);
+    }
+
+    private function blockMoveHistoryInserts(): void
+    {
+        $Db = Db::getConnection();
+        $Db->execute($Db->prepare(
+            "CREATE TRIGGER block_move_history BEFORE INSERT ON storage_units_history
+                FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'blocked by test'"
+        ));
+    }
+
+    private function unblockMoveHistoryInserts(): void
+    {
+        $Db = Db::getConnection();
+        $Db->execute($Db->prepare('DROP TRIGGER IF EXISTS block_move_history'));
     }
 
     /**

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -249,6 +249,46 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->StorageUnits->patch(Action::Update, array('capacity' => 'lots'));
     }
 
+    public function testCountContainersIsNotAffectedByBinning(): void
+    {
+        $Item = $this->getFreshItem();
+        $storageId = $this->StorageUnits->create('Box for occupancy count');
+        new Containers2ItemsLinks($Item, $storageId)->createWithQuantity(1.0, 'mL');
+        $this->assertSame(1, $this->StorageUnits->countContainers($storageId));
+        // binning the resource does not take the container out of the box
+        $Item->destroy();
+        $this->assertSame(1, $this->StorageUnits->countContainers($storageId));
+    }
+
+    public function testAssertHasRoomWithoutCapacityNeverThrows(): void
+    {
+        $Item = $this->getFreshItem();
+        $storageId = $this->StorageUnits->create('Box with no capacity');
+        $Links = new Containers2ItemsLinks($Item, $storageId);
+        $Links->createWithQuantity(1.0, 'mL');
+        $Links->createWithQuantity(1.0, 'mL');
+        $this->StorageUnits->assertHasRoom($storageId);
+        $this->assertSame(2, $this->StorageUnits->countContainers($storageId));
+    }
+
+    public function testAssertHasRoomThrowsWhenFull(): void
+    {
+        $Item = $this->getFreshItem();
+        $storageId = $this->StorageUnits->create('Box that is full');
+        new Containers2ItemsLinks($Item, $storageId)->createWithQuantity(1.0, 'mL');
+        $this->StorageUnits->setId($storageId);
+        $this->StorageUnits->patch(Action::Update, array('capacity' => 1));
+        $this->expectException(ImproperActionException::class);
+        $this->StorageUnits->assertHasRoom($storageId);
+    }
+
+    public function testAssertHasRoomOnMissingUnitIsTolerated(): void
+    {
+        // no row to read a capacity from: the foreign key deals with it, not the guard
+        $this->StorageUnits->assertHasRoom(PHP_INT_MAX);
+        $this->assertSame(0, $this->StorageUnits->countContainers(PHP_INT_MAX));
+    }
+
     public function testPatchDoesNotPersistRenameWhenMoveFails(): void
     {
         $original = 'Atomicity test original';


### PR DESCRIPTION
# Give storage locations a capacity, enforce it, and show it

## Pull Request Checklist

- [x] I have added tests for any new features. → 21 cases across `tests/unit/models/StorageUnitsTest.php` and `tests/unit/models/ContainersLinksTest.php`.
- [x] I have mentioned the related issue (if applicable). → #7249, where `capacity` was suggested as the next logical step.
- [x] I have updated or verified the relevant documentation. → `apidoc/v2/openapi.yaml` covers the new fields and the new rejection.

## Summary

`storage_units` has no notion of how much a location should hold, so nothing distinguishes a shelf that takes twenty boxes from a box position that takes one tube. This adds an optional `capacity` per location, refuses to store past it, and shows how full each location is at the point where someone picks one.

In order to make these enforcements usable on the site, this also surfaces the current occupancy and capacity on the container modal on the site.

## What this does

- adds a nullable `capacity` column to `storage_units` (schema 220): `NULL` unlimited, `0` nothing may be stored directly here, `n` at most n containers;
- refuses to add or move a container into a unit that is at its capacity, under a `SELECT ... FOR UPDATE` on the unit row inside the caller's transaction, so a concurrent batch cannot slip past a check-then-insert;
- returns `capacity` and `occupancy` from `readOne()` and the hierarchy query, and shows them as a badge (`3 / 10`, red at the limit) on every node of the storage tree in the web app;
- caps each per-location stepper in the add-container modal at the room left, replaces the stepper with "Full" where there is none, and disables full destinations in the move modal — except the container's current location, which is a no-op move;
- switches the distribution batch to `Promise.allSettled`, so a rejection on one location no longer hides the containers that landed in the others, and refreshes the trees afterwards so the counts do not go stale.

## Decisions

**Occupancy is just how many containers point at a location.** It is counted straight from `containers2items` and `containers2experiments`: no join to the experiment or resource behind the container, no filter on state or on what the reader is allowed to see, and no counting of what child locations hold. Keeping it that simple keeps it stable — sending an entity to the bin or restoring it does not change the count, so a restore can never push a location past its capacity and needs no guard of its own. The template tables are left out because the containers in them are defaults to copy when something is created, not physical stock.

**The number shown and the number enforced come from the same SQL.** `occupancySql()` builds the count from one list of tables, and `countContainers()`, `readOne()` and the hierarchy query all call it. Telling a user a slot is free and then refusing it would be worse than showing nothing at all, so there is no second definition that could drift out of step, and a test asserts the two agree.

**`0` means zero, not unlimited.** Some containers may exist only to hold other units (e.g. shelves in a cupboard), and saying so is more useful than leaving it unlimited. Only `null` and `''` clear the limit. Capacity 0 still accepts child units, since capacity constrains containers and never the tree.

**The rule blocks additions rather than requiring compliance.** Setting a capacity below the current occupancy is allowed, so a legacy over-filled location is always drainable — rejecting that would require the data to be correct before the user may say what correct means.

**A move is an add to the destination.** The source is never checked: freeing a slot needs no permission.

## Performance

No new requests. The tree is already server-rendered into every entity page, so this adds one integer per node — a few percent of markup that was being sent anyway. Occupancy is counted in each query's final projection rather than inside the recursive CTE, which makes it two indexed lookups per unit (`storage_id` is indexed by its foreign key) rather than scaling with the number of containers stored.

## Deliberately out of scope

There did not seem to be an elegant way to handle:
* Duplication of items with containers (incl. from templates)
* CSV import.
Specifically I couldn't really see how to elegantly feed back partial successes to a user, and suspected it would cause more problems (by a user missing failures) than solve (preventing storage overspill) to accomodate this.

## Side effects

`GET /api/v2/storage_units/{id}` and `?hierarchy=true` gain `capacity` and `occupancy`. Purely additive, and `capacity` is `NULL` for every existing unit.

`occupancy` is not permission-filtered: it reveals that *something* is stored in a location to a user who cannot read that entity. This matches `hasContainers()`, which already blocks deleting a unit on unfiltered occupancy, and exposes a number and nothing else.

Storing past a capacity now returns `400` where it previously succeeded. Existing over-filled locations are unaffected until someone sets a capacity on them.

## Testing

21 cases: capacity round-trips through create and patch; `0`/`null`/`''` handled distinctly; negative and non-numeric rejected; the guard fires on add and on move, tolerates a missing unit, and reports a zero capacity differently from a full one; a rejected store rolls back and leaves no changelog entry; a no-op move into a full location is allowed; occupancy is direct-only, survives binning, and equals what the guard counts.

Not run — `tests/run.sh` needs `elabftw/elabimg:ci`, which is not built in my environment, and there is no Node toolchain for `tsc`/eslint. Run before merge:

```bash
bash tests/run.sh unit --filter 'StorageUnitsTest|ContainersLinksTest'
yarn tsc --noEmit && yarn csslint
```

`php-cs-fixer` and `phpstan` are clean on the changed files, and the OpenAPI document parses. The templates were checked by rendering them against fabricated hierarchy rows in all four contexts (inventory, add container, move container, move storage unit), and both new queries were executed against a scratch schema to confirm occupancy is direct-only and counts both container tables.

Five new translatable strings need the usual `.pot`/`.po` regeneration; `Capacity: %s` is no longer used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Storage locations support configurable, unlimited, or zero capacity.
  - Occupancy and capacity appear throughout storage hierarchies.
  - Container placement and relocation account for available capacity.
  - Full locations are marked, with controls disabled when appropriate.
- **Bug Fixes**
  - Capacity violations receive clear feedback and safely roll back.
  - CSV imports continue when locations exceed capacity.
- **Documentation**
  - API documentation covers capacity, occupancy, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->