### PR TITLE
bug/medium: invoker: create missing dir in entrypoint

### DIFF
--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -348,7 +348,7 @@ phpConf() {
 
 elabftwConf() {
     rm -rf /var/cache/elabftw/php/* /var/cache/elabftw/nginx/*
-    mkdir -p /var/cache/elabftw/nginx/client_body /var/cache/elabftw/nginx/fastcgi /var/cache/elabftw/nginx/proxy /var/cache/elabftw/php/tmp /var/cache/elabftw/php/cache/elab /var/cache/elabftw/php/cache/mpdf /var/cache/elabftw/php/cache/twig /var/cache/elabftw/php/cache/purifier/CSS /var/cache/elabftw/php/cache/purifier/HTML /var/cache/elabftw/php/cache/purifier/URI
+    mkdir -p /run/elabftw /var/cache/elabftw/nginx/client_body /var/cache/elabftw/nginx/fastcgi /var/cache/elabftw/nginx/proxy /var/cache/elabftw/php/tmp /var/cache/elabftw/php/cache/elab /var/cache/elabftw/php/cache/mpdf /var/cache/elabftw/php/cache/twig /var/cache/elabftw/php/cache/purifier/CSS /var/cache/elabftw/php/cache/purifier/HTML /var/cache/elabftw/php/cache/purifier/URI
 }
 
 ldapConf() {


### PR DESCRIPTION
with USE_REDIS=true the invoker couldn't create its socket because /run/elabftw didn't exist, as it was created by the php sessions path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by ensuring the required runtime directory is created before the application initializes its cache directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->