### PR TITLE
feat: sql: compare exact strings

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -819,7 +819,7 @@ class Users extends AbstractRest
         $Db = Db::getConnection();
         // Prefer an active account, but return an archived account if it is the only match.
         $sql = sprintf(
-            'SELECT userid FROM users WHERE %s = :term %s
+            'SELECT userid FROM users WHERE %s = :term AND CAST(%s AS BINARY) = CAST(:exact_term AS BINARY) %s
              ORDER BY EXISTS (
               SELECT 1
               FROM users2teams AS ut
@@ -828,10 +828,12 @@ class Users extends AbstractRest
             ) DESC, users.userid ASC
             LIMIT 1',
             $column->value,
+            $column->value,
             $filterValidated ? 'AND validated = 1' : 'AND 1=1',
         );
         $req = $Db->prepare($sql);
         $req->bindParam(':term', $term);
+        $req->bindParam(':exact_term', $term);
         $Db->execute($req);
         $res = (int) $req->fetchColumn();
         if ($res === 0) {

--- a/tests/unit/Auth/SamlTest.php
+++ b/tests/unit/Auth/SamlTest.php
@@ -90,6 +90,51 @@ final class SamlTest extends TestCase
         self::assertSame(AuthMethod::Saml, $authentication->method);
     }
 
+    public function testEmailLookupRejectsCollationEquivalentAttribute(): void
+    {
+        $victim = $this->createLocalUser(
+            'saml-collation-elab@example.com',
+        );
+
+        $samlUserdata = $this->samlUserdata;
+        $samlUserdata['User.email'] = "saml-collation-\xC3\xA9lab@example.com";
+
+        try {
+            $this->assertIdpResponse($samlUserdata);
+            self::fail('A collation-equivalent SAML email must not bind an existing user.');
+        } catch (ImproperActionException) {
+            self::assertSame(
+                'saml-collation-elab@example.com',
+                (new ExistingUser($victim->getUserid()))->userData['email'],
+            );
+        }
+    }
+
+    public function testOrgidLookupRejectsCollationEquivalentAttribute(): void
+    {
+        $victim = $this->createLocalUser(
+            'saml-collation-orgid@example.com',
+            orgid: 'saml-collation-elab-id',
+        );
+
+        $samlUserdata = $this->samlUserdata;
+        $samlUserdata['User.email'] = 'saml-collation-orgid-attacker@example.com';
+        $samlUserdata['internal_id'] = "saml-collation-\xC3\xA9lab-id";
+
+        $config = $this->configArr;
+        $config['saml_fallback_orgid'] = '1';
+
+        try {
+            $this->assertIdpResponse($samlUserdata, $config);
+            self::fail('A collation-equivalent SAML orgid must not bind an existing user.');
+        } catch (ImproperActionException) {
+            self::assertSame(
+                'saml-collation-elab-id',
+                (new ExistingUser($victim->getUserid()))->userData['orgid'],
+            );
+        }
+    }
+
     public function testExistingUserDoesNotNeedTeamAttributeWhenSyncIsDisabled(): void
     {
         $samlUserdata = $this->samlUserdata;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account searches to require exact, case-sensitive matches.
  * Prevented SAML sign-ins from linking to accounts when email addresses or organization IDs differ by character collation.
  * Preserved validation filtering and active-account ordering during searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->