### PR TITLE
bug/minor: fix procurement read

### DIFF
--- a/src/Models/ProcurementRequests.php
+++ b/src/Models/ProcurementRequests.php
@@ -82,9 +82,10 @@ final class ProcurementRequests extends AbstractRest
     public function readActiveForEntity(int $entityId): array
     {
         $sql = "SELECT CONCAT(users.firstname, ' ', users.lastname) AS requester_fullname, pr.id, pr.created_at, pr.team, pr.requester_userid, pr.entity_id, pr.qty_ordered, pr.body, pr.quote, pr.email_sent, pr.state
-            FROM procurement_requests AS pr LEFT JOIN users ON (requester_userid = users.userid) WHERE entity_id = :entity_id AND state NOT IN (:state_received, :state_archived)";
+            FROM procurement_requests AS pr LEFT JOIN users ON (requester_userid = users.userid) WHERE pr.entity_id = :entity_id AND pr.team = :team AND pr.state NOT IN (:state_received, :state_archived)";
         $req = $this->Db->prepare($sql);
         $req->bindParam(':entity_id', $entityId, PDO::PARAM_INT);
+        $req->bindParam(':team', $this->Teams->id, PDO::PARAM_INT);
         $req->bindValue(':state_received', ProcurementState::Received->value, PDO::PARAM_INT);
         $req->bindValue(':state_archived', ProcurementState::Archived->value, PDO::PARAM_INT);
         $this->Db->execute($req);

--- a/tests/unit/models/ProcurementRequestsTest.php
+++ b/tests/unit/models/ProcurementRequestsTest.php
@@ -41,6 +41,7 @@ class ProcurementRequestsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($this->pr->readOne());
         $this->assertIsArray($this->pr->readActiveForEntity($entityId));
         $this->assertNotEmpty($this->pr->readActiveForEntity($entityId));
+        $this->assertSame(array(), $this->otherTeamPr->readActiveForEntity($entityId));
         $this->assertIsArray($this->pr->patch(Action::Update, array('qty_received' => 2)));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed active procurement requests appearing across different teams.
  * Procurement request listings are now limited to the currently selected team.

* **Tests**
  * Added coverage confirming that requests from one team do not appear in another team’s results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->