### PR TITLE
bug/minor: fix notif issue

### DIFF
--- a/src/Models/Notifications/EventDeleted.php
+++ b/src/Models/Notifications/EventDeleted.php
@@ -16,12 +16,16 @@ use Elabftw\Elabftw\Env;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\EmailTarget;
 use Elabftw\Enums\Notifications;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\MailableInterface;
 use Elabftw\Interfaces\QueryParamsInterface;
 use Elabftw\Interfaces\RestInterface;
+use Elabftw\Models\TeamGroups;
 use Elabftw\Models\Users\Users;
 use Elabftw\Services\Email;
 use Elabftw\Services\Filter;
+use Elabftw\Services\TeamsHelper;
 use Override;
 
 use function _;
@@ -59,17 +63,24 @@ final class EventDeleted extends AbstractNotifications implements MailableInterf
     #[Override]
     public function postAction(Action $action, array $reqBody): int
     {
+        if (!$this->canNotify()) {
+            throw new IllegalActionException();
+        }
         if (!empty($reqBody['msg'])) {
             $this->msg = Filter::body($reqBody['msg']);
         }
-        // target can be bookable_item, team or teamgroup
-        $this->target = EmailTarget::from($reqBody['target']);
+        $target = EmailTarget::tryFrom((string) ($reqBody['target'] ?? ''));
+        if ($target === null) {
+            throw new ImproperActionException('Invalid target for an event deletion notification.');
+        }
+        $this->target = $target;
+        $targetId = $this->getTargetId($reqBody);
         $range = array(
             'direction' => $reqBody['range_direction'] ?? null,
             'value' => $reqBody['range_value'] ?? null,
             'unit' => $reqBody['range_unit'] ?? null,
         );
-        $userids = Email::getIdsOfRecipients($this->target, $reqBody['targetid'], $range);
+        $userids = Email::getIdsOfRecipients($this->target, $targetId, $range);
         foreach ($userids as $userid) {
             $recipient = new Users($userid);
             $Notif = new self($recipient, $this->event, $this->actor, $this->msg, $this->target);
@@ -122,5 +133,37 @@ final class EventDeleted extends AbstractNotifications implements MailableInterf
             'msg' => $this->msg,
             'target' => $this->target,
         );
+    }
+
+    private function canNotify(): bool
+    {
+        $userid = $this->targetUser->getUserid();
+        if ($this->event['userid'] === $userid) {
+            return true;
+        }
+        return (new TeamsHelper($this->event['team']))->isAdminInTeam($userid);
+    }
+
+    private function getTargetId(array $reqBody): int
+    {
+        return match ($this->target) {
+            EmailTarget::Team => $this->event['team'],
+            EmailTarget::BookableItem,
+            EmailTarget::BookableItemRange => $this->event['item'],
+            EmailTarget::TeamGroup => $this->getTeamGroupTargetId((int) ($reqBody['targetid'] ?? 0)),
+            default => throw new ImproperActionException('Invalid target for an event deletion notification.'),
+        };
+    }
+
+    private function getTeamGroupTargetId(int $targetId): int
+    {
+        if ($targetId < 1) {
+            throw new ImproperActionException('A team group target is required.');
+        }
+        $teamGroup = (new TeamGroups($this->targetUser, $targetId))->readOne();
+        if ($teamGroup['team'] !== $this->event['team']) {
+            throw new ImproperActionException('The team group does not belong to the event team.');
+        }
+        return $targetId;
     }
 }

--- a/tests/unit/models/EventDeletedTest.php
+++ b/tests/unit/models/EventDeletedTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2026 Nicolas CARPi
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use DateTimeImmutable;
+use Elabftw\Enums\Action;
+use Elabftw\Enums\EmailTarget;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Models\Notifications\EventDeleted;
+use Elabftw\Models\Users\Users;
+use Elabftw\Services\Email;
+use Elabftw\Traits\TestsUtilsTrait;
+
+use function count;
+use function sprintf;
+
+class EventDeletedTest extends \PHPUnit\Framework\TestCase
+{
+    use TestsUtilsTrait;
+
+    public function testTeamTargetIsDerivedFromEvent(): void
+    {
+        $requester = $this->getRandomUserInTeam(1);
+        $Notifications = $this->getNotifications($requester);
+        $expected = count(Email::getIdsOfRecipients(EmailTarget::Team, 1));
+
+        $actual = $Notifications->postAction(Action::Create, array(
+            'target' => EmailTarget::Team->value,
+            'targetid' => 2,
+        ));
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testInstanceWideTargetsAreRejected(): void
+    {
+        $requester = $this->getRandomUserInTeam(1);
+        $targets = array(
+            EmailTarget::Admins,
+            EmailTarget::Sysadmins,
+            EmailTarget::ActiveUsers,
+            EmailTarget::AdminsOfTeam,
+        );
+        foreach ($targets as $target) {
+            try {
+                $this->getNotifications($requester)->postAction(Action::Create, array('target' => $target->value));
+                $this->fail(sprintf('Target %s should not be accepted.', $target->value));
+            } catch (ImproperActionException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function testForeignTeamGroupIsRejected(): void
+    {
+        $requester = $this->getRandomUserInTeam(1);
+        $teamTwoAdmin = $this->getUserInTeam(2, admin: 1);
+        $foreignGroupId = (new TeamGroups($teamTwoAdmin))->postAction(
+            Action::Create,
+            array('name' => 'Foreign notification target'),
+        );
+
+        $this->expectException(ImproperActionException::class);
+        $this->getNotifications($requester)->postAction(Action::Create, array(
+            'target' => EmailTarget::TeamGroup->value,
+            'targetid' => $foreignGroupId,
+        ));
+    }
+
+    public function testReadOnlyUserCannotNotifyEventRecipients(): void
+    {
+        $requester = $this->getRandomUserInTeam(1);
+        $this->expectException(IllegalActionException::class);
+        $this->getNotifications($requester, eventOwner: -1)->postAction(Action::Create, array(
+            'target' => EmailTarget::Team->value,
+        ));
+    }
+
+    private function getNotifications(Users $requester, ?int $eventOwner = null): EventDeleted
+    {
+        $now = new DateTimeImmutable();
+        return new EventDeleted($requester, array(
+            'item' => 12,
+            'team' => 1,
+            'userid' => $eventOwner ?? $requester->userid,
+            'start' => $now->format('Y-m-d H:i:s'),
+            'end' => $now->format('Y-m-d H:i:s'),
+        ), 'Test User');
+    }
+}

--- a/tests/unit/services/EmailNotificationsTest.php
+++ b/tests/unit/services/EmailNotificationsTest.php
@@ -56,7 +56,13 @@ class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
 
         $Notifications = new EventDeleted(
             $targetUser,
-            array('item' => 12, 'start' => $d->format('Y-m-d H:i:s'), 'end' => $d->format('Y-m-d H:i:s')),
+            array(
+                'item' => 12,
+                'team' => 1,
+                'userid' => 1,
+                'start' => $d->format('Y-m-d H:i:s'),
+                'end' => $d->format('Y-m-d H:i:s'),
+            ),
             'Daniel Balavoine',
         );
         $targetCount = $Notifications->postAction(Action::Create, array(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization when sending event-deletion notifications.
  * Notifications now target only valid recipients associated with the event’s team.
  * Rejected invalid, instance-wide, cross-team, or unauthorized notification targets.
  * Prevented read-only users from sending event-deletion notifications.

* **Tests**
  * Added coverage for valid team targeting and rejected notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->