### PR TITLE
bug/medium: mathjax: fix incorrect render of multilines

### DIFF
--- a/src/Elabftw/Tools.php
+++ b/src/Elabftw/Tools.php
@@ -12,8 +12,12 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
+use Elabftw\Markdown\DisplayMathExtension;
+use League\CommonMark\Environment\Environment;
 use League\CommonMark\Exception\UnexpectedEncodingException;
-use League\CommonMark\GithubFlavoredMarkdownConverter;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\MarkdownConverter;
 use Symfony\Component\HttpFoundation\Request;
 
 use function bin2hex;
@@ -60,16 +64,20 @@ final class Tools
     {
         $config = array(
             'allow_unsafe_links' => false,
+            'html_input' => 'strip',
             'max_nesting_level' => 42,
         );
 
         try {
-            $converter = new GithubFlavoredMarkdownConverter($config);
+            $environment = new Environment($config);
+            $environment->addExtension(new CommonMarkCoreExtension());
+            $environment->addExtension(new GithubFlavoredMarkdownExtension());
+            $environment->addExtension(new DisplayMathExtension());
+            $converter = new MarkdownConverter($environment);
             return trim($converter->convert($md)->getContent(), "\n");
         } catch (UnexpectedEncodingException) {
-            // fix for incorrect utf8 encoding, just return md and hope it's html
-            // so at least the thing is displayed instead of triggering a fatal error
-            return $md;
+            // At least display invalid UTF-8 instead of returning unsanitized HTML.
+            return self::eLabHtmlspecialchars($md);
         }
     }
 

--- a/src/Markdown/DisplayMath.php
+++ b/src/Markdown/DisplayMath.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Markdown;
+
+use League\CommonMark\Node\Block\AbstractBlock;
+use League\CommonMark\Node\StringContainerInterface;
+use Override;
+
+final class DisplayMath extends AbstractBlock implements StringContainerInterface
+{
+    private string $literal = '';
+
+    #[Override]
+    public function getLiteral(): string
+    {
+        return $this->literal;
+    }
+
+    #[Override]
+    public function setLiteral(string $literal): void
+    {
+        $this->literal = $literal;
+    }
+}

--- a/src/Markdown/DisplayMathExtension.php
+++ b/src/Markdown/DisplayMathExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Markdown;
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\ExtensionInterface;
+use Override;
+
+final class DisplayMathExtension implements ExtensionInterface
+{
+    #[Override]
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment
+            ->addBlockStartParser(new DisplayMathStartParser(), 80)
+            ->addRenderer(DisplayMath::class, new DisplayMathRenderer());
+    }
+}

--- a/src/Markdown/DisplayMathParser.php
+++ b/src/Markdown/DisplayMathParser.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Markdown;
+
+use League\CommonMark\Parser\Block\AbstractBlockContinueParser;
+use League\CommonMark\Parser\Block\BlockContinue;
+use League\CommonMark\Parser\Block\BlockContinueParserInterface;
+use League\CommonMark\Parser\Cursor;
+use Override;
+
+use function implode;
+use function trim;
+use function array_slice;
+
+final class DisplayMathParser extends AbstractBlockContinueParser
+{
+    private DisplayMath $block;
+
+    /** @var array<int, string> */
+    private array $lines = array();
+
+    private bool $closed = false;
+
+    public function __construct(private string $opening, private string $closing)
+    {
+        $this->block = new DisplayMath();
+    }
+
+    #[Override]
+    public function getBlock(): DisplayMath
+    {
+        return $this->block;
+    }
+
+    #[Override]
+    public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): BlockContinue
+    {
+        if (!$cursor->isIndented() && trim($cursor->getRemainder()) === $this->closing) {
+            $this->closed = true;
+            return BlockContinue::finished();
+        }
+        return BlockContinue::at($cursor);
+    }
+
+    #[Override]
+    public function addLine(string $line): void
+    {
+        $this->lines[] = $line;
+    }
+
+    #[Override]
+    public function closeBlock(): void
+    {
+        // CommonMark adds the empty remainder of the consumed opening line first.
+        $lines = array($this->opening, ...array_slice($this->lines, 1));
+        if ($this->closed) {
+            $lines[] = $this->closing;
+        }
+        $this->block->setLiteral(implode("\n", $lines));
+    }
+}

--- a/src/Markdown/DisplayMathRenderer.php
+++ b/src/Markdown/DisplayMathRenderer.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Markdown;
+
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use League\CommonMark\Util\Xml;
+use Override;
+use Stringable;
+
+final class DisplayMathRenderer implements NodeRendererInterface
+{
+    #[Override]
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): Stringable
+    {
+        DisplayMath::assertInstanceOf($node);
+        /** @var DisplayMath $node */
+        return new HtmlElement('div', array(), Xml::escape($node->getLiteral()));
+    }
+}

--- a/src/Markdown/DisplayMathStartParser.php
+++ b/src/Markdown/DisplayMathStartParser.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Markdown;
+
+use League\CommonMark\Parser\Block\BlockStart;
+use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\MarkdownParserStateInterface;
+use Override;
+
+use function in_array;
+use function trim;
+
+final class DisplayMathStartParser implements BlockStartParserInterface
+{
+    #[Override]
+    public function tryStart(Cursor $cursor, MarkdownParserStateInterface $parserState): ?BlockStart
+    {
+        if ($cursor->isIndented() || !in_array($cursor->getNextNonSpaceCharacter(), array('$', '\\'), true)) {
+            return BlockStart::none();
+        }
+        $opening = $cursor->match('/^[ \t]*(?:\$\$|\\\\\[)[ \t]*$/');
+        if ($opening === null) {
+            return BlockStart::none();
+        }
+        $opening = trim($opening);
+        $closing = $opening === '$$' ? '$$' : '\\]';
+        return BlockStart::of(new DisplayMathParser($opening, $closing))->at($cursor);
+    }
+}

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -554,6 +554,10 @@ abstract class AbstractEntity extends AbstractRest
                     if (array_key_exists('userid', $params) || array_key_exists('team', $params)) {
                         throw new ImproperActionException("Use the 'action:updateowner' to transfer ownership.");
                     }
+                    $contentType = BodyContentType::tryFrom((int) ($params['content_type'] ?? $this->entityData['content_type']))
+                        ?? throw new ImproperActionException('Invalid content type.');
+                    // Body filtering must use the final content type, regardless of parameter order.
+                    $this->entityData['content_type'] = $contentType->value;
                     foreach ($params as $key => $value) {
                         $this->update(new EntityParams($key, (string) $value));
                     }
@@ -856,7 +860,14 @@ abstract class AbstractEntity extends AbstractRest
     // Update an entity. The revision is saved before so it can easily compare old and new body.
     public function update(ContentParamsInterface $params): bool
     {
-        $content = $params->getContent();
+        if (
+            ($params->getTarget() === 'body' || $params->getTarget() === 'bodyappend')
+            && $this->entityData['content_type'] === BodyContentType::Markdown->value
+        ) {
+            $content = Filter::bodyMarkdown($params->getUnfilteredContent());
+        } else {
+            $content = $params->getContent();
+        }
         if ($params->getTarget() === 'bodyappend') {
             $content = $this->readColumn('body') . $content;
         }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -554,10 +554,38 @@ abstract class AbstractEntity extends AbstractRest
                     if (array_key_exists('userid', $params) || array_key_exists('team', $params)) {
                         throw new ImproperActionException("Use the 'action:updateowner' to transfer ownership.");
                     }
+                    $currentContentType = BodyContentType::from((int) $this->entityData['content_type']);
                     $contentType = BodyContentType::tryFrom((int) ($params['content_type'] ?? $this->entityData['content_type']))
                         ?? throw new ImproperActionException('Invalid content type.');
                     // Body filtering must use the final content type, regardless of parameter order.
                     $this->entityData['content_type'] = $contentType->value;
+
+                    // Persist the safe content type before storing raw Markdown.
+                    if (
+                        $currentContentType === BodyContentType::Html
+                        && $contentType === BodyContentType::Markdown
+                    ) {
+                        $this->update(new EntityParams('content_type', (string) $contentType->value));
+                        unset($params['content_type']);
+                    }
+
+                    // Sanitize the complete resulting body before exposing it as HTML.
+                    if (
+                        $currentContentType === BodyContentType::Markdown
+                        && $contentType === BodyContentType::Html
+                    ) {
+                        $hasBodyUpdate = false;
+                        foreach ($params as $key => $value) {
+                            if ($key === 'body' || $key === 'bodyappend') {
+                                $this->update(new EntityParams($key, (string) $value));
+                                unset($params[$key]);
+                                $hasBodyUpdate = true;
+                            }
+                        }
+                        if (!$hasBodyUpdate) {
+                            $this->update(new EntityParams('body', $this->readColumn('body')));
+                        }
+                    }
                     foreach ($params as $key => $value) {
                         $this->update(new EntityParams($key, (string) $value));
                     }
@@ -860,16 +888,16 @@ abstract class AbstractEntity extends AbstractRest
     // Update an entity. The revision is saved before so it can easily compare old and new body.
     public function update(ContentParamsInterface $params): bool
     {
-        if (
-            ($params->getTarget() === 'body' || $params->getTarget() === 'bodyappend')
-            && $this->entityData['content_type'] === BodyContentType::Markdown->value
-        ) {
-            $content = Filter::bodyMarkdown($params->getUnfilteredContent());
+        if ($params->getTarget() === 'body' || $params->getTarget() === 'bodyappend') {
+            $content = $params->getUnfilteredContent();
+            if ($params->getTarget() === 'bodyappend') {
+                $content = $this->readColumn('body') . $content;
+            }
+            $content = $this->entityData['content_type'] === BodyContentType::Markdown->value
+                ? Filter::bodyMarkdown($content)
+                : Filter::body($content);
         } else {
             $content = $params->getContent();
-        }
-        if ($params->getTarget() === 'bodyappend') {
-            $content = $this->readColumn('body') . $content;
         }
         if ($params->getTarget() === 'metadatamerge') {
             $content = Mh::mergeMetadataValues($this->readColumn('metadata'), $content);

--- a/src/Models/Experiments.php
+++ b/src/Models/Experiments.php
@@ -64,7 +64,9 @@ final class Experiments extends AbstractConcreteEntity
         // defaults
         $title = Filter::title($title ?? _('Untitled'));
         $date ??= new DateTimeImmutable();
-        $body = Filter::body($body);
+        $body = $contentType === BodyContentType::Markdown
+            ? Filter::bodyMarkdown($body)
+            : Filter::body($body);
         if (empty($body)) {
             $body = null;
         }

--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -71,7 +71,9 @@ final class Items extends AbstractConcreteEntity
     ): int {
         $title = Filter::title($title ?? _('Untitled'));
         $date ??= new DateTimeImmutable();
-        $body = Filter::body($body);
+        $body = $contentType === BodyContentType::Markdown
+            ? Filter::bodyMarkdown($body)
+            : Filter::body($body);
         if (empty($body)) {
             $body = null;
         }

--- a/src/Models/ItemsTypes.php
+++ b/src/Models/ItemsTypes.php
@@ -61,7 +61,9 @@ final class ItemsTypes extends AbstractTemplateEntity
         BasePermissions $canbookBase = BasePermissions::Team,
     ): int {
         $title = Filter::title($title ?? _('Default'));
-        $body = Filter::body($body);
+        $body = $contentType === BodyContentType::Markdown
+            ? Filter::bodyMarkdown($body)
+            : Filter::body($body);
         if (empty($body)) {
             $body = null;
         }

--- a/src/Models/Templates.php
+++ b/src/Models/Templates.php
@@ -59,7 +59,9 @@ final class Templates extends AbstractTemplateEntity
         ?int $createdFromId = null,
     ): int {
         $title = Filter::title($title ?? _('Untitled'));
-        $body = Filter::body($body);
+        $body = $contentType === BodyContentType::Markdown
+            ? Filter::bodyMarkdown($body)
+            : Filter::body($body);
         if (empty($body)) {
             $body = null;
         }

--- a/src/Params/EntityParams.php
+++ b/src/Params/EntityParams.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Params;
 
+use Elabftw\Enums\BodyContentType;
 use Elabftw\Enums\Currency;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\ContentParamsInterface;
@@ -33,7 +34,8 @@ final class EntityParams extends ContentParams implements ContentParamsInterface
             'canread', 'canwrite', 'canbook', 'canread_target', 'canwrite_target' => $this->getCanJson(),
             'canread_base', 'canwrite_base', 'canbook_base', 'canread_target_base', 'canwrite_target_base', 'canbook_target_base' => $this->getCanBase(),
             'color' => Check::color($this->asString()),
-            'book_max_minutes', 'book_max_slots', 'book_cancel_minutes', 'booking_window_days', 'content_type', 'proc_pack_qty', 'rating', 'userid', 'team' => $this->asInt(),
+            'book_max_minutes', 'book_max_slots', 'book_cancel_minutes', 'booking_window_days', 'proc_pack_qty', 'rating', 'userid', 'team' => $this->asInt(),
+            'content_type' => $this->getEnum(BodyContentType::class, $this->asInt())->value,
             'state' => $this->getState(),
             'custom_id', 'status', 'category', 'storage', 'qty_stored' => $this->getPositiveIntOrNull(),
             'is_procurable', 'book_can_overlap', 'book_is_cancellable', 'book_users_can_in_past', 'is_bookable', 'canread_is_immutable', 'canwrite_is_immutable', 'hide_main_text' => $this->getBinary(),

--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -193,13 +193,7 @@ final class Filter
      */
     public static function body(?string $input = null): string
     {
-        if ($input === null) {
-            return '';
-        }
-        // use strlen() instead of mb_strlen() because we want the size in bytes
-        if (strlen($input) > self::MAX_BODY_SIZE) {
-            throw new ImproperActionException('Content is too big! Cannot save!');
-        }
+        $input = self::validateBodySize($input);
         // create base config for html5
         $config = HTMLPurifier_HTML5Config::createDefault();
         // allow only certain elements
@@ -275,6 +269,11 @@ final class Filter
         return $purifier->purify($input);
     }
 
+    public static function bodyMarkdown(?string $input = null): string
+    {
+        return self::validateBodySize($input);
+    }
+
     public static function pem(string $pem): string
     {
         // Trim outer whitespace
@@ -294,5 +293,17 @@ final class Filter
             return null;
         }
         return Check::color($input);
+    }
+
+    private static function validateBodySize(?string $input): string
+    {
+        if ($input === null) {
+            return '';
+        }
+        // use strlen() instead of mb_strlen() because we want the size in bytes
+        if (strlen($input) > self::MAX_BODY_SIZE) {
+            throw new ImproperActionException('Content is too big! Cannot save!');
+        }
+        return $input;
     }
 }

--- a/src/Traits/TwigTrait.php
+++ b/src/Traits/TwigTrait.php
@@ -54,7 +54,6 @@ trait TwigTrait
         // custom twig filters
         $filterOptions = array('is_safe' => array('html'));
         $msgFilter = new TwigFilter('msg', '\Elabftw\Elabftw\TwigFilters::displayMessage', $filterOptions);
-        $mdFilter = new TwigFilter('md2html', '\Elabftw\Elabftw\Tools::md2html', $filterOptions);
         $bytesFilter = new TwigFilter('formatBytes', '\Elabftw\Elabftw\Tools::formatBytes', $filterOptions);
         $extFilter = new TwigFilter('getExt', '\Elabftw\Elabftw\Tools::getExt', $filterOptions);
         $metadataFilter = new TwigFilter('formatMetadata', '\Elabftw\Elabftw\TwigFilters::formatMetadata', $filterOptions);
@@ -96,7 +95,6 @@ trait TwigTrait
         }
 
         $TwigEnvironment->addFilter($msgFilter);
-        $TwigEnvironment->addFilter($mdFilter);
         $TwigEnvironment->addFilter($bytesFilter);
         $TwigEnvironment->addFilter($extFilter);
         $TwigEnvironment->addFilter($metadataFilter);

--- a/src/ts/Editor.class.ts
+++ b/src/ts/Editor.class.ts
@@ -8,12 +8,16 @@
 import $ from 'jquery';
 import tinymce from 'tinymce/tinymce';
 import { getTinymceBaseConfig } from './tinymce';
-import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import { Marked } from 'marked';
 import type { MathJaxObject } from '@mathjax/src/js/components/startup.js';
 import { Target } from './interfaces';
 import type { Entity } from './interfaces';
 import { ApiC } from './api';
+import { displayMathExtension } from './markedDisplayMath';
 declare const MathJax: MathJaxObject;
+
+const markdown = new Marked(displayMathExtension);
 
 interface EditorInterface {
   type: string;
@@ -65,7 +69,7 @@ export class MdEditor extends Editor implements EditorInterface {
     /* eslint-disable-next-line */
     ($('.markdown-textarea') as any).markdown({
       onPreview: ed => {
-        const html = marked(ed.$textarea.val()) as string;
+        const html = DOMPurify.sanitize(markdown.parse(ed.$textarea.val() as string) as string);
 
         window.setTimeout(() => {
           void MathJax.typesetPromise().catch(error => {

--- a/src/ts/markedDisplayMath.ts
+++ b/src/ts/markedDisplayMath.ts
@@ -1,0 +1,62 @@
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2012 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+import type { MarkedExtension, Tokens } from 'marked';
+
+interface DisplayMathToken extends Tokens.Generic {
+  type: 'displayMath';
+  text: string;
+}
+
+const openingLine = /^ {0,3}(\$\$|\\\[)[ \t]*(?:\r?\n|$)/;
+const dollarClosingLine = /^ {0,3}\$\$[ \t]*$/;
+const bracketClosingLine = /^ {0,3}\\\][ \t]*$/;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export const displayMathExtension: MarkedExtension = {
+  extensions: [{
+    name: 'displayMath',
+    level: 'block',
+    start(src): number | undefined {
+      return /^ {0,3}(?:\$\$|\\\[)[ \t]*(?=\r?$)/m.exec(src)?.index;
+    },
+    tokenizer(src): DisplayMathToken | undefined {
+      const opening = openingLine.exec(src);
+      if (!opening) {
+        return undefined;
+      }
+      const closingLine = opening[1] === '$$' ? dollarClosingLine : bracketClosingLine;
+      let lineStart = opening[0].length;
+      while (lineStart < src.length) {
+        const nextLineBreak = src.indexOf('\n', lineStart);
+        const lineEnd = nextLineBreak === -1 ? src.length : nextLineBreak;
+        const line = src.slice(lineStart, lineEnd).replace(/\r$/, '');
+        if (closingLine.test(line)) {
+          const rawEnd = nextLineBreak === -1 ? lineEnd : nextLineBreak + 1;
+          const raw = src.slice(0, rawEnd);
+          return { type: 'displayMath', raw, text: raw.replace(/\r?\n$/, '') };
+        }
+        if (nextLineBreak === -1) {
+          break;
+        }
+        lineStart = nextLineBreak + 1;
+      }
+      return { type: 'displayMath', raw: src, text: src.replace(/\r?\n$/, '') };
+    },
+    renderer(token): string {
+      return `<div>${escapeHtml((token as DisplayMathToken).text)}</div>\n`;
+    },
+  }],
+};

--- a/src/ts/markedDisplayMath.ts
+++ b/src/ts/markedDisplayMath.ts
@@ -1,6 +1,6 @@
 /**
- * @author Nicolas CARPi <nico-git@deltablot.email>
- * @copyright 2012 Nicolas CARPi
+ * @author Nicolas CARPi / Deltablot
+ * @copyright 2026 Nicolas CARPi
  * @see https://www.elabftw.net Official website
  * @license AGPL-3.0
  * @package elabftw

--- a/tests/unit/classes/ToolsTest.php
+++ b/tests/unit/classes/ToolsTest.php
@@ -41,6 +41,75 @@ class ToolsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($html, Tools::md2html($md));
     }
 
+    public function testMd2htmlPreservesDisplayMath(): void
+    {
+        $markdown = <<<'MARKDOWN'
+            **matrix**
+
+            $$
+            \begin{bmatrix}
+            H & \mathbf{1} \\
+            \mathbf{1}^{T} & 0
+            \end{bmatrix}
+            $$
+
+            \[
+            \begin{align}
+            a &= b \\
+            c &= d
+            \end{align}
+            \]
+            MARKDOWN;
+        $html = Tools::md2html($markdown);
+
+        $matrix = <<<'HTML'
+            <div>$$
+            \begin{bmatrix}
+            H &amp; \mathbf{1} \\
+            \mathbf{1}^{T} &amp; 0
+            \end{bmatrix}
+            $$</div>
+            HTML;
+        $align = <<<'HTML'
+            <div>\[
+            \begin{align}
+            a &amp;= b \\
+            c &amp;= d
+            \end{align}
+            \]</div>
+            HTML;
+
+        $this->assertStringContainsString('<strong>matrix</strong>', $html);
+        $this->assertStringContainsString($matrix, $html);
+        $this->assertStringContainsString($align, $html);
+        $this->assertStringNotContainsString("$$\n\n", $html);
+        $this->assertStringNotContainsString("\\[\n\n", $html);
+        $this->assertStringNotContainsString('<br', $html);
+    }
+
+    public function testMd2htmlDoesNotParseDisplayMathInFencedCode(): void
+    {
+        $markdown = <<<'MARKDOWN'
+            ```latex
+            $$
+            a & b \\
+            c & d
+            $$
+            ```
+            MARKDOWN;
+        $html = Tools::md2html($markdown);
+
+        $this->assertStringContainsString('<pre><code class="language-latex">$$', $html);
+        $this->assertStringNotContainsString('<div>$$', $html);
+    }
+
+    public function testMd2htmlStripsRawHtml(): void
+    {
+        $html = Tools::md2html('<span onclick="alert(1)">text</span> **safe**');
+
+        $this->assertSame('<p>text <strong>safe</strong></p>', $html);
+    }
+
     public function testGetShortElabid(): void
     {
         $this->assertEquals('7995340c', Tools::getShortElabid('20220627-7995340c1921f38fd833c447be50b7101e4f852c'));

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -177,6 +177,37 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('<p>safe</p>', $entityData['body']);
     }
 
+    public function testMarkdownToHtmlTypeOnlyUpdateSanitizesStoredBody(): void
+    {
+        $body = '<p>safe</p><script>unsafe</script>';
+        $new = $this->Experiments->create(body: $body, contentType: BodyContentType::Markdown);
+        $this->Experiments->setId($new);
+
+        $entityData = $this->Experiments->patch(Action::Update, array(
+            'content_type' => BodyContentType::Html->value,
+        ));
+
+        $this->assertSame('<p>safe</p>', $entityData['body']);
+        $this->assertSame($entityData['body'], $entityData['body_html']);
+    }
+
+    public function testMarkdownToHtmlBodyAppendSanitizesCompleteBody(): void
+    {
+        $body = '<p>stored</p><script>unsafe</script>';
+        $new = $this->Experiments->create(body: $body, contentType: BodyContentType::Markdown);
+        $this->Experiments->setId($new);
+
+        $entityData = $this->Experiments->patch(Action::Update, array(
+            'content_type' => BodyContentType::Html->value,
+            'bodyappend' => '<p>appended</p>',
+        ));
+
+        $this->assertStringContainsString('<p>stored</p>', $entityData['body']);
+        $this->assertStringContainsString('<p>appended</p>', $entityData['body']);
+        $this->assertStringNotContainsString('<script', $entityData['body']);
+        $this->assertSame($entityData['body'], $entityData['body_html']);
+    }
+
     public function testUpdateIncorrectState(): void
     {
         $new = $this->Experiments->create();

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -13,6 +13,7 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
+use Elabftw\Enums\BodyContentType;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\FileFromString;
 use Elabftw\Enums\Meaning;
@@ -36,6 +37,7 @@ use function is_array;
 use function json_decode;
 use function random_bytes;
 use function sprintf;
+use function str_replace;
 
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {
@@ -132,6 +134,47 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Untitled', $entityData['title']);
         $this->assertEquals('2016-07-29', $entityData['date']);
         $this->assertEquals('<p>Body</p>', $entityData['body']);
+    }
+
+    public function testMarkdownBodyPreservesDisplayMath(): void
+    {
+        $body = <<<'MARKDOWN'
+            $$
+            \begin{bmatrix}
+            H & \mathbf{1} \\
+            \mathbf{1}^{T} & 0
+            \end{bmatrix}
+            $$
+            MARKDOWN;
+        $new = $this->Experiments->create(body: $body, contentType: BodyContentType::Markdown);
+        $this->Experiments->setId($new);
+        $entityData = $this->Experiments->readOne();
+
+        $this->assertSame($body, $entityData['body']);
+        $this->assertStringContainsString('H &amp; \\mathbf{1}', $entityData['body_html']);
+        $this->assertStringNotContainsString('<br', $entityData['body_html']);
+
+        $updated = str_replace('H', 'G', $body);
+        $entityData = $this->Experiments->patch(Action::Update, array('body' => $updated));
+        $this->assertSame($updated, $entityData['body']);
+        $this->assertStringNotContainsString('&amp;', $entityData['body']);
+    }
+
+    public function testBodyUpdateUsesFinalContentType(): void
+    {
+        $new = $this->Experiments->create();
+        $this->Experiments->setId($new);
+        $entityData = $this->Experiments->patch(Action::Update, array(
+            'body' => 'H & \\mathbf{1}',
+            'content_type' => BodyContentType::Markdown->value,
+        ));
+        $this->assertSame('H & \\mathbf{1}', $entityData['body']);
+
+        $entityData = $this->Experiments->patch(Action::Update, array(
+            'content_type' => BodyContentType::Html->value,
+            'body' => '<p>safe</p><script>unsafe</script>',
+        ));
+        $this->assertSame('<p>safe</p>', $entityData['body']);
     }
 
     public function testUpdateIncorrectState(): void

--- a/tests/unit/services/FilterTest.php
+++ b/tests/unit/services/FilterTest.php
@@ -64,6 +64,13 @@ class FilterTest extends \PHPUnit\Framework\TestCase
         Filter::body(str_repeat('a', 4120001));
     }
 
+    public function testBodyMarkdown(): void
+    {
+        $this->assertSame('H & \\mathbf{1}', Filter::bodyMarkdown('H & \\mathbf{1}'));
+        $this->expectException(ImproperActionException::class);
+        Filter::bodyMarkdown(str_repeat('a', 4120001));
+    }
+
     public function testBodyAllowsInternalLinksToOpenInNewWindow(): void
     {
         $link = '<a href="/experiments/1" target="_blank" rel="noreferrer noopener">Experiment</a>';


### PR DESCRIPTION
fix #6824
superseedes #6832

* add a CommonMark extension
* add a marked.js extension



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for display math using `$$...$$` and `\[...\]` notation in Markdown content and previews.
  - Markdown previews now sanitize rendered HTML for improved safety.
- **Bug Fixes**
  - Markdown content preserves display-math expressions while removing raw HTML.
  - Content updates now apply the correct filtering based on the final content type.
  - Improved handling of invalid text encoding and oversized content.
- **Tests**
  - Added coverage for display math, HTML removal, fenced code, content updates, and Markdown validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->