### PR TITLE
feat: ui: remove save button from tinymce

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -202,7 +202,7 @@ const imagesUploadHandler = (blobInfo: TinyMCEBlobInfo) => new Promise((resolve,
 // options for tinymce to pass to tinymce.init()
 export function getTinymceBaseConfig(page: string): object {
   let plugins = 'accordion advlist anchor autolink autoresize table searchreplace code fullscreen insertdatetime charmap lists save image media link pagebreak codesample template mention visualblocks visualchars emoticons preview';
-  let toolbar1 = 'custom-save preview | undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link | sort-table';
+  let toolbar1 = 'preview | undo redo | styles fontsize bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | superscript subscript | bullist numlist outdent indent | forecolor backcolor | charmap emoticons adddate | codesample | link | sort-table';
   let removedMenuItems = 'newdocument, image, anchor';
   let fileMenuItems = 'preview | print';
   if (page === 'edit') {
@@ -423,13 +423,6 @@ export function getTinymceBaseConfig(page: string): object {
         tooltip: 'Insert timestamp',
         onAction: function() {
           editor.insertContent(`${getDatetime()} `);
-        },
-      });
-      editor.ui.registry.addButton('custom-save', {
-        icon: 'customSave',
-        tooltip: 'Save',
-        onAction: function() {
-          editor.execCommand('mceSave');
         },
       });
       // save and go back button for toolbar, inside "File" menu.


### PR DESCRIPTION
there is now always the big blue save icon on top
fix #7303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the custom save button from the TinyMCE toolbar.
  * Saving remains available through the existing menu option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->