### PR TITLE
bug/minor: admin panel: fix tag count

### DIFF
--- a/containers/elabtmp/docker-compose.yml
+++ b/containers/elabtmp/docker-compose.yml
@@ -3,11 +3,13 @@ networks:
     name: elabftw-net
 services:
   web:
-    image: elabtmp
+    image: elabftw/elabtmp:edge
     user: 1000:1000
     build:
       context: ../..
       dockerfile: ./containers/elabtmp/Dockerfile
+      args:
+        - ELABIMG_TAG=edge
     container_name: elabtmp
     cap_drop:
       - ALL

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 223;
+    public const int REQUIRED_SCHEMA = 224;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Models/TeamTags.php
+++ b/src/Models/TeamTags.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Enums\State;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
@@ -80,11 +81,21 @@ final class TeamTags extends AbstractRest
     #[Override]
     public function readOne(): array
     {
-        $sql = 'SELECT tags.id, (tags_id IS NOT NULL) AS is_favorite, COUNT(tags2entity.id) AS item_count, tags.tag, tags.team
+        $sql = "SELECT tags.id, (tags_id IS NOT NULL) AS is_favorite,
+            COUNT(CASE
+                WHEN COALESCE(experiments.state, experiments_templates.state, items.state, items_types.state) <> :deleted_state
+                THEN tags2entity.id
+            END) AS item_count,
+            tags.tag, tags.team
             FROM tags LEFT JOIN tags2entity ON tags2entity.tag_id = tags.id
+            LEFT JOIN experiments ON (tags2entity.item_type = 'experiments' AND experiments.id = tags2entity.item_id)
+            LEFT JOIN experiments_templates ON (tags2entity.item_type = 'experiments_templates' AND experiments_templates.id = tags2entity.item_id)
+            LEFT JOIN items ON (tags2entity.item_type = 'items' AND items.id = tags2entity.item_id)
+            LEFT JOIN items_types ON (tags2entity.item_type = 'items_types' AND items_types.id = tags2entity.item_id)
             LEFT JOIN favtags2users ON (favtags2users.users_id = :userid AND favtags2users.tags_id = tags.id)
-            WHERE team = :team AND tags.id = :id HAVING tags.id IS NOT NULL';
+            WHERE tags.team = :team AND tags.id = :id HAVING tags.id IS NOT NULL";
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':deleted_state', State::Deleted->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
@@ -101,11 +112,21 @@ final class TeamTags extends AbstractRest
     {
         $queryParams ??= $this->getQueryParams();
         $query = $queryParams->getQuery()->getString('q');
-        $sql = 'SELECT tags.id, (tags_id IS NOT NULL) AS is_favorite, COUNT(tags2entity.id) AS item_count, tags.tag, tags.team
+        $sql = "SELECT tags.id, (tags_id IS NOT NULL) AS is_favorite,
+            COUNT(CASE
+                WHEN COALESCE(experiments.state, experiments_templates.state, items.state, items_types.state) <> :deleted_state
+                THEN tags2entity.id
+            END) AS item_count,
+            tags.tag, tags.team
             FROM tags LEFT JOIN tags2entity ON tags2entity.tag_id = tags.id
+            LEFT JOIN experiments ON (tags2entity.item_type = 'experiments' AND experiments.id = tags2entity.item_id)
+            LEFT JOIN experiments_templates ON (tags2entity.item_type = 'experiments_templates' AND experiments_templates.id = tags2entity.item_id)
+            LEFT JOIN items ON (tags2entity.item_type = 'items' AND items.id = tags2entity.item_id)
+            LEFT JOIN items_types ON (tags2entity.item_type = 'items_types' AND items_types.id = tags2entity.item_id)
             LEFT JOIN favtags2users ON (favtags2users.users_id = :userid AND favtags2users.tags_id = tags.id)
-            WHERE team = :team AND tags.tag LIKE :query GROUP BY tags.id ORDER BY tag';
+            WHERE tags.team = :team AND tags.tag LIKE :query GROUP BY tags.id ORDER BY tag";
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':deleted_state', State::Deleted->value, PDO::PARAM_INT);
         $req->bindParam(':userid', $this->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindParam(':team', $this->Users->userData['team'], PDO::PARAM_INT);
         $req->bindValue(':query', '%' . $query . '%');

--- a/src/sql/schema224-down.sql
+++ b/src/sql/schema224-down.sql
@@ -1,0 +1,4 @@
+-- revert schema 224
+CALL DropIdx('tags2entity', 'idx_tags2entity_tag_type_item');
+
+UPDATE config SET conf_value = 223 WHERE conf_name = 'schema';

--- a/src/sql/schema224.sql
+++ b/src/sql/schema224.sql
@@ -1,0 +1,3 @@
+-- schema 224
+ALTER TABLE `tags2entity`
+    ADD INDEX `idx_tags2entity_tag_type_item` (`tag_id`, `item_type`, `item_id`);

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -1175,7 +1175,8 @@ CREATE TABLE `tags2entity` (
   `item_id` int(10) UNSIGNED NOT NULL,
   `tag_id` int(10) UNSIGNED NOT NULL,
   `item_type` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `idx_tags2entity_tag_type_item` (`tag_id`, `item_type`, `item_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
 --

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -17,8 +17,8 @@ docker rm elab-cypress
 
 # Remove elabtmp and elab-cypress images
 # we keep mysql image because it's the official one
-docker image rm elabftw/elabimg:ci
-docker image rm elabtmp
+docker image rm elabftw/elabimg:edge
+docker image rm elabftw/elabtmp:egde
 docker image rm elab-cypress
 
 # Remove codecept files as they can cause errors between changes

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -18,7 +18,7 @@ docker rm elab-cypress
 # Remove elabtmp and elab-cypress images
 # we keep mysql image because it's the official one
 docker image rm elabftw/elabimg:edge
-docker image rm elabftw/elabtmp:egde
+docker image rm elabftw/elabtmp:edge
 docker image rm elab-cypress
 
 # Remove codecept files as they can cause errors between changes

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 
 # make sure elabftw/elabimg:ci exists locally (elabtmp depends on it)
 if ! docker image inspect elabftw/elabtmp:edge >/dev/null 2>&1; then
-    docker build -t elabftw/elabtmp --build-arg ELABIMG_TAG=edge -f containers/elabtmp/Dockerfile .
+    docker build -t elabftw/elabtmp:edge --build-arg ELABIMG_TAG=edge -f containers/elabtmp/Dockerfile .
 fi
 
 # launch a fresh environment if needed

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,8 +18,8 @@ cleanup() {
 trap cleanup EXIT
 
 # make sure elabftw/elabimg:ci exists locally (elabtmp depends on it)
-if ! docker image inspect elabftw/elabimg:ci >/dev/null 2>&1; then
-    docker build -t elabftw/elabimg:ci --build-arg BUILD_ALL=0 -f containers/elabimg/Dockerfile .
+if ! docker image inspect elabftw/elabtmp:edge >/dev/null 2>&1; then
+    docker build -t elabftw/elabtmp --build-arg ELABIMG_TAG=edge -f containers/elabtmp/Dockerfile .
 fi
 
 # launch a fresh environment if needed

--- a/tests/unit/models/TeamTagsTest.php
+++ b/tests/unit/models/TeamTagsTest.php
@@ -17,7 +17,9 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Params\TagParam;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function bin2hex;
 use function count;
+use function random_bytes;
 
 class TeamTagsTest extends \PHPUnit\Framework\TestCase
 {
@@ -50,6 +52,29 @@ class TeamTagsTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertIsArray($this->TeamTags->readAll());
         // TODO test with query
+    }
+
+    public function testDeletedEntitiesAreNotCounted(): void
+    {
+        $Experiments = $this->getFreshExperiment();
+        $Tags = new Tags($Experiments);
+        $tagId = $Tags->postAction(Action::Create, array('tag' => 'deleted entity count ' . bin2hex(random_bytes(8))));
+        $this->TeamTags->setId($tagId);
+
+        $this->assertSame(1, (int) $this->TeamTags->readOne()['item_count']);
+
+        $Experiments->patch(Action::Destroy, array());
+
+        $this->assertSame(0, (int) $this->TeamTags->readOne()['item_count']);
+
+        foreach ($this->TeamTags->readAll() as $tag) {
+            if ((int) $tag['id'] !== $tagId) {
+                continue;
+            }
+            $this->assertSame(0, (int) $tag['item_count']);
+            return;
+        }
+        $this->fail('Tag not found in team tags.');
     }
 
     public function testNoAdmin(): void


### PR DESCRIPTION
was counting deleted too
also add an index for this query
and fix local tests




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team tag counts no longer include tags linked to deleted experiments, templates, items, or item types.
  * Deleted tags remain visible with a count of zero.

* **Performance**
  * Improved tag lookup performance with a new database index.

* **Maintenance**
  * Updated the application schema to version 224.
  * Updated development and test environments to use the edge image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->