### PR TITLE
bug/minor: accordions: fix selection

### DIFF
--- a/src/Services/Filter.php
+++ b/src/Services/Filter.php
@@ -203,7 +203,7 @@ final class Filter
         // create base config for html5
         $config = HTMLPurifier_HTML5Config::createDefault();
         // allow only certain elements
-        $config->set('HTML.Allowed', 'div[class|style],br,p[class|style],sub,img[src|class|style|width|height],sup,strong,b,em,u,a[href|target],s,span[style],ul[style],li[style],ol[style],dl,dt,dd,blockquote,h1[class|style],h2[class|style],h3[class|style],h4[class|style],h5[class|style],h6[class|style],hr,table[style|data-table-sort|border],tr[style],td[style|colspan|rowspan],th[style|colspan|rowspan],code,source[src|type],video[src|controls|style|width|height],audio[src|controls],pre[class],details,summary,caption,figure,figcaption');
+        $config->set('HTML.Allowed', 'div[class|style],br,p[class|style],sub,img[src|class|style|width|height],sup,strong,b,em,u,a[href|target],s,span[style],ul[style],li[style],ol[style],dl,dt,dd,blockquote,h1[class|style],h2[class|style],h3[class|style],h4[class|style],h5[class|style],h6[class|style],hr,table[style|data-table-sort|border],tr[style],td[style|colspan|rowspan],th[style|colspan|rowspan],code,source[src|type],video[src|controls|style|width|height],audio[src|controls],pre[class],details[class|open],summary,caption,figure,figcaption');
         $config->set('Attr.AllowedFrameTargets', array('_blank'));
         $config->set('HTML.TargetBlank', true);
         // configure the cache for htmlpurifier
@@ -238,6 +238,7 @@ final class Filter
             'language-tcl',
             'language-vhdl',
             'language-yaml',
+            'mce-accordion',
         ));
         // note: hyphens and word-break are not supported
         $config->set('CSS.AllowedProperties', array(
@@ -269,6 +270,7 @@ final class Filter
         // allow 'data-table-sort' attribute to indicate that a table shall be sortable by js
         if ($def = $config->maybeGetRawHTMLDefinition()) {
             $def->addAttribute('table', 'data-table-sort', 'Enum#true');
+            $def->addAttribute('table', 'border', 'Pixels');
         }
 
         $purifier = new HTMLPurifier($config);

--- a/tests/unit/services/FilterTest.php
+++ b/tests/unit/services/FilterTest.php
@@ -103,4 +103,10 @@ class FilterTest extends \PHPUnit\Framework\TestCase
         $this->assertNull(Filter::intOrNull(''));
         $this->assertSame(42, Filter::intOrNull('42'));
     }
+
+    public function testBodyPreservesTinyMceAccordionClass(): void
+    {
+        $input = '<details class="mce-accordion"><summary>Summary</summary><p>One</p><p>Two</p></details>';
+        $this->assertSame($input, Filter::body($input));
+    }
 }


### PR DESCRIPTION
only on chrome
fix #7250
also fix [Warning] Attribute 'border' in element 'table' not supported


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preserving accordion content created in the editor, including expandable state and styling.
  - Improved handling of table border values in formatted content.

- **Bug Fixes**
  - Prevented accordion markup from being stripped when content is filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->