### PR TITLE
dev: apidoc and doc for custom fields multi

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -1867,7 +1867,7 @@ components:
         extra_fields:
           type: object
           nullable: true
-          description: See https://doc.elabftw.net/docs/usage/metadata#extra-fields-objects
+          description: See https://doc.elabftw.net/docs/usage/user-guide/custom-fields
           additionalProperties:
             type: object
             nullable: true
@@ -1875,10 +1875,29 @@ components:
               type:
                 nullable: true
                 type: string
-                enum: ['allow_multi_values', 'blank_value_on_duplicate', 'checkbox', 'date', 'datetime-local', 'description', 'email', 'experiments', 'group_id', 'items', 'number', 'options', 'position', 'radio', 'required', 'select', 'text', 'time', 'unit', 'url', 'users']
+                enum: ['checkbox', 'compounds', 'date', 'datetime-local', 'email', 'experiments', 'items', 'number', 'radio', 'select', 'text', 'time', 'uploads', 'url', 'users']
               value:
-                nullable: true
-                type: string
+                description: |
+                  The selected or input value. Fields accept a single string or number by default.
+                  When `allow_multi_values` is `true`, the value is stored as an array of strings
+                  or numbers. An empty array represents a multi-value field with no values.
+                oneOf:
+                  - type: string
+                    nullable: true
+                  - type: number
+                  - type: array
+                    items:
+                      oneOf:
+                        - type: string
+                        - type: number
+                example: ['first', 'second']
+              allow_multi_values:
+                type: boolean
+                default: false
+                description: |
+                  Allow this custom field to hold multiple values. When enabled, `value` is stored
+                  as an array. Dropdown fields use a multi-select input; all other field types use
+                  repeatable inputs. Arrays are not accepted for fields where this is `false`.
               group_id:
                 type: integer
                 nullable: true

--- a/documentation/docs/usage/user-guide/custom-fields.md
+++ b/documentation/docs/usage/user-guide/custom-fields.md
@@ -117,12 +117,21 @@ This will allow you to copy/paste easily the following code block into the edito
         "405",
         "647"
       ]
+    },
+    "Sample labels": {
+      "type": "text",
+      "position": 5,
+      "allow_multi_values": true,
+      "value": [
+        "control",
+        "replicate 1"
+      ]
     }
   }
 }
 ~~~
 
-Now click Save and scroll up a bit. Above the Steps you should now see four new inputs under the "Custom fields" header. When they are modified, the change is saved immediately.
+Now click Save and scroll up a bit. Above the Steps you should now see five new inputs under the "Custom fields" header. When they are modified, the change is saved immediately.
 
 
 <figure>
@@ -167,9 +176,9 @@ The rest will be ignored by eLabFTW, so you can have other things in there, too.
 Here is a list and description of the properties that `extra_fields` objects can have:
 
 ### value (required)
-The field that will hold the selected/input value. You can set a default value here or leave it empty. It is the only required attribute for an `extra_field`.
+The field that will hold the selected/input value. You can set a default value here or leave it empty. It is the only required attribute for an `extra_field`. A single-value field stores a string or number.
 
-When `allow_multi_values` is `true`, `value` is an array. For example, a multi-value text field can use `"value": ["first", "second"]`.
+When `allow_multi_values` is `true`, `value` is stored as an array of strings or numbers. For example, a multi-value text field can use `"value": ["first", "second"]`. Use an empty array (`"value": []`) when the field has no values. Arrays are rejected for fields that do not enable `allow_multi_values`.
 
 ### type (optional)
 
@@ -207,7 +216,7 @@ A text input that only accepts a valid URL. In view mode, the link will be click
 An array of string (`[]`) with different options for the dropdown element.
 
 ### allow_multi_values
-A `boolean` attribute for allowing any custom field type to hold multiple values. The `value` property is stored as an array when enabled. Dropdown fields use a native multi-select input; other field types display repeatable inputs that can be added or removed individually.
+A `boolean` attribute, which defaults to `false`, for allowing any custom field type to hold multiple values. The `value` property is stored as an array when enabled. Dropdown fields use a native multi-select input; other field types display repeatable inputs that can be added or removed individually.
 
 ### required
 A `boolean` attribute to indicate that filling this field is required. Please note that this won't prevent a user from leaving the page even if the value is empty. It will indicate visually that a value is required but won't block the workflow.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded custom-field guidance with examples for single-value and multi-value fields.
  * Clarified how empty and array values are stored and validated.
  * Documented that multi-value support is disabled by default.

* **API Documentation**
  * Updated metadata schema documentation to describe supported field types, scalar or multi-value values, and multi-value configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->