### PR TITLE
bug/minor: fix archived admin authorization

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -453,7 +453,7 @@ class Users extends AbstractRest
     public function isAdminSomewhere(): bool
     {
         // TODO use the existing userData instead of making a query
-        $sql = 'SELECT users_id FROM users2teams WHERE users_id = :userid AND is_admin = 1';
+        $sql = 'SELECT users_id FROM users2teams WHERE users_id = :userid AND is_admin = 1 AND is_archived = 0';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $this->userData['userid'], PDO::PARAM_INT);
         $this->Db->execute($req);
@@ -596,7 +596,8 @@ class Users extends AbstractRest
                     ON (u1.teams_id = u2.teams_id)
                 WHERE u1.users_id = :admin_userid
                     AND u2.users_id = :user_userid
-                    AND u1.is_admin = 1';
+                    AND u1.is_admin = 1
+                    AND u1.is_archived = 0';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':admin_userid', $this->getUserid(), PDO::PARAM_INT);
         $req->bindParam(':user_userid', $userid, PDO::PARAM_INT);

--- a/src/Services/TeamsHelper.php
+++ b/src/Services/TeamsHelper.php
@@ -64,7 +64,8 @@ final class TeamsHelper
     {
         $sql = 'SELECT `is_admin` FROM `users2teams`
             WHERE `teams_id` = :team
-                AND `users_id` = :userid';
+                AND `users_id` = :userid
+                AND `is_archived` = 0';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
@@ -89,7 +90,7 @@ final class TeamsHelper
 
     public function getUserInTeam(int $userid): array
     {
-        $sql = 'SELECT `users_id`, `is_admin` FROM `users2teams` WHERE `teams_id` = :team AND `users_id` = :userid';
+        $sql = 'SELECT `users_id`, `is_admin` FROM `users2teams` WHERE `teams_id` = :team AND `users_id` = :userid AND `is_archived` = 0';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -56,6 +56,29 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
         $Team1->readOne();
     }
 
+    public function testArchivedAdminCannotAccessTeamByExplicitId(): void
+    {
+        $admin = $this->getUserInTeam(team: 2, admin: 1);
+        $this->updateArchiveStatus($admin->userid, 1);
+        try {
+            $Teams = new Teams($admin, 2);
+            try {
+                $Teams->readOne();
+                $this->fail('Archived membership allowed reading the team.');
+            } catch (ImproperActionException) {
+                $this->addToAssertionCount(1);
+            }
+            try {
+                $Teams->canWriteOrExplode();
+                $this->fail('Archived admin membership allowed writing the team.');
+            } catch (IllegalActionException) {
+                $this->addToAssertionCount(1);
+            }
+        } finally {
+            $this->updateArchiveStatus($admin->userid, 0);
+        }
+    }
+
     public function testCanWriteOrExplode(): void
     {
         $Teams = new Teams($this->getUserInTeam(1));

--- a/tests/unit/models/Users2TeamsTest.php
+++ b/tests/unit/models/Users2TeamsTest.php
@@ -13,6 +13,7 @@ namespace Elabftw\Models;
 
 use Elabftw\Elabftw\NullLocalPassword;
 use Elabftw\Enums\Action;
+use Elabftw\Enums\Usergroup;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
@@ -89,6 +90,53 @@ class Users2TeamsTest extends \PHPUnit\Framework\TestCase
             'content' => 0,
         );
         $this->assertEquals(0, $this->Users2Teams->patchUser2Team($params, 2));
+    }
+
+    public function testArchivedAdminCannotUnarchiveOwnMembership(): void
+    {
+        $sysadmin = new Users(1, 1);
+        $attackerUserid = $sysadmin->createOne(
+            'archived-admin-authorization@example.com',
+            array(1, 2),
+            new NullLocalPassword(),
+            usergroup: Usergroup::User,
+            automaticValidationEnabled: true,
+            alertAdmin: false,
+        );
+        $SysadminUsers2Teams = new Users2Teams($sysadmin);
+        $SysadminUsers2Teams->patchUser2Team(array(
+            'team' => 2,
+            'target' => 'is_admin',
+            'content' => 1,
+        ), $attackerUserid);
+        $SysadminUsers2Teams->patchUser2Team(array(
+            'team' => 2,
+            'target' => 'is_archived',
+            'content' => 1,
+        ), $attackerUserid);
+
+        // The requester remains active in team 1, but their archived admin row
+        // in team 2 must not authorize an explicit team 2 operation.
+        $attacker = new Users($attackerUserid, 1);
+        try {
+            try {
+                (new Users2Teams($attacker))->patchUser2Team(array(
+                    'team' => 2,
+                    'target' => 'is_archived',
+                    'content' => 0,
+                ), $attackerUserid);
+                $this->fail('Archived admin was able to unarchive their own membership.');
+            } catch (IllegalActionException) {
+                $this->addToAssertionCount(1);
+            }
+        } finally {
+            $SysadminUsers2Teams->patchUser2Team(array(
+                'team' => 2,
+                'target' => 'is_archived',
+                'content' => 0,
+            ), $attackerUserid);
+            (new Users($attackerUserid, 1, $sysadmin))->destroy();
+        }
     }
 
     public function testPatchIsOwner(): void

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -196,6 +196,22 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($admin2->isAdminOf(2));
     }
 
+    public function testArchivedRequesterIsNotAnAdmin(): void
+    {
+        $admin = $this->getUserInTeam(team: 2, admin: 1);
+        $target = $this->getUserInTeam(team: 2);
+        $this->assertTrue($admin->isAdminSomewhere());
+        $this->assertTrue($admin->isAdminOf($target->userid));
+
+        $this->updateArchiveStatus($admin->userid, 1);
+        try {
+            $this->assertFalse($admin->isAdminSomewhere());
+            $this->assertFalse($admin->isAdminOf($target->userid));
+        } finally {
+            $this->updateArchiveStatus($admin->userid, 0);
+        }
+    }
+
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/users/', $this->Users->getApiPath());

--- a/tests/unit/services/TeamsHelperTest.php
+++ b/tests/unit/services/TeamsHelperTest.php
@@ -38,6 +38,25 @@ class TeamsHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Usergroup::Admin, $TeamsHelper->getGroup());
     }
 
+    public function testArchivedMembershipDoesNotGrantTeamAuthorization(): void
+    {
+        $admin = $this->getUserInTeam(team: 2, admin: 1);
+        $TeamsHelper = new TeamsHelper(2);
+        $this->assertTrue($TeamsHelper->isAdmin($admin->userid));
+        $this->assertTrue($TeamsHelper->isAdminInTeam($admin->userid));
+        $this->assertTrue($TeamsHelper->isUserInTeam($admin->userid));
+
+        $this->updateArchiveStatus($admin->userid, 1);
+        try {
+            $this->assertFalse($TeamsHelper->isAdmin($admin->userid));
+            $this->assertSame(array(), $TeamsHelper->getUserInTeam($admin->userid));
+            $this->assertFalse($TeamsHelper->isAdminInTeam($admin->userid));
+            $this->assertFalse($TeamsHelper->isUserInTeam($admin->userid));
+        } finally {
+            $this->updateArchiveStatus($admin->userid, 0);
+        }
+    }
+
     public function testIsActiveUserInTeam(): void
     {
         $target = $this->getRandomUserInTeam(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived team memberships are no longer treated as active administrator access.
  - Archived administrators can no longer read or modify teams through direct access.
  - Archived memberships no longer grant team authorization or allow users to restore their own access.

- **Tests**
  - Added coverage to verify administrator permissions are correctly removed when memberships are archived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->