### PR TITLE
bug/minor: prevent anonymous user compounds read api

### DIFF
--- a/src/Models/Compounds.php
+++ b/src/Models/Compounds.php
@@ -23,6 +23,7 @@ use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\FingerprinterInterface;
 use Elabftw\Interfaces\QueryParamsInterface;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\BaseQueryParams;
 use Elabftw\Params\CompoundParams;
@@ -90,6 +91,7 @@ final class Compounds extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        $this->canReadOrExplode();
         $queryParams ??= $this->getQueryParams();
         if (!empty($queryParams->getQuery()->get('search_pubchem_cid'))) {
             return $this->searchPubChem($queryParams->getQuery()->getInt('search_pubchem_cid'))->toArray();
@@ -160,6 +162,7 @@ final class Compounds extends AbstractRest
     #[Override]
     public function readOne(): array
     {
+        $this->canReadOrExplode();
         $sql = $this->getSelectBeforeWhere() . ' WHERE entity.id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
@@ -530,6 +533,13 @@ final class Compounds extends AbstractRest
     protected function canWriteOrExplode(): void
     {
         if (!$this->canWrite()) {
+            throw new IllegalActionException();
+        }
+    }
+
+    private function canReadOrExplode(): void
+    {
+        if ($this->requester instanceof AnonymousUser) {
             throw new IllegalActionException();
         }
     }

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -85,6 +85,20 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode());
     }
 
+    public function testAnonymousUserCannotReadCompounds(): void
+    {
+        foreach (array('/api/v2/compounds', '/api/v2/compounds/1') as $uri) {
+            $Controller = new Apiv2Controller(
+                new AnonymousUser(1),
+                Request::create($uri, 'GET'),
+            );
+
+            $res = $Controller->getResponse();
+
+            self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode());
+        }
+    }
+
     public function testCannotReadAnotherTeamsSubmodel(): void
     {
         $Controller = new Apiv2Controller(

--- a/tests/unit/models/CompoundsTest.php
+++ b/tests/unit/models/CompoundsTest.php
@@ -18,6 +18,7 @@ use Elabftw\Enums\Storage;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Links\Compounds2ExperimentsLinks;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Services\HttpGetter;
 use Elabftw\Services\NullFingerprinter;
@@ -161,6 +162,24 @@ class CompoundsTest extends \PHPUnit\Framework\TestCase
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/compounds/', $this->Compounds->getApiPath());
+    }
+
+    public function testAnonymousUserCannotReadAll(): void
+    {
+        $Compounds = new Compounds($this->httpGetter, new AnonymousUser(1), new NullFingerprinter(), false);
+
+        $this->expectException(IllegalActionException::class);
+
+        $Compounds->readAll();
+    }
+
+    public function testAnonymousUserCannotReadOne(): void
+    {
+        $Compounds = new Compounds($this->httpGetter, new AnonymousUser(1), new NullFingerprinter(), false, 1);
+
+        $this->expectException(IllegalActionException::class);
+
+        $Compounds->readOne();
     }
 
     public function testReadAll(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted anonymous visitors from reading compound collections and individual compound details.
  * Anonymous access attempts now receive a forbidden response.

* **Tests**
  * Added coverage confirming access is denied for both collection and individual compound requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->