### PR TITLE
bug/minor: only look at visible teams for saml/ldap

### DIFF
--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -64,15 +64,23 @@ final class Teams extends AbstractRest
     {
         $res = array();
         $sql = 'SELECT id, name FROM teams WHERE visible = 1 AND (id = :query OR name = :query OR orgid = :query)';
+        $existsSql = 'SELECT 1 FROM teams WHERE id = :query OR name = :query OR orgid = :query LIMIT 1';
         $req = $this->Db->prepare($sql);
+        $existsReq = $this->Db->prepare($existsSql);
         foreach ($teams as $query) {
-            $req->bindValue(':query', trim((string) $query));
+            $identifier = trim((string) $query);
+            $req->bindValue(':query', $identifier);
             $this->Db->execute($req);
             $team = $req->fetch();
             // team was not found, we need to create it, but only if we're allowed to
             if ($team === false && $allowTeamCreation === true) {
-                $freshTeam = new self($this->Users, $this->create($query));
-                $team = $freshTeam->selectOne();
+                $existsReq->bindValue(':query', $identifier);
+                $this->Db->execute($existsReq);
+                // Only create if the team does not already exist, including hidden teams.
+                if ($existsReq->fetch() === false) {
+                    $freshTeam = new self($this->Users, $this->create($identifier));
+                    $team = $freshTeam->selectOne();
+                }
             }
             // this prevents adding a bool(false)
             if (is_array($team)) {

--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -63,7 +63,7 @@ final class Teams extends AbstractRest
     public function getTeamsFromIdOrNameOrOrgidArray(array $teams, bool $allowTeamCreation = false): array
     {
         $res = array();
-        $sql = 'SELECT id, name FROM teams WHERE id = :query OR name = :query OR orgid = :query';
+        $sql = 'SELECT id, name FROM teams WHERE visible = 1 AND (id = :query OR name = :query OR orgid = :query)';
         $req = $this->Db->prepare($sql);
         foreach ($teams as $query) {
             $req->bindValue(':query', trim((string) $query));

--- a/src/Services/Populate.php
+++ b/src/Services/Populate.php
@@ -115,7 +115,6 @@ final class Populate
             $Teams = new Teams($Users, $teamid);
 
             $columns = array(
-                'visible',
                 'onboarding_email_body',
                 'onboarding_email_subject',
                 'onboarding_email_active',
@@ -137,6 +136,12 @@ final class Populate
             }
             for ($i = 0; $i < $iter; $i++) {
                 $this->createUser($teamid, array());
+            }
+            // Hide the team only after its users have been populated.
+            if (isset($team['visible'])) {
+                $Teams->patch(Action::Update, array(
+                    'visible' => (int) $team['visible'],
+                ));
             }
 
             // USER GROUPS

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -19,6 +19,7 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
 use function array_column;
+use function count;
 
 class TeamsTest extends \PHPUnit\Framework\TestCase
 {
@@ -183,6 +184,14 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
                 $this->fail('A hidden team was resolved from an external identifier.');
             } catch (ImproperActionException) {
                 $this->addToAssertionCount(1);
+            }
+
+            $teamCount = count($this->Teams->selectAll());
+            try {
+                $this->Teams->getTeamsFromIdOrNameOrOrgidArray(array($orgid), true);
+                $this->fail('A hidden team caused a duplicate team to be created.');
+            } catch (ImproperActionException) {
+                $this->assertCount($teamCount, $this->Teams->selectAll());
             }
         } finally {
             $HiddenTeam->destroy();

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -18,6 +18,8 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
 
+use function array_column;
+
 class TeamsTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;
@@ -153,6 +155,38 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(ImproperActionException::class);
         $this->Teams->getTeamsFromIdOrNameOrOrgidArray(array('Not existing'), false);
+    }
+
+    public function testHiddenTeamCannotBeResolvedByExternalIdentifier(): void
+    {
+        $name = 'Hidden external auth team';
+        $id = $this->Teams->postAction(Action::Create, array('name' => $name));
+        $HiddenTeam = new Teams(new Users(1, 1), $id);
+        $orgid = 'hidden-external-auth-team';
+        $HiddenTeam->patch(Action::Update, array(
+            'visible' => 0,
+            'orgid' => $orgid,
+        ));
+
+        try {
+            $visibleTeam = $this->Teams->readAllVisible()[0];
+            $resolvedTeams = $this->Teams->getTeamsFromIdOrNameOrOrgidArray(array(
+                (string) $id,
+                $name,
+                $orgid,
+                (string) $visibleTeam['id'],
+            ));
+            $this->assertSame(array($visibleTeam['id']), array_column($resolvedTeams, 'id'));
+
+            try {
+                $this->Teams->getTeamsFromIdOrNameOrOrgidArray(array((string) $id, $name, $orgid));
+                $this->fail('A hidden team was resolved from an external identifier.');
+            } catch (ImproperActionException) {
+                $this->addToAssertionCount(1);
+            }
+        } finally {
+            $HiddenTeam->destroy();
+        }
     }
 
     public function testCannotCreateWithoutTeamPermission(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden teams are no longer returned during team lookup.
  * Prevented duplicate team creation when a hidden team already exists.
  * Team members are fully populated before a team is hidden, ensuring hidden teams retain their configured users.
  * Added coverage to verify that visible teams remain discoverable while hidden teams cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->