### PR TITLE
bug/minor: make sure anonymous user is limited to public entities

### DIFF
--- a/src/Elabftw/CanSqlBuilder.php
+++ b/src/Elabftw/CanSqlBuilder.php
@@ -15,6 +15,7 @@ namespace Elabftw\Elabftw;
 use Elabftw\Enums\AccessType;
 use Elabftw\Enums\BasePermissions;
 use Elabftw\Models\TeamGroups;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 
 use function array_column;
@@ -31,6 +32,9 @@ final class CanSqlBuilder
     public function getCanFilter(): string
     {
         $sql = '';
+        if ($this->requester instanceof AnonymousUser) {
+            $sql .= ' AND ' . $this->canAnon();
+        }
         $sql .= sprintf(
             ' AND (%s)',
             implode(' OR ', array(
@@ -45,6 +49,17 @@ final class CanSqlBuilder
         );
 
         return $sql;
+    }
+
+    /**
+     * anon filter
+     */
+    protected function canAnon(): string
+    {
+        return sprintf(
+            'entity.canread_base = %d',
+            BasePermissions::Full->value,
+        );
     }
 
     /**

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -14,6 +14,7 @@ namespace Elabftw\Models;
 
 use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
+use Elabftw\Enums\BasePermissions;
 use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Links\Containers2ItemsLinks;
@@ -23,6 +24,7 @@ use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\HttpFoundation\InputBag;
 
 use function array_column;
+use function array_filter;
 use function sprintf;
 
 class StorageUnitsTest extends \PHPUnit\Framework\TestCase
@@ -98,6 +100,31 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('children_count', $result[0]);
         $this->assertArrayHasKey('occupancy', $result[0]);
         $this->assertArrayNotHasKey('entity_id', $result[0]);
+    }
+
+    public function testAnonymousUserOnlyReadsPublicEntitiesFromStorage(): void
+    {
+        $storageId = $this->StorageUnits->create('Anonymous read permission test');
+
+        $teamItem = $this->getFreshItem();
+        $teamItem->patch(Action::Update, array('canread_base' => BasePermissions::Team->value));
+        new Containers2ItemsLinks($teamItem, $storageId)->createWithQuantity(1.0, 'mL');
+
+        $publicItem = $this->getFreshItem();
+        $publicItem->patch(Action::Update, array('canread_base' => BasePermissions::Full->value));
+        new Containers2ItemsLinks($publicItem, $storageId)->createWithQuantity(1.0, 'mL');
+
+        $StorageUnitsAsAnonymous = new StorageUnits(new AnonymousUser(1), false);
+        $visibleItemIds = array_column(
+            array_filter(
+                $StorageUnitsAsAnonymous->readAll(),
+                static fn(array $row): bool => $row['page'] === 'database',
+            ),
+            'entity_id',
+        );
+
+        $this->assertNotContains($teamItem->id, $visibleItemIds);
+        $this->assertContains($publicItem->id, $visibleItemIds);
     }
 
     public function testReadAllFromStorage(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous users can now view only storage items with publicly enabled read permissions.
  * Storage items restricted to team members are hidden from anonymous access.

* **Tests**
  * Added coverage verifying anonymous users see only publicly readable storage items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->