### PR TITLE
feat: sql: add auto-rollback for failed updates

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -96,7 +96,7 @@ final class Install extends Command
 
         $output->writeln('<info>→ Initializing MySQL database...</info>');
         $sqlFs = FsTools::getFs(dirname(__DIR__) . '/sql');
-        (new Sql($sqlFs))->execFile('structure.sql');
+        (new Sql($sqlFs, $output))->execFile('structure.sql');
         $output->writeln('<info>✓ Installation successful! Now creating the first team...</info>');
         // now create the default team
         $Teams = new Teams(new Users());

--- a/src/Commands/UpdateTo3.php
+++ b/src/Commands/UpdateTo3.php
@@ -44,7 +44,7 @@ final class UpdateTo3 extends Command
             'Preparing database for 3.0 update',
             '=================================',
         ));
-        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')));
+        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')), $output);
         $Sql->execFile('prepare30.sql');
         $output->writeln('Database ready to be cleaned. Now running db:clean command...');
 

--- a/src/Commands/UpdateTo34.php
+++ b/src/Commands/UpdateTo34.php
@@ -47,7 +47,7 @@ final class UpdateTo34 extends Command
             'Preparing database for 3.4 update',
             '=================================',
         ));
-        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')));
+        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')), $output);
         try {
             $Sql->execFile('prepare34-a.sql');
         } catch (Exception) {

--- a/src/Elabftw/Sql.php
+++ b/src/Elabftw/Sql.php
@@ -93,6 +93,29 @@ final class Sql
     }
 
     /**
+     * Execute a SQL file and compensate a failed migration with its down file
+     */
+    public function execFileWithRollback(string $filename, string $rollbackFilename, bool $force = false): int
+    {
+        if ($force) {
+            return $this->execFile($filename, true);
+        }
+
+        try {
+            return $this->execFile($filename);
+        } catch (DatabaseErrorException $e) {
+            if ($this->output !== null) {
+                $this->output->writeln(sprintf('<error>Failed to apply %s. Rolling back with %s.</error>', $filename, $rollbackFilename));
+            }
+            // DDL statements cannot be rolled back as a transaction in MySQL, so
+            // run the compensating migration and ignore operations that were not
+            // reached by the failed up migration.
+            $this->execFile($rollbackFilename, true);
+            throw $e;
+        }
+    }
+
+    /**
      * Read a file and return the significant lines as array
      */
     private function getLines(string $filename): array

--- a/src/Elabftw/Sql.php
+++ b/src/Elabftw/Sql.php
@@ -16,6 +16,7 @@ use Elabftw\Exceptions\DatabaseErrorException;
 use League\Flysystem\FilesystemOperator;
 use PDOException;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 use function array_filter;
 use function array_merge;
@@ -37,7 +38,7 @@ final class Sql
 
     private Db $Db;
 
-    public function __construct(private FilesystemOperator $filesystem, private ?OutputInterface $output = null)
+    public function __construct(private FilesystemOperator $filesystem, private OutputInterface $output)
     {
         $this->Db = Db::getConnection();
     }
@@ -47,13 +48,11 @@ final class Sql
      */
     public function execFile(string $filename, bool $force = false): int
     {
-        if ($this->output !== null) {
-            // add two for the spaces around
-            $len = strlen($filename) + 2;
-            $this->output->writeln(sprintf('<bg=green;fg=black>%s</>', str_repeat(' ', $len)));
-            $this->output->writeln(sprintf('<bg=green;fg=black> %s </>', strtoupper($filename)));
-            $this->output->writeln(sprintf('<bg=green;fg=black>%s</>', str_repeat(' ', $len)));
-        }
+        // add two for the spaces around
+        $len = strlen($filename) + 2;
+        $this->output->writeln(sprintf('<bg=green;fg=black>%s</>', str_repeat(' ', $len)));
+        $this->output->writeln(sprintf('<bg=green;fg=black> %s </>', strtoupper($filename)));
+        $this->output->writeln(sprintf('<bg=green;fg=black>%s</>', str_repeat(' ', $len)));
         $lines = $this->getLines($filename);
         // temporary variable, used to store current query
         $queryline = '';
@@ -65,18 +64,14 @@ final class Sql
             // If it has a semicolon at the end, it's the end of the query
             if (str_ends_with($line, ';')) {
                 // display which query we are running
-                if ($this->output !== null) {
-                    $this->output->writeln('Executing: ' . $queryline);
-                }
+                $this->output->writeln('Executing: ' . $queryline);
                 // Perform the query
                 try {
                     $this->Db->q($queryline);
                 } catch (PDOException | DatabaseErrorException $e) {
                     if ($force) {
-                        if ($this->output !== null) {
-                            $this->output->writeln('<bg=yellow;fg=black>WARNING: Ignoring error because of force option active.</>');
-                            $this->output->writeln($e->getMessage());
-                        }
+                        $this->output->writeln('<bg=yellow;fg=black>WARNING: Ignoring error because of force option active.</>');
+                        $this->output->writeln($e->getMessage());
                         // Reset temp variable to empty
                         $queryline = '';
                         $lineCount++;
@@ -104,13 +99,16 @@ final class Sql
         try {
             return $this->execFile($filename);
         } catch (DatabaseErrorException $e) {
-            if ($this->output !== null) {
-                $this->output->writeln(sprintf('<error>Failed to apply %s. Rolling back with %s.</error>', $filename, $rollbackFilename));
-            }
+            $this->output->writeln(sprintf('<error>Failed to apply %s. Rolling back with %s.</error>', $filename, $rollbackFilename));
             // DDL statements cannot be rolled back as a transaction in MySQL, so
             // run the compensating migration and ignore operations that were not
             // reached by the failed up migration.
-            $this->execFile($rollbackFilename, true);
+            try {
+                $this->execFile($rollbackFilename, true);
+            } catch (Throwable $rollbackException) {
+                $this->output->writeln(sprintf('<error>Failed to roll back with %s.</error>', $rollbackFilename));
+                $this->output->writeln($rollbackException->getMessage());
+            }
             throw $e;
         }
     }

--- a/src/Elabftw/Update.php
+++ b/src/Elabftw/Update.php
@@ -65,8 +65,13 @@ final class Update
         // new style with SQL files instead of functions
         $Config = Config::getConfig();
         while ($this->currentSchema < SchemaVersionChecker::REQUIRED_SCHEMA) {
-            ++$this->currentSchema;
-            $this->Sql->execFile(sprintf('schema%d.sql', $this->currentSchema), $force);
+            $nextSchema = $this->currentSchema + 1;
+            $this->Sql->execFileWithRollback(
+                sprintf('schema%d.sql', $nextSchema),
+                sprintf('schema%d-down.sql', $nextSchema),
+                $force,
+            );
+            $this->currentSchema = $nextSchema;
             // this will bust cache
             $Config->patch(Action::Update, array('schema' => $this->currentSchema));
             // schema57: add an elabid to existing database items

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -570,7 +570,7 @@ final class Populate
         $Db->q('USE ' . Env::asString('DB_NAME'));
 
         // load structure
-        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')));
+        $Sql = new Sql(new Fs(new LocalFilesystemAdapter(dirname(__DIR__) . '/sql')), $this->output);
         $Sql->execFile('structure.sql');
         new Branding(true)->populate();
     }

--- a/src/sql/README.md
+++ b/src/sql/README.md
@@ -15,6 +15,10 @@ Procedures are loaded and can be used in the sql files:
 
 See `src/sql/procedures.sql`.
 
+## Failed upgrades
+
+`db:update` automatically executes the matching `schemaN-down.sql` file if a schema migration fails. MySQL DDL statements cannot be rolled back as a transaction, so down migrations act as compensating rollbacks and must be safe to run after a partially applied up migration. Prefer `IF EXISTS` and the helper procedures above where applicable.
+
 ## Former columns
 
 Columns that should be removed after a while because they are not used anymore but were kept around so the `-down` action would not lose information:

--- a/tests/unit/classes/SqlTest.php
+++ b/tests/unit/classes/SqlTest.php
@@ -41,6 +41,22 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, $this->Sql->execFile('dummy-broken.sql'));
     }
 
+    public function testExecFileWithRollback(): void
+    {
+        $fsMock = $this->createMock(Fs::class);
+        $fsMock->method('fileExists')->willReturn(false);
+        $fsMock->expects($this->exactly(2))
+            ->method('read')
+            ->willReturnMap(array(
+                array('broken.sql', 'SELECT * FROM users;' . PHP_EOL . 'SELECT not_existing FROM not_existing_either;'),
+                array('rollback.sql', 'SELECT * FROM teams;'),
+            ));
+        $Sql = new Sql($fsMock);
+
+        $this->expectException(DatabaseErrorException::class);
+        $Sql->execFileWithRollback('broken.sql', 'rollback.sql');
+    }
+
     public function testExecNonExistingFile(): void
     {
         $this->expectException(UnableToReadFile::class);

--- a/tests/unit/classes/SqlTest.php
+++ b/tests/unit/classes/SqlTest.php
@@ -15,7 +15,7 @@ use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\DatabaseErrorException;
 use League\Flysystem\Filesystem as Fs;
 use League\Flysystem\UnableToReadFile;
-use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\NullOutput;
 
 class SqlTest extends \PHPUnit\Framework\TestCase
 {
@@ -23,8 +23,7 @@ class SqlTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $outMock = $this->createMock(Output::class);
-        $this->Sql = new Sql(Storage::FIXTURES->getStorage()->getFs(), $outMock);
+        $this->Sql = new Sql(Storage::FIXTURES->getStorage()->getFs(), new NullOutput());
     }
 
     public function testExecFile(): void
@@ -51,7 +50,25 @@ class SqlTest extends \PHPUnit\Framework\TestCase
                 array('broken.sql', 'SELECT * FROM users;' . PHP_EOL . 'SELECT not_existing FROM not_existing_either;'),
                 array('rollback.sql', 'SELECT * FROM teams;'),
             ));
-        $Sql = new Sql($fsMock);
+        $Sql = new Sql($fsMock, new NullOutput());
+
+        $this->expectException(DatabaseErrorException::class);
+        $Sql->execFileWithRollback('broken.sql', 'rollback.sql');
+    }
+
+    public function testExecFileWithRollbackPreservesOriginalExceptionWhenRollbackFails(): void
+    {
+        $fsMock = $this->createMock(Fs::class);
+        $fsMock->method('fileExists')->willReturn(false);
+        $fsMock->expects($this->exactly(2))
+            ->method('read')
+            ->willReturnCallback(static function (string $filename): string {
+                if ($filename === 'broken.sql') {
+                    return 'SELECT not_existing FROM not_existing_either;';
+                }
+                throw new UnableToReadFile();
+            });
+        $Sql = new Sql($fsMock, new NullOutput());
 
         $this->expectException(DatabaseErrorException::class);
         $Sql->execFileWithRollback('broken.sql', 'rollback.sql');
@@ -67,7 +84,7 @@ class SqlTest extends \PHPUnit\Framework\TestCase
     {
         $fsMock = $this->createMock(Fs::class);
         $fsMock->method('read')->will($this->throwException(new UnableToReadFile()));
-        $Sql = new Sql($fsMock);
+        $Sql = new Sql($fsMock, new NullOutput());
         $this->expectException(UnableToReadFile::class);
         $Sql->execFile('osef');
     }

--- a/tests/unit/classes/UpdateTest.php
+++ b/tests/unit/classes/UpdateTest.php
@@ -15,6 +15,7 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\InvalidSchemaException;
 use League\Flysystem\Filesystem as Fs;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use Symfony\Component\Console\Output\NullOutput;
 
 use function sprintf;
 
@@ -27,7 +28,7 @@ class UpdateTest extends \PHPUnit\Framework\TestCase
     public function setUp(): void
     {
         $this->Fs = new Fs(new InMemoryFilesystemAdapter());
-        $this->Sql = new Sql($this->Fs);
+        $this->Sql = new Sql($this->Fs, new NullOutput());
     }
 
     public function testCheckSchema(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema upgrade reliability by automatically running the matching rollback migration when an upgrade fails.
  * Preserved the original database error after rollback attempts.

* **Documentation**
  * Added guidance for writing safe rollback migrations, including handling partially applied database changes.

* **Improvements**
  * Improved visibility of database installation and migration progress through command output.

* **Tests**
  * Added coverage for failed migrations and rollback error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->