### PR TITLE
fix: make empty checkbox values searchable

### DIFF
--- a/src/Services/AdvancedSearchQuery/Visitors/QueryBuilderVisitor.php
+++ b/src/Services/AdvancedSearchQuery/Visitors/QueryBuilderVisitor.php
@@ -124,9 +124,11 @@ final class QueryBuilderVisitor implements Visitor
             'additional_columns' => $column,
         );
         // value
+        $value = $metadataField->getValue();
+        $bindValue = $value === '' ? '' : $metadataField->getAffix() . $value . $metadataField->getAffix();
         $bindValues[] = array(
             'param' => $valueParam,
-            'value' => $metadataField->getAffix() . $metadataField->getValue() . $metadataField->getAffix(),
+            'value' => $bindValue,
             'additional_columns' => $column,
         );
 

--- a/src/node/grammar/queryGrammar.pegjs
+++ b/src/node/grammar/queryGrammar.pegjs
@@ -177,7 +177,7 @@ ListString1
     [^\n\r\f\\']
     / "\\'" {return "'";}
     / Escape
-  )+
+  )*
   {
     return join("", $chars);
   }
@@ -190,7 +190,7 @@ ListString2
     [^\n\r\f\\"]
     / '\\"' {return '"';}
     / Escape
-  )+
+  )*
   {
     return join("", $chars);
   }

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -107,6 +107,18 @@
                 type='text'
                 value='{{ Request.query.get('metavalue') != '' ? Request.query.get('metavalue') }}'
               />
+
+              <div class='input-group-append'>
+                <button
+                  type='button'
+                  class='btn btn-secondary'
+                  data-action='search-empty-extrafield'
+                  aria-label='{{ 'Search for empty value'|trans }}'
+                  title='{{ 'Search for empty value'|trans }}'
+                >
+                  <i class='fas fa-ban'></i>
+                </button>
+              </div>
             </div>
 
             <div id='autocompleteAnchorDiv_extra_fields_keys'></div>

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -588,7 +588,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function quoteSearchToken(value: string): string {
-    if (value === '""' || value === "''") {
+    if (value === '""' || value === '\'\'') {
       return '""';
     }
 
@@ -612,7 +612,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return '';
     }
 
-    if (forceEmptyValue || value === '""' || value === "''") {
+    if (forceEmptyValue || value === '""' || value === '\'\'') {
       return `extrafield:${quoteSearchToken(key)}:""`;
     }
 

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -518,7 +518,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function buildFilterHelperRegex(filterName: string): RegExp {
-    const baseRegex = '(?:(?:"((?:\\\\"|(?:(?!")).)+)")|(?:\'((?:\\\\\'|(?:(?!\')).)+)\')|([^\\s:\'"()&|!]+))';
+    const baseRegex = '(?:(?:"((?:\\\\"|(?:(?!")).)*)")|(?:\'((?:\\\\\'|(?:(?!\')).)*)\')|([^\\s:\'"()&|!]+))';
     const operatorRegex = '(?:[<>]=?|!?=)?';
     let valueRegex = baseRegex;
 
@@ -584,10 +584,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function getSearchTokenRegexPart(): string {
-    return '(?:(?:"(?:\\\\"|[^"])+")|(?:\'(?:\\\\\'|[^\'])*\')|[^\\s:\'"()&|!]+)';
+    return '(?:(?:"(?:\\\\"|[^"])*")|(?:\'(?:\\\\\'|[^\'])*\')|[^\\s:\'"()&|!]+)';
   }
 
   function quoteSearchToken(value: string): string {
+    if (value === '""' || value === "''") {
+      return '""';
+    }
+
     const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
     if (/[\s:'"()&|!]/.test(escaped)) {
@@ -597,19 +601,23 @@ document.addEventListener('DOMContentLoaded', () => {
     return escaped;
   }
 
-  function buildExtrafieldFilter(): string {
+  function buildExtrafieldFilter(forceEmptyValue = false): string {
     const metakey = document.getElementById('metakey') as HTMLSelectElement | null;
     const metavalue = document.getElementById('metavalue') as HTMLInputElement | null;
 
     const key = metakey?.value.trim() ?? '';
     const value = metavalue?.value.trim() ?? '';
 
-    if (key === '' && value === '') {
+    if (key === '') {
       return '';
     }
 
-    if (key === '' || value === '') {
-      return `extrafield:${quoteSearchToken(key || value)}`;
+    if (forceEmptyValue || value === '""' || value === "''") {
+      return `extrafield:${quoteSearchToken(key)}:""`;
+    }
+
+    if (value === '') {
+      return '';
     }
 
     return `extrafield:${quoteSearchToken(key)}:${quoteSearchToken(value)}`;
@@ -623,12 +631,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // extrafield:Manufacturer:abc
     // extrafield:Manufacturer:"abc"
     // extrafield:"Some Field":"abc"
+    // extrafield:"Some Field":""
     return new RegExp(`(^|\\s)extrafield:${token}(?::${token})?\\s?`);
   }
 
-  function syncExtrafieldFilterToSearchQuery(): void {
+  function syncExtrafieldFilterToSearchQuery(forceEmptyValue = false): void {
     const curVal = get(searchQuery);
-    const filter = buildExtrafieldFilter();
+    const filter = buildExtrafieldFilter(forceEmptyValue);
     const regex = buildExtrafieldRegex();
 
     if (regex.test(curVal)) {
@@ -828,6 +837,19 @@ document.addEventListener('DOMContentLoaded', () => {
       el.classList.remove('selected');
     });
     el.classList.add('selected');
+  });
+
+  on('search-empty-extrafield', () => {
+    const metakey = document.getElementById('metakey') as HTMLSelectElement | null;
+    const metavalue = document.getElementById('metavalue') as HTMLInputElement | null;
+    const key = metakey?.value.trim() ?? '';
+    if (key === '') {
+      return;
+    }
+    if (metavalue) {
+      metavalue.value = '';
+    }
+    syncExtrafieldFilterToSearchQuery(true);
   });
 
   // CHECK AN ENTITY BOX

--- a/tests/cypress/integration/extendedSearch.cy.ts
+++ b/tests/cypress/integration/extendedSearch.cy.ts
@@ -23,6 +23,7 @@ describe('Search', () => {
 
   it('Searches an experiment with an unchecked and checked checkbox using extended metadata syntax', () => {
     const fieldName = 'Approved';
+
     // create experiment with unchecked checkbox
     cy.createEntity().then(() => {
       cy.get('#documentTitle').invoke('text').then((titleUnchecked) => {
@@ -34,9 +35,11 @@ describe('Search', () => {
           cy.get('#documentTitle').invoke('text').then((titleChecked) => {
             const trimmedTitleChecked = titleChecked.trim();
             cy.addMetadataField(fieldName, 'checkbox');
-            // check the checkbox
+
+            // check the checkbox and wait for the PATCH update to complete
+            cy.intercept('PATCH', '**/api/v2/experiments/*').as('patchExp');
             cy.get(`input[type="checkbox"][data-field="${fieldName}"]`).click();
-            cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
+            cy.wait('@patchExp');
 
             // 1. Search for empty/unchecked value
             cy.visit('experiments.php');

--- a/tests/cypress/integration/extendedSearch.cy.ts
+++ b/tests/cypress/integration/extendedSearch.cy.ts
@@ -20,4 +20,46 @@ describe('Search', () => {
       });
     });
   });
+
+  it('Searches an experiment with an unchecked and checked checkbox using extended metadata syntax', () => {
+    const fieldName = 'Approved';
+    // create experiment with unchecked checkbox
+    cy.createEntity().then(() => {
+      cy.get('#documentTitle').invoke('text').then((titleUnchecked) => {
+        const trimmedTitleUnchecked = titleUnchecked.trim();
+        cy.addMetadataField(fieldName, 'checkbox');
+
+        // create second experiment with checked checkbox
+        cy.createEntity().then(() => {
+          cy.get('#documentTitle').invoke('text').then((titleChecked) => {
+            const trimmedTitleChecked = titleChecked.trim();
+            cy.addMetadataField(fieldName, 'checkbox');
+            // check the checkbox
+            cy.get(`input[type="checkbox"][data-field="${fieldName}"]`).click();
+            cy.get('.overlay').first().should('be.visible').should('contain', 'Saved');
+
+            // 1. Search for empty/unchecked value
+            cy.visit('experiments.php');
+            const emptyQuery = `extrafield:"${fieldName}":""`;
+            cy.get('#extendedArea').should('be.visible').type(`${emptyQuery}{enter}`);
+            cy.url().should('include', 'q=');
+
+            // Unchecked experiment should be visible, checked should not
+            cy.get('#itemList').should('be.visible').contains(trimmedTitleUnchecked).should('exist');
+            cy.get('#itemList').contains(trimmedTitleChecked).should('not.exist');
+
+            // 2. Search for checked value ("on")
+            cy.visit('experiments.php');
+            const checkedQuery = `extrafield:"${fieldName}":on`;
+            cy.get('#extendedArea').should('be.visible').type(`${checkedQuery}{enter}`);
+            cy.url().should('include', 'q=');
+
+            // Checked experiment should be visible, unchecked should not
+            cy.get('#itemList').should('be.visible').contains(trimmedTitleChecked).should('exist');
+            cy.get('#itemList').contains(trimmedTitleUnchecked).should('not.exist');
+          });
+        });
+      });
+    });
+  });
 });

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -18,6 +18,7 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
 
 use function implode;
+use function sprintf;
 
 class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/services/AdvancedSearchQueryTest.php
+++ b/tests/unit/services/AdvancedSearchQueryTest.php
@@ -153,4 +153,40 @@ class AdvancedSearchQueryTest extends \PHPUnit\Framework\TestCase
         $advancedSearchQuery->getWhereClause();
         $this->assertEmpty($advancedSearchQuery->getException());
     }
+
+    public function testExtraFieldEmptyValues(): void
+    {
+        $queries = array(
+            'extrafield:Approved:""',
+            'extrafield:\'Approved\':\'\'',
+            'extrafield:s:Approved:""',
+            '!extrafield:Approved:""',
+        );
+
+        foreach ($queries as $query) {
+            $advancedSearchQuery = new AdvancedSearchQuery($query, new VisitorParameters(
+                'experiments',
+                $this->groups,
+            ));
+            $whereClause = $advancedSearchQuery->getWhereClause();
+            $this->assertIsArray($whereClause);
+            $this->assertEmpty($advancedSearchQuery->getException(), sprintf('Expected no exception for query: %s', $query));
+            $this->assertStringContainsString('JSON_UNQUOTE(JSON_EXTRACT(LOWER(entity.metadata), LOWER(', $whereClause['where']);
+
+            $bindValues = $whereClause['bindValues'];
+            $this->assertCount(2, $bindValues);
+            $pathBind = null;
+            $valueBind = null;
+            foreach ($bindValues as $bind) {
+                if ($bind['value'] === '$.extra_fields."Approved".value') {
+                    $pathBind = $bind;
+                } else {
+                    $valueBind = $bind;
+                }
+            }
+            $this->assertNotNull($pathBind);
+            $this->assertNotNull($valueBind);
+            $this->assertSame('', $valueBind['value'], sprintf('Expected empty string value bind without wildcard for query: %s', $query));
+        }
+    }
 }


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have added tests for any new features.
- [x] I have mentioned the related issue (if applicable).
- [x] I have updated or verified the relevant documentation (in documentation directory).

---

## Description

Closes #7160.

Unchecked checkbox custom fields are stored with an empty value (`""`), but the advanced search syntax could not represent or search for an empty custom-field value.

As a result, checked checkbox fields could be searched using `on`, while unchecked checkbox fields could not be searched.

### Solution

This PR introduces a targeted, backward-compatible fix:

- Allows empty quoted custom-field values such as `extrafield:"Approved":""`
- Adds a **Search for empty value** action to the custom-field filter
- Makes empty-value searches match fields whose stored value is exactly `""`
- Preserves existing behavior for non-empty values such as `extrafield:Approved:on`
- Supports empty-value searches with strict and negated queries
- Adds regression tests covering the new behavior

This also addresses the related empty extra-field search limitation described in #5227.

The existing checkbox storage format is unchanged, and no new custom-field type or database migration is introduced.

### Example

For a checkbox custom field named `Approved`:

```text
Checked:
extrafield:Approved:on

Unchecked:
extrafield:"Approved":""

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for searching custom fields with empty values.
  - Added a dedicated action to find records where a custom field is blank.
  - Empty quoted search terms are now accepted.

- **Bug Fixes**
  - Improved handling of empty metadata values while preserving existing behavior for non-empty values.
  - Improved empty-value searches for checkbox fields and negated queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->