### PR TITLE
bug/minor: prevent Anon from reading /info

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -336,7 +336,7 @@ final class Apiv2Controller extends AbstractApiController
             ApiEndpoint::Idps => new Idps($this->requester, $this->id),
             ApiEndpoint::IdpsSources => new IdpsSources($this->requester, $this->id),
             ApiEndpoint::Import => new ImportHandler($this->requester, App::getDefaultLogger()),
-            ApiEndpoint::Info => new Info(),
+            ApiEndpoint::Info => new Info($this->requester),
             ApiEndpoint::Instance => new Instance($this->requester, $this->getEmail(), (bool) Config::getConfig()->configArr['email_send_grouped']),
             ApiEndpoint::Export => new Exports(App::getDefaultLogger(), $this->requester, Storage::EXPORTS->getStorage(), $this->id),
             ApiEndpoint::Experiments,

--- a/src/Models/Info.php
+++ b/src/Models/Info.php
@@ -15,6 +15,7 @@ namespace Elabftw\Models;
 use Elabftw\Elabftw\BuildInfo;
 use Elabftw\Elabftw\Tools;
 use Elabftw\Interfaces\QueryParamsInterface;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Override;
 use PDO;
@@ -29,6 +30,11 @@ final class Info extends AbstractRest
 {
     private const int DEFAULT_HIST_BUCKET_SIZE = 120;
 
+    public function __construct(private ?Users $requester = null)
+    {
+        parent::__construct();
+    }
+
     #[Override]
     public function getApiPath(): string
     {
@@ -38,6 +44,9 @@ final class Info extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        if ($this->requester instanceof AnonymousUser) {
+            return array();
+        }
         if ($queryParams && $queryParams->getQuery()->has('hist')) {
             $columns = $queryParams->getQuery()->has('columns') ? $queryParams->getQuery()->getInt('columns') : null;
             return $this->hist($columns);

--- a/tests/unit/models/InfoTest.php
+++ b/tests/unit/models/InfoTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Models;
 
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\BaseQueryParams;
 use Symfony\Component\HttpFoundation\InputBag;
@@ -45,5 +46,17 @@ class InfoTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($hist['items']);
         $this->assertIsArray($hist['experiments']);
         $this->assertIsArray($hist['users']);
+    }
+
+    public function testAnonymousUserCannotRead(): void
+    {
+        $Info = new Info(new AnonymousUser(1));
+
+        $this->assertSame(array(), $Info->readAll());
+        $this->assertSame(array(), $Info->readOne());
+        $this->assertSame(
+            array(),
+            $Info->readAll(new BaseQueryParams(new InputBag(array('hist' => 1)))),
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted information and statistics endpoints for anonymous visitors.
  * Anonymous requests now receive empty results instead of potentially accessible data.
  * Authenticated access retains existing behavior.

* **Tests**
  * Added coverage confirming anonymous users cannot retrieve current or historical information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->