### PR TITLE
feat: security: store token hashed

### DIFF
--- a/src/Auth/Cookie.php
+++ b/src/Auth/Cookie.php
@@ -18,6 +18,7 @@ use Elabftw\Enums\AuthMethod;
 use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Interfaces\AuthenticatorInterface;
 use Override;
+use PDO;
 
 use function sprintf;
 
@@ -32,14 +33,14 @@ final class Cookie implements AuthenticatorInterface
     public function authenticate(): Authentication
     {
         $Db = Db::getConnection();
-        // compare the provided token with the token saved in SQL database
+        // compare the hash of the provided token with the hash saved in SQL database
         $sql = sprintf(
             'SELECT userid
-            FROM users WHERE token = :token AND token_created_at > NOW() - INTERVAL %d MINUTE LIMIT 1',
+            FROM users WHERE token_hash = :token_hash AND token_created_at > NOW() - INTERVAL %d MINUTE LIMIT 1',
             $this->validityMinutes
         );
         $req = $Db->prepare($sql);
-        $req->bindValue(':token', $this->Token->getToken());
+        $req->bindValue(':token_hash', $this->Token->getTokenHash(), PDO::PARAM_LOB);
         $Db->execute($req);
         $userid = (int) $req->fetchColumn();
         if ($userid === 0) {

--- a/src/Auth/CookieToken.php
+++ b/src/Auth/CookieToken.php
@@ -13,15 +13,17 @@ declare(strict_types=1);
 namespace Elabftw\Auth;
 
 use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Env;
 use Elabftw\Services\Filter;
 use PDO;
 
 use function bin2hex;
+use function hash_hmac;
 use function random_bytes;
 use function strlen;
 
 /**
- * The cookie "token" acts as a key to login back thanks to the cookie value and the value stored in database
+ * The cookie token acts as a key to login back; only its hash is stored in the database
  */
 final class CookieToken
 {
@@ -40,16 +42,16 @@ final class CookieToken
     }
 
     /**
-     * Save the token in the database for a user
+     * Save the token hash in the database for a user
      */
     public function saveToken(int $userid): bool
     {
         if ($this->token === '') {
             return true;
         }
-        $sql = 'UPDATE users SET token = :token, token_created_at = NOW() WHERE userid = :userid';
+        $sql = 'UPDATE users SET token_hash = :token_hash, token_created_at = NOW() WHERE userid = :userid';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':token', $this->getToken());
+        $req->bindValue(':token_hash', $this->getTokenHash(), PDO::PARAM_LOB);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }
@@ -57,6 +59,11 @@ final class CookieToken
     public function getToken(): string
     {
         return $this->token;
+    }
+
+    public function getTokenHash(): string
+    {
+        return hash_hmac('sha256', $this->token, Env::asString('SECRET_KEY'), true);
     }
 
     public static function generate(): string

--- a/src/Auth/LoginHelper.php
+++ b/src/Auth/LoginHelper.php
@@ -109,7 +109,7 @@ final class LoginHelper
     }
 
     /**
-     * Set a $_COOKIE['token'] and update the database with this token.
+     * Set a $_COOKIE['token'] and update the database with its hash.
      * Also set a token_team cookie for the team
      */
     private function setToken(): void

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 221;
+    public const int REQUIRED_SCHEMA = 222;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -429,7 +429,7 @@ class Users extends AbstractRest
         unset($userData['password_hash']);
         unset($userData['salt']);
         unset($userData['mfa_secret']);
-        unset($userData['token']);
+        unset($userData['token_hash']);
         // keep sig_privkey in response if requester is target
         if ($this->requester->userData['userid'] !== $this->userData['userid']) {
             unset($userData['sig_privkey']);
@@ -535,7 +535,7 @@ class Users extends AbstractRest
      */
     public function invalidateToken(): bool
     {
-        $sql = 'UPDATE users SET token = NULL, token_created_at = NULL WHERE userid = :userid';
+        $sql = 'UPDATE users SET token_hash = NULL, token_created_at = NULL WHERE userid = :userid';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
         return $this->Db->execute($req);

--- a/src/sql/schema222-down.sql
+++ b/src/sql/schema222-down.sql
@@ -1,0 +1,8 @@
+-- revert schema 222
+ALTER TABLE `users`
+    DROP INDEX `idx_users_token_hash`,
+    DROP COLUMN `token_hash`,
+    ADD COLUMN `token` CHAR(32) CHARACTER SET ascii COLLATE ascii_bin NULL DEFAULT NULL AFTER `created_at`,
+    ADD UNIQUE INDEX `idx_users_token` (`token`);
+
+UPDATE config SET conf_value = 221 WHERE conf_name = 'schema';

--- a/src/sql/schema222.sql
+++ b/src/sql/schema222.sql
@@ -1,0 +1,7 @@
+-- schema 222
+UPDATE `users` SET `token_created_at` = NULL;
+ALTER TABLE `users`
+    DROP INDEX `idx_users_token`,
+    DROP COLUMN `token`,
+    ADD COLUMN `token_hash` BINARY(32) NULL DEFAULT NULL AFTER `created_at`,
+    ADD UNIQUE INDEX `idx_users_token_hash` (`token_hash`);

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1345,7 +1345,7 @@ CREATE TABLE `users` (
   `orcid` varchar(19) NULL DEFAULT NULL,
   `orgid` varchar(255) NULL DEFAULT NULL,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `token` char(32) CHARACTER SET ascii COLLATE ascii_bin NULL DEFAULT NULL,
+  `token_hash` BINARY(32) NULL DEFAULT NULL,
   `token_created_at` TIMESTAMP NULL DEFAULT NULL,
   `limit_nb` tinyint UNSIGNED NOT NULL DEFAULT 15,
   `sc_create` varchar(1) NOT NULL DEFAULT 'c',
@@ -2358,7 +2358,7 @@ ALTER TABLE `experiments_templates_edit_mode`
 --
 ALTER TABLE `users` ADD INDEX `idx_users_email_userid` (email, userid);
 ALTER TABLE `users` ADD INDEX `idx_users_orgid_userid` (orgid, userid);
-ALTER TABLE `users` ADD UNIQUE INDEX `idx_users_token` (`token`);
+ALTER TABLE `users` ADD UNIQUE INDEX `idx_users_token_hash` (`token_hash`);
 
 --
 -- Indexes and Constraints for table `users2teams`

--- a/tests/unit/Auth/CookieTest.php
+++ b/tests/unit/Auth/CookieTest.php
@@ -14,8 +14,11 @@ namespace Elabftw\Auth;
 
 use Elabftw\Elabftw\Authentication;
 use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Env;
 use Elabftw\Exceptions\UnauthorizedException;
 use PDO;
+
+use function hash_hmac;
 
 class CookieTest extends \PHPUnit\Framework\TestCase
 {
@@ -32,13 +35,31 @@ class CookieTest extends \PHPUnit\Framework\TestCase
         $this->CookieToken->saveToken($this->userid);
     }
 
+    public function testTokenIsHashedBeforeStorage(): void
+    {
+        $req = $this->Db->prepare('SELECT token_hash FROM users WHERE userid = :userid');
+        $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $storedTokenHash = $req->fetchColumn();
+        $expectedTokenHash = hash_hmac(
+            'sha256',
+            $this->CookieToken->getToken(),
+            Env::asString('SECRET_KEY'),
+            true,
+        );
+        $this->assertSame($expectedTokenHash, $this->CookieToken->getTokenHash());
+        $this->assertSame($expectedTokenHash, $storedTokenHash);
+        $this->assertNotSame($this->CookieToken->getToken(), $storedTokenHash);
+    }
+
     public function testTryAuthExpired(): void
     {
         // cookie is valid only one minute
         $CookieAuth = new Cookie(1, $this->CookieToken);
         // create a token but 4 minutes in the past
-        $req = $this->Db->prepare('UPDATE users SET token = :token, token_created_at = DATE_SUB(NOW(), INTERVAL 4 MINUTE) WHERE userid = :userid');
-        $req->bindValue(':token', $this->CookieToken->getToken());
+        $req = $this->Db->prepare('UPDATE users SET token_hash = :token_hash, token_created_at = DATE_SUB(NOW(), INTERVAL 4 MINUTE) WHERE userid = :userid');
+        $req->bindValue(':token_hash', $this->CookieToken->getTokenHash(), PDO::PARAM_LOB);
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
         // now try login but our cookie isn't valid anymore
@@ -70,15 +91,15 @@ class CookieTest extends \PHPUnit\Framework\TestCase
 
     public function testEmptyTokenIsNotSaved(): void
     {
-        $currentToken = $this->CookieToken->getToken();
+        $currentTokenHash = $this->CookieToken->getTokenHash();
         $CookieToken = new CookieToken('invalid length');
 
         $this->assertTrue($CookieToken->saveToken($this->userid));
 
-        $req = $this->Db->prepare('SELECT token FROM users WHERE userid = :userid');
+        $req = $this->Db->prepare('SELECT token_hash FROM users WHERE userid = :userid');
         $req->bindParam(':userid', $this->userid, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $this->assertSame($currentToken, $req->fetchColumn());
+        $this->assertSame($currentTokenHash, $req->fetchColumn());
     }
 }


### PR DESCRIPTION
* use hmac sha256 with the secret key of server
* store it as binary
* keep it indexed like before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Login tokens are now stored and validated as secure HMAC-SHA256 hashes rather than plaintext values.
  - Logout invalidates stored token hashes and token timestamps.

- **Database**
  - Updated the database schema to use a dedicated hashed-token field.
  - Existing login tokens are cleared during migration; rollback support is included.

- **Tests**
  - Added coverage confirming tokens are hashed before storage and authentication continues to handle expired or empty tokens correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->