### PR TITLE
bug/minor: metadata: make option validation case-insensitive

### DIFF
--- a/src/Elabftw/MetadataHelpers.php
+++ b/src/Elabftw/MetadataHelpers.php
@@ -291,12 +291,12 @@ final class MetadataHelpers
         }
 
         $options = array_map(
-            static fn(mixed $option): mixed => is_scalar($option) ? (string) $option : $option,
+            static fn(mixed $option): mixed => is_scalar($option) ? mb_strtolower(trim((string) $option)) : $option,
             $options,
         );
 
         foreach ($values as $option) {
-            if ($option !== '' && $option !== null && !in_array((string) $option, $options, true)) {
+            if ($option !== '' && $option !== null && !in_array(mb_strtolower(trim((string) $option)), $options, true)) {
                 throw new ImproperActionException(
                     sprintf(
                         _('Metadata field %s contains an invalid option.'),


### PR DESCRIPTION
Would throw when an incoming csv has columns expected in the template such as "Select with options: Alpha, Beta" and the csv provides beta without capital

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select and radio field validation now treats option values as case-insensitive.
  * Leading and trailing spaces are ignored when comparing configured options with submitted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->