### PR TITLE
bug/minor: fix user reading request actions from other user

### DIFF
--- a/src/Models/UserRequestActions.php
+++ b/src/Models/UserRequestActions.php
@@ -37,6 +37,7 @@ final class UserRequestActions extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        $this->requester->isSelfOrExplode();
         $tables = array(
             array(
                 'page' => EntityType::Experiments->toPage(),

--- a/tests/unit/models/UserRequestActionsTest.php
+++ b/tests/unit/models/UserRequestActionsTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Models\Users\Users;
 
 class UserRequestActionsTest extends \PHPUnit\Framework\TestCase
@@ -27,6 +28,13 @@ class UserRequestActionsTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertIsArray($this->ura->readAll());
         $this->assertIsArray($this->ura->readAllFull());
+    }
+
+    public function testCannotReadAnotherUsersRequests(): void
+    {
+        $target = new Users(1, 1, new Users(2, 1));
+        $this->expectException(IllegalActionException::class);
+        new UserRequestActions($target)->readAll();
     }
 
     public function testGetApiPath(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from viewing another user’s request actions.
  * Unauthorized access now returns an appropriate error instead of request action data.

* **Tests**
  * Added coverage to verify access restrictions for request action history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->