### PR TITLE
Clean up orphaned tags2entity entries during prune:entries

### DIFF
--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -59,7 +59,7 @@ final class EntityPruner implements CleanerInterface
 
             // delete orphaned tags2entity rows via subquery (no PHP-side ID list)
             $tagsSql = 'DELETE FROM tags2entity WHERE item_type = :item_type'
-                     . ' AND item_id IN (SELECT id FROM ' . $entityTable . $baseWhere . ')';
+                     . ' AND item_id IN (SELECT id FROM ' . $entityTable . $baseWhere . ' FOR UPDATE)';
             $tagsReq = $this->Db->prepare($tagsSql);
             $tagsReq->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
             $tagsReq->bindValue(':item_type', $entityTable, PDO::PARAM_STR);

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -51,20 +51,21 @@ final class EntityPruner implements CleanerInterface
     #[Override]
     public function cleanup(): int
     {
-        // collect the IDs of entities that match the filter
-        $selectStmt = $this->buildSelectStmt();
-        $matchingIds = $selectStmt->fetchAll(PDO::FETCH_COLUMN);
-        if (empty($matchingIds)) {
-            return 0;
-        }
-
-        // wrap both deletes in a transaction to ensure consistency
+        // begin transaction before selecting so rows are locked with FOR UPDATE
         $this->Db->beginTransaction();
         try {
+            // select matching deleted entity ids with row lock
+            $selectStmt = $this->buildSelectStmt();
+            $matchingIds = $selectStmt->fetchAll(PDO::FETCH_COLUMN);
+            if (empty($matchingIds)) {
+                $this->Db->rollBack();
+                return 0;
+            }
+
             // delete orphaned tags2entity entries before the entity rows
             $this->cleanupTags2entity($matchingIds);
 
-            // delete the entity rows
+            // delete the entity rows, but only those still in Deleted state
             $deleted = $this->deleteEntities($matchingIds);
 
             $this->Db->commit();
@@ -83,6 +84,7 @@ final class EntityPruner implements CleanerInterface
         $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE state = :state';
         $binds = array();
         $this->applyFilters($sql, $binds);
+        $sql .= ' FOR UPDATE';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
         foreach ($binds as $key => $bindData) {
@@ -131,11 +133,12 @@ final class EntityPruner implements CleanerInterface
             $placeholders[] = $key;
             $binds[$key] = array($id, PDO::PARAM_INT);
         }
-        $sql = 'DELETE FROM ' . $this->entityType->value . ' WHERE id IN (' . implode(',', $placeholders) . ')';
+        $sql = 'DELETE FROM ' . $this->entityType->value . ' WHERE id IN (' . implode(',', $placeholders) . ') AND state = :state';
         $req = $this->Db->prepare($sql);
         foreach ($binds as $key => $bindData) {
             $req->bindValue($key, $bindData[0], $bindData[1]);
         }
+        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->rowCount();
     }

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -59,7 +59,7 @@ final class EntityPruner implements CleanerInterface
 
             // delete orphaned tags2entity rows via subquery (no PHP-side ID list)
             $tagsSql = 'DELETE FROM tags2entity WHERE item_type = :item_type'
-                     . ' AND item_id IN (SELECT id FROM ' . $entityTable . $baseWhere . ' FOR UPDATE)';
+                     . ' AND item_id IN (SELECT id FROM ' . $entityTable . $baseWhere . ')';
             $tagsReq = $this->Db->prepare($tagsSql);
             $tagsReq->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
             $tagsReq->bindValue(':item_type', $entityTable, PDO::PARAM_STR);

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -20,7 +20,6 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\CleanerInterface;
 use Override;
 use PDO;
-use PDOStatement;
 use Exception;
 
 use function implode;
@@ -51,22 +50,39 @@ final class EntityPruner implements CleanerInterface
     #[Override]
     public function cleanup(): int
     {
-        // begin transaction before selecting so rows are locked with FOR UPDATE
         $this->Db->beginTransaction();
         try {
-            // select matching deleted entity ids with row lock
-            $selectStmt = $this->buildSelectStmt();
-            $matchingIds = $selectStmt->fetchAll(PDO::FETCH_COLUMN);
-            if (empty($matchingIds)) {
-                $this->Db->rollBack();
-                return 0;
+            $baseWhere = ' WHERE state = :state';
+            $binds = array();
+            $this->applyFilters($baseWhere, $binds);
+            $entityTable = $this->entityType->value;
+
+            // delete orphaned tags2entity rows via subquery (no PHP-side ID list)
+            $tagsSql = 'DELETE FROM tags2entity WHERE item_type = :item_type'
+                     . ' AND item_id IN (SELECT id FROM ' . $entityTable . $baseWhere . ' FOR UPDATE)';
+            $tagsReq = $this->Db->prepare($tagsSql);
+            $tagsReq->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
+            $tagsReq->bindValue(':item_type', $entityTable, PDO::PARAM_STR);
+            foreach ($binds as $key => $bindData) {
+                $tagsReq->bindValue($key, $bindData[0], $bindData[1]);
             }
+            if ($this->since !== null) {
+                $tagsReq->bindValue(':since', $this->parseSince($this->since));
+            }
+            $this->Db->execute($tagsReq);
 
-            // delete orphaned tags2entity entries before the entity rows
-            $this->cleanupTags2entity($matchingIds);
-
-            // delete the entity rows, but only those still in Deleted state
-            $deleted = $this->deleteEntities($matchingIds);
+            // delete the entity rows (same WHERE, so restored entities are skipped)
+            $entitySql = 'DELETE FROM ' . $entityTable . $baseWhere;
+            $entityReq = $this->Db->prepare($entitySql);
+            $entityReq->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
+            foreach ($binds as $key => $bindData) {
+                $entityReq->bindValue($key, $bindData[0], $bindData[1]);
+            }
+            if ($this->since !== null) {
+                $entityReq->bindValue(':since', $this->parseSince($this->since));
+            }
+            $this->Db->execute($entityReq);
+            $deleted = $entityReq->rowCount();
 
             $this->Db->commit();
             return $deleted;
@@ -74,73 +90,6 @@ final class EntityPruner implements CleanerInterface
             $this->Db->rollBack();
             throw $e;
         }
-    }
-
-    /**
-     * Build a prepared SELECT statement that returns the ids of matching deleted entities
-     */
-    private function buildSelectStmt(): PDOStatement
-    {
-        $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE state = :state';
-        $binds = array();
-        $this->applyFilters($sql, $binds);
-        $sql .= ' FOR UPDATE';
-        $req = $this->Db->prepare($sql);
-        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
-        foreach ($binds as $key => $bindData) {
-            $req->bindValue($key, $bindData[0], $bindData[1]);
-        }
-        if ($this->since !== null) {
-            $req->bindValue(':since', $this->parseSince($this->since));
-        }
-        $this->Db->execute($req);
-        return $req;
-    }
-
-    /**
-     * Delete orphaned tag relations for the given entity ids
-     */
-    private function cleanupTags2entity(array $idValues): void
-    {
-        if (empty($idValues)) {
-            return;
-        }
-        $placeholders = array();
-        $binds = array();
-        foreach ($idValues as $k => $id) {
-            $key = ":id_$k";
-            $placeholders[] = $key;
-            $binds[$key] = array($id, PDO::PARAM_INT);
-        }
-        $sql = 'DELETE FROM tags2entity WHERE item_type = :item_type AND item_id IN (' . implode(',', $placeholders) . ')';
-        $req = $this->Db->prepare($sql);
-        $req->bindValue(':item_type', $this->entityType->value, PDO::PARAM_STR);
-        foreach ($binds as $key => $bindData) {
-            $req->bindValue($key, $bindData[0], $bindData[1]);
-        }
-        $this->Db->execute($req);
-    }
-
-    /**
-     * Delete entity rows by id
-     */
-    private function deleteEntities(array $idValues): int
-    {
-        $placeholders = array();
-        $binds = array();
-        foreach ($idValues as $k => $id) {
-            $key = ":id_$k";
-            $placeholders[] = $key;
-            $binds[$key] = array($id, PDO::PARAM_INT);
-        }
-        $sql = 'DELETE FROM ' . $this->entityType->value . ' WHERE id IN (' . implode(',', $placeholders) . ') AND state = :state';
-        $req = $this->Db->prepare($sql);
-        foreach ($binds as $key => $bindData) {
-            $req->bindValue($key, $bindData[0], $bindData[1]);
-        }
-        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
-        $this->Db->execute($req);
-        return $req->rowCount();
     }
 
     /**

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -49,9 +49,90 @@ final class EntityPruner implements CleanerInterface
     #[Override]
     public function cleanup(): int
     {
-        $sql = 'DELETE FROM ' . $this->entityType->value . ' WHERE state = :state';
+        // collect the IDs of entities that match the filter
+        $selectStmt = $this->buildSelectStmt();
+        $matchingIds = $selectStmt->fetchAll(PDO::FETCH_COLUMN);
+        if (empty($matchingIds)) {
+            return 0;
+        }
 
+        // delete orphaned tags2entity entries before the entity rows
+        $this->cleanupTags2entity($matchingIds);
+
+        // delete the entity rows
+        return $this->deleteEntities($matchingIds);
+    }
+
+    /**
+     * Build a prepared SELECT statement that returns the ids of matching deleted entities
+     */
+    private function buildSelectStmt(): \PDOStatement
+    {
+        $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE state = :state';
         $binds = array();
+        $this->applyFilters($sql, $binds);
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
+        foreach ($binds as $key => $bindData) {
+            $req->bindValue($key, $bindData[0], $bindData[1]);
+        }
+        if ($this->since !== null) {
+            $req->bindValue(':since', $this->parseSince($this->since));
+        }
+        $this->Db->execute($req);
+        return $req;
+    }
+
+    /**
+     * Delete orphaned tag relations for the given entity ids
+     */
+    private function cleanupTags2entity(array $idValues): void
+    {
+        if (empty($idValues)) {
+            return;
+        }
+        $placeholders = array();
+        $binds = array();
+        foreach ($idValues as $k => $id) {
+            $key = ":id_$k";
+            $placeholders[] = $key;
+            $binds[$key] = array($id, PDO::PARAM_INT);
+        }
+        $sql = 'DELETE FROM tags2entity WHERE item_type = :item_type AND item_id IN (' . implode(',', $placeholders) . ')';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':item_type', $this->entityType->value, PDO::PARAM_STR);
+        foreach ($binds as $key => $bindData) {
+            $req->bindValue($key, $bindData[0], $bindData[1]);
+        }
+        $this->Db->execute($req);
+    }
+
+    /**
+     * Delete entity rows by id
+     */
+    private function deleteEntities(array $idValues): int
+    {
+        $placeholders = array();
+        $binds = array();
+        foreach ($idValues as $k => $id) {
+            $key = ":id_$k";
+            $placeholders[] = $key;
+            $binds[$key] = array($id, PDO::PARAM_INT);
+        }
+        $sql = 'DELETE FROM ' . $this->entityType->value . ' WHERE id IN (' . implode(',', $placeholders) . ')';
+        $req = $this->Db->prepare($sql);
+        foreach ($binds as $key => $bindData) {
+            $req->bindValue($key, $bindData[0], $bindData[1]);
+        }
+        $this->Db->execute($req);
+        return $req->rowCount();
+    }
+
+    /**
+     * Apply the filters (ids, userids, teams, since) to a SQL query string
+     */
+    private function applyFilters(string &$sql, array &$binds): void
+    {
         if (!empty($this->ids)) {
             $idPlaceholders = array();
             foreach ($this->ids as $k => $id) {
@@ -82,17 +163,6 @@ final class EntityPruner implements CleanerInterface
         if ($this->since !== null) {
             $sql .= ' AND created_at >= :since';
         }
-
-        $req = $this->Db->prepare($sql);
-        $req->bindValue(':state', State::Deleted->value, PDO::PARAM_INT);
-        foreach ($binds as $key => $bindData) {
-            $req->bindValue($key, $bindData[0], $bindData[1]);
-        }
-        if ($this->since !== null) {
-            $req->bindValue(':since', $this->parseSince($this->since));
-        }
-        $this->Db->execute($req);
-        return $req->rowCount();
     }
 
     private function parseSince(string $since): string

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -56,11 +56,21 @@ final class EntityPruner implements CleanerInterface
             return 0;
         }
 
-        // delete orphaned tags2entity entries before the entity rows
-        $this->cleanupTags2entity($matchingIds);
+        // wrap both deletes in a transaction to ensure consistency
+        $this->Db->beginTransaction();
+        try {
+            // delete orphaned tags2entity entries before the entity rows
+            $this->cleanupTags2entity($matchingIds);
 
-        // delete the entity rows
-        return $this->deleteEntities($matchingIds);
+            // delete the entity rows
+            $deleted = $this->deleteEntities($matchingIds);
+
+            $this->Db->commit();
+            return $deleted;
+        } catch (\Exception $e) {
+            $this->Db->rollBack();
+            throw $e;
+        }
     }
 
     /**

--- a/src/Services/EntityPruner.php
+++ b/src/Services/EntityPruner.php
@@ -20,6 +20,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\CleanerInterface;
 use Override;
 use PDO;
+use PDOStatement;
+use Exception;
 
 use function implode;
 use function preg_match;
@@ -67,7 +69,7 @@ final class EntityPruner implements CleanerInterface
 
             $this->Db->commit();
             return $deleted;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->Db->rollBack();
             throw $e;
         }
@@ -76,7 +78,7 @@ final class EntityPruner implements CleanerInterface
     /**
      * Build a prepared SELECT statement that returns the ids of matching deleted entities
      */
-    private function buildSelectStmt(): \PDOStatement
+    private function buildSelectStmt(): PDOStatement
     {
         $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE state = :state';
         $binds = array();

--- a/tests/unit/services/EntityPrunerTest.php
+++ b/tests/unit/services/EntityPrunerTest.php
@@ -136,4 +136,34 @@ class EntityPrunerTest extends TestCase
         $Cleaner = new EntityPruner(EntityType::Experiments, array(), array(), array(), '2026-02-30');
         $Cleaner->cleanup();
     }
+
+    public function testCleanupRemovesOrphanedTags2entity(): void
+    {
+        $Exp = $this->getFreshExperiment();
+        $id = $Exp->id;
+        // add a tag to the experiment
+        $Tags = new \Elabftw\Models\Tags($Exp);
+        $Tags->create(new \Elabftw\Params\TagParam('test-tag'), true);
+        // verify the tag relation exists
+        $Db = Db::getConnection();
+        $req = $Db->prepare('SELECT COUNT(*) FROM tags2entity WHERE item_id = :id AND item_type = :type');
+        $req->execute(array(':id' => $id, ':type' => EntityType::Experiments->value));
+        $this->assertGreaterThan(0, (int) $req->fetchColumn());
+
+        // soft-delete and prune
+        $Exp->destroy();
+        $Cleaner = new EntityPruner(EntityType::Experiments, array($id));
+        $res = $Cleaner->cleanup();
+        $this->assertSame(1, $res);
+
+        // verify the entity is gone
+        $req = $Db->prepare('SELECT id FROM experiments WHERE id = :id');
+        $req->execute(array(':id' => $id));
+        $this->assertEmpty($req->fetchAll());
+
+        // verify the tags2entity rows are also gone (the bug from issue #6952)
+        $req = $Db->prepare('SELECT COUNT(*) FROM tags2entity WHERE item_id = :id AND item_type = :type');
+        $req->execute(array(':id' => $id, ':type' => EntityType::Experiments->value));
+        $this->assertSame(0, (int) $req->fetchColumn(), 'tags2entity rows should be removed after prune');
+    }
 }


### PR DESCRIPTION
The \prune:entries\ command (formerly \prune:experiments\) deletes soft-deleted entity rows from the \experiments\/\items\/\experiments_templates\ tables but leaves orphaned rows in the \	ags2entity\ table referencing the deleted entity ids.

**Changes:**
- Refactored \EntityPruner::cleanup()\ to first SELECT the matching entity ids, then DELETE from \	ags2entity\ where \item_type\ matches the entity type and \item_id\ is in the set of matching ids, and finally DELETE the entity rows.
- Added \cleanupTags2entity()\ and \deleteEntities()\ helper methods.
- Extracted \pplyFilters()\ to reuse the filter logic for both SELECT and DELETE queries.

The fix applies to all entity types (\experiments\, \items\, \experiments_templates\) because \prune:entries\ loops over each \EntityType\ and calls \EntityPruner\ for each.

Fixes #6952.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of deleted entities by removing associated tag relationships before deleting entity records.
  * Improved filtering and deletion reliability during cleanup.
  * Added safeguards to prevent partial cleanup results when an error occurs.
  * Cleanup now safely rolls back changes if an unexpected failure occurs.

* **Tests**
  * Added coverage verifying that pruning removes both deleted entities and their associated tag relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->