### PR TITLE
feat: use uuidv4 instead of uuidv1 for access keys

### DIFF
--- a/src/Services/AccessKeyHelper.php
+++ b/src/Services/AccessKeyHelper.php
@@ -47,7 +47,8 @@ final class AccessKeyHelper
         $accessKey = $this->getAccessKey() === null ? Tools::getUuidv4() : null;
         $sql = 'UPDATE ' . $this->entityType->value . ' SET access_key = :access_key WHERE id = :id';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':access_key', $accessKey, $accessKey === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $pdoType = $accessKey === null ? PDO::PARAM_NULL : PDO::PARAM_STR;
+        $req->bindValue(':access_key', $accessKey, $pdoType);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $this->getAccessKey();

--- a/src/Services/AccessKeyHelper.php
+++ b/src/Services/AccessKeyHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Elabftw\Services;
 
 use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Tools;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\State;
 use PDO;
@@ -43,19 +44,13 @@ final class AccessKeyHelper
 
     public function toggleAccessKey(): ?string
     {
-        $sql = 'UPDATE ' . $this->entityType->value . ' SET access_key = ' . $this->getSqlValue() . ' WHERE id = :id';
+        $accessKey = $this->getAccessKey() === null ? Tools::getUuidv4() : null;
+        $sql = 'UPDATE ' . $this->entityType->value . ' SET access_key = :access_key WHERE id = :id';
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':access_key', $accessKey, $accessKey === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $req->bindParam(':id', $this->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $this->getAccessKey();
-    }
-
-    private function getSqlValue(): string
-    {
-        if ($this->getAccessKey() === null) {
-            return 'UUID()';
-        }
-        return 'NULL';
     }
 
     private function getAccessKey(): ?string

--- a/src/Services/Check.php
+++ b/src/Services/Check.php
@@ -163,7 +163,7 @@ final class Check
 
     public static function accessKey(string $ak): string
     {
-        if (preg_match('/^[0-9A-F]{8}-[0-9A-F]{4}-(?:1[0-9A-F]{3}-[0-9A-F]{4}|4[0-9A-F]{3}-[89AB][0-9A-F]{3})-[0-9A-F]{12}$/i', $ak) === 1) {
+        if (preg_match('/^[0-9A-F]{8}-[0-9A-F]{4}-(?:1[0-9A-F]{3}-[89AB][0-9A-F]{3}|4[0-9A-F]{3}-[89AB][0-9A-F]{3})-[0-9A-F]{12}$/i', $ak) === 1) {
             return $ak;
         }
         throw new ImproperActionException('Incorrect value for access key!');

--- a/src/Services/Check.php
+++ b/src/Services/Check.php
@@ -163,7 +163,7 @@ final class Check
 
     public static function accessKey(string $ak): string
     {
-        if (preg_match('/^[0-9A-F]{8}-[0-9A-F]{4}-1[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i', $ak) === 1) {
+        if (preg_match('/^[0-9A-F]{8}-[0-9A-F]{4}-(?:1[0-9A-F]{3}-[0-9A-F]{4}|4[0-9A-F]{3}-[89AB][0-9A-F]{3})-[0-9A-F]{12}$/i', $ak) === 1) {
             return $ak;
         }
         throw new ImproperActionException('Incorrect value for access key!');

--- a/tests/unit/services/AccessKeyHelperTest.php
+++ b/tests/unit/services/AccessKeyHelperTest.php
@@ -25,6 +25,8 @@ class AccessKeyHelperTest extends \PHPUnit\Framework\TestCase
         $AkHelper = new AccessKeyHelper(EntityType::Experiments, $id);
         // set an ak
         $ak = $AkHelper->toggleAccessKey();
+        $this->assertNotNull($ak);
+        $this->assertMatchesRegularExpression('/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/', $ak);
         $this->assertEquals($id, $AkHelper->getIdFromAccessKey($ak));
         // now remove ak
         $AkHelper->toggleAccessKey();

--- a/tests/unit/services/CheckTest.php
+++ b/tests/unit/services/CheckTest.php
@@ -75,8 +75,10 @@ class CheckTest extends \PHPUnit\Framework\TestCase
 
     public function testAk(): void
     {
-        $ak = '4da7ac2a-a3f0-11ed-bb95-0242ac160008';
-        $this->assertEquals($ak, Check::accessKey($ak));
+        $uuidV1 = '4da7ac2a-a3f0-11ed-bb95-0242ac160008';
+        $this->assertEquals($uuidV1, Check::accessKey($uuidV1));
+        $uuidV4 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+        $this->assertEquals($uuidV4, Check::accessKey($uuidV4));
         $this->expectException(ImproperActionException::class);
         Check::accessKey('pwet');
     }


### PR DESCRIPTION
uuidv1 really is the md5 of uuids



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access keys can now be generated using UUIDv4 format.
  * Access-key validation now supports both UUIDv1 and UUIDv4 formats.

* **Bug Fixes**
  * Improved access-key handling when creating, updating, or clearing keys.
  * Invalid, malformed, or unsupported access-key formats continue to be rejected.
  * Clearing an access key now reliably preserves the intended empty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->