### PR TITLE
feat: eln: validate zip members

### DIFF
--- a/src/Import/AbstractZip.php
+++ b/src/Import/AbstractZip.php
@@ -14,6 +14,7 @@ namespace Elabftw\Import;
 
 use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\Storage;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperator;
@@ -23,10 +24,18 @@ use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use RuntimeException;
+use ZipArchive;
 
+use function explode;
 use function fclose;
+use function in_array;
+use function iterator_to_array;
+use function preg_match;
+use function rawurldecode;
 use function sprintf;
+use function str_contains;
 use function str_replace;
+use function str_starts_with;
 
 /**
  * Mother class for importing zip file
@@ -60,6 +69,7 @@ abstract class AbstractZip extends AbstractImport
         $this->emitLog(sprintf('temporary directory: %s', $this->tmpDir), LogLevel::DEBUG);
         // we use the Exports storage to store decompressed data
         $this->tmpFs = Storage::EXPORTS->getStorage()->getFs();
+        $this->assertArchiveMemberNamesAreSafe();
 
         $adapter = new ZipArchiveAdapter(
             new FilesystemZipArchiveProvider($this->UploadedFile->getPathname())
@@ -106,13 +116,42 @@ abstract class AbstractZip extends AbstractImport
     }
 
     /**
+     * Validate original ZIP member names before the Flysystem adapter normalizes them.
+     */
+    private function assertArchiveMemberNamesAreSafe(): void
+    {
+        $archive = new ZipArchive();
+        if ($archive->open($this->UploadedFile->getPathname(), ZipArchive::RDONLY) !== true) {
+            throw new ImproperActionException('The uploaded file is not a valid ZIP archive.');
+        }
+
+        try {
+            for ($index = 0; $index < $archive->numFiles; $index++) {
+                $rawPath = $archive->getNameIndex($index, ZipArchive::FL_UNCHANGED);
+                if ($rawPath === false) {
+                    throw new ImproperActionException('The archive contains an invalid path.');
+                }
+                $this->assertArchivePathIsSafe($rawPath);
+            }
+        } finally {
+            $archive->close();
+        }
+    }
+
+    /**
      * Extract everything from a ZIP-backed Flysystem into another directory
      * on any Flysystem backend (local, S3, etc).
      */
     private function extractZipFilesystemToDir(FilesystemAdapter $zipFs): void
     {
-        foreach ($zipFs->listContents('', true) as $item) {
+        // Validate the complete archive before writing anything. This prevents a
+        // later unsafe member from leaving a partially extracted import behind.
+        $items = iterator_to_array($zipFs->listContents('', true), false);
+        foreach ($items as $item) {
+            $this->assertArchivePathIsSafe($item->path());
+        }
 
+        foreach ($items as $item) {
             $rawPath = $item->path();
             $this->emitLog(sprintf('ZIP: extracting: %s', $rawPath), LogLevel::DEBUG);
 
@@ -136,6 +175,34 @@ abstract class AbstractZip extends AbstractImport
             } finally {
                 fclose($stream);
             }
+        }
+    }
+
+    /**
+     * Reject paths which can escape the per-import directory on any supported backend.
+     */
+    private function assertArchivePathIsSafe(string $rawPath): void
+    {
+        // Decode repeatedly so double-encoded traversal cannot become dangerous
+        // if another storage layer decodes the path in the future.
+        $decodedPath = $rawPath;
+        do {
+            $previousPath = $decodedPath;
+            $decodedPath = rawurldecode($decodedPath);
+        } while ($decodedPath !== $previousPath);
+
+        // ZIP member names use forward slashes. Backslashes are rejected instead
+        // of normalized so their meaning cannot vary between storage backends.
+        $normalizedPath = str_replace('\\', '/', $decodedPath);
+        if (
+            $normalizedPath === ''
+            || str_contains($decodedPath, "\0")
+            || str_contains($decodedPath, '\\')
+            || str_starts_with($normalizedPath, '/')
+            || preg_match('/^[a-zA-Z]:/', $normalizedPath) === 1
+            || in_array('..', explode('/', $normalizedPath), true)
+        ) {
+            throw new ImproperActionException('The archive contains an unsafe path.');
         }
     }
 }

--- a/tests/unit/Import/ElnTest.php
+++ b/tests/unit/Import/ElnTest.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace Elabftw\Import;
 
+use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\EntityType;
+use Elabftw\Enums\Storage;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Experiments;
@@ -22,10 +24,14 @@ use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\InputBag;
+use ZipArchive;
 
 use function array_column;
 use function dirname;
 use function sprintf;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
 
 use const UPLOAD_ERR_INI_SIZE;
 use const UPLOAD_ERR_OK;
@@ -83,6 +89,62 @@ class ElnTest extends \PHPUnit\Framework\TestCase
             $this->logger,
             EntityType::Items,
             category: 1,
+        );
+    }
+
+    /**
+     * @dataProvider unsafeArchivePathProvider
+     */
+    public function testRejectUnsafeArchivePath(string $unsafePath): void
+    {
+        $exportsFs = Storage::EXPORTS->getStorage()->getFs();
+        $target = Tools::getUuidv4();
+        $exportsFs->write($target, 'original export');
+
+        $archivePath = tempnam(sys_get_temp_dir(), 'elabftw-unsafe-eln-');
+        $this->assertIsString($archivePath);
+        $archive = new ZipArchive();
+        $this->assertTrue($archive->open($archivePath, ZipArchive::OVERWRITE));
+        $this->assertTrue($archive->addFromString('ro-crate-metadata.json', '{}'));
+        $this->assertTrue($archive->addFromString(sprintf($unsafePath, $target), 'poisoned export'));
+        $this->assertTrue($archive->close());
+
+        $uploadedFile = new UploadedFile(
+            $archivePath,
+            'unsafe.eln',
+            null,
+            UPLOAD_ERR_OK,
+            true,
+        );
+
+        try {
+            new Eln(
+                new Users(1, 1),
+                new Users(1, 1),
+                $uploadedFile,
+                $this->fs,
+                $this->logger,
+                EntityType::Experiments,
+            );
+            $this->fail('An ELN archive containing an unsafe path was accepted.');
+        } catch (ImproperActionException) {
+            $this->assertSame('original export', $exportsFs->read($target));
+        } finally {
+            $exportsFs->delete($target);
+            unlink($archivePath);
+        }
+    }
+
+    public static function unsafeArchivePathProvider(): array
+    {
+        return array(
+            'parent traversal' => array('../%s'),
+            'nested parent traversal' => array('attachments/../../%s'),
+            'backslash traversal' => array('..\\%s'),
+            'absolute path' => array('/%s'),
+            'Windows drive path' => array('C:/%s'),
+            'encoded traversal' => array('%%2e%%2e/%%2f%s'),
+            'double encoded traversal' => array('%%252e%%252e/%%252f%s'),
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP imports now reject archives containing unsafe or invalid file paths, including traversal, absolute, Windows drive-letter, backslash, null-byte, and encoded traversal paths.
  * Archives are fully validated before extraction, preventing partial writes when an unsafe entry is detected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->