### PR TITLE
bug/minor: fix anon access to storage api

### DIFF
--- a/src/Controllers/AbstractApiController.php
+++ b/src/Controllers/AbstractApiController.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 namespace Elabftw\Controllers;
 
 use Elabftw\Enums\ApiEndpoint;
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\InvalidEndpointException;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Services\Check;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -41,6 +43,10 @@ abstract class AbstractApiController extends AbstractController
 
     protected function parseReq(): array
     {
+        if ($this->requester instanceof AnonymousUser && $this->Request->getMethod() !== Request::METHOD_GET) {
+            throw new IllegalActionException();
+        }
+
         if ($this->canWrite === false && $this->Request->getMethod() !== Request::METHOD_GET) {
             throw new ImproperActionException('You are using a read-only key to execute a write action.');
         }

--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -19,6 +19,7 @@ use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Interfaces\QueryParamsInterface;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\CommentParam;
 use Elabftw\Services\Filter;
@@ -485,6 +486,10 @@ final class StorageUnits extends AbstractRest
 
     public function canWrite(): bool
     {
+        if ($this->requester instanceof AnonymousUser) {
+            return false;
+        }
+
         return $this->requester->userData['can_manage_inventory_locations'] === 1 || $this->requireEditRights === false;
     }
 

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -66,6 +66,25 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         self::assertSame('[]', $res->getContent());
     }
 
+    public function testAnonymousUserCannotWriteEvenWhenCanWriteIsTrue(): void
+    {
+        $Controller = new Apiv2Controller(
+            new AnonymousUser(1),
+            Request::create(
+                '/api/v2/info',
+                'POST',
+                server: array('CONTENT_TYPE' => 'application/json'),
+                content: '{}',
+            ),
+        );
+        // PHP session requests normally set this to true. Anonymous users must still be read-only.
+        $Controller->canWrite = true;
+
+        $res = $Controller->getResponse();
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode());
+    }
+
     public function testBadJson(): void
     {
         $user = $this->getRandomUserInTeam(1);

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -17,6 +17,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Links\Containers2ItemsLinks;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
@@ -194,6 +195,16 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $StorageUnitsAsUser->setId($unitId);
         $this->expectException(\Elabftw\Exceptions\IllegalActionException::class);
         $StorageUnitsAsUser->patch(Action::Update, array('parent_id' => $newParentId));
+    }
+
+    public function testAnonymousUserCannotWriteWhenEditRightsAreDisabled(): void
+    {
+        $StorageUnitsAsAnonymous = new StorageUnits(new AnonymousUser(1), false);
+
+        $this->assertFalse($StorageUnitsAsAnonymous->canWrite());
+        $this->expectException(\Elabftw\Exceptions\IllegalActionException::class);
+
+        $StorageUnitsAsAnonymous->canWriteOrExplode();
     }
 
     public function testPatchWithNoTargetIsRejected(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous users can no longer submit non-GET API requests, even when write access is enabled.
  * Anonymous users are prevented from modifying storage-unit data without the required edit permissions.
  * Unauthorized write attempts now consistently return a forbidden response or raise an appropriate error.

* **Tests**
  * Added regression coverage for anonymous API and storage-unit write restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->