### PR TITLE
bug/minor: delete msg: use i18n string

### DIFF
--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -152,7 +152,7 @@ on('toggle-modal', (el: HTMLElement) => {
 on('delete-selected-entities', async () => {
   if (pageMode == 'view' || pageMode == 'edit') {
     await ApiC.delete(`${entity.type}/${entity.id}`, { notifOnSaved:0 });
-    sessionStorage.setItem('flash_deleted', i18next.t('delete_success'));
+    sessionStorage.setItem('flash_deleted', i18next.t('delete-success'));
     window.location.href = window.location.pathname;
     return;
   }
@@ -166,7 +166,7 @@ on('delete-selected-entities', async () => {
     ApiC.delete(`${entity.type}/${id}`, { notifOnSaved:0 }),
   );
   Promise.all(deletes).then(() => {
-    notify.success(i18next.t('delete_success'));
+    notify.success(i18next.t('delete-success'));
     reloadEntitiesShow();
   });
 });


### PR DESCRIPTION
fix i18n wrong key

<img width="218" height="157" alt="Capture d’écran du 2026-08-24 14-19-02" src="https://github.com/user-attachments/assets/1a507b29-5834-4b29-9ecc-6256999739ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deletion success notifications so they display the correct translated message after single or multiple items are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->