### PR TITLE
bug/minor: fix cross-team read

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -413,6 +413,13 @@ final class Apiv2Controller extends AbstractApiController
             };
         }
         if ($this->Model instanceof Teams) {
+            if ($this->requester instanceof AnonymousUser) {
+                if ($this->requester->getTeam() !== $this->Model->id) {
+                    throw new ImproperActionException('Cannot query team information if not part of that team or not Sysadmin!');
+                }
+            } else {
+                $this->Model->readOne();
+            }
             return match ($submodel) {
                 // backward compatibility: Status == ExperimentsStatus
                 ApiSubModels::Status, ApiSubModels::ExperimentsStatus => new ExperimentsStatus($this->Model, $this->subId),

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -85,6 +85,54 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode());
     }
 
+    public function testCannotReadAnotherTeamsSubmodel(): void
+    {
+        $Controller = new Apiv2Controller(
+            $this->getRandomUserInTeam(2),
+            Request::create('/api/v2/teams/1/procurement_requests', 'GET'),
+        );
+
+        $res = $Controller->getResponse();
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $res->getStatusCode());
+    }
+
+    public function testAnonymousUserCannotReadAnotherTeamsSubmodel(): void
+    {
+        $Controller = new Apiv2Controller(
+            new AnonymousUser(1),
+            Request::create('/api/v2/teams/2/status', 'GET'),
+        );
+
+        $res = $Controller->getResponse();
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $res->getStatusCode());
+    }
+
+    public function testAnonymousUserCanReadCurrentTeamsSubmodel(): void
+    {
+        $Controller = new Apiv2Controller(
+            new AnonymousUser(1),
+            Request::create('/api/v2/teams/1/status', 'GET'),
+        );
+
+        $res = $Controller->getResponse();
+
+        self::assertSame(Response::HTTP_OK, $res->getStatusCode());
+    }
+
+    public function testCanReadCurrentTeamsSubmodel(): void
+    {
+        $Controller = new Apiv2Controller(
+            $this->getRandomUserInTeam(1),
+            Request::create('/api/v2/teams/1/status', 'GET'),
+        );
+
+        $res = $Controller->getResponse();
+
+        self::assertSame(Response::HTTP_OK, $res->getStatusCode());
+    }
+
     public function testBadJson(): void
     {
         $user = $this->getRandomUserInTeam(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access controls for anonymous team information requests.
  * Requests for another team’s information now return an error, while requests for the current team continue to work.

* **Tests**
  * Added coverage for authorized and unauthorized team information requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->