### PR TITLE
bug/minor: restrict anon login to visible teams

### DIFF
--- a/src/Auth/AnonymousLoginValidator.php
+++ b/src/Auth/AnonymousLoginValidator.php
@@ -29,7 +29,7 @@ final readonly class AnonymousLoginValidator
         }
 
         $Db = Db::getConnection();
-        $sql = 'SELECT 1 FROM teams WHERE id = :team_id';
+        $sql = 'SELECT 1 FROM teams WHERE id = :team_id AND visible = 1';
         $req = $Db->prepare($sql);
         $req->bindValue(':team_id', $teamId, PDO::PARAM_INT);
         $Db->execute($req);

--- a/tests/unit/controllers/LoginControllerTest.php
+++ b/tests/unit/controllers/LoginControllerTest.php
@@ -25,6 +25,7 @@ use Elabftw\Auth\TeamRequestRequired;
 use Elabftw\Auth\TeamSelectionRequired;
 use Elabftw\Auth\UserLoginContext;
 use Elabftw\Elabftw\Authentication;
+use Elabftw\Enums\Action;
 use Elabftw\Enums\AuthMethod;
 use Elabftw\Enums\LoginAction;
 use Elabftw\Exceptions\IllegalActionException;
@@ -36,6 +37,7 @@ use Elabftw\Exceptions\UnauthorizedException;
 use Elabftw\Interfaces\AuthenticatorInterface;
 use Elabftw\Interfaces\LoginStepInterface;
 use Elabftw\Interfaces\MfaVerifierInterface;
+use Elabftw\Models\Teams;
 use Elabftw\Models\Users\ExistingUser;
 use Elabftw\Traits\TestsUtilsTrait;
 use LogicException;
@@ -259,6 +261,25 @@ final class LoginControllerTest extends \PHPUnit\Framework\TestCase
             $request,
             anonymousLoginValidator: new AnonymousLoginValidator(true),
         )->getResponse();
+    }
+
+    public function testAnonymousLoginRejectsInvisibleTeam(): void
+    {
+        $Team = new Teams($this->getUserInTeam(1, 1), 1);
+        $wasVisible = $Team->teamArr['visible'];
+        $Team->patch(Action::Update, array('visible' => 0));
+
+        try {
+            try {
+                $Validator = new AnonymousLoginValidator(true);
+                $Validator->validate(1);
+                self::fail('Anonymous login to an invisible team should be rejected.');
+            } catch (UnauthorizedException) {
+                self::addToAssertionCount(1);
+            }
+        } finally {
+            $Team->patch(Action::Update, array('visible' => $wasVisible));
+        }
     }
 
     public function testAnonymousLoginCompletesLogin(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous login now only works for teams marked as visible.
  * Attempts to log in anonymously to an invisible team are rejected as unauthorized.

* **Tests**
  * Added coverage to verify invisible teams cannot be used for anonymous login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->