### PR TITLE
bug/minor: fix ordering steps code, was too permissive

### DIFF
--- a/src/Models/Steps.php
+++ b/src/Models/Steps.php
@@ -14,17 +14,19 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Enums\AccessType;
+use Elabftw\Enums\EntityType;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Models\Notifications\StepDeadline;
 use Elabftw\Params\ContentParams;
+use Elabftw\Params\OrderingParams;
 use Elabftw\Params\StepParams;
 use Elabftw\Services\Filter;
 use Elabftw\Traits\SetIdTrait;
-use Elabftw\Traits\SortableTrait;
 use Override;
 use PDO;
 
+use function array_column;
 use function array_intersect;
 use function array_keys;
 use function _;
@@ -39,7 +41,6 @@ use function str_replace;
  */
 final class Steps extends AbstractRest
 {
-    use SortableTrait;
     use SetIdTrait;
 
     public function __construct(public AbstractEntity $Entity, ?int $id = null)
@@ -164,6 +165,50 @@ final class Steps extends AbstractRest
             $req->bindParam(':is_immutable', $step['is_immutable'], PDO::PARAM_INT);
             $this->Db->execute($req);
         }
+    }
+
+    /**
+     * Reorder steps belonging to the parent entity.
+     */
+    public function updateOrdering(OrderingParams $params): void
+    {
+        $this->Entity->canOrExplode(AccessType::Write);
+
+        $table = $this->Entity->entityType->value . '_steps';
+        if ($params->table->value !== $table) {
+            throw new ImproperActionException(_('The steps table does not match the entity type.'));
+        }
+
+        $steps = array_column($this->readAll(), null, 'id');
+        $enforceImmutability = in_array(
+            $this->Entity->entityType,
+            array(EntityType::Experiments, EntityType::Items),
+            true,
+        );
+        foreach ($params->ordering as $id) {
+            if (!array_key_exists($id, $steps)) {
+                throw new ImproperActionException(_('Cannot reorder a step that does not belong to this entity.'));
+            }
+            if ($enforceImmutability && (int) $steps[$id]['is_immutable'] === 1) {
+                throw new ImproperActionException(_('This step is immutable: it cannot be modified.'));
+            }
+        }
+
+        $sql = sprintf(
+            'UPDATE %s_steps SET ordering = :ordering WHERE id = :id AND item_id = :item_id',
+            $this->Entity->entityType->value,
+        );
+        $req = $this->Db->prepare($sql);
+        foreach ($params->ordering as $ordering => $id) {
+            $req->bindParam(':ordering', $ordering, PDO::PARAM_INT);
+            $req->bindParam(':id', $id, PDO::PARAM_INT);
+            $req->bindParam(':item_id', $this->Entity->id, PDO::PARAM_INT);
+            $this->Db->execute($req);
+        }
+
+        $this->Entity->touch();
+        $Changelog = new Changelog($this->Entity);
+        $Changelog->create(new ContentParams('steps', Action::Update->value));
     }
 
     #[Override]

--- a/tests/unit/models/StepsTest.php
+++ b/tests/unit/models/StepsTest.php
@@ -12,12 +12,16 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
+use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
+use Elabftw\Models\Users\AuthenticatedUser;
+use Elabftw\Params\OrderingParams;
 use Elabftw\Traits\TestsUtilsTrait;
 
 use function array_filter;
 use function array_values;
+use function count;
 
 class StepsTest extends \PHPUnit\Framework\TestCase
 {
@@ -81,6 +85,83 @@ class StepsTest extends \PHPUnit\Framework\TestCase
         $Steps->patch(Action::Notif, array());
         // update finish time_time
         $Steps->patch(Action::Update, array('finished_time' => '2022-03-23 13:37:00'));
+    }
+
+    public function testUpdateOrdering(): void
+    {
+        $first = $this->Steps->postAction(Action::Create, array('body' => 'first'));
+        $second = $this->Steps->postAction(Action::Create, array('body' => 'second'));
+        $changelogCount = count((new Changelog($this->Experiments))->readAll());
+
+        $this->Steps->updateOrdering(new OrderingParams(array(
+            'table' => 'experiments_steps',
+            'ordering' => array('step_' . $second, 'step_' . $first),
+        )));
+
+        $steps = $this->Steps->readAll();
+        $this->assertSame($second, (int) $steps[0]['id']);
+        $this->assertSame($first, (int) $steps[1]['id']);
+        $this->assertCount($changelogCount + 1, (new Changelog($this->Experiments))->readAll());
+    }
+
+    public function testCannotReorderStepFromAnotherExperiment(): void
+    {
+        $victimStep = $this->Steps->postAction(Action::Create, array('body' => 'victim'));
+        $otherSteps = new Steps($this->getFreshExperiment());
+        $params = new OrderingParams(array(
+            'table' => 'experiments_steps',
+            'ordering' => array('step_' . $victimStep),
+        ));
+
+        try {
+            $otherSteps->updateOrdering($params);
+            $this->fail('A step from another experiment was reordered.');
+        } catch (ImproperActionException) {
+            $this->assertSame($victimStep, (int) $this->Steps->readAll()[0]['id']);
+        }
+    }
+
+    public function testCannotReorderPrivateExperimentFromAnotherTeam(): void
+    {
+        $victimExperiment = $this->getFreshExperimentWithGivenUser(new AuthenticatedUser(2, 1));
+        $victimSteps = new Steps($victimExperiment);
+        $first = $victimSteps->postAction(Action::Create, array('body' => 'first'));
+        $second = $victimSteps->postAction(Action::Create, array('body' => 'second'));
+        $attacker = $this->getUserInTeam(2);
+        $params = new OrderingParams(array(
+            'table' => 'experiments_steps',
+            'ordering' => array('step_' . $second, 'step_' . $first),
+        ));
+
+        try {
+            $attackerSteps = new Steps(new Experiments($attacker, $victimExperiment->id));
+            $attackerSteps->updateOrdering($params);
+            $this->fail('A user from another team reordered private experiment steps.');
+        } catch (ForbiddenException) {
+            $steps = $victimSteps->readAll();
+            $this->assertSame($first, (int) $steps[0]['id']);
+            $this->assertSame($second, (int) $steps[1]['id']);
+        }
+    }
+
+    public function testCannotReorderImmutableExperimentStep(): void
+    {
+        $first = $this->Steps->postAction(Action::Create, array('body' => 'first'));
+        $second = $this->Steps->postAction(Action::Create, array('body' => 'second'));
+        $this->Steps->patch(Action::ForceLock, array());
+        $params = new OrderingParams(array(
+            'table' => 'experiments_steps',
+            'ordering' => array('step_' . $second, 'step_' . $first),
+        ));
+
+        try {
+            $this->Steps->updateOrdering($params);
+            $this->fail('Immutable experiment steps were reordered.');
+        } catch (ImproperActionException) {
+            $steps = $this->Steps->readAll();
+            $this->assertSame($first, (int) $steps[0]['id']);
+            $this->assertSame($second, (int) $steps[1]['id']);
+        }
     }
 
     public function testCannotPatchImmutabilityFromExperiment(): void

--- a/web/app/controllers/SortableAjaxController.php
+++ b/web/app/controllers/SortableAjaxController.php
@@ -14,6 +14,7 @@ namespace Elabftw\Elabftw;
 use Elabftw\Enums\Messages;
 use Elabftw\Enums\Orderable;
 use Elabftw\Exceptions\DatabaseErrorException;
+use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\UnauthorizedException;
@@ -29,6 +30,7 @@ use Elabftw\Models\Teams;
 use Elabftw\Models\Templates;
 use Elabftw\Models\Todolist;
 use Elabftw\Params\ExtraFieldsOrderingParams;
+use Elabftw\Params\Guard;
 use Elabftw\Params\OrderingParams;
 use Exception;
 use JsonException;
@@ -83,11 +85,19 @@ try {
             $Entity = new ItemsStatus(new Teams($App->Users));
             break;
         case Orderable::ExperimentsSteps:
-            $model = new Experiments($App->Users);
+            $entityId = Guard::getNonZeroPositiveIntValueOfRequiredParam(
+                'id',
+                (array) ($reqBody['entity'] ?? array()),
+            );
+            $model = new Experiments($App->Users, $entityId);
             $Entity = new Steps($model);
             break;
         case Orderable::ItemsSteps:
-            $model = new Items($App->Users);
+            $entityId = Guard::getNonZeroPositiveIntValueOfRequiredParam(
+                'id',
+                (array) ($reqBody['entity'] ?? array()),
+            );
+            $model = new Items($App->Users, $entityId);
             $Entity = new Steps($model);
             break;
         case Orderable::Todolist:
@@ -97,11 +107,19 @@ try {
             $Entity = new Templates($App->Users);
             break;
         case Orderable::ExperimentsTemplatesSteps:
-            $model = new Templates($App->Users);
+            $entityId = Guard::getNonZeroPositiveIntValueOfRequiredParam(
+                'id',
+                (array) ($reqBody['entity'] ?? array()),
+            );
+            $model = new Templates($App->Users, $entityId);
             $Entity = new Steps($model);
             break;
         case Orderable::ItemsTypesSteps:
-            $model = new ItemsTypes($App->Users);
+            $entityId = Guard::getNonZeroPositiveIntValueOfRequiredParam(
+                'id',
+                (array) ($reqBody['entity'] ?? array()),
+            );
+            $model = new ItemsTypes($App->Users, $entityId);
             $Entity = new Steps($model);
             break;
         default:
@@ -114,7 +132,7 @@ try {
         'res' => false,
         'msg' => Messages::InsufficientPermissions->toHuman(),
     ));
-} catch (ImproperActionException | UnauthorizedException $e) {
+} catch (ForbiddenException | ImproperActionException | UnauthorizedException $e) {
     $Response->setData(array(
         'res' => false,
         'msg' => $e->getMessage(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reordering steps within supported experiments and resources.
  - Reordering now records the updated order and activity history.

- **Bug Fixes**
  - Improved validation prevents invalid, cross-entity, or unauthorized step reordering.
  - Protected immutable steps from being reordered.
  - Improved handling of invalid or unauthorized ordering requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->