### PR TITLE
bug/minor: better query for active users

### DIFF
--- a/src/Services/TeamsHelper.php
+++ b/src/Services/TeamsHelper.php
@@ -111,10 +111,13 @@ final class TeamsHelper
 
     public function isActiveUserInTeam(int $userid): bool
     {
-        $sql = 'SELECT 1 FROM `users2teams`
-            WHERE `teams_id` = :team
-                AND `users_id` = :userid
-                AND `is_archived` = 0';
+        $sql = 'SELECT 1 FROM `users2teams` AS u2t
+            INNER JOIN `users` AS u ON u.userid = u2t.users_id
+            WHERE u2t.teams_id = :team
+                AND u2t.users_id = :userid
+                AND u2t.is_archived = 0
+                AND u.validated = 1
+                AND IFNULL(u.valid_until, \'3000-01-01\') > NOW()';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':team', $this->team, PDO::PARAM_INT);
         $req->bindParam(':userid', $userid, PDO::PARAM_INT);

--- a/src/Traits/TestsUtilsTrait.php
+++ b/src/Traits/TestsUtilsTrait.php
@@ -43,7 +43,7 @@ trait TestsUtilsTrait
     protected function getRandomUserInTeam(int $team, int $admin = 0, int $archived = 0): AuthenticatedUser
     {
         $Db = Db::getConnection();
-        $sql = 'SELECT * FROM users2teams INNER JOIN users ON users.userid = users2teams.users_id WHERE users.validated = 1 AND teams_id = :team AND is_admin = :admin AND is_archived = :archived';
+        $sql = 'SELECT * FROM users2teams INNER JOIN users ON users.userid = users2teams.users_id WHERE users.validated = 1 AND (users.valid_until IS NULL OR users.valid_until > NOW()) AND teams_id = :team AND is_admin = :admin AND is_archived = :archived';
         $req = $Db->prepare($sql);
         $req->bindValue(':team', $team, PDO::PARAM_INT);
         $req->bindValue(':admin', $admin, PDO::PARAM_INT);

--- a/tests/unit/services/TeamsHelperTest.php
+++ b/tests/unit/services/TeamsHelperTest.php
@@ -11,11 +11,13 @@ declare(strict_types=1);
 
 namespace Elabftw\Services;
 
+use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Usergroup;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
+use PDO;
 
 class TeamsHelperTest extends \PHPUnit\Framework\TestCase
 {
@@ -67,6 +69,49 @@ class TeamsHelperTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($this->TeamsHelper->isActiveUserInTeam($target->userid));
         } finally {
             $this->updateArchiveStatus($target->userid, 0);
+        }
+    }
+
+    public function testSuspendedUserIsNotActiveInTeam(): void
+    {
+        $target = $this->getRandomUserInTeam(1);
+        $this->assertTrue($this->TeamsHelper->isActiveUserInTeam($target->userid));
+
+        $Db = Db::getConnection();
+        $req = $Db->prepare('UPDATE users SET validated = :validated WHERE userid = :userid');
+        $req->bindValue(':userid', $target->userid, PDO::PARAM_INT);
+        $req->bindValue(':validated', 0, PDO::PARAM_INT);
+        $Db->execute($req);
+        try {
+            $this->assertFalse($this->TeamsHelper->isActiveUserInTeam($target->userid));
+        } finally {
+            $req->bindValue(':validated', 1, PDO::PARAM_INT);
+            $Db->execute($req);
+        }
+    }
+
+    public function testExpiredUserIsNotActiveInTeam(): void
+    {
+        $target = $this->getRandomUserInTeam(1);
+        $originalValidUntil = $target->userData['valid_until'];
+        $Db = Db::getConnection();
+        $req = $Db->prepare('UPDATE users SET valid_until = :valid_until WHERE userid = :userid');
+        $req->bindValue(':userid', $target->userid, PDO::PARAM_INT);
+        $req->bindValue(':valid_until', null, PDO::PARAM_NULL);
+        $Db->execute($req);
+        try {
+            $this->assertTrue($this->TeamsHelper->isActiveUserInTeam($target->userid));
+
+            $req->bindValue(':valid_until', '2000-01-01');
+            $Db->execute($req);
+            $this->assertFalse($this->TeamsHelper->isActiveUserInTeam($target->userid));
+        } finally {
+            $req->bindValue(
+                ':valid_until',
+                $originalValidUntil,
+                $originalValidUntil === null ? PDO::PARAM_NULL : PDO::PARAM_STR,
+            );
+            $Db->execute($req);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team membership is now considered active only when the membership is not archived, the user account is validated, and its validity period has not expired.
  * Users without an expiration date remain active indefinitely.
  * User selection for team-related actions now excludes accounts with expired validity periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->