### PR TITLE
fix: only apply max-width-70 layout for item-list display mode

### DIFF
--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -280,7 +280,7 @@
 {% endif %}
 
   {% set pageSupportsWide = scriptName in ['experiments.php', 'database.php', 'templates.php', 'experiments-categories.php', 'experiments-status.php', 'resources-templates.php', 'resources-categories.php', 'resources-status.php'] %}
-  {% set enableWide = App.Request.query.get('mode') == 'show' or (pageSupportsWide and App.Users.userData.display_mode == 'it' and not App.Request.query.has('mode')) %}
+  {% set enableWide = App.Users.userData.display_mode == 'it' and (App.Request.query.get('mode') == 'show' or (pageSupportsWide and not App.Request.query.has('mode'))) %}
   <div id='realContainer' class='real-container {{ enableWide ? 'max-width-70' : '' }}'>
 
     <div id='safariWarning' hidden>


### PR DESCRIPTION
### Problem

Reported in #7302: with the same category filter, the dashboard quick link (`experiments.php?mode=show&category=…`) renders a narrow, centered layout, while the same filter built from the search page (`experiments.php?category=…`, no `mode` param) renders full width.

### Root cause

In `src/templates/head.html`, the width cap is applied when:

```twig
{% set enableWide = App.Request.query.get('mode') == 'show' or (pageSupportsWide and App.Users.userData.display_mode == 'it' and not App.Request.query.has('mode')) %}
```

#7041 added the `display_mode == 'it'` gate to the no-mode branch (tabular mode should be full width) but the `mode == 'show'` branch was left without the gate. So for a user with display mode = tabular, any URL carrying `mode=show` — which the dashboard quick links (`src/templates/dashboard.html`), the table tag links (`entities-table.jsx`), and the search form's hidden input all generate — wrongly gets the `max-width-70` (1280 px) cap, while the same view without the param is full width. This also makes the server-side initial render inconsistent with the client-side toggle in `src/ts/show.ts`, which only applies `max-width-70` for the item-list mode.

### Fix

Gate both branches on the item-list display mode (one line):

```twig
{% set enableWide = App.Users.userData.display_mode == 'it' and (App.Request.query.get('mode') == 'show' or (pageSupportsWide and not App.Request.query.has('mode'))) %}
```

Item-list users keep the exact same behavior as before (both branches); tabular users now always get full width, whichever URL they arrive from. The same line exists in 5.6.12 and master; this PR is against master.

Fixes #7302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wide-layout mode now activates only when the selected display mode supports it.
  * Explicit wide-mode requests no longer override incompatible display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->