### PR TITLE
bug/minor: auth: fix device token validation

### DIFF
--- a/src/Models/AuthFail.php
+++ b/src/Models/AuthFail.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Auth\DeviceToken;
+use Elabftw\Auth\DeviceTokenValidator;
 use Elabftw\Elabftw\Db;
 use PDO;
 
@@ -32,6 +34,7 @@ final class AuthFail
      */
     public function register(): bool
     {
+        $this->validateDeviceToken();
         $this->create();
         if ($this->deviceToken === null) {
             return $this->countAndLockUser();
@@ -53,6 +56,21 @@ final class AuthFail
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
+    }
+
+    private function validateDeviceToken(): void
+    {
+        if ($this->deviceToken === null) {
+            return;
+        }
+        $validator = new DeviceTokenValidator(
+            DeviceToken::getConfig(),
+            $this->deviceToken,
+            $this->userid,
+        );
+        if (!$validator->validate()) {
+            $this->deviceToken = null;
+        }
     }
 
     /**

--- a/tests/unit/models/AuthFailTest.php
+++ b/tests/unit/models/AuthFailTest.php
@@ -34,6 +34,31 @@ class AuthFailTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($AuthFail->register());
     }
 
+    public function testInvalidDeviceTokenFallsBackToUserLockout(): void
+    {
+        $AuthFail = new AuthFail(0, 1, 'attacker-controlled');
+        $lockedDevices = $AuthFail->getLockoutDevicesCount();
+
+        $this->assertTrue($AuthFail->register());
+        $this->assertSame(
+            $lockedDevices,
+            $AuthFail->getLockoutDevicesCount(),
+        );
+    }
+
+    public function testDeviceTokenForAnotherUserFallsBackToUserLockout(): void
+    {
+        $deviceToken = DeviceToken::getToken(2);
+        $AuthFail = new AuthFail(0, 1, $deviceToken);
+        $lockedDevices = $AuthFail->getLockoutDevicesCount();
+
+        $this->assertTrue($AuthFail->register());
+        $this->assertSame(
+            $lockedDevices,
+            $AuthFail->getLockoutDevicesCount(),
+        );
+    }
+
     public function testLockDevice(): void
     {
         $DeviceToken = new DeviceToken();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or mismatched device tokens are now handled as user-level authentication failures.
  - Prevents invalid device tokens from incorrectly triggering device lockouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->