### PR TITLE
bug/minor: api: better check of expired/archived accounts

### DIFF
--- a/src/Models/ApiKeys.php
+++ b/src/Models/ApiKeys.php
@@ -148,10 +148,15 @@ final class ApiKeys extends AbstractRest
 
     private function readFromTokenHash(string $tokenHash): array|false
     {
-        $sql = 'SELECT id, userid, can_write, team,
-                IF(last_used_at IS NULL OR last_used_at <= NOW() - INTERVAL 5 MINUTE, 1, 0) AS touch_required
-            FROM api_keys
-            WHERE token_hash = :token_hash
+        $sql = 'SELECT ak.id, ak.userid, ak.can_write, ak.team,
+                IF(ak.last_used_at IS NULL OR ak.last_used_at <= NOW() - INTERVAL 5 MINUTE, 1, 0) AS touch_required
+            FROM api_keys AS ak
+            INNER JOIN users AS u ON u.userid = ak.userid
+            INNER JOIN users2teams AS u2t ON u2t.users_id = ak.userid AND u2t.teams_id = ak.team
+            WHERE ak.token_hash = :token_hash
+                AND u.validated = 1
+                AND IFNULL(u.valid_until, \'3000-01-01\') > NOW()
+                AND u2t.is_archived = 0
             LIMIT 1';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':token_hash', $tokenHash, PDO::PARAM_LOB);
@@ -173,9 +178,14 @@ final class ApiKeys extends AbstractRest
             return false;
         }
 
-        $sql = 'SELECT id, hash, userid, can_write, team
-            FROM api_keys
-            WHERE id = :id AND hash IS NOT NULL
+        $sql = 'SELECT ak.id, ak.hash, ak.userid, ak.can_write, ak.team
+            FROM api_keys AS ak
+            INNER JOIN users AS u ON u.userid = ak.userid
+            INNER JOIN users2teams AS u2t ON u2t.users_id = ak.userid AND u2t.teams_id = ak.team
+            WHERE ak.id = :id AND ak.hash IS NOT NULL
+                AND u.validated = 1
+                AND IFNULL(u.valid_until, \'3000-01-01\') > NOW()
+                AND u2t.is_archived = 0
             LIMIT 1';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':id', (int) $matches[1], PDO::PARAM_INT);

--- a/tests/unit/models/ApiKeysTest.php
+++ b/tests/unit/models/ApiKeysTest.php
@@ -34,7 +34,13 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->Db = Db::getConnection();
+        $this->Db->beginTransaction();
         $this->ApiKeys = new ApiKeys(new Users(1, 1));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->Db->rollBack();
     }
 
     public function testCreateAndGetApiPathAndDestroy(): void
@@ -87,6 +93,59 @@ class ApiKeysTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(UnauthorizedException::class);
         $this->ApiKeys->readFromApiKey(str_repeat('0', 32));
+    }
+
+    public function testExpiredUserKeyIsRejected(): void
+    {
+        $this->ApiKeys->postAction(Action::Create, array('name' => 'expired user key'));
+        $apiKey = $this->ApiKeys->getApiPath();
+
+        $req = $this->Db->prepare('UPDATE users SET valid_until = :valid_until WHERE userid = 1');
+        $req->bindValue(':valid_until', '2000-01-01');
+        $this->Db->execute($req);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->ApiKeys->readFromApiKey($apiKey);
+    }
+
+    public function testSuspendedUserKeyIsRejected(): void
+    {
+        $this->ApiKeys->postAction(Action::Create, array('name' => 'suspended user key'));
+        $apiKey = $this->ApiKeys->getApiPath();
+
+        $req = $this->Db->prepare('UPDATE users SET validated = 0 WHERE userid = 1');
+        $this->Db->execute($req);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->ApiKeys->readFromApiKey($apiKey);
+    }
+
+    public function testArchivedTeamMembershipKeyIsRejected(): void
+    {
+        $this->ApiKeys->postAction(Action::Create, array('name' => 'archived user key'));
+        $apiKey = $this->ApiKeys->getApiPath();
+
+        $req = $this->Db->prepare(
+            'UPDATE users2teams SET is_archived = 1 WHERE users_id = 1 AND teams_id = 1',
+        );
+        $this->Db->execute($req);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->ApiKeys->readFromApiKey($apiKey);
+    }
+
+    public function testExpiredLegacyUserKeyIsRejected(): void
+    {
+        $secret = bin2hex(random_bytes(42));
+        $id = $this->createLegacyKey($secret);
+        $apiKey = sprintf('%d-%s', $id, $secret);
+
+        $req = $this->Db->prepare('UPDATE users SET valid_until = :valid_until WHERE userid = 1');
+        $req->bindValue(':valid_until', '2000-01-01');
+        $this->Db->execute($req);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->ApiKeys->readFromApiKey($apiKey);
     }
 
     public function testLegacyKeyRequiresIdAndMigratesOnFirstUse(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys are now rejected when the owning account is expired or suspended.
  * Keys are rejected when associated team membership is inactive or archived.
  * These validation rules apply to both current and legacy API keys.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->