### PR TITLE
bug/minor: kick user immediatly if account is no longer active in team

### DIFF
--- a/src/Elabftw/App.php
+++ b/src/Elabftw/App.php
@@ -25,6 +25,7 @@ use Elabftw\Models\ResourcesCategories;
 use Elabftw\Models\Notifications\UserNotifications;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users\Users;
+use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\TwigTrait;
 use Exception;
 use Monolog\Handler\ErrorLogHandler;
@@ -103,10 +104,12 @@ final class App
                     $this->Session->has('is_auth')
                     && $this->Session->get('userid') !== 0
                 ) {
-                    $this->loadUser(new AuthenticatedUser(
-                        $this->Session->get('userid'),
-                        $this->Session->get('team'),
-                    ));
+                    $userid = (int) $this->Session->get('userid');
+                    $team = (int) $this->Session->get('team');
+                    if (!new TeamsHelper($team)->isActiveUserInTeam($userid)) {
+                        throw new IllegalActionException();
+                    }
+                    $this->loadUser(new AuthenticatedUser($userid, $team));
                 }
             } catch (IllegalActionException) {
                 $this->Session->invalidate();

--- a/src/Services/TeamsHelper.php
+++ b/src/Services/TeamsHelper.php
@@ -108,6 +108,19 @@ final class TeamsHelper
         return !empty($this->getUserInTeam($userid));
     }
 
+    public function isActiveUserInTeam(int $userid): bool
+    {
+        $sql = 'SELECT 1 FROM `users2teams`
+            WHERE `teams_id` = :team
+                AND `users_id` = :userid
+                AND `is_archived` = 0';
+        $req = $this->Db->prepare($sql);
+        $req->bindParam(':team', $this->team, PDO::PARAM_INT);
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $req->fetchColumn() !== false;
+    }
+
     /**
      * Get all the userid of active admins of the team
      */

--- a/tests/unit/classes/AppTest.php
+++ b/tests/unit/classes/AppTest.php
@@ -12,11 +12,56 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
+use Elabftw\Exceptions\UnauthorizedException;
+use Elabftw\Models\Config;
+use Elabftw\Models\Users\Users;
+use Elabftw\Traits\TestsUtilsTrait;
+use PDO;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
 class AppTest extends \PHPUnit\Framework\TestCase
 {
+    use TestsUtilsTrait;
+
     public function testGetWhatsnewLink(): void
     {
         $this->assertEquals('https://www.deltablot.com/posts/release-50100', App::getWhatsnewLink(50169));
         $this->assertEquals('https://www.deltablot.com/posts/release-66600', App::getWhatsnewLink(66642));
+    }
+
+    public function testArchivedUserSessionIsRejected(): void
+    {
+        $User = $this->getRandomUserInTeam(1);
+        $Session = new Session(new MockArraySessionStorage());
+        $Session->set('is_auth', 1);
+        $Session->set('userid', $User->userid);
+        $Session->set('team', 1);
+        $Db = Db::getConnection();
+        $Db->beginTransaction();
+
+        try {
+            $req = $Db->prepare('UPDATE users2teams SET is_archived = 1 WHERE users_id = :userid AND teams_id = :team');
+            $req->bindValue(':userid', $User->userid, PDO::PARAM_INT);
+            $req->bindValue(':team', 1, PDO::PARAM_INT);
+            $Db->execute($req);
+
+            $App = new App(
+                Request::create('/index.php'),
+                $Session,
+                Config::getConfig(),
+                App::getDefaultLogger(),
+                new Users(),
+            );
+            try {
+                $App->boot();
+                self::fail('Expected archived user session to be rejected.');
+            } catch (UnauthorizedException) {
+                self::assertFalse($Session->has('is_auth'));
+            }
+        } finally {
+            $Db->rollBack();
+        }
     }
 }

--- a/tests/unit/services/TeamsHelperTest.php
+++ b/tests/unit/services/TeamsHelperTest.php
@@ -38,6 +38,19 @@ class TeamsHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Usergroup::Admin, $TeamsHelper->getGroup());
     }
 
+    public function testIsActiveUserInTeam(): void
+    {
+        $target = $this->getRandomUserInTeam(1);
+        $this->assertTrue($this->TeamsHelper->isActiveUserInTeam($target->userid));
+
+        $this->updateArchiveStatus($target->userid, 1);
+        try {
+            $this->assertFalse($this->TeamsHelper->isActiveUserInTeam($target->userid));
+        } finally {
+            $this->updateArchiveStatus($target->userid, 0);
+        }
+    }
+
     public function testIsArchivedInAllTeams(): void
     {
         $target = $this->getRandomUserInTeam(1);


### PR DESCRIPTION
don't wait on session expiration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived or inactive team members can no longer access an authenticated session.
  * Invalid team membership sessions are now rejected and authentication is cleared.
* **Tests**
  * Added coverage for archived-user session rejection.
  * Added validation for active versus archived team membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->