### PR TITLE
bug/minor: fix access key still valid on deleted entries

### DIFF
--- a/src/Services/AccessKeyHelper.php
+++ b/src/Services/AccessKeyHelper.php
@@ -14,6 +14,7 @@ namespace Elabftw\Services;
 
 use Elabftw\Elabftw\Db;
 use Elabftw\Enums\EntityType;
+use Elabftw\Enums\State;
 use PDO;
 
 use function is_int;
@@ -32,9 +33,10 @@ final class AccessKeyHelper
 
     public function getIdFromAccessKey(string $ak): int
     {
-        $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE access_key = :ak';
+        $sql = 'SELECT id FROM ' . $this->entityType->value . ' WHERE access_key = :ak AND state != :deleted';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':ak', $ak);
+        $req->bindValue(':deleted', State::Deleted->value, PDO::PARAM_INT);
         $this->Db->execute($req);
         return (int) $req->fetchColumn();
     }

--- a/tests/unit/services/AccessKeyHelperTest.php
+++ b/tests/unit/services/AccessKeyHelperTest.php
@@ -29,5 +29,9 @@ class AccessKeyHelperTest extends \PHPUnit\Framework\TestCase
         // now remove ak
         $AkHelper->toggleAccessKey();
         $this->assertEquals(0, $AkHelper->getIdFromAccessKey($ak));
+        // a soft-deleted entity must not be resolved from its old access key
+        $ak = $AkHelper->toggleAccessKey();
+        $Entity->destroy();
+        $this->assertEquals(0, $AkHelper->getIdFromAccessKey($ak));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Access keys associated with deleted records are no longer resolved, preventing access to unavailable entities.
* **Tests**
  * Added coverage confirming deleted records cannot be retrieved through their access keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->