### PR TITLE
feat: optional per-value labels for multi-value extra fields

### DIFF
--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -34,6 +34,7 @@ use function _;
 use function array_key_exists;
 use function in_array;
 use function trim;
+use function array_values;
 
 /**
  * Twig filters

--- a/src/Elabftw/TwigFilters.php
+++ b/src/Elabftw/TwigFilters.php
@@ -131,11 +131,20 @@ final class TwigFilters
 
                 if (is_array($value)) {
                     $html = '';
-                    foreach ($value as $item) {
+                    $valueLabels = $field['value_labels'] ?? array();
+                    foreach (array_values($value) as $index => $item) {
+                        $label = '';
+                        if (isset($valueLabels[$index]) && is_string($valueLabels[$index]) && $valueLabels[$index] !== '') {
+                            $label = sprintf(
+                                '<span class="badge badge-pill badge-light ml-2">%s</span>',
+                                Tools::eLabHtmlspecialchars($valueLabels[$index]),
+                            );
+                        }
                         $html .= sprintf(
-                            '<p>%s%s</p>',
+                            '<p>%s%s%s</p>',
                             self::formatMetadataValue($metadataType, $item, $newTab),
                             $unit,
+                            $label,
                         );
                     }
                     $value = $html;

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -1542,6 +1542,25 @@ abstract class AbstractEntity extends AbstractRest
     // Update only one field in the metadata json
     private function updateJsonField(string $key, string|array|int|float $value): bool
     {
+        $hasValueLabels = false;
+        $valueLabels = null;
+        if (is_array($value) && array_key_exists('value_labels', $value)) {
+            if (!array_key_exists('value', $value)) {
+                throw new ImproperActionException(sprintf(_('Invalid metadata value for field %s.'), $key));
+            }
+            $valueLabels = $value['value_labels'];
+            if ($valueLabels !== null && !is_array($valueLabels)) {
+                throw new ImproperActionException(sprintf(_('Metadata field %s has invalid value labels.'), $key));
+            }
+            foreach ($valueLabels ?? array() as $label) {
+                if (!is_string($label)) {
+                    throw new ImproperActionException(sprintf(_('Metadata field %s has invalid value labels.'), $key));
+                }
+            }
+            $hasValueLabels = true;
+            $value = $value['value'];
+        }
+
         $extraFields = new Metadata($this->entityData['metadata'] ?? null)->getExtraFields();
         if (!array_key_exists($key, $extraFields)) {
             throw new ImproperActionException(sprintf(_('Invalid metadata field %s.'), $key));
@@ -1578,11 +1597,35 @@ abstract class AbstractEntity extends AbstractRest
             json_encode($key, JSON_HEX_APOS | JSON_THROW_ON_ERROR)
         );
 
-        // the CAST as json is necessary to avoid double encoding
-        $sql = 'UPDATE ' . $this->entityType->value . ' SET metadata = JSON_SET(metadata, :field, CAST(:value AS JSON)) WHERE id = :id';
+        // The CAST as json is necessary to avoid double encoding. When labels
+        // are supplied, update both arrays in the same SQL expression so a
+        // concurrent metadata change cannot leave value and value_labels out
+        // of sync.
+        $metadataExpression = 'JSON_SET(metadata, :field, CAST(:value AS JSON))';
+        if ($hasValueLabels) {
+            $labelsField = sprintf(
+                '$.%s.%s.value_labels',
+                MetadataEnum::ExtraFields->value,
+                json_encode($key, JSON_HEX_APOS | JSON_THROW_ON_ERROR)
+            );
+            if ($valueLabels === null) {
+                $metadataExpression = 'JSON_REMOVE(' . $metadataExpression . ', :labelsField)';
+            } else {
+                $labels = json_encode($valueLabels, JSON_HEX_APOS | JSON_THROW_ON_ERROR);
+                $metadataExpression = 'JSON_SET(' . $metadataExpression . ', :labelsField, CAST(:labels AS JSON))';
+            }
+        }
+
+        $sql = 'UPDATE ' . $this->entityType->value . ' SET metadata = ' . $metadataExpression . ' WHERE id = :id';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':field', $field);
         $req->bindValue(':value', $value);
+        if ($hasValueLabels) {
+            $req->bindParam(':labelsField', $labelsField);
+            if ($valueLabels !== null) {
+                $req->bindValue(':labels', $labels);
+            }
+        }
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         return $this->Db->execute($req);
     }

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -1611,7 +1611,6 @@ abstract class AbstractEntity extends AbstractRest
             if ($valueLabels === null) {
                 $metadataExpression = 'JSON_REMOVE(' . $metadataExpression . ', :labelsField)';
             } else {
-                $labels = json_encode($valueLabels, JSON_HEX_APOS | JSON_THROW_ON_ERROR);
                 $metadataExpression = 'JSON_SET(' . $metadataExpression . ', :labelsField, CAST(:labels AS JSON))';
             }
         }
@@ -1623,7 +1622,7 @@ abstract class AbstractEntity extends AbstractRest
         if ($hasValueLabels) {
             $req->bindParam(':labelsField', $labelsField);
             if ($valueLabels !== null) {
-                $req->bindValue(':labels', $labels);
+                $req->bindValue(':labels', json_encode($valueLabels, JSON_HEX_APOS | JSON_THROW_ON_ERROR));
             }
         }
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -85,6 +85,7 @@ use Symfony\Component\HttpFoundation\Request;
 use ZipArchive;
 
 use function array_column;
+use function array_is_list;
 use function array_merge;
 use function implode;
 use function in_array;
@@ -1549,7 +1550,7 @@ abstract class AbstractEntity extends AbstractRest
                 throw new ImproperActionException(sprintf(_('Invalid metadata value for field %s.'), $key));
             }
             $valueLabels = $value['value_labels'];
-            if ($valueLabels !== null && !is_array($valueLabels)) {
+            if ($valueLabels !== null && (!is_array($valueLabels) || !array_is_list($valueLabels))) {
                 throw new ImproperActionException(sprintf(_('Metadata field %s has invalid value labels.'), $key));
             }
             foreach ($valueLabels ?? array() as $label) {
@@ -1571,6 +1572,12 @@ abstract class AbstractEntity extends AbstractRest
             $value,
             preserveNumericTypes: true,
         );
+        if ($hasValueLabels && $valueLabels !== null) {
+            $valueCount = is_array($value) ? count($value) : 1;
+            if (count($valueLabels) > $valueCount) {
+                throw new ImproperActionException(sprintf(_('Metadata field %s has invalid value labels.'), $key));
+            }
+        }
 
         $Changelog = new Changelog($this);
         $valueAsString = is_array($value) ? implode(', ', $value) : (string) $value;

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -108,11 +108,10 @@ export class Metadata {
 
     const multiValueHolder = el.closest('[data-purpose="multi-value-holder"]') as HTMLElement | null;
     if (multiValueHolder) {
-      const values = this.getMultiValues(multiValueHolder);
-      if (values === null) {
-        return false;
-      }
-      value = values;
+      // structural edits (add/remove row) shift value indexes: value_labels
+      // must be rebuilt together with value, so persist both via a full
+      // metadata save instead of the value-only field update.
+      return this.saveMultiValueHolder(multiValueHolder);
     }
 
     return this.updateMetadataField(fieldName, value);
@@ -390,6 +389,20 @@ export class Metadata {
     return row;
   }
 
+  /**
+   * Collect the labels of the rendered multi-value rows, index-aligned with
+   * the values. Rows without a badge yield an empty string so the
+   * value <-> label association survives add/remove/reorder operations.
+   */
+  getMultiValueLabels(holder: HTMLElement): string[] {
+    const labels: Array<string> = [];
+    for (const row of Array.from(holder.querySelectorAll<HTMLElement>('[data-purpose="multi-value-row"]'))) {
+      const badge = row.querySelector<HTMLElement>('[data-purpose="value-label"]');
+      labels.push(badge?.textContent ?? '');
+    }
+    return labels;
+  }
+
   saveMultiValueHolder(holder: HTMLElement): Promise<Response>|boolean {
     const fieldName = holder.dataset.field;
     if (!fieldName) {
@@ -399,7 +412,27 @@ export class Metadata {
     if (values === null) {
       return false;
     }
-    return this.updateMetadataField(fieldName, values);
+    // persist value and value_labels together: a value-only PATCH leaves
+    // stale labels behind after rows are removed or added.
+    return this.read().then(metadata => {
+      if (!metadata.extra_fields || !metadata.extra_fields[fieldName]) {
+        return this.updateMetadataField(fieldName, values);
+      }
+      metadata.extra_fields[fieldName].value = values;
+      const labels = this.getMultiValueLabels(holder);
+      // only keep a labels array when at least one row actually has one,
+      // so plain fields stay exactly as before
+      if (labels.some(label => label !== '')) {
+        metadata.extra_fields[fieldName].value_labels = labels;
+      } else {
+        delete metadata.extra_fields[fieldName].value_labels;
+      }
+      return this.save(metadata as ValidMetadata).then(response => {
+        this.editor.loadMetadata();
+        // re-render the fields so the UI reflects the persisted arrays
+        return this.display('edit').then(() => response);
+      });
+    });
   }
 
   getRandomId(): string {
@@ -439,15 +472,20 @@ export class Metadata {
       valueCell.append(this.generateViewableValue(properties, ''));
     } else {
       for (const [index, value] of values.entries()) {
-        valueCell.append(this.generateViewableValue(properties, value));
+        // keep each value and its label badge in a shared row container so
+        // the badge sits beside its value instead of on a separate line
+        const valueRow = document.createElement('div');
+        valueRow.classList.add('d-flex', 'align-items-center');
+        valueRow.append(this.generateViewableValue(properties, value));
         const label = properties.value_labels?.[index];
         if (label) {
           const labelBadge = document.createElement('span');
           labelBadge.classList.add('badge', 'badge-pill', 'badge-light', 'ml-2');
           labelBadge.dataset.purpose = 'value-label';
           labelBadge.textContent = label;
-          valueCell.append(labelBadge);
+          valueRow.append(labelBadge);
         }
+        valueCell.append(valueRow);
       }
     }
 

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -108,9 +108,8 @@ export class Metadata {
 
     const multiValueHolder = el.closest('[data-purpose="multi-value-holder"]') as HTMLElement | null;
     if (multiValueHolder) {
-      // structural edits (add/remove row) shift value indexes: value_labels
-      // must be rebuilt together with value, so persist both via a full
-      // metadata save instead of the value-only field update.
+      // Structural edits (add/remove row) shift value indexes: value_labels
+      // must be rebuilt together with value, so persist both in one field update.
       return this.saveMultiValueHolder(multiValueHolder);
     }
 
@@ -163,6 +162,15 @@ export class Metadata {
   updateMetadataField(fieldName: string, value: string|number|Array<string|number>): Promise<Response> {
     const params: Record<string, unknown> = {action: Action.UpdateMetadataField};
     params[fieldName] = value;
+    return ApiC.patch(`${this.entity.type}/${this.entity.id}`, params).then(response => {
+      this.editor.loadMetadata();
+      return response;
+    });
+  }
+
+  updateMultiValueMetadataField(fieldName: string, value: Array<string|number>, valueLabels: string[]|null): Promise<Response> {
+    const params: Record<string, unknown> = {action: Action.UpdateMetadataField};
+    params[fieldName] = {value, value_labels: valueLabels};
     return ApiC.patch(`${this.entity.type}/${this.entity.id}`, params).then(response => {
       this.editor.loadMetadata();
       return response;
@@ -412,27 +420,12 @@ export class Metadata {
     if (values === null) {
       return false;
     }
-    // persist value and value_labels together: a value-only PATCH leaves
-    // stale labels behind after rows are removed or added.
-    return this.read().then(metadata => {
-      if (!metadata.extra_fields || !metadata.extra_fields[fieldName]) {
-        return this.updateMetadataField(fieldName, values);
-      }
-      metadata.extra_fields[fieldName].value = values;
-      const labels = this.getMultiValueLabels(holder);
-      // only keep a labels array when at least one row actually has one,
-      // so plain fields stay exactly as before
-      if (labels.some(label => label !== '')) {
-        metadata.extra_fields[fieldName].value_labels = labels;
-      } else {
-        delete metadata.extra_fields[fieldName].value_labels;
-      }
-      return this.save(metadata as ValidMetadata).then(response => {
-        this.editor.loadMetadata();
-        // re-render the fields so the UI reflects the persisted arrays
-        return this.display('edit').then(() => response);
-      });
-    });
+    // Persist value and value_labels in one metadata JSON update. A value-only
+    // PATCH leaves stale labels behind after rows are removed or added, while
+    // a full metadata read/replace can overwrite a concurrent field update.
+    const labels = this.getMultiValueLabels(holder);
+    const valueLabels = labels.some(label => label !== '') ? labels : null;
+    return this.updateMultiValueMetadataField(fieldName, values, valueLabels);
   }
 
   getRandomId(): string {

--- a/src/ts/Metadata.class.ts
+++ b/src/ts/Metadata.class.ts
@@ -309,8 +309,8 @@ export class Metadata {
       values.push('');
     }
 
-    for (const value of values) {
-      holder.append(this.buildMultiValueRow(name, properties, value, holder));
+    for (const [index, value] of values.entries()) {
+      holder.append(this.buildMultiValueRow(name, properties, value, holder, index));
     }
 
     if (properties.readonly !== true) {
@@ -344,6 +344,7 @@ export class Metadata {
     properties: ExtraFieldProperties,
     value: string|number,
     holder: HTMLElement,
+    index?: number,
   ): HTMLElement {
     const row = document.createElement('div');
     row.dataset.purpose = 'multi-value-row';
@@ -360,6 +361,15 @@ export class Metadata {
       allow_multi_values: false,
     }));
     row.append(inputWrapper);
+
+    const label = properties.value_labels?.[index ?? -1];
+    if (label) {
+      const labelBadge = document.createElement('span');
+      labelBadge.classList.add('badge', 'badge-pill', 'badge-light', 'ml-2');
+      labelBadge.dataset.purpose = 'value-label';
+      labelBadge.textContent = label;
+      row.append(labelBadge);
+    }
 
     if (properties.readonly !== true) {
       const removeButton = document.createElement('button');
@@ -428,8 +438,16 @@ export class Metadata {
     if (values.length === 0) {
       valueCell.append(this.generateViewableValue(properties, ''));
     } else {
-      for (const value of values) {
+      for (const [index, value] of values.entries()) {
         valueCell.append(this.generateViewableValue(properties, value));
+        const label = properties.value_labels?.[index];
+        if (label) {
+          const labelBadge = document.createElement('span');
+          labelBadge.classList.add('badge', 'badge-pill', 'badge-light', 'ml-2');
+          labelBadge.dataset.purpose = 'value-label';
+          labelBadge.textContent = label;
+          valueCell.append(labelBadge);
+        }
       }
     }
 

--- a/src/ts/metadata.ts
+++ b/src/ts/metadata.ts
@@ -456,6 +456,7 @@ if (document.getElementById('metadataDiv') && entity.id) {
           // preserve properties that aren't editable in this modal
           if (prevField?.readonly === true) field['readonly'] = true;
           if (typeof prevField?.position === 'number') field['position'] = prevField.position;
+          if (Array.isArray(prevField?.value_labels)) field['value_labels'] = prevField.value_labels;
           // ensure the old extra field is replaced
           if (!json['extra_fields']) json['extra_fields'] = {};
           if (originalFieldKey && originalFieldKey !== newFieldKey) {

--- a/src/ts/metadataInterfaces.ts
+++ b/src/ts/metadataInterfaces.ts
@@ -39,6 +39,7 @@ export interface ExtraFieldProperties {
   group_id?: number;
   position?: number;
   options?: string[];
+  value_labels?: string[];
   description?: string;
   allow_multi_values?: boolean;
   required?: boolean;

--- a/tests/cypress/integration/metadata.cy.ts
+++ b/tests/cypress/integration/metadata.cy.ts
@@ -9,4 +9,48 @@ describe('Metadata Extra fields', () => {
     cy.removeMetadataField();
     cy.addUserMetadataField('Owner', 'Titi');
   });
+
+  it('Keeps multi-value labels paired after deleting a row', () => {
+    const fieldName = 'Checks';
+    const metadata = JSON.stringify({
+      extra_fields: {
+        [fieldName]: {
+          type: 'text',
+          allow_multi_values: true,
+          value: ['A', 'B'],
+          value_labels: ['labelA', 'labelB'],
+        },
+      },
+    });
+
+    cy.request({
+      method: 'POST',
+      url: '/api/v2/experiments',
+      body: { title: `Cypress labeled values ${Date.now()}` },
+    }).then(createResponse => {
+      expect(createResponse.status).to.eq(201);
+      cy.extractIdFromLocation(createResponse).then(experimentId => {
+        cy.request({
+          method: 'PATCH',
+          url: `/api/v2/experiments/${experimentId}`,
+          body: { metadata },
+        }).its('status').should('eq', 200);
+
+        cy.visit(`/experiments.php?mode=edit&id=${experimentId}`);
+        const holder = `[data-purpose="multi-value-holder"][data-field="${fieldName}"]`;
+
+        cy.get(`${holder} [data-purpose="multi-value-row"]`).should('have.length', 2);
+        cy.intercept('PATCH', `**/api/v2/experiments/${experimentId}`).as('saveMetadata');
+        cy.get(`${holder} [data-purpose="multi-value-row"]`).first().find('button').click();
+        cy.wait('@saveMetadata').its('response.statusCode').should('eq', 200);
+
+        cy.reload();
+        cy.get(`${holder} [data-purpose="multi-value-row"]`).should('have.length', 1)
+          .first().within(() => {
+            cy.get('textarea').should('have.value', 'B');
+            cy.get('[data-purpose="value-label"]').should('have.text', 'labelB');
+          });
+      });
+    });
+  });
 });

--- a/tests/cypress/integration/metadata.cy.ts
+++ b/tests/cypress/integration/metadata.cy.ts
@@ -43,13 +43,15 @@ describe('Metadata Extra fields', () => {
         cy.intercept('GET', `**/api/v2/experiments/${experimentId}`).as('readMetadata');
         cy.intercept('PATCH', `**/api/v2/experiments/${experimentId}`).as('saveMetadata');
         cy.get(`${holder} [data-purpose="multi-value-row"]`).first().find('button').click();
-        cy.wait('@readMetadata').its('response.statusCode').should('eq', 200);
-        cy.wait('@saveMetadata').its('response.statusCode').should('eq', 200);
-        // Saving refreshes both the JSON editor and the rendered fields. Wait
-        // for both reads before reloading so Firefox does not abort them.
-        cy.wait(['@readMetadata', '@readMetadata']).then(interceptions => {
-          interceptions.forEach(interception => expect(interception.response.statusCode).to.eq(200));
+        cy.wait('@saveMetadata').then(interception => {
+          expect(interception.response?.statusCode).to.eq(200);
+          expect(interception.request.body.action).to.eq('updatemetadatafield');
+          expect(interception.request.body[fieldName]).to.deep.eq({
+            value: ['B'],
+            value_labels: ['labelB'],
+          });
         });
+        cy.wait('@readMetadata').its('response.statusCode').should('eq', 200);
 
         cy.reload();
         cy.get(`${holder} [data-purpose="multi-value-row"]`).should('have.length', 1)

--- a/tests/cypress/integration/metadata.cy.ts
+++ b/tests/cypress/integration/metadata.cy.ts
@@ -40,9 +40,16 @@ describe('Metadata Extra fields', () => {
         const holder = `[data-purpose="multi-value-holder"][data-field="${fieldName}"]`;
 
         cy.get(`${holder} [data-purpose="multi-value-row"]`).should('have.length', 2);
+        cy.intercept('GET', `**/api/v2/experiments/${experimentId}`).as('readMetadata');
         cy.intercept('PATCH', `**/api/v2/experiments/${experimentId}`).as('saveMetadata');
         cy.get(`${holder} [data-purpose="multi-value-row"]`).first().find('button').click();
+        cy.wait('@readMetadata').its('response.statusCode').should('eq', 200);
         cy.wait('@saveMetadata').its('response.statusCode').should('eq', 200);
+        // Saving refreshes both the JSON editor and the rendered fields. Wait
+        // for both reads before reloading so Firefox does not abort them.
+        cy.wait(['@readMetadata', '@readMetadata']).then(interceptions => {
+          interceptions.forEach(interception => expect(interception.response.statusCode).to.eq(200));
+        });
 
         cy.reload();
         cy.get(`${holder} [data-purpose="multi-value-row"]`).should('have.length', 1)

--- a/tests/unit/classes/MetadataHelpersTest.php
+++ b/tests/unit/classes/MetadataHelpersTest.php
@@ -37,6 +37,15 @@ class MetadataHelpersTest extends \PHPUnit\Framework\TestCase
         $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
     }
 
+    public function testMergeMetadataPreservesValueLabels(): void
+    {
+        $source = '{"extra_fields":{"Checks":{"type":"checkbox","allow_multi_values":true,"value_labels":["Calibrated","Reviewed"],"value":["on","off"]}}}';
+        $incoming = '{"extra_fields":{"Checks":{"type":"text","value":["on","on"]}}}';
+        $expected = '{"extra_fields":{"Checks":{"type":"checkbox","allow_multi_values":true,"value_labels":["Calibrated","Reviewed"],"value":["on","on"]}}}';
+
+        $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));
+    }
+
     public function testMergeMetadataAddsNewFieldWithIncomingSchema(): void
     {
         $source = '{"extra_fields":{"Existing":{"type":"text","value":"old"}}}';

--- a/tests/unit/classes/MetadataHelpersTest.php
+++ b/tests/unit/classes/MetadataHelpersTest.php
@@ -40,7 +40,7 @@ class MetadataHelpersTest extends \PHPUnit\Framework\TestCase
     public function testMergeMetadataPreservesValueLabels(): void
     {
         $source = '{"extra_fields":{"Checks":{"type":"checkbox","allow_multi_values":true,"value_labels":["Calibrated","Reviewed"],"value":["on","off"]}}}';
-        $incoming = '{"extra_fields":{"Checks":{"type":"text","value":["on","on"]}}}';
+        $incoming = '{"extra_fields":{"Checks":{"type":"text","value_labels":["Incoming A","Incoming B"],"value":["on","on"]}}}';
         $expected = '{"extra_fields":{"Checks":{"type":"checkbox","allow_multi_values":true,"value_labels":["Calibrated","Reviewed"],"value":["on","on"]}}}';
 
         $this->assertJsonStringEqualsJsonString($expected, MetadataHelpers::mergeMetadata($source, $incoming));

--- a/tests/unit/classes/TwigFiltersTest.php
+++ b/tests/unit/classes/TwigFiltersTest.php
@@ -126,8 +126,8 @@ class TwigFiltersTest extends \PHPUnit\Framework\TestCase
 
         $result = TwigFilters::formatMetadata($metadataJson);
 
-        $this->assertStringContainsString('<span class="badge badge-pill badge-light ml-2">Calibrated</span>', $result);
-        $this->assertStringContainsString('<span class="badge badge-pill badge-light ml-2">Reviewed &lt;&amp;&quot; done</span>', $result);
+        $this->assertStringContainsString('<p><input class="d-block" disabled type="checkbox" checked="checked"><span class="badge badge-pill badge-light ml-2">Calibrated</span></p>', $result);
+        $this->assertStringContainsString('<p><input class="d-block" disabled type="checkbox"><span class="badge badge-pill badge-light ml-2">Reviewed &lt;&amp;&quot; done</span></p>', $result);
     }
 
     public function testFormatMetadataWithMultipleValuesForAllTypes(): void

--- a/tests/unit/classes/TwigFiltersTest.php
+++ b/tests/unit/classes/TwigFiltersTest.php
@@ -111,6 +111,25 @@ class TwigFiltersTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, TwigFilters::formatMetadata($metadataJson));
     }
 
+    public function testFormatMetadataWithMultiValueLabels(): void
+    {
+        $metadataJson = '{
+          "extra_fields": {
+            "checks": {
+              "type": "checkbox",
+              "allow_multi_values": true,
+              "value": ["on", "off"],
+              "value_labels": ["Calibrated", "Reviewed <&\\" done"]
+            }
+          }
+        }';
+
+        $result = TwigFilters::formatMetadata($metadataJson);
+
+        $this->assertStringContainsString('<span class="badge badge-pill badge-light ml-2">Calibrated</span>', $result);
+        $this->assertStringContainsString('<span class="badge badge-pill badge-light ml-2">Reviewed &lt;&amp;&quot; done</span>', $result);
+    }
+
     public function testFormatMetadataWithMultipleValuesForAllTypes(): void
     {
         $metadataJson = '{

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -455,6 +455,72 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayNotHasKey('value_labels', $decoded['extra_fields']['multitext']);
     }
 
+    public function testUpdateJsonFieldAcceptsShortValueLabels(): void
+    {
+        $metadata = '{"extra_fields": {"multitext": {"type": "text", "value": ["old", "other"], "allow_multi_values": true}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $res = $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                'value' => array('old', 'other'),
+                'value_labels' => array('Old label'),
+            ),
+        ));
+        $decoded = json_decode($res['metadata'], true);
+        $this->assertSame(array('old', 'other'), $decoded['extra_fields']['multitext']['value']);
+        $this->assertSame(array('Old label'), $decoded['extra_fields']['multitext']['value_labels']);
+    }
+
+    public function testUpdateJsonFieldRejectsTooManyValueLabelsAfterNormalization(): void
+    {
+        $metadata = '{"extra_fields": {"multitext": {"type": "text", "value": ["old", "other"], "allow_multi_values": true}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field multitext has invalid value labels.');
+        $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                // A scalar is normalized to one value for a multi-value field.
+                'value' => 'other',
+                'value_labels' => array('Other label', 'Extra label'),
+            ),
+        ));
+    }
+
+    public function testUpdateJsonFieldRejectsNonSequentialValueLabels(): void
+    {
+        $metadata = '{"extra_fields": {"multitext": {"type": "text", "value": ["other"], "allow_multi_values": true}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field multitext has invalid value labels.');
+        $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                'value' => array('other'),
+                'value_labels' => array(1 => 'Other label'),
+            ),
+        ));
+    }
+
+    public function testUpdateJsonFieldRejectsNonStringValueLabels(): void
+    {
+        $metadata = '{"extra_fields": {"multitext": {"type": "text", "value": ["other"], "allow_multi_values": true}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $this->expectException(ImproperActionException::class);
+        $this->expectExceptionMessage('Metadata field multitext has invalid value labels.');
+        $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                'value' => array('other'),
+                'value_labels' => array('Other label', 123),
+            ),
+        ));
+    }
+
     public function testUpdateJsonFieldWithMultipleCompoundValues(): void
     {
         $metadata = '{"extra_fields": {"components": {"type": "compounds", "value": [], "allow_multi_values": true}}}';

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -428,6 +428,33 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array('first', 'second'), $decoded['extra_fields']['multitext']['value']);
     }
 
+    public function testUpdateJsonFieldWithValueLabels(): void
+    {
+        $metadata = '{"extra_fields": {"multitext": {"type": "text", "value": ["old", "other"], "value_labels": ["Old label", "Other label"], "allow_multi_values": true}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $res = $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                'value' => array('other'),
+                'value_labels' => array('Other label'),
+            ),
+        ));
+        $decoded = json_decode($res['metadata'], true);
+        $this->assertSame(array('other'), $decoded['extra_fields']['multitext']['value']);
+        $this->assertSame(array('Other label'), $decoded['extra_fields']['multitext']['value_labels']);
+
+        $res = $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            'multitext' => array(
+                'value' => array('other'),
+                'value_labels' => null,
+            ),
+        ));
+        $decoded = json_decode($res['metadata'], true);
+        $this->assertArrayNotHasKey('value_labels', $decoded['extra_fields']['multitext']);
+    }
+
     public function testUpdateJsonFieldWithMultipleCompoundValues(): void
     {
         $metadata = '{"extra_fields": {"components": {"type": "compounds", "value": [], "allow_multi_values": true}}}';


### PR DESCRIPTION
Implements the part of #7312 endorsed in the maintainer comment: a per-value label for multi-value custom fields — *keep one field but add more context to each value* (e.g. a multi-value checkbox with a label next to each box).

### How it works

A field definition may carry an optional `value_labels` array, index-aligned with `value`:

```json
"Checks": {"type": "checkbox", "allow_multi_values": true, "value": ["on", "off"], "value_labels": ["Calibrated", "Reviewed"]}
```

- edit view: each multi-value row gets a badge with its label (`Metadata.class.ts` `buildMultiValueRow`)
- view page + PDF export: each rendered value gets the same badge (`TwigFilters::formatMetadata`, escaped via `eLabHtmlspecialchars`)
- fields without `value_labels` (or with a shorter array) render exactly as before — no migration, fully backward compatible
- the field-builder edit path now preserves `value_labels` the same way `readonly`/`position` are preserved, so editing a field no longer silently drops labels
- labels can be set today via the metadata JSON editor; a dedicated field-builder UI for them would be a natural follow-up

### Scope

Text-only labels, matching the maintainer comment. The original issue also proposes colors; since that part has not been reviewed yet, it is intentionally left out and the structure (a per-index array) leaves room for it.

### Tests

- `TwigFiltersTest::testFormatMetadataWithMultiValueLabels` — badge rendered, HTML-escaped (runs green locally with the unit suite; the DB-touching `testFormatMetadata` error in my sandbox is a missing pdo driver, pre-existing)
- `MetadataHelpersTest::testMergeMetadataPreservesValueLabels` — merging values from an incoming update keeps the source schema's `value_labels` (full MetadataHelpers suite: 46 tests, 140 assertions, OK)

Closes #7312 (label part)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom labels for multi-value metadata.
  * Labels appear as safely escaped badges beside corresponding values in edit and view modes.
  * Labels remain aligned when values are added, edited, or removed.

* **Bug Fixes**
  * Preserved custom labels when editing and saving metadata.
  * Retained metadata configuration and label information during updates.
  * Fixed label pairings after deleting values and reloading.
  * Removed labels when no labeled values remain.
  * Left values unchanged when labels are invalid or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->