### PR TITLE
feat: change how apikeys are stored

### DIFF
--- a/apidoc/v2/openapi.yaml
+++ b/apidoc/v2/openapi.yaml
@@ -313,8 +313,6 @@ components:
           type: string
         last_used_at:
           type: string
-        hash:
-          type: string
         can_write:
           type: integer
         team:

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -125,7 +125,7 @@ final class Install extends Command
             $ApiKeys = new ApiKeys($Sysadmin);
             $ApiKeys->create('Sysadmin key', 1);
             $output->writeln('<info>✓ Sysadmin account successfully created.</info>');
-            $output->writeln(sprintf('<info>→ Sysadmin API key: %d-%s</info>', $ApiKeys->key, $ApiKeys->key));
+            $output->writeln(sprintf('<info>→ Sysadmin API key: %s</info>', $ApiKeys->key));
         } else {
             $output->writeln('<info>→ Register your Sysadmin account here: ' . Env::asUrl('SITE_URL') . '/register.php</info>');
         }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -125,7 +125,7 @@ final class Install extends Command
             $ApiKeys = new ApiKeys($Sysadmin);
             $ApiKeys->create('Sysadmin key', 1);
             $output->writeln('<info>✓ Sysadmin account successfully created.</info>');
-            $output->writeln(sprintf('<info>→ Sysadmin API key: %d-%s</info>', $ApiKeys->keyId, $ApiKeys->key));
+            $output->writeln(sprintf('<info>→ Sysadmin API key: %d-%s</info>', $ApiKeys->key, $ApiKeys->key));
         } else {
             $output->writeln('<info>→ Register your Sysadmin account here: ' . Env::asUrl('SITE_URL') . '/register.php</info>');
         }

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -251,7 +251,10 @@ final class Apiv2Controller extends AbstractApiController
             $this->action = Action::tryFrom($this->Request->request->getString('action')) ?? Action::Update;
         }
         $id = $this->Model->postAction($this->action, $this->reqBody);
-        return new Response('', Response::HTTP_CREATED, array('Location' => sprintf('%s/%s%d', Env::asUrl('SITE_URL'), $this->Model->getApiPath(), $id)));
+        $location = $this->Model instanceof ApiKeys
+            ? $this->Model->getApiPath()
+            : sprintf('%s%d', $this->Model->getApiPath(), $id);
+        return new Response('', Response::HTTP_CREATED, array('Location' => sprintf('%s/%s', Env::asUrl('SITE_URL'), $location)));
     }
 
     private function getArray(): array

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 222;
+    public const int REQUIRED_SCHEMA = 223;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -23,14 +23,12 @@ use Elabftw\Traits\SetIdTrait;
 use Override;
 use PDO;
 
-use function bin2hex;
-use function password_hash;
-use function password_verify;
-use function random_bytes;
 use function _;
-use function explode;
-use function sprintf;
-use function str_contains;
+use function bin2hex;
+use function hash;
+use function password_verify;
+use function preg_match;
+use function random_bytes;
 
 /**
  * Api keys CRUD class
@@ -39,9 +37,11 @@ final class ApiKeys extends AbstractRest
 {
     use SetIdTrait;
 
-    public string $key = '';
+    private const int KEY_RANDOM_BYTES = 16;
 
-    public int $keyId = 0;
+    private const string LEGACY_KEY_PATTERN = '/\A([1-9][0-9]*)-(.+)\z/';
+
+    public string $key = '';
 
     public function __construct(private Users $Users, ?int $id = null)
     {
@@ -58,7 +58,7 @@ final class ApiKeys extends AbstractRest
     #[Override]
     public function getApiPath(): string
     {
-        return sprintf('%d-%s', $this->keyId, $this->key);
+        return $this->key;
     }
 
     /**
@@ -68,8 +68,8 @@ final class ApiKeys extends AbstractRest
      */
     public function createKnown(string $apiKey): int
     {
-        $hash = password_hash($apiKey, PASSWORD_BCRYPT);
-        return $this->insert('known key used from db:populate command', 1, $hash);
+        $this->key = $apiKey;
+        return $this->insert('known key used from db:populate command', 1, $this->getTokenHash($apiKey));
     }
 
     /**
@@ -78,7 +78,7 @@ final class ApiKeys extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
-        $sql = 'SELECT ak.id, ak.name, ak.created_at, ak.last_used_at, ak.hash, ak.can_write, ak.team, teams.name AS team_name
+        $sql = 'SELECT ak.id, ak.name, ak.created_at, ak.last_used_at, ak.can_write, ak.team, teams.name AS team_name
             FROM api_keys AS ak
             LEFT JOIN teams ON teams.id = ak.team
             WHERE ak.userid = :userid ORDER BY last_used_at DESC';
@@ -91,33 +91,22 @@ final class ApiKeys extends AbstractRest
 
     /**
      * Get a user from an API key
-     * Note: at some point we should drop support for keys without id header
-     * Id header avoids looping over all the keys to find the correct one
      */
     public function readFromApiKey(string $apiKey): array
     {
-        $idFilter = '';
-        // do we have key id information? old keys don't have it
-        if (str_contains($apiKey, '-')) {
-            // extract the keyId from the key
-            $exploded = explode('-', $apiKey, 2);
-            $this->keyId = (int) $exploded[0];
-            // we reassign it to this variable so it's transparent for the code below
-            $apiKey = $exploded[1] ?? '';
-            $idFilter = ' WHERE id = :id';
+        $tokenHash = $this->getTokenHash($apiKey);
+        $key = $this->readFromTokenHash($tokenHash);
+        if ($key !== false) {
+            return $key;
         }
-        $sql = 'SELECT id, hash, userid, can_write, team FROM api_keys' . $idFilter;
-        $req = $this->Db->prepare($sql);
-        if ($idFilter) {
-            $req->bindParam(':id', $this->keyId, PDO::PARAM_INT);
+
+        // Legacy keys are migrated to token_hash after their first successful use.
+        $key = $this->readLegacyKey($apiKey);
+        if ($key !== false) {
+            $this->migrateLegacyKey((int) $key['id'], $tokenHash);
+            return $key;
         }
-        $this->Db->execute($req);
-        foreach ($req->fetchAll() as $key) {
-            if (password_verify($apiKey, $key['hash'])) {
-                $this->touch($key['id']);
-                return $key;
-            }
-        }
+
         throw new UnauthorizedException(description: _('No corresponding API key found!'));
     }
 
@@ -153,13 +142,69 @@ final class ApiKeys extends AbstractRest
 
     public function create(string $name, int $canwrite): int
     {
-        $hash = password_hash($this->generateKey(), PASSWORD_BCRYPT);
-        return $this->insert(Filter::title($name), $canwrite, $hash);
+        $this->key = $this->generateKey();
+        return $this->insert(Filter::title($name), $canwrite, $this->getTokenHash($this->key));
+    }
+
+    private function readFromTokenHash(string $tokenHash): array|false
+    {
+        $sql = 'SELECT id, userid, can_write, team,
+                IF(last_used_at IS NULL OR last_used_at <= NOW() - INTERVAL 5 MINUTE, 1, 0) AS touch_required
+            FROM api_keys
+            WHERE token_hash = :token_hash
+            LIMIT 1';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':token_hash', $tokenHash, PDO::PARAM_LOB);
+        $this->Db->execute($req);
+        $key = $req->fetch();
+        if ($key === false) {
+            return false;
+        }
+        if ((bool) $key['touch_required']) {
+            $this->touch((int) $key['id']);
+        }
+        unset($key['touch_required']);
+        return $key;
+    }
+
+    private function readLegacyKey(string $apiKey): array|false
+    {
+        if (preg_match(self::LEGACY_KEY_PATTERN, $apiKey, $matches) !== 1) {
+            return false;
+        }
+
+        $sql = 'SELECT id, hash, userid, can_write, team
+            FROM api_keys
+            WHERE id = :id AND hash IS NOT NULL
+            LIMIT 1';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', (int) $matches[1], PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $key = $req->fetch();
+        if ($key === false || !password_verify($matches[2], (string) $key['hash'])) {
+            return false;
+        }
+        unset($key['hash']);
+        return $key;
+    }
+
+    private function migrateLegacyKey(int $keyId, string $tokenHash): bool
+    {
+        $sql = 'UPDATE api_keys
+            SET token_hash = :token_hash, hash = NULL, last_used_at = NOW()
+            WHERE id = :id AND token_hash IS NULL AND hash IS NOT NULL';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':token_hash', $tokenHash, PDO::PARAM_LOB);
+        $req->bindValue(':id', $keyId, PDO::PARAM_INT);
+        return $this->Db->execute($req);
     }
 
     private function touch(int $keyId): bool
     {
-        $sql = 'UPDATE api_keys SET last_used_at = NOW() WHERE id = :id';
+        $sql = 'UPDATE api_keys
+            SET last_used_at = NOW()
+            WHERE id = :id
+                AND (last_used_at IS NULL OR last_used_at <= NOW() - INTERVAL 5 MINUTE)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $keyId, PDO::PARAM_INT);
         return $this->Db->execute($req);
@@ -167,27 +212,30 @@ final class ApiKeys extends AbstractRest
 
     private function generateKey(): string
     {
-        // keep it in the object so we can display it to the user after
-        $this->key = bin2hex(random_bytes(42));
-        return $this->key;
+        return bin2hex(random_bytes(self::KEY_RANDOM_BYTES));
     }
 
-    private function insert(string $name, int $canwrite, string $hash): int
+    private function getTokenHash(string $apiKey): string
     {
-        $sql = 'INSERT INTO api_keys (name, hash, can_write, userid, team) VALUES (:name, :hash, :can_write, :userid, :team)';
+        return hash('sha256', $apiKey, true);
+    }
+
+    private function insert(string $name, int $canwrite, string $tokenHash): int
+    {
+        $sql = 'INSERT INTO api_keys (name, token_hash, can_write, userid, team)
+            VALUES (:name, :token_hash, :can_write, :userid, :team)';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':name', $name);
-        $req->bindParam(':hash', $hash);
+        $req->bindValue(':token_hash', $tokenHash, PDO::PARAM_LOB);
         $req->bindParam(':can_write', $canwrite, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $res = $this->Db->execute($req);
-        // we store the id of the key in the object to serve it as part of the key
         // must be executed before AuditLog request!
-        $this->keyId = $this->Db->lastInsertId();
+        $keyId = $this->Db->lastInsertId();
         if ($res) {
             AuditLogs::create(new ApiKeyCreated((int) $this->Users->requester->userid, (int) $this->Users->userid));
         }
-        return $this->keyId;
+        return $keyId;
     }
 }

--- a/src/sql/schema223-down.sql
+++ b/src/sql/schema223-down.sql
@@ -1,0 +1,8 @@
+-- revert schema 223
+-- API keys created or migrated on schema 223 cannot be converted back to bcrypt.
+-- Preserve their rows but make those credentials unusable after a downgrade.
+UPDATE `api_keys` SET `hash` = CONCAT('disabled-', UUID()) WHERE `hash` IS NULL;
+CALL DropIdx('api_keys', 'idx_api_keys_token_hash');
+CALL DropColumn('api_keys', 'token_hash');
+ALTER TABLE `api_keys` MODIFY COLUMN `hash` VARCHAR(255) NOT NULL;
+UPDATE config SET conf_value = 222 WHERE conf_name = 'schema';

--- a/src/sql/schema223.sql
+++ b/src/sql/schema223.sql
@@ -1,0 +1,5 @@
+-- schema 223
+ALTER TABLE `api_keys`
+    MODIFY COLUMN `hash` VARCHAR(255) NULL DEFAULT NULL,
+    ADD COLUMN `token_hash` BINARY(32) NULL DEFAULT NULL AFTER `hash`,
+    ADD UNIQUE INDEX `idx_api_keys_token_hash` (`token_hash`);

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -31,13 +31,15 @@ SET time_zone = "+00:00";
 CREATE TABLE `api_keys` (
   `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
-  `hash` varchar(255) NOT NULL,
+  `hash` varchar(255) DEFAULT NULL,
+  `token_hash` binary(32) DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `last_used_at` timestamp NULL DEFAULT NULL,
   `can_write` tinyint UNSIGNED NOT NULL DEFAULT 0,
   `userid` int(10) UNSIGNED NOT NULL,
   `team` int(10) UNSIGNED NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_api_keys_token_hash` (`token_hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
 --

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Controllers;
 
+use Elabftw\Models\ApiKeys;
 use Elabftw\Models\Config;
 use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Traits\TestsUtilsTrait;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+use function basename;
 use function json_decode;
 
 class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
@@ -103,6 +105,26 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         $Controller->canWrite = true;
         $res = $Controller->getResponse();
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $res->getStatusCode());
+    }
+
+    public function testCreateApiKeyReturnsRawTokenInLocation(): void
+    {
+        $user = $this->getRandomUserInTeam(1);
+        $Controller = new Apiv2Controller(
+            $user,
+            Request::create('/api/v2/apikeys', 'POST', content: '{"name": "controller test key", "canwrite": 0}'),
+        );
+        $Controller->canWrite = true;
+        $res = $Controller->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $res->getStatusCode());
+        $apiKey = basename((string) $res->headers->get('Location'));
+        $this->assertMatchesRegularExpression('/\A[[:xdigit:]]{32}\z/', $apiKey);
+
+        $ApiKeys = new ApiKeys($user);
+        $storedKey = $ApiKeys->readFromApiKey($apiKey);
+        $ApiKeys->setId((int) $storedKey['id']);
+        $this->assertTrue($ApiKeys->destroy());
     }
 
     public function testGetCompounds(): void

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -112,7 +112,12 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         $user = $this->getRandomUserInTeam(1);
         $Controller = new Apiv2Controller(
             $user,
-            Request::create('/api/v2/apikeys', 'POST', content: '{"name": "controller test key", "canwrite": 0}'),
+            Request::create(
+                '/api/v2/apikeys',
+                'POST',
+                server: array('CONTENT_TYPE' => 'application/json'),
+                content: '{"name": "controller test key", "canwrite": 0}',
+            ),
         );
         $Controller->canWrite = true;
         $res = $Controller->getResponse();

--- a/tests/unit/models/ApiKeysTest.php
+++ b/tests/unit/models/ApiKeysTest.php
@@ -11,26 +11,44 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Models\Users\Users;
+use PDO;
+
+use function bin2hex;
+use function hash;
+use function password_hash;
+use function random_bytes;
+use function sprintf;
+use function str_repeat;
 
 class ApiKeysTest extends \PHPUnit\Framework\TestCase
 {
     private ApiKeys $ApiKeys;
 
+    private Db $Db;
+
     protected function setUp(): void
     {
+        $this->Db = Db::getConnection();
         $this->ApiKeys = new ApiKeys(new Users(1, 1));
     }
 
     public function testCreateAndGetApiPathAndDestroy(): void
     {
         $id = $this->ApiKeys->postAction(Action::Create, array('name' => 'test key', 'canwrite' => 1));
+        $apiKey = $this->ApiKeys->getApiPath();
         $this->assertIsInt($id);
-        $this->assertIsString($this->ApiKeys->getApiPath());
-        $this->assertMatchesRegularExpression('/\d+-[[:xdigit:]]{84}/', $this->ApiKeys->getApiPath());
+        $this->assertMatchesRegularExpression('/\A[[:xdigit:]]{32}\z/', $apiKey);
+
+        $storage = $this->readStorage($id);
+        $this->assertNull($storage['hash']);
+        $this->assertSame(hash('sha256', $apiKey, true), $storage['token_hash']);
+        $this->assertIsArray($this->ApiKeys->readFromApiKey($apiKey));
+
         $this->ApiKeys->setId($id);
         $this->assertTrue($this->ApiKeys->destroy());
     }
@@ -59,22 +77,76 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateKnown(): void
     {
-        $this->ApiKeys->createKnown('phpunit');
+        $id = $this->ApiKeys->createKnown('phpunit');
         $this->assertIsArray($this->ApiKeys->readFromApiKey('phpunit'));
+        $this->ApiKeys->setId($id);
+        $this->assertTrue($this->ApiKeys->destroy());
     }
 
     public function testInvalidKey(): void
     {
         $this->expectException(UnauthorizedException::class);
-        $this->ApiKeys->readFromApiKey('666-unknown key');
+        $this->ApiKeys->readFromApiKey(str_repeat('0', 32));
+    }
+
+    public function testLegacyKeyRequiresIdAndMigratesOnFirstUse(): void
+    {
+        $secret = bin2hex(random_bytes(42));
+        $id = $this->createLegacyKey($secret);
+
+        $unauthorized = false;
+        try {
+            $this->ApiKeys->readFromApiKey($secret);
+        } catch (UnauthorizedException) {
+            $unauthorized = true;
+        }
+        $this->assertTrue($unauthorized, 'Legacy keys without their database id must be rejected.');
+
+        $apiKey = sprintf('%d-%s', $id, $secret);
+        $this->assertIsArray($this->ApiKeys->readFromApiKey($apiKey));
+
+        $storage = $this->readStorage($id);
+        $this->assertNull($storage['hash']);
+        $this->assertSame(hash('sha256', $apiKey, true), $storage['token_hash']);
+        $this->assertIsArray($this->ApiKeys->readFromApiKey($apiKey));
+
+        $this->ApiKeys->setId($id);
+        $this->assertTrue($this->ApiKeys->destroy());
+    }
+
+    public function testLastUsedAtIsTouchedAtMostEveryFiveMinutes(): void
+    {
+        $id = $this->ApiKeys->postAction(Action::Create, array('name' => 'touch test'));
+        $apiKey = $this->ApiKeys->getApiPath();
+
+        $this->setLastUsedAt($id, 1);
+        $before = $this->readStorage($id)['last_used_at'];
+        $this->ApiKeys->readFromApiKey($apiKey);
+        $this->assertSame($before, $this->readStorage($id)['last_used_at']);
+
+        $this->setLastUsedAt($id, 6);
+        $before = $this->readStorage($id)['last_used_at'];
+        $this->ApiKeys->readFromApiKey($apiKey);
+        $this->assertNotSame($before, $this->readStorage($id)['last_used_at']);
+
+        $this->ApiKeys->setId($id);
+        $this->assertTrue($this->ApiKeys->destroy());
     }
 
     public function testReadAll(): void
     {
         $res = $this->ApiKeys->readAll();
         $this->assertIsArray($res);
-        $this->assertSame('known key used from db:populate command', $res[1]['name']);
-        $this->assertSame(1, $res[1]['can_write']);
+        $knownKey = null;
+        foreach ($res as $key) {
+            $this->assertArrayNotHasKey('hash', $key);
+            $this->assertArrayNotHasKey('token_hash', $key);
+            if ($key['name'] === 'known key used from db:populate command') {
+                $knownKey = $key;
+            }
+        }
+        $this->assertIsArray($knownKey);
+        $this->assertSame(1, $knownKey['can_write']);
     }
 
     public function testDestroyKeyOnCascade(): void
@@ -89,5 +161,35 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
         // Ensure apikey is removed as well
         $this->expectException(UnauthorizedException::class);
         $ApiKeys->readFromApiKey('in team 3');
+    }
+
+    private function createLegacyKey(string $secret): int
+    {
+        $sql = 'INSERT INTO api_keys (name, hash, can_write, userid, team)
+            VALUES (:name, :hash, 1, 1, 1)';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':name', 'legacy test key');
+        $req->bindValue(':hash', password_hash($secret, PASSWORD_BCRYPT));
+        $this->Db->execute($req);
+        return $this->Db->lastInsertId();
+    }
+
+    private function readStorage(int $id): array
+    {
+        $sql = 'SELECT hash, token_hash, last_used_at FROM api_keys WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $req->fetch();
+    }
+
+    private function setLastUsedAt(int $id, int $minutesAgo): void
+    {
+        $sql = sprintf('UPDATE api_keys
+            SET last_used_at = NOW() - INTERVAL %d MINUTE
+            WHERE id = :id', $minutesAgo);
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
     }
 }


### PR DESCRIPTION
this is backward compatible with keys that look like 5-something, but not the very old format without an id in front of it.

This is more performant than before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys are now represented by secure, raw tokens when created and displayed.
  * Existing legacy API keys continue to work and are upgraded automatically after successful authentication.
  * API key listings no longer expose stored credential hashes.
* **Bug Fixes**
  * API responses now provide the correct API key location and token.
  * API key usage timestamps update less frequently.
* **Documentation**
  * Updated API documentation for the revised API key response format.
* **Database**
  * Added secure token storage migration support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->