### PR TITLE
feat: webhooks: outgoing events for entity changes

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -90,6 +90,7 @@ $Application->add(new MfaCode());
 $Application->add(new RefreshIdps($Config->configArr['proxy']));
 $Application->add(new SendNotifications($Email));
 $Application->add(new SendExpirationNotifications($Email));
+$Application->add(new SendWebhooks());
 $Application->add(new TagsTeamsSync());
 $Application->add(new PruneUploads());
 $Application->add(new PruneEntries());

--- a/containers/elabimg/helpers/chronos.go
+++ b/containers/elabimg/helpers/chronos.go
@@ -40,6 +40,7 @@ func main() {
 	go scheduleDaily(ctx, 13, 37, []string{"notifications:tsbalance"})
 	go scheduleDaily(ctx, 3, 37, []string{"idps:refresh"})
 	go scheduleEveryMinute(ctx, []string{"notifications:send"})
+	go scheduleEveryMinute(ctx, []string{"webhooks:send"})
 	log.Println("scheduled tasks started")
 
 	// wait until context is canceled

--- a/src/Commands/SendWebhooks.php
+++ b/src/Commands/SendWebhooks.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Commands;
+
+use Elabftw\Elabftw\Env;
+use Elabftw\Models\Config;
+use Elabftw\Services\HttpGetter;
+use Elabftw\Services\WebhookDispatcher;
+use Elabftw\Services\WebhookUrlValidator;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Override;
+
+use function sprintf;
+
+/**
+ * Deliver the queued webhook events
+ */
+#[AsCommand(name: 'webhooks:send')]
+final class SendWebhooks extends Command
+{
+    #[Override]
+    protected function configure(): void
+    {
+        $this->setDescription('Send the queued webhook events')
+            ->setHelp('Look for all webhook deliveries that are due and POST them to their target. Run every minute by chronos.');
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // a development instance necessarily talks to a receiver on a private address,
+        // so the address checks are relaxed there, exactly like tls verification is
+        $strict = !Env::asBool('DEV_MODE');
+        $Config = Config::getConfig();
+        $httpGetter = new HttpGetter(new Client(), $Config->configArr['proxy'], $strict);
+        $Dispatcher = new WebhookDispatcher($httpGetter, new WebhookUrlValidator($strict));
+        $count = $Dispatcher->send($output);
+        if ($output->isVerbose()) {
+            $output->writeln(sprintf('Delivered %d webhook events', $count));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -50,6 +50,7 @@ use Elabftw\Models\IdpsSources;
 use Elabftw\Models\Info;
 use Elabftw\Models\Instance;
 use Elabftw\Models\Instance2Rors;
+use Elabftw\Models\InstanceWebhooks;
 use Elabftw\Models\Items;
 use Elabftw\Models\ItemsStatus;
 use Elabftw\Models\Notifications\EventDeleted;
@@ -66,12 +67,14 @@ use Elabftw\Models\Tags;
 use Elabftw\Models\TeamGroups;
 use Elabftw\Models\Teams;
 use Elabftw\Models\Teams2Rors;
+use Elabftw\Models\TeamsWebhooks;
 use Elabftw\Models\TeamTags;
 use Elabftw\Models\Todolist;
 use Elabftw\Models\UnfinishedSteps;
 use Elabftw\Models\Uploads;
 use Elabftw\Models\UserRequestActions;
 use Elabftw\Models\Users2Rors;
+use Elabftw\Models\UsersWebhooks;
 use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Models\Users\Users;
 use Elabftw\Models\UserUploads;
@@ -428,6 +431,7 @@ final class Apiv2Controller extends AbstractApiController
                 ApiSubModels::ItemsStatus => new ItemsStatus($this->Model, $this->subId),
                 ApiSubModels::ProcurementRequests => new ProcurementRequests($this->Model, $this->subId),
                 ApiSubModels::Rors => new Teams2Rors($this->Model->id ?? 0, $this->Model->canWrite(), $this->subIdString),
+                ApiSubModels::Webhooks => new TeamsWebhooks($this->Model->id ?? 0, $this->Model->canWrite(), $this->subId),
                 ApiSubModels::Tags => new TeamTags($this->requester, $this->subId),
                 ApiSubModels::Teamgroups => new TeamGroups($this->requester, $this->subId),
                 default => throw new InvalidApiSubModelException(ApiEndpoint::Teams),
@@ -440,6 +444,7 @@ final class Apiv2Controller extends AbstractApiController
                 ApiSubModels::RequestActions => new UserRequestActions($this->Model),
                 ApiSubModels::SigKeys => new SigKeys($this->requester, $this->subId),
                 ApiSubModels::Rors => new Users2Rors($this->Model->getUserid(), $this->requester->isAdminOf($this->Model->getUserid()), $this->subIdString),
+                ApiSubModels::Webhooks => new UsersWebhooks($this->Model->getUserid(), $this->requester->isAdminOf($this->Model->getUserid()), $this->subId),
                 // the uploads users/X/uploads endpoint forces the use of the requester
                 ApiSubModels::Uploads => new UserUploads($this->requester, $this->subId),
                 default => throw new InvalidApiSubModelException(ApiEndpoint::Users),
@@ -462,6 +467,7 @@ final class Apiv2Controller extends AbstractApiController
             return match ($submodel) {
                 ApiSubModels::Branding => new Branding($this->requester->isSysadmin(), $this->subId),
                 ApiSubModels::Rors => new Instance2Rors($this->requester->isSysadmin(), $this->subIdString),
+                ApiSubModels::Webhooks => new InstanceWebhooks($this->requester->isSysadmin(), $this->subId),
                 default => throw new InvalidApiSubModelException(ApiEndpoint::Instance),
             };
         }

--- a/src/Elabftw/Db.php
+++ b/src/Elabftw/Db.php
@@ -183,6 +183,11 @@ final class Db
         return $this->connection->beginTransaction();
     }
 
+    public function inTransaction(): bool
+    {
+        return $this->connection->inTransaction();
+    }
+
     public function commit(): bool
     {
         return $this->connection->commit();

--- a/src/Elabftw/SchemaVersionChecker.php
+++ b/src/Elabftw/SchemaVersionChecker.php
@@ -20,7 +20,7 @@ use Elabftw\Exceptions\InvalidSchemaException;
 final class SchemaVersionChecker
 {
     /** @var int REQUIRED_SCHEMA the current version of the database structure */
-    public const int REQUIRED_SCHEMA = 224;
+    public const int REQUIRED_SCHEMA = 225;
 
     public function __construct(public int $currentSchema) {}
 

--- a/src/Enums/ApiSubModels.php
+++ b/src/Enums/ApiSubModels.php
@@ -43,6 +43,7 @@ enum ApiSubModels: string
     case Tags = 'tags';
     case Teamgroups = 'teamgroups';
     case Uploads = 'uploads';
+    case Webhooks = 'webhooks';
 
     public static function validSubModelsForEndpoint(ApiEndpoint $apiEndpoint): array
     {
@@ -93,6 +94,7 @@ enum ApiSubModels: string
                 self::Status,
                 self::Tags,
                 self::Teamgroups,
+                self::Webhooks,
             ),
         );
     }
@@ -107,6 +109,7 @@ enum ApiSubModels: string
                 self::SigKeys,
                 self::Rors,
                 self::Uploads,
+                self::Webhooks,
             ),
         );
     }
@@ -139,6 +142,7 @@ enum ApiSubModels: string
             array(
                 self::Branding,
                 self::Rors,
+                self::Webhooks,
             ),
         );
     }

--- a/src/Enums/Notifications.php
+++ b/src/Enums/Notifications.php
@@ -27,4 +27,5 @@ enum Notifications: int
     case NewVersionInstalled = 70;
     case OnboardingEmail = 80;
     case ActionRequested = 90;
+    case WebhookDisabled = 100;
 }

--- a/src/Enums/WebhookEvent.php
+++ b/src/Enums/WebhookEvent.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Enums;
+
+use function array_map;
+use function implode;
+use function in_array;
+use function is_string;
+
+/**
+ * The events that a webhook can subscribe to.
+ * Deliberately small for a first version: only entity changes, and only for
+ * concrete entities. Templates and items types do not emit anything.
+ */
+enum WebhookEvent: string
+{
+    case ExperimentCreated = 'experiment.created';
+    case ExperimentUpdated = 'experiment.updated';
+    case ExperimentStatusChanged = 'experiment.status_changed';
+    case ItemCreated = 'item.created';
+    case ItemUpdated = 'item.updated';
+    case ItemStatusChanged = 'item.status_changed';
+
+    /**
+     * Map a changelog write to an event, or null if that write is not observable.
+     * The changelog is where "something changed" is already recorded, so this is
+     * the only place that needs to know about targets.
+     */
+    public static function fromChangelogTarget(EntityType $entityType, string $target): ?self
+    {
+        return match ($entityType) {
+            EntityType::Experiments => match ($target) {
+                'created' => self::ExperimentCreated,
+                'status' => self::ExperimentStatusChanged,
+                default => self::ExperimentUpdated,
+            },
+            EntityType::Items => match ($target) {
+                'created' => self::ItemCreated,
+                'status' => self::ItemStatusChanged,
+                default => self::ItemUpdated,
+            },
+            // no events for templates and items types in this version
+            EntityType::Templates, EntityType::ItemsTypes => null,
+        };
+    }
+
+    public static function toCsList(): string
+    {
+        return implode(', ', array_map(fn(self $case): string => $case->value, self::cases()));
+    }
+
+    /**
+     * Keep only valid event names from user input, discarding anything unknown.
+     * @return array<int, string>
+     */
+    public static function filterValid(array $events): array
+    {
+        $valid = array();
+        foreach ($events as $event) {
+            if (!is_string($event)) {
+                continue;
+            }
+            $case = self::tryFrom($event);
+            if ($case !== null && !in_array($case->value, $valid, true)) {
+                $valid[] = $case->value;
+            }
+        }
+        return $valid;
+    }
+}

--- a/src/Enums/WebhookScope.php
+++ b/src/Enums/WebhookScope.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Enums;
+
+/**
+ * The three levels a webhook can live at.
+ * A webhook only ever sees events it is entitled to see, see WebhooksQueue::fanout().
+ */
+enum WebhookScope: string
+{
+    case Instance = 'instance';
+    case Team = 'team';
+    case User = 'user';
+}

--- a/src/Enums/WebhookState.php
+++ b/src/Enums/WebhookState.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Enums;
+
+/**
+ * State of a row in the webhooks_queue table.
+ * Sending exists so two overlapping drains cannot pick up the same row.
+ */
+enum WebhookState: int
+{
+    case Queued = 0;
+    case Sending = 1;
+    case Delivered = 2;
+    case Failed = 3;
+}

--- a/src/Models/AbstractWebhooks.php
+++ b/src/Models/AbstractWebhooks.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Env;
+use Elabftw\Enums\Action;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Enums\WebhookScope;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+use Elabftw\Interfaces\QueryParamsInterface;
+use Elabftw\Services\Filter;
+use Elabftw\Services\WebhookUrlValidator;
+use Override;
+use PDO;
+use PDOStatement;
+
+use function array_key_exists;
+use function array_keys;
+use function bin2hex;
+use function in_array;
+use function is_array;
+use function json_encode;
+use function random_bytes;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Mother class for the three webhook levels: instance, team and user.
+ *
+ * The three levels share one table, because a webhook is a row with a dozen columns and
+ * triplicating that DDL buys nothing. What differs per level is who may write it and which
+ * events it is entitled to see, and both of those live outside the table anyway: the first
+ * in the controller, the second in WebhooksQueue::fanout().
+ */
+abstract class AbstractWebhooks extends AbstractRest
+{
+    public function __construct(
+        protected readonly bool $canwrite = false,
+        protected readonly ?int $id = null,
+    ) {
+        $this->Db = Db::getConnection();
+    }
+
+    #[Override]
+    public function readAll(?QueryParamsInterface $queryParams = null): array
+    {
+        $sql = sprintf(
+            'SELECT %s FROM webhooks WHERE scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id ORDER BY id ASC',
+            $this->getColumns(),
+        );
+        $req = $this->Db->prepare($sql);
+        $this->bindScope($req);
+        $this->Db->execute($req);
+        return $req->fetchAll();
+    }
+
+    #[Override]
+    public function readOne(): array
+    {
+        if ($this->id === null) {
+            return $this->readAll();
+        }
+        // the secret is only readable by someone who may write the webhook: it cannot be
+        // hashed like an api key (we need it to sign), so the owner has to be able to read it back
+        $columns = $this->canwrite ? $this->getColumns() . ', secret' : $this->getColumns();
+        $sql = sprintf(
+            'SELECT %s FROM webhooks WHERE id = :id AND scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id',
+            $columns,
+        );
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $this->bindScope($req);
+        $this->Db->execute($req);
+        return $this->Db->fetch($req);
+    }
+
+    #[Override]
+    public function postAction(Action $action, array $reqBody): int
+    {
+        $this->canwriteOrExplode();
+        return match ($action) {
+            Action::Create => $this->create($reqBody),
+            default => throw new ImproperActionException('Incorrect action for webhook.'),
+        };
+    }
+
+    #[Override]
+    public function patch(Action $action, array $params): array
+    {
+        $this->canwriteOrExplode();
+        return match ($action) {
+            Action::Update => $this->update($params),
+            default => throw new ImproperActionException('Incorrect action for webhook.'),
+        };
+    }
+
+    #[Override]
+    public function destroy(): bool
+    {
+        $this->canwriteOrExplode();
+        $this->idOrExplode();
+        $sql = 'DELETE FROM webhooks WHERE id = :id AND scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $this->bindScope($req);
+        return $this->Db->execute($req);
+    }
+
+    abstract protected function getScope(): WebhookScope;
+
+    abstract protected function getTeamId(): ?int;
+
+    abstract protected function getUserId(): ?int;
+
+    protected function canwriteOrExplode(): void
+    {
+        if (!$this->canwrite) {
+            throw new IllegalActionException();
+        }
+    }
+
+    protected function create(array $reqBody): int
+    {
+        $url = $this->getValidator()->validate((string) ($reqBody['url'] ?? ''));
+        $events = $this->filterEvents($reqBody['events'] ?? array());
+        $sql = 'INSERT INTO webhooks (scope, teams_id, users_id, name, url, secret, events)
+            VALUES (:scope, :teams_id, :users_id, :name, :url, :secret, :events)';
+        $req = $this->Db->prepare($sql);
+        $this->bindScope($req);
+        $req->bindValue(':name', Filter::title((string) ($reqBody['name'] ?? '')));
+        $req->bindValue(':url', $url);
+        // 32 bytes of entropy, stored as 64 hex characters
+        $req->bindValue(':secret', bin2hex(random_bytes(32)));
+        $req->bindValue(':events', json_encode($events, JSON_THROW_ON_ERROR));
+        $this->Db->execute($req);
+
+        return $this->Db->lastInsertId();
+    }
+
+    protected function update(array $params): array
+    {
+        $this->idOrExplode();
+        // the action is how we got here, it is not a column
+        unset($params['action']);
+        // an unknown key is a typo on the client side, and silently ignoring it means the
+        // caller believes they changed something they did not
+        $allowed = array('name', 'url', 'events', 'enabled');
+        foreach (array_keys($params) as $key) {
+            if (!in_array($key, $allowed, true)) {
+                throw new ImproperActionException(sprintf('Invalid parameter for webhook: %s', $key));
+            }
+        }
+        if (array_key_exists('name', $params)) {
+            $this->updateColumn('name', Filter::title((string) $params['name']));
+        }
+        if (array_key_exists('url', $params)) {
+            $this->updateColumn('url', $this->getValidator()->validate((string) $params['url']));
+        }
+        if (array_key_exists('events', $params)) {
+            $this->updateColumn('events', json_encode($this->filterEvents($params['events']), JSON_THROW_ON_ERROR));
+        }
+        if (array_key_exists('enabled', $params)) {
+            $enabled = (bool) $params['enabled'];
+            $this->updateColumn('enabled', $enabled ? 1 : 0);
+            // re-enabling is how an admin acknowledges the failures that disabled it
+            if ($enabled) {
+                $this->resetFailures();
+            }
+        }
+        return $this->readOne();
+    }
+
+    private function getValidator(): WebhookUrlValidator
+    {
+        return new WebhookUrlValidator(!Env::asBool('DEV_MODE'));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function filterEvents(mixed $events): array
+    {
+        if (!is_array($events)) {
+            throw new ImproperActionException(sprintf('Webhook events must be a list. Available values are: %s.', WebhookEvent::toCsList()));
+        }
+        $filtered = WebhookEvent::filterValid($events);
+        if (empty($filtered)) {
+            throw new ImproperActionException(sprintf('A webhook must subscribe to at least one valid event. Available values are: %s.', WebhookEvent::toCsList()));
+        }
+        return $filtered;
+    }
+
+    private function updateColumn(string $column, string|int $value): void
+    {
+        // $column is never user input: it comes from the allow list above
+        $sql = sprintf(
+            'UPDATE webhooks SET %s = :value WHERE id = :id AND scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id',
+            $column,
+        );
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':value', $value);
+        $req->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $this->bindScope($req);
+        $this->Db->execute($req);
+    }
+
+    private function resetFailures(): void
+    {
+        $sql = 'UPDATE webhooks SET consecutive_failures = 0, disabled_at = NULL, last_error = NULL
+            WHERE id = :id AND scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $this->id, PDO::PARAM_INT);
+        $this->bindScope($req);
+        $this->Db->execute($req);
+    }
+
+    private function idOrExplode(): void
+    {
+        if ($this->id === null) {
+            throw new ImproperActionException('Missing webhook id in URL.');
+        }
+    }
+
+    private function bindScope(PDOStatement $req): void
+    {
+        $teamId = $this->getTeamId();
+        $userId = $this->getUserId();
+        $req->bindValue(':scope', $this->getScope()->value);
+        $req->bindValue(':teams_id', $teamId, $teamId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $req->bindValue(':users_id', $userId, $userId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+    }
+
+    private function getColumns(): string
+    {
+        return 'id, scope, teams_id, users_id, name, url, events, enabled, consecutive_failures, last_error, disabled_at, created_at, modified_at';
+    }
+}

--- a/src/Models/AbstractWebhooks.php
+++ b/src/Models/AbstractWebhooks.php
@@ -57,6 +57,9 @@ abstract class AbstractWebhooks extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        // a webhook target is an outbound data flow, so reading one takes the same
+        // authority as changing it: sysadmin, team admin, or the owning user
+        $this->canwriteOrExplode();
         $sql = sprintf(
             'SELECT %s FROM webhooks WHERE scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id ORDER BY id ASC',
             $this->getColumns(),
@@ -70,15 +73,15 @@ abstract class AbstractWebhooks extends AbstractRest
     #[Override]
     public function readOne(): array
     {
+        $this->canwriteOrExplode();
         if ($this->id === null) {
             return $this->readAll();
         }
-        // the secret is only readable by someone who may write the webhook: it cannot be
-        // hashed like an api key (we need it to sign), so the owner has to be able to read it back
-        $columns = $this->canwrite ? $this->getColumns() . ', secret' : $this->getColumns();
+        // the secret cannot be hashed like an api key, we need it to sign, so whoever may
+        // write the webhook can read it back
         $sql = sprintf(
             'SELECT %s FROM webhooks WHERE id = :id AND scope = :scope AND teams_id <=> :teams_id AND users_id <=> :users_id',
-            $columns,
+            $this->getColumns() . ', secret',
         );
         $req = $this->Db->prepare($sql);
         $req->bindValue(':id', $this->id, PDO::PARAM_INT);

--- a/src/Models/Changelog.php
+++ b/src/Models/Changelog.php
@@ -15,6 +15,7 @@ namespace Elabftw\Models;
 use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\Env;
 use Elabftw\Interfaces\ContentParamsInterface;
+use Elabftw\Services\WebhookEmitter;
 use PDO;
 
 use function is_string;
@@ -57,7 +58,13 @@ final class Changelog
         $req->bindParam(':users_id', $this->entity->Users->userData['userid'], PDO::PARAM_INT);
         $req->bindValue(':target', $params->getTarget());
         $req->bindParam(':content', $content);
-        return $this->Db->execute($req);
+        $res = $this->Db->execute($req);
+        if ($res) {
+            // the changelog is where "something changed" is already recorded, so it is also
+            // where outgoing events are emitted from
+            WebhookEmitter::fromChangelog($this->entity, $params->getTarget());
+        }
+        return $res;
     }
 
     public function readAll(): array

--- a/src/Models/InstanceWebhooks.php
+++ b/src/Models/InstanceWebhooks.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\WebhookScope;
+use Override;
+
+/**
+ * Webhooks configured by a sysadmin, they see events from the whole instance.
+ */
+final class InstanceWebhooks extends AbstractWebhooks
+{
+    #[Override]
+    public function getApiPath(): string
+    {
+        return 'api/v2/instance/webhooks/';
+    }
+
+    #[Override]
+    protected function getScope(): WebhookScope
+    {
+        return WebhookScope::Instance;
+    }
+
+    #[Override]
+    protected function getTeamId(): ?int
+    {
+        return null;
+    }
+
+    #[Override]
+    protected function getUserId(): ?int
+    {
+        return null;
+    }
+}

--- a/src/Models/Notifications/WebhookDisabled.php
+++ b/src/Models/Notifications/WebhookDisabled.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models\Notifications;
+
+use Elabftw\Enums\Notifications;
+use Elabftw\Models\Users\Users;
+use Override;
+
+/**
+ * A webhook was disabled automatically because it failed too many times in a row.
+ * Sent to whoever is responsible for that webhook: the user for a user level webhook,
+ * the team admins for a team one, the sysadmins for an instance one.
+ */
+final class WebhookDisabled extends WebOnlyNotifications
+{
+    protected Notifications $category = Notifications::WebhookDisabled;
+
+    public function __construct(Users $targetUser, private int $webhookId, private string $url)
+    {
+        parent::__construct($targetUser);
+    }
+
+    #[Override]
+    protected function getBody(): array
+    {
+        return array(
+            'webhook_id' => $this->webhookId,
+            'url' => $this->url,
+        );
+    }
+}

--- a/src/Models/TeamsWebhooks.php
+++ b/src/Models/TeamsWebhooks.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\WebhookScope;
+use Override;
+
+use function sprintf;
+
+/**
+ * Webhooks configured by a team admin, they see events from that team. Submodel for teams.
+ */
+final class TeamsWebhooks extends AbstractWebhooks
+{
+    public function __construct(
+        private readonly int $teamid,
+        bool $canwrite = false,
+        ?int $id = null,
+    ) {
+        parent::__construct($canwrite, $id);
+    }
+
+    #[Override]
+    public function getApiPath(): string
+    {
+        return sprintf('api/v2/teams/%d/webhooks/', $this->teamid);
+    }
+
+    #[Override]
+    protected function getScope(): WebhookScope
+    {
+        return WebhookScope::Team;
+    }
+
+    #[Override]
+    protected function getTeamId(): int
+    {
+        return $this->teamid;
+    }
+
+    #[Override]
+    protected function getUserId(): ?int
+    {
+        return null;
+    }
+}

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -80,6 +80,13 @@ class Users extends AbstractRest
 
     public bool $isAdmin = false;
 
+    /**
+     * Id of the api key used to authenticate this request, if any. Not a secret: it is the
+     * primary key of the api_keys row, and it lets a webhook subscriber recognise the changes
+     * it made itself through its own key.
+     */
+    public ?int $apiKeyId = null;
+
     public function __construct(public ?int $userid = null, public ?int $team = null, ?self $requester = null)
     {
         parent::__construct();

--- a/src/Models/UsersWebhooks.php
+++ b/src/Models/UsersWebhooks.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\WebhookScope;
+use Override;
+
+use function sprintf;
+
+/**
+ * Webhooks configured by a user in their control panel. They only see events for entries
+ * owned by that user, see WebhooksQueue::fanout(). Submodel for users.
+ */
+final class UsersWebhooks extends AbstractWebhooks
+{
+    public function __construct(
+        private readonly int $userid,
+        bool $canwrite = false,
+        ?int $id = null,
+    ) {
+        parent::__construct($canwrite, $id);
+    }
+
+    #[Override]
+    public function getApiPath(): string
+    {
+        return sprintf('api/v2/users/%d/webhooks/', $this->userid);
+    }
+
+    #[Override]
+    protected function getScope(): WebhookScope
+    {
+        return WebhookScope::User;
+    }
+
+    #[Override]
+    protected function getTeamId(): ?int
+    {
+        return null;
+    }
+
+    #[Override]
+    protected function getUserId(): int
+    {
+        return $this->userid;
+    }
+}

--- a/src/Models/Webhooks.php
+++ b/src/Models/Webhooks.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Enums\WebhookScope;
+use Elabftw\Models\Notifications\WebhookDisabled;
+use Elabftw\Models\Users\Users;
+use Elabftw\Services\TeamsHelper;
+use PDO;
+
+use function mb_substr;
+
+/**
+ * Operations on the webhooks table that belong to no particular level: this is what the
+ * delivery command uses to keep track of how a target is doing.
+ */
+final class Webhooks
+{
+    /** after this many consecutive failed deliveries a webhook is turned off */
+    public const int FAILURE_CAP = 10;
+
+    private Db $Db;
+
+    public function __construct()
+    {
+        $this->Db = Db::getConnection();
+    }
+
+    /**
+     * A delivery went through, so whatever failures came before are no longer consecutive.
+     */
+    public function recordSuccess(int $id): void
+    {
+        $sql = 'UPDATE webhooks SET consecutive_failures = 0, last_error = NULL WHERE id = :id AND consecutive_failures > 0';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    /**
+     * A delivery gave up. Past the cap the webhook is disabled, so a target that has been
+     * gone for a week stops generating queue rows forever.
+     *
+     * @return bool true if this failure disabled the webhook
+     */
+    public function recordFailure(int $id, string $error): bool
+    {
+        $sql = 'UPDATE webhooks SET consecutive_failures = consecutive_failures + 1, last_error = :error WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':error', mb_substr($error, 0, 500));
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $webhook = $this->readOne($id);
+        if ($webhook === null || (int) $webhook['enabled'] !== 1 || (int) $webhook['consecutive_failures'] < self::FAILURE_CAP) {
+            return false;
+        }
+        $this->disable($id);
+        $this->notifyOwners($webhook);
+        return true;
+    }
+
+    public function readOne(int $id): ?array
+    {
+        $sql = 'SELECT id, scope, teams_id, users_id, url, enabled, consecutive_failures FROM webhooks WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $res = $req->fetch();
+        return $res === false ? null : $res;
+    }
+
+    private function disable(int $id): void
+    {
+        $sql = 'UPDATE webhooks SET enabled = 0, disabled_at = NOW() WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    /**
+     * Tell whoever can do something about it. Silence would mean an integration quietly
+     * stops working and nobody knows why.
+     */
+    private function notifyOwners(array $webhook): void
+    {
+        foreach ($this->getOwnersUserid($webhook) as $userid) {
+            new WebhookDisabled(new Users($userid), (int) $webhook['id'], (string) $webhook['url'])->create();
+        }
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function getOwnersUserid(array $webhook): array
+    {
+        return match (WebhookScope::from($webhook['scope'])) {
+            WebhookScope::User => array((int) $webhook['users_id']),
+            WebhookScope::Team => new TeamsHelper((int) $webhook['teams_id'])->getAllAdminsUserid(),
+            WebhookScope::Instance => $this->getSysadmins(),
+        };
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function getSysadmins(): array
+    {
+        $sql = 'SELECT userid FROM users WHERE is_sysadmin = 1 AND validated = 1';
+        $req = $this->Db->prepare($sql);
+        $this->Db->execute($req);
+        return $req->fetchAll(PDO::FETCH_COLUMN);
+    }
+}

--- a/src/Models/Webhooks.php
+++ b/src/Models/Webhooks.php
@@ -19,6 +19,8 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\TeamsHelper;
 use PDO;
 
+use function array_map;
+use function intval;
 use function mb_substr;
 
 /**
@@ -107,7 +109,7 @@ final class Webhooks
     {
         return match (WebhookScope::from($webhook['scope'])) {
             WebhookScope::User => array((int) $webhook['users_id']),
-            WebhookScope::Team => new TeamsHelper((int) $webhook['teams_id'])->getAllAdminsUserid(),
+            WebhookScope::Team => array_map(intval(...), new TeamsHelper((int) $webhook['teams_id'])->getAllAdminsUserid()),
             WebhookScope::Instance => $this->getSysadmins(),
         };
     }
@@ -120,6 +122,6 @@ final class Webhooks
         $sql = 'SELECT userid FROM users WHERE is_sysadmin = 1 AND validated = 1';
         $req = $this->Db->prepare($sql);
         $this->Db->execute($req);
-        return $req->fetchAll(PDO::FETCH_COLUMN);
+        return array_map(intval(...), $req->fetchAll(PDO::FETCH_COLUMN));
     }
 }

--- a/src/Models/WebhooksQueue.php
+++ b/src/Models/WebhooksQueue.php
@@ -140,10 +140,14 @@ final class WebhooksQueue
         $req->bindValue(':limit', $limit, PDO::PARAM_INT);
         $this->Db->execute($req);
 
+        // enabled is checked again here: a webhook switched off between the two statements
+        // would otherwise still be handed to the dispatcher. This narrows the window rather
+        // than closing it, since a webhook can also be switched off while a request is in
+        // flight, which no amount of coordination can catch.
         $sql = 'SELECT q.id, q.event, q.event_id, q.body, q.attempts, q.claim_token, w.id AS webhook_id, w.url, w.secret
             FROM webhooks_queue AS q
             INNER JOIN webhooks AS w ON (w.id = q.webhooks_id)
-            WHERE q.claim_token = :token
+            WHERE q.claim_token = :token AND w.enabled = 1
             ORDER BY q.id ASC';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':token', $token);

--- a/src/Models/WebhooksQueue.php
+++ b/src/Models/WebhooksQueue.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Models;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Enums\WebhookState;
+use PDO;
+
+use function bin2hex;
+use function json_encode;
+use function mb_substr;
+use function random_bytes;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * The webhooks_queue table: one row per delivery, so a slow or broken target only affects
+ * its own rows.
+ *
+ * Nothing here talks HTTP. Rows are inserted during a normal request (cheap: one select and
+ * one insert per subscriber) and drained out of band by the webhooks:send command.
+ */
+final class WebhooksQueue
+{
+    /** rows in Sending state older than this are considered abandoned by a crashed drain */
+    public const int STALE_CLAIM_MINUTES = 10;
+
+    /** delivered rows are kept this long, as a delivery log for the admin */
+    public const int KEEP_DELIVERED_DAYS = 7;
+
+    private Db $Db;
+
+    public function __construct()
+    {
+        $this->Db = Db::getConnection();
+    }
+
+    /**
+     * Insert one row per webhook that is entitled to this event and subscribed to it.
+     *
+     * The entitlement rules are deliberately restrictive for a first version: an instance
+     * webhook sees everything, a team webhook sees its own team, and a user webhook sees only
+     * entries owned by that user. Widening this later is harmless, narrowing it would break
+     * existing integrations.
+     *
+     * @return int number of deliveries queued
+     */
+    public function fanout(WebhookEvent $event, array $payload, int $teamId, int $ownerId): int
+    {
+        $sql = "SELECT id FROM webhooks
+            WHERE enabled = 1
+                AND JSON_CONTAINS(events, JSON_QUOTE(:event))
+                AND (
+                    scope = 'instance'
+                    OR (scope = 'team' AND teams_id = :team)
+                    OR (scope = 'user' AND users_id = :owner)
+                )";
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':event', $event->value);
+        $req->bindValue(':team', $teamId, PDO::PARAM_INT);
+        $req->bindValue(':owner', $ownerId, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        $webhooks = $req->fetchAll();
+        if (empty($webhooks)) {
+            return 0;
+        }
+
+        $body = json_encode($payload, JSON_THROW_ON_ERROR);
+        $sql = 'INSERT INTO webhooks_queue (webhooks_id, event_id, event, body) VALUES (:webhooks_id, :event_id, :event, :body)';
+        $req = $this->Db->prepare($sql);
+        $count = 0;
+        foreach ($webhooks as $webhook) {
+            $req->bindValue(':webhooks_id', $webhook['id'], PDO::PARAM_INT);
+            // the same event id on every copy: a subscriber can tell two deliveries of one
+            // event apart from two separate events
+            $req->bindValue(':event_id', (string) $payload['event_id']);
+            $req->bindValue(':event', $event->value);
+            $req->bindValue(':body', $body);
+            $this->Db->execute($req);
+            $count++;
+        }
+        return $count;
+    }
+
+    /**
+     * Take ownership of up to $limit due rows and return them with their target.
+     *
+     * The claim is a two step update/select on a random token instead of a plain select:
+     * two overlapping drains would otherwise both pick up the same row and deliver it twice.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function claim(int $limit): array
+    {
+        $token = bin2hex(random_bytes(16));
+        $sql = 'UPDATE webhooks_queue
+            SET state = :sending, claim_token = :token, attempts = attempts + 1, next_attempt_at = NOW()
+            WHERE state = :queued AND next_attempt_at <= NOW()
+            ORDER BY id ASC
+            LIMIT :limit';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':sending', WebhookState::Sending->value, PDO::PARAM_INT);
+        $req->bindValue(':queued', WebhookState::Queued->value, PDO::PARAM_INT);
+        $req->bindValue(':token', $token);
+        $req->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        $sql = 'SELECT q.id, q.event, q.event_id, q.body, q.attempts, w.id AS webhook_id, w.url, w.secret
+            FROM webhooks_queue AS q
+            INNER JOIN webhooks AS w ON (w.id = q.webhooks_id)
+            WHERE q.claim_token = :token
+            ORDER BY q.id ASC';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':token', $token);
+        $this->Db->execute($req);
+        return $req->fetchAll();
+    }
+
+    public function markDelivered(int $id): void
+    {
+        $sql = 'UPDATE webhooks_queue
+            SET state = :state, delivered_at = NOW(), claim_token = NULL, last_error = NULL
+            WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', WebhookState::Delivered->value, PDO::PARAM_INT);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    /**
+     * Put a row back in the queue, due again after $delay seconds.
+     */
+    public function markRetry(int $id, string $error, int $delay): void
+    {
+        $sql = 'UPDATE webhooks_queue
+            SET state = :state, claim_token = NULL, last_error = :error,
+                next_attempt_at = DATE_ADD(NOW(), INTERVAL :delay SECOND)
+            WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', WebhookState::Queued->value, PDO::PARAM_INT);
+        $req->bindValue(':error', $this->truncate($error));
+        $req->bindValue(':delay', $delay, PDO::PARAM_INT);
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    public function markFailed(int $id, string $error): void
+    {
+        $sql = 'UPDATE webhooks_queue SET state = :state, claim_token = NULL, last_error = :error WHERE id = :id';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', WebhookState::Failed->value, PDO::PARAM_INT);
+        $req->bindValue(':error', $this->truncate($error));
+        $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $this->Db->execute($req);
+    }
+
+    /**
+     * Rows left in Sending by a drain that died. Without this they would never be retried.
+     */
+    public function releaseStaleClaims(): int
+    {
+        $sql = 'UPDATE webhooks_queue
+            SET state = :queued, claim_token = NULL
+            WHERE state = :sending AND next_attempt_at < DATE_SUB(NOW(), INTERVAL :minutes MINUTE)';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':queued', WebhookState::Queued->value, PDO::PARAM_INT);
+        $req->bindValue(':sending', WebhookState::Sending->value, PDO::PARAM_INT);
+        $req->bindValue(':minutes', self::STALE_CLAIM_MINUTES, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $req->rowCount();
+    }
+
+    public function pruneDelivered(): int
+    {
+        $sql = 'DELETE FROM webhooks_queue
+            WHERE state = :state AND delivered_at < DATE_SUB(NOW(), INTERVAL :days DAY)';
+        $req = $this->Db->prepare($sql);
+        $req->bindValue(':state', WebhookState::Delivered->value, PDO::PARAM_INT);
+        $req->bindValue(':days', self::KEEP_DELIVERED_DAYS, PDO::PARAM_INT);
+        $this->Db->execute($req);
+        return $req->rowCount();
+    }
+
+    // the column is a TEXT but there is no value in storing a whole html error page
+    private function truncate(string $error): string
+    {
+        return mb_substr($error, 0, 500);
+    }
+}

--- a/src/Models/WebhooksQueue.php
+++ b/src/Models/WebhooksQueue.php
@@ -16,6 +16,7 @@ use Elabftw\Elabftw\Db;
 use Elabftw\Enums\WebhookEvent;
 use Elabftw\Enums\WebhookState;
 use PDO;
+use Throwable;
 
 use function bin2hex;
 use function json_encode;
@@ -78,17 +79,36 @@ final class WebhooksQueue
 
         $body = json_encode($payload, JSON_THROW_ON_ERROR);
         $sql = 'INSERT INTO webhooks_queue (webhooks_id, event_id, event, body) VALUES (:webhooks_id, :event_id, :event, :body)';
-        $req = $this->Db->prepare($sql);
-        $count = 0;
-        foreach ($webhooks as $webhook) {
-            $req->bindValue(':webhooks_id', $webhook['id'], PDO::PARAM_INT);
-            // the same event id on every copy: a subscriber can tell two deliveries of one
-            // event apart from two separate events
-            $req->bindValue(':event_id', (string) $payload['event_id']);
-            $req->bindValue(':event', $event->value);
-            $req->bindValue(':body', $body);
-            $this->Db->execute($req);
-            $count++;
+
+        // All or nothing: a fanout that inserted three rows and then failed would leave the
+        // event half delivered, and the retry would carry a different event id. If a caller
+        // already opened a transaction, ride along with theirs instead of nesting, which
+        // pdo does not support.
+        $ownTransaction = !$this->Db->inTransaction();
+        if ($ownTransaction) {
+            $this->Db->beginTransaction();
+        }
+        try {
+            $req = $this->Db->prepare($sql);
+            $count = 0;
+            foreach ($webhooks as $webhook) {
+                $req->bindValue(':webhooks_id', $webhook['id'], PDO::PARAM_INT);
+                // the same event id on every copy: a subscriber can tell two deliveries of
+                // one event apart from two separate events
+                $req->bindValue(':event_id', (string) $payload['event_id']);
+                $req->bindValue(':event', $event->value);
+                $req->bindValue(':body', $body);
+                $this->Db->execute($req);
+                $count++;
+            }
+            if ($ownTransaction) {
+                $this->Db->commit();
+            }
+        } catch (Throwable $e) {
+            if ($ownTransaction) {
+                $this->Db->rollBack();
+            }
+            throw $e;
         }
         return $count;
     }

--- a/src/Models/WebhooksQueue.php
+++ b/src/Models/WebhooksQueue.php
@@ -209,6 +209,31 @@ final class WebhooksQueue
     }
 
     /**
+     * Hand back rows that were claimed but never attempted, so they are due again at once
+     * instead of waiting out the stale window. The attempt is given back too: nothing was
+     * sent, so it should not count against the row's five tries.
+     *
+     * @param array<int, array<string, mixed>> $rows as returned by claim()
+     * @return int number of rows handed back
+     */
+    public function release(array $rows): int
+    {
+        $sql = 'UPDATE webhooks_queue
+            SET state = :queued, claim_token = NULL, attempts = attempts - 1
+            WHERE id = :id AND claim_token = :token';
+        $req = $this->Db->prepare($sql);
+        $released = 0;
+        foreach ($rows as $row) {
+            $req->bindValue(':queued', WebhookState::Queued->value, PDO::PARAM_INT);
+            $req->bindValue(':id', (int) $row['id'], PDO::PARAM_INT);
+            $req->bindValue(':token', (string) $row['claim_token']);
+            $this->Db->execute($req);
+            $released += $req->rowCount();
+        }
+        return $released;
+    }
+
+    /**
      * Rows left in Sending by a drain that died. Without this they would never be retried.
      */
     public function releaseStaleClaims(): int

--- a/src/Models/WebhooksQueue.php
+++ b/src/Models/WebhooksQueue.php
@@ -124,9 +124,13 @@ final class WebhooksQueue
     public function claim(int $limit): array
     {
         $token = bin2hex(random_bytes(16));
+        // a disabled webhook receives nothing, including whatever was queued before it was
+        // turned off: an admin switching it off expects deliveries to stop, not to drain
         $sql = 'UPDATE webhooks_queue
             SET state = :sending, claim_token = :token, attempts = attempts + 1, next_attempt_at = NOW()
-            WHERE state = :queued AND next_attempt_at <= NOW()
+            WHERE state = :queued
+                AND next_attempt_at <= NOW()
+                AND webhooks_id IN (SELECT id FROM webhooks WHERE enabled = 1)
             ORDER BY id ASC
             LIMIT :limit';
         $req = $this->Db->prepare($sql);
@@ -136,7 +140,7 @@ final class WebhooksQueue
         $req->bindValue(':limit', $limit, PDO::PARAM_INT);
         $this->Db->execute($req);
 
-        $sql = 'SELECT q.id, q.event, q.event_id, q.body, q.attempts, w.id AS webhook_id, w.url, w.secret
+        $sql = 'SELECT q.id, q.event, q.event_id, q.body, q.attempts, q.claim_token, w.id AS webhook_id, w.url, w.secret
             FROM webhooks_queue AS q
             INNER JOIN webhooks AS w ON (w.id = q.webhooks_id)
             WHERE q.claim_token = :token
@@ -147,42 +151,61 @@ final class WebhooksQueue
         return $req->fetchAll();
     }
 
-    public function markDelivered(int $id): void
+    /**
+     * Every state change carries the token the row was claimed with. A drain that hung long
+     * enough for releaseStaleClaims() to hand its row to someone else would otherwise
+     * overwrite the newer result on its way out, and could requeue an already delivered row.
+     *
+     * @return bool false when the claim was lost, meaning another drain owns the row now
+     */
+    public function markDelivered(int $id, string $token): bool
     {
         $sql = 'UPDATE webhooks_queue
             SET state = :state, delivered_at = NOW(), claim_token = NULL, last_error = NULL
-            WHERE id = :id';
+            WHERE id = :id AND claim_token = :token';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', WebhookState::Delivered->value, PDO::PARAM_INT);
         $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $req->bindValue(':token', $token);
         $this->Db->execute($req);
+        return $req->rowCount() === 1;
     }
 
     /**
      * Put a row back in the queue, due again after $delay seconds.
+     *
+     * @return bool false when the claim was lost
      */
-    public function markRetry(int $id, string $error, int $delay): void
+    public function markRetry(int $id, string $token, string $error, int $delay): bool
     {
         $sql = 'UPDATE webhooks_queue
             SET state = :state, claim_token = NULL, last_error = :error,
                 next_attempt_at = DATE_ADD(NOW(), INTERVAL :delay SECOND)
-            WHERE id = :id';
+            WHERE id = :id AND claim_token = :token';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', WebhookState::Queued->value, PDO::PARAM_INT);
         $req->bindValue(':error', $this->truncate($error));
         $req->bindValue(':delay', $delay, PDO::PARAM_INT);
         $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $req->bindValue(':token', $token);
         $this->Db->execute($req);
+        return $req->rowCount() === 1;
     }
 
-    public function markFailed(int $id, string $error): void
+    /**
+     * @return bool false when the claim was lost
+     */
+    public function markFailed(int $id, string $token, string $error): bool
     {
-        $sql = 'UPDATE webhooks_queue SET state = :state, claim_token = NULL, last_error = :error WHERE id = :id';
+        $sql = 'UPDATE webhooks_queue SET state = :state, claim_token = NULL, last_error = :error
+            WHERE id = :id AND claim_token = :token';
         $req = $this->Db->prepare($sql);
         $req->bindValue(':state', WebhookState::Failed->value, PDO::PARAM_INT);
         $req->bindValue(':error', $this->truncate($error));
         $req->bindValue(':id', $id, PDO::PARAM_INT);
+        $req->bindValue(':token', $token);
         $this->Db->execute($req);
+        return $req->rowCount() === 1;
     }
 
     /**
@@ -204,9 +227,13 @@ final class WebhooksQueue
     public function pruneDelivered(): int
     {
         $sql = 'DELETE FROM webhooks_queue
-            WHERE state = :state AND delivered_at < DATE_SUB(NOW(), INTERVAL :days DAY)';
+            WHERE (state = :delivered AND delivered_at < DATE_SUB(NOW(), INTERVAL :days DAY))
+                OR (state = :queued AND created_at < DATE_SUB(NOW(), INTERVAL :days DAY))';
         $req = $this->Db->prepare($sql);
-        $req->bindValue(':state', WebhookState::Delivered->value, PDO::PARAM_INT);
+        $req->bindValue(':delivered', WebhookState::Delivered->value, PDO::PARAM_INT);
+        // queued rows this old belong to a webhook that was disabled or is long dead: the
+        // longest backoff is an hour, so nothing legitimate waits for days
+        $req->bindValue(':queued', WebhookState::Queued->value, PDO::PARAM_INT);
         $req->bindValue(':days', self::KEEP_DELIVERED_DAYS, PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->rowCount();

--- a/src/Services/Transform.php
+++ b/src/Services/Transform.php
@@ -128,6 +128,16 @@ final class Transform
                     ),
                     $notif['created_at'],
                 ),
+            Notifications::WebhookDisabled =>
+                sprintf(
+                    '<span data-action="ack-notif" data-id="%d">%s</span>' . $relativeMoment,
+                    (int) $notif['id'],
+                    sprintf(
+                        _('A webhook was disabled after too many failed deliveries: %s'),
+                        $notif['body']['url'],
+                    ),
+                    $notif['created_at'],
+                ),
             default => throw new ImproperActionException('Invalid notification type.'),
         };
     }

--- a/src/Services/WebhookDispatcher.php
+++ b/src/Services/WebhookDispatcher.php
@@ -18,15 +18,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 use function array_slice;
+use function filter_var;
 use function hash_hmac;
+use function implode;
 use function max;
 use function min;
 use function parse_url;
 use function sprintf;
+use function str_contains;
 use function strtolower;
 use function time;
+use function trim;
 
 use const CURLOPT_RESOLVE;
+use const FILTER_VALIDATE_IP;
 
 /**
  * Drains the webhook queue: this is the only place that talks to the outside world.
@@ -205,12 +210,25 @@ final class WebhookDispatcher
         if ($parts === false || empty($parts['host'])) {
             return array();
         }
-        $host = strtolower($parts['host']);
-        $port = $parts['port'] ?? (strtolower($parts['scheme'] ?? 'https') === 'http' ? 80 : 443);
-        $list = array();
-        foreach ($this->validator->resolve($host) as $address) {
-            $list[] = sprintf('%s:%d:%s', $host, $port, $address);
+        $host = strtolower(trim($parts['host'], '[]'));
+        // an address literal has no name to rebind, so there is nothing to pin: curl resolves
+        // it to itself. Building an entry here would only hand curl a host part containing
+        // colons, which it cannot read.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return array();
         }
-        return $list;
+        $port = $parts['port'] ?? (strtolower($parts['scheme'] ?? 'https') === 'http' ? 80 : 443);
+        $addresses = array();
+        foreach ($this->validator->resolve($host) as $address) {
+            // curl splits the entry on colons, so an ipv6 address has to be bracketed or the
+            // entry is misread and the pinning quietly stops working
+            $addresses[] = str_contains($address, ':') ? sprintf('[%s]', $address) : $address;
+        }
+        if (empty($addresses)) {
+            return array();
+        }
+        // one entry per host and port, with the addresses comma separated: repeating the
+        // same host and port in several entries makes curl keep only one of them
+        return array(sprintf('%s:%d:%s', $host, $port, implode(',', $addresses)));
     }
 }

--- a/src/Services/WebhookDispatcher.php
+++ b/src/Services/WebhookDispatcher.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Services;
+
+use Elabftw\Models\Webhooks;
+use Elabftw\Models\WebhooksQueue;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function hash_hmac;
+use function max;
+use function min;
+use function parse_url;
+use function sprintf;
+use function strtolower;
+use function time;
+
+use const CURLOPT_RESOLVE;
+
+/**
+ * Drains the webhook queue: this is the only place that talks to the outside world.
+ *
+ * Run every minute by chronos. Two things follow from that: it must not run longer than a
+ * minute (or the next tick starts immediately after this one ends), and it must never retry
+ * inline, because a target that hangs would otherwise hold up every other target behind it.
+ */
+final class WebhookDispatcher
+{
+    public const string SIGNATURE_HEADER = 'X-Elabftw-Signature';
+
+    public const string EVENT_HEADER = 'X-Elabftw-Event';
+
+    public const string DELIVERY_HEADER = 'X-Elabftw-Delivery';
+
+    /** give up on a delivery after this many attempts */
+    private const int MAX_ATTEMPTS = 5;
+
+    /** rows taken per round */
+    private const int BATCH_SIZE = 20;
+
+    /** stop starting new rounds after this many seconds, chronos ticks every 60 */
+    private const int TIME_BUDGET = 45;
+
+    private const int CONNECT_TIMEOUT = 5;
+
+    private const int REQUEST_TIMEOUT = 10;
+
+    private const int FIRST_RETRY_DELAY = 60;
+
+    private const int MAX_RETRY_DELAY = 3600;
+
+    private WebhooksQueue $Queue;
+
+    private Webhooks $Webhooks;
+
+    public function __construct(
+        private readonly HttpGetter $httpGetter,
+        private readonly WebhookUrlValidator $validator,
+    ) {
+        $this->Queue = new WebhooksQueue();
+        $this->Webhooks = new Webhooks();
+    }
+
+    /**
+     * @return int number of deliveries that succeeded
+     */
+    public function send(OutputInterface $output): int
+    {
+        $deadline = time() + self::TIME_BUDGET;
+        $this->Queue->releaseStaleClaims();
+
+        $delivered = 0;
+        while (time() < $deadline) {
+            $batch = $this->Queue->claim(self::BATCH_SIZE);
+            if (empty($batch)) {
+                break;
+            }
+            foreach ($batch as $row) {
+                if ($this->deliver($row, $output)) {
+                    $delivered++;
+                }
+            }
+        }
+        $this->Queue->pruneDelivered();
+
+        return $delivered;
+    }
+
+    private function deliver(array $row, OutputInterface $output): bool
+    {
+        $id = (int) $row['id'];
+        $webhookId = (int) $row['webhook_id'];
+        $body = (string) $row['body'];
+        try {
+            $url = (string) $row['url'];
+            // the address checks are redone here, not just when the webhook was configured:
+            // the row may have been queued minutes ago, and dns for a host that was public
+            // then can answer with an internal address now
+            $resolved = $this->getResolveList($url);
+            $response = $this->httpGetter->post($url, $this->getOptions($row, $body, $resolved));
+            $status = $response->getStatusCode();
+            if ($status >= 200 && $status < 300) {
+                $this->Queue->markDelivered($id);
+                $this->Webhooks->recordSuccess($webhookId);
+                return true;
+            }
+            $this->handleFailure($id, $webhookId, (int) $row['attempts'], sprintf('target answered %d', $status), $output);
+        } catch (Throwable $e) {
+            $this->handleFailure($id, $webhookId, (int) $row['attempts'], $e->getMessage(), $output);
+        }
+        return false;
+    }
+
+    private function handleFailure(int $id, int $webhookId, int $attempts, string $error, OutputInterface $output): void
+    {
+        if ($attempts < self::MAX_ATTEMPTS) {
+            $this->Queue->markRetry($id, $error, $this->getRetryDelay($attempts));
+            return;
+        }
+        $this->Queue->markFailed($id, $error);
+        $disabled = $this->Webhooks->recordFailure($webhookId, $error);
+        if ($output->isVerbose()) {
+            $output->writeln(sprintf(
+                'webhook %d: delivery %d gave up after %d attempts (%s)%s',
+                $webhookId,
+                $id,
+                $attempts,
+                $error,
+                $disabled ? ' - webhook disabled' : '',
+            ));
+        }
+    }
+
+    // exponential, so a target that is down for an hour is not hammered every minute
+    private function getRetryDelay(int $attempts): int
+    {
+        // shift rather than ** so the result stays an int, both analysers insist on that
+        $steps = min(max($attempts - 1, 0), 16);
+        return min(self::FIRST_RETRY_DELAY << $steps, self::MAX_RETRY_DELAY);
+    }
+
+    /**
+     * @param array<int, string> $resolved
+     */
+    private function getOptions(array $row, string $body, array $resolved): array
+    {
+        return array(
+            'body' => $body,
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'eLabFTW-Webhook',
+                // signature is over the raw body, so a receiver can verify without reparsing
+                self::SIGNATURE_HEADER => 'sha256=' . hash_hmac('sha256', $body, (string) $row['secret']),
+                self::EVENT_HEADER => (string) $row['event'],
+                self::DELIVERY_HEADER => (string) $row['event_id'],
+            ),
+            // a redirect would take us to a host that never passed the address checks
+            'allow_redirects' => false,
+            'connect_timeout' => self::CONNECT_TIMEOUT,
+            'timeout' => self::REQUEST_TIMEOUT,
+            // a non 2xx answer is a failed delivery, not an exception to unwind
+            'http_errors' => false,
+            // pin the connection to the addresses that were just checked, otherwise a second
+            // dns answer could send the request somewhere else entirely
+            'curl' => array(CURLOPT_RESOLVE => $resolved),
+        );
+    }
+
+    /**
+     * Resolve the target and check every address it answers with, returning curl's
+     * host:port:address form so the connection can be pinned to what was checked.
+     *
+     * @return array<int, string>
+     */
+    private function getResolveList(string $url): array
+    {
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['host'])) {
+            return array();
+        }
+        $host = strtolower($parts['host']);
+        $port = $parts['port'] ?? (strtolower($parts['scheme'] ?? 'https') === 'http' ? 80 : 443);
+        $list = array();
+        foreach ($this->validator->resolve($host) as $address) {
+            $list[] = sprintf('%s:%d:%s', $host, $port, $address);
+        }
+        return $list;
+    }
+}

--- a/src/Services/WebhookDispatcher.php
+++ b/src/Services/WebhookDispatcher.php
@@ -17,6 +17,7 @@ use Elabftw\Models\WebhooksQueue;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
+use function array_slice;
 use function hash_hmac;
 use function max;
 use function min;
@@ -48,7 +49,10 @@ final class WebhookDispatcher
     /** rows taken per round */
     private const int BATCH_SIZE = 20;
 
-    /** stop starting new rounds after this many seconds, chronos ticks every 60 */
+    /**
+     * Stop taking on work after this many seconds. chronos ticks every 60, and a delivery
+     * already under way may still add up to REQUEST_TIMEOUT on top.
+     */
     private const int TIME_BUDGET = 45;
 
     private const int CONNECT_TIMEOUT = 5;
@@ -85,7 +89,14 @@ final class WebhookDispatcher
             if (empty($batch)) {
                 break;
             }
-            foreach ($batch as $row) {
+            foreach ($batch as $index => $row) {
+                // the deadline has to be checked per row, not per batch: a batch of slow
+                // targets would otherwise run for batch size times the request timeout, and
+                // the next chronos tick would start on top of this one
+                if (time() >= $deadline) {
+                    $this->Queue->release(array_slice($batch, $index));
+                    break 2;
+                }
                 if ($this->deliver($row, $output)) {
                     $delivered++;
                 }

--- a/src/Services/WebhookDispatcher.php
+++ b/src/Services/WebhookDispatcher.php
@@ -99,6 +99,7 @@ final class WebhookDispatcher
     private function deliver(array $row, OutputInterface $output): bool
     {
         $id = (int) $row['id'];
+        $token = (string) $row['claim_token'];
         $webhookId = (int) $row['webhook_id'];
         $body = (string) $row['body'];
         try {
@@ -110,24 +111,29 @@ final class WebhookDispatcher
             $response = $this->httpGetter->post($url, $this->getOptions($row, $body, $resolved));
             $status = $response->getStatusCode();
             if ($status >= 200 && $status < 300) {
-                $this->Queue->markDelivered($id);
+                if (!$this->Queue->markDelivered($id, $token)) {
+                    // another drain owns this row now, its result is the one that counts
+                    return false;
+                }
                 $this->Webhooks->recordSuccess($webhookId);
                 return true;
             }
-            $this->handleFailure($id, $webhookId, (int) $row['attempts'], sprintf('target answered %d', $status), $output);
+            $this->handleFailure($id, $token, $webhookId, (int) $row['attempts'], sprintf('target answered %d', $status), $output);
         } catch (Throwable $e) {
-            $this->handleFailure($id, $webhookId, (int) $row['attempts'], $e->getMessage(), $output);
+            $this->handleFailure($id, $token, $webhookId, (int) $row['attempts'], $e->getMessage(), $output);
         }
         return false;
     }
 
-    private function handleFailure(int $id, int $webhookId, int $attempts, string $error, OutputInterface $output): void
+    private function handleFailure(int $id, string $token, int $webhookId, int $attempts, string $error, OutputInterface $output): void
     {
         if ($attempts < self::MAX_ATTEMPTS) {
-            $this->Queue->markRetry($id, $error, $this->getRetryDelay($attempts));
+            $this->Queue->markRetry($id, $token, $error, $this->getRetryDelay($attempts));
             return;
         }
-        $this->Queue->markFailed($id, $error);
+        if (!$this->Queue->markFailed($id, $token, $error)) {
+            return;
+        }
         $disabled = $this->Webhooks->recordFailure($webhookId, $error);
         if ($output->isVerbose()) {
             $output->writeln(sprintf(

--- a/src/Services/WebhookEmitter.php
+++ b/src/Services/WebhookEmitter.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Services;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Elabftw\Elabftw\Db;
+use Elabftw\Elabftw\Env;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Models\AbstractEntity;
+use Elabftw\Models\WebhooksQueue;
+use PDO;
+use Throwable;
+
+use function bin2hex;
+use function error_log;
+use function random_bytes;
+use function rtrim;
+use function sprintf;
+
+/**
+ * Turns a changelog write into queued webhook deliveries.
+ *
+ * This is called from Changelog::create(), which is the one place that already knows
+ * "something changed on this entity", so emitting events does not scatter hooks across
+ * the models.
+ *
+ * The payload carries identifiers only, never the entity body: a body would be a second
+ * serialization to maintain next to the API, and it would hand out content that the
+ * subscriber may not be allowed to read. Subscribers fetch the url with their own api key
+ * and get exactly what they are entitled to.
+ */
+final class WebhookEmitter
+{
+    /**
+     * Events already emitted in this request, keyed by event and entity.
+     * An update that touches five columns writes five changelog rows but is one change as far
+     * as a subscriber is concerned.
+     *
+     * @var array<string, true>
+     */
+    private static array $emitted = array();
+
+    public static function fromChangelog(AbstractEntity $entity, string $target): void
+    {
+        try {
+            self::emit($entity, $target);
+        } catch (Throwable $e) {
+            // a broken webhook configuration must never make a save fail
+            error_log(sprintf('webhook emission failed: %s', $e->getMessage()));
+        }
+    }
+
+    /**
+     * Only used by tests, to get a clean slate between cases.
+     */
+    public static function reset(): void
+    {
+        self::$emitted = array();
+    }
+
+    private static function emit(AbstractEntity $entity, string $target): void
+    {
+        if ($entity->id === null) {
+            return;
+        }
+        $event = WebhookEvent::fromChangelogTarget($entity->entityType, $target);
+        if ($event === null) {
+            return;
+        }
+        $key = sprintf('%s:%d', $event->value, $entity->id);
+        if (isset(self::$emitted[$key])) {
+            return;
+        }
+
+        $owner = self::readOwner($entity);
+        if ($owner === null) {
+            return;
+        }
+        self::$emitted[$key] = true;
+
+        $payload = array(
+            'event' => $event->value,
+            'event_id' => bin2hex(random_bytes(16)),
+            'id' => $entity->id,
+            'team' => (int) $owner['team'],
+            'url' => sprintf(
+                '%s/api/v2/%s/%d',
+                rtrim(Env::asUrl('SITE_URL'), '/'),
+                $entity->entityType->value,
+                $entity->id,
+            ),
+            'at' => new DateTimeImmutable()->format(DateTimeInterface::ATOM),
+            'actor' => array(
+                'userid' => $entity->Users->userData['userid'] ?? null,
+                // present when the change came through the api, so an integration can
+                // recognise and skip the changes it caused itself
+                'apikey_id' => $entity->Users->apiKeyId,
+            ),
+        );
+
+        new WebhooksQueue()->fanout($event, $payload, (int) $owner['team'], (int) $owner['userid']);
+    }
+
+    /**
+     * Read team and owner straight from the table rather than from entityData: this runs on
+     * every write, and it must not depend on how the entity was loaded.
+     *
+     * @return array{team: int, userid: int}|null
+     */
+    private static function readOwner(AbstractEntity $entity): ?array
+    {
+        // the table name comes from an enum, never from user input
+        $Db = Db::getConnection();
+        $sql = sprintf('SELECT team, userid FROM %s WHERE id = :id', $entity->entityType->value);
+        $req = $Db->prepare($sql);
+        $req->bindValue(':id', $entity->id, PDO::PARAM_INT);
+        $Db->execute($req);
+        $res = $req->fetch();
+        if ($res === false) {
+            return null;
+        }
+        return array('team' => (int) $res['team'], 'userid' => (int) $res['userid']);
+    }
+}

--- a/src/Services/WebhookEmitter.php
+++ b/src/Services/WebhookEmitter.php
@@ -87,7 +87,6 @@ final class WebhookEmitter
         if ($owner === null) {
             return;
         }
-        self::$emitted[$key] = true;
 
         $payload = array(
             'event' => $event->value,
@@ -110,6 +109,9 @@ final class WebhookEmitter
         );
 
         new WebhooksQueue()->fanout($event, $payload, (int) $owner['team'], (int) $owner['userid']);
+        // only now: if the fanout throws, the next write for this entity gets another
+        // chance instead of being swallowed by the dedup cache
+        self::$emitted[$key] = true;
     }
 
     /**

--- a/src/Services/WebhookUrlValidator.php
+++ b/src/Services/WebhookUrlValidator.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+declare(strict_types=1);
+
+namespace Elabftw\Services;
+
+use Elabftw\Exceptions\ImproperActionException;
+
+use function array_unique;
+use function array_values;
+use function dns_get_record;
+use function filter_var;
+use function gethostbynamel;
+use function inet_pton;
+use function intdiv;
+use function is_array;
+use function ord;
+use function parse_url;
+use function sprintf;
+use function str_contains;
+use function strlen;
+use function strrpos;
+use function strtolower;
+use function substr;
+use function trim;
+
+use const DNS_A;
+use const DNS_AAAA;
+use const FILTER_FLAG_IPV4;
+use const FILTER_FLAG_IPV6;
+use const FILTER_VALIDATE_IP;
+use const PHP_URL_FRAGMENT;
+
+/**
+ * A webhook target is a URL supplied by a user and fetched by the server, which is the exact
+ * shape of an SSRF. This class is the guard: it rejects anything that is not a public https
+ * endpoint, and it resolves the host so the caller can pin the connection to the addresses
+ * that were actually checked (otherwise DNS could answer differently the second time).
+ *
+ * In DEV_MODE the address checks are relaxed, because a development instance talks to a
+ * receiver on a private address by definition.
+ */
+final class WebhookUrlValidator
+{
+    public const int MAX_URL_LENGTH = 512;
+
+    /** @var array<int, array{0: string, 1: int}> network/prefix pairs that must never be reached */
+    private const array BLOCKED_V4 = array(
+        array('0.0.0.0', 8),
+        array('10.0.0.0', 8),
+        array('100.64.0.0', 10),
+        array('127.0.0.0', 8),
+        array('169.254.0.0', 16),
+        array('172.16.0.0', 12),
+        array('192.0.0.0', 24),
+        array('192.0.2.0', 24),
+        array('192.88.99.0', 24),
+        array('192.168.0.0', 16),
+        array('198.18.0.0', 15),
+        array('198.51.100.0', 24),
+        array('203.0.113.0', 24),
+        array('224.0.0.0', 4),
+        array('240.0.0.0', 4),
+    );
+
+    /** @var array<int, array{0: string, 1: int}> */
+    private const array BLOCKED_V6 = array(
+        array('::', 128),
+        array('::1', 128),
+        array('64:ff9b::', 96),
+        array('100::', 64),
+        array('2001::', 32),
+        array('2001:db8::', 32),
+        array('fc00::', 7),
+        array('fe80::', 10),
+        array('ff00::', 8),
+    );
+
+    public function __construct(private readonly bool $strict = true) {}
+
+    /**
+     * Check a URL before it is stored. Throws if it can never be a legitimate target.
+     * DNS is resolved here too, so an obviously internal name is refused at configuration
+     * time rather than silently failing later.
+     */
+    public function validate(string $url): string
+    {
+        $url = trim($url);
+        if ($url === '' || strlen($url) > self::MAX_URL_LENGTH) {
+            throw new ImproperActionException(sprintf('Webhook URL must be between 1 and %d characters.', self::MAX_URL_LENGTH));
+        }
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['host']) || empty($parts['scheme'])) {
+            throw new ImproperActionException('Could not parse webhook URL.');
+        }
+        $scheme = strtolower($parts['scheme']);
+        if ($scheme !== 'https' && !($scheme === 'http' && !$this->strict)) {
+            throw new ImproperActionException('Webhook URL must use https.');
+        }
+        // credentials in the URL are a way to smuggle a different host past a naive parser
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            throw new ImproperActionException('Webhook URL must not contain credentials.');
+        }
+        if (parse_url($url, PHP_URL_FRAGMENT) !== null) {
+            throw new ImproperActionException('Webhook URL must not contain a fragment.');
+        }
+        // resolving here means an internal name is refused at configuration time rather than
+        // silently failing later. Skipped in dev, where the target is private by definition
+        // and dns may not even be reachable
+        if ($this->strict) {
+            $this->resolve($parts['host']);
+        }
+        return $url;
+    }
+
+    /**
+     * Resolve a host to the addresses that passed the checks.
+     * The caller pins the connection to these, so what was checked is what gets connected to.
+     *
+     * @return array<int, string>
+     */
+    public function resolve(string $host): array
+    {
+        $host = strtolower(trim($host, '[]'));
+        // an address literal needs no resolution, but still needs checking
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            $this->guardAddress($host);
+            return array($host);
+        }
+        $addresses = $this->lookup($host);
+        if (empty($addresses)) {
+            if (!$this->strict) {
+                // nothing to pin, let the http client resolve it itself
+                return array();
+            }
+            throw new ImproperActionException(sprintf('Could not resolve webhook host: %s', $host));
+        }
+        foreach ($addresses as $address) {
+            $this->guardAddress($address);
+        }
+        return $addresses;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function lookup(string $host): array
+    {
+        $addresses = array();
+        // the @ is deliberate: a failing lookup is reported as "could not resolve", not as a warning
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+        if (is_array($records)) {
+            foreach ($records as $record) {
+                $address = $record['ip'] ?? $record['ipv6'] ?? null;
+                if ($address !== null) {
+                    $addresses[] = (string) $address;
+                }
+            }
+        }
+        // dns_get_record is not always available inside containers, fall back to the resolver
+        if (empty($addresses)) {
+            $fallback = @gethostbynamel($host);
+            if (is_array($fallback)) {
+                $addresses = $fallback;
+            }
+        }
+        return array_values(array_unique($addresses));
+    }
+
+    private function guardAddress(string $address): void
+    {
+        if ($this->strict === false) {
+            return;
+        }
+        // ipv4 written as ipv6, unwrap it so the v4 rules apply
+        if (str_contains($address, '.') && str_contains($address, ':')) {
+            $address = substr($address, (int) strrpos($address, ':') + 1);
+        }
+        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            $this->guardAgainst($address, self::BLOCKED_V4);
+            return;
+        }
+        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            $this->guardAgainst($address, self::BLOCKED_V6);
+            return;
+        }
+        throw new ImproperActionException(sprintf('Webhook host resolves to an invalid address: %s', $address));
+    }
+
+    /**
+     * @param array<int, array{0: string, 1: int}> $blocked
+     */
+    private function guardAgainst(string $address, array $blocked): void
+    {
+        foreach ($blocked as [$network, $prefix]) {
+            if ($this->isInNetwork($address, $network, $prefix)) {
+                throw new ImproperActionException(sprintf(
+                    'Webhook URL points to a reserved address (%s). Only public addresses are allowed.',
+                    $address,
+                ));
+            }
+        }
+    }
+
+    private function isInNetwork(string $address, string $network, int $prefix): bool
+    {
+        $addressBin = inet_pton($address);
+        $networkBin = inet_pton($network);
+        if ($addressBin === false || $networkBin === false || strlen($addressBin) !== strlen($networkBin)) {
+            return false;
+        }
+        $fullBytes = intdiv($prefix, 8);
+        if ($fullBytes > 0 && substr($addressBin, 0, $fullBytes) !== substr($networkBin, 0, $fullBytes)) {
+            return false;
+        }
+        $remainingBits = $prefix % 8;
+        if ($remainingBits === 0) {
+            return true;
+        }
+        $mask = 0xff << (8 - $remainingBits) & 0xff;
+        return (ord($addressBin[$fullBytes]) & $mask) === (ord($networkBin[$fullBytes]) & $mask);
+    }
+}

--- a/src/Services/WebhookUrlValidator.php
+++ b/src/Services/WebhookUrlValidator.php
@@ -45,8 +45,10 @@ use const PHP_URL_FRAGMENT;
  *
  * In DEV_MODE the address checks are relaxed, because a development instance talks to a
  * receiver on a private address by definition.
+ *
+ * @final mocked in tests
  */
-final class WebhookUrlValidator
+class WebhookUrlValidator
 {
     public const int MAX_URL_LENGTH = 512;
 

--- a/src/Services/WebhookUrlValidator.php
+++ b/src/Services/WebhookUrlValidator.php
@@ -19,23 +19,21 @@ use function array_values;
 use function dns_get_record;
 use function filter_var;
 use function gethostbynamel;
+use function inet_ntop;
 use function inet_pton;
 use function intdiv;
 use function is_array;
 use function ord;
 use function parse_url;
 use function sprintf;
-use function str_contains;
+use function str_repeat;
 use function strlen;
-use function strrpos;
 use function strtolower;
 use function substr;
 use function trim;
 
 use const DNS_A;
 use const DNS_AAAA;
-use const FILTER_FLAG_IPV4;
-use const FILTER_FLAG_IPV6;
 use const FILTER_VALIDATE_IP;
 use const PHP_URL_FRAGMENT;
 
@@ -51,6 +49,9 @@ use const PHP_URL_FRAGMENT;
 final class WebhookUrlValidator
 {
     public const int MAX_URL_LENGTH = 512;
+
+    /** length of an ipv4 address in binary form */
+    private const int V4_LENGTH = 4;
 
     /** @var array<int, array{0: string, 1: int}> network/prefix pairs that must never be reached */
     private const array BLOCKED_V4 = array(
@@ -180,19 +181,23 @@ final class WebhookUrlValidator
         if ($this->strict === false) {
             return;
         }
-        // ipv4 written as ipv6, unwrap it so the v4 rules apply
-        if (str_contains($address, '.') && str_contains($address, ':')) {
-            $address = substr($address, (int) strrpos($address, ':') + 1);
+        $binary = inet_pton($address);
+        if ($binary === false) {
+            throw new ImproperActionException(sprintf('Webhook host resolves to an invalid address: %s', $address));
         }
-        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+        if (strlen($binary) === self::V4_LENGTH) {
             $this->guardAgainst($address, self::BLOCKED_V4);
             return;
         }
-        if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
-            $this->guardAgainst($address, self::BLOCKED_V6);
+        // Only a v4-mapped address (::ffff:a.b.c.d) really carries a v4 address, and that has
+        // to be decided on the bytes: fc00::1.2.3.4 is written with dots as well, but it is an
+        // ordinary unique-local v6 address, and judging it as v4 would walk it straight past
+        // the v6 rules.
+        if (substr($binary, 0, 10) === str_repeat("\0", 10) && substr($binary, 10, 2) === "\xff\xff") {
+            $this->guardAgainst((string) inet_ntop(substr($binary, 12, self::V4_LENGTH)), self::BLOCKED_V4);
             return;
         }
-        throw new ImproperActionException(sprintf('Webhook host resolves to an invalid address: %s', $address));
+        $this->guardAgainst($address, self::BLOCKED_V6);
     }
 
     /**

--- a/src/sql/schema225-down.sql
+++ b/src/sql/schema225-down.sql
@@ -1,0 +1,5 @@
+-- revert schema 225
+DROP TABLE IF EXISTS `webhooks_queue`;
+DROP TABLE IF EXISTS `webhooks`;
+
+UPDATE config SET conf_value = 224 WHERE conf_name = 'schema';

--- a/src/sql/schema225.sql
+++ b/src/sql/schema225.sql
@@ -1,0 +1,48 @@
+-- schema 225
+-- The pairing of scope with teams_id/users_id is not expressed as a CHECK constraint:
+-- MySQL refuses a CHECK on a column that takes part in a foreign key referential action,
+-- and the cascading deletes matter more. Without them a deleted team or user would leave
+-- webhook rows behind that keep receiving events. The invariant is guaranteed in the model
+-- layer instead, where each scope is its own class and hardcodes both values.
+CREATE TABLE `webhooks` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `scope` varchar(8) NOT NULL,
+  `teams_id` int(10) UNSIGNED DEFAULT NULL,
+  `users_id` int(10) UNSIGNED DEFAULT NULL,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `url` varchar(512) NOT NULL,
+  `secret` varchar(64) NOT NULL,
+  `events` json NOT NULL,
+  `enabled` tinyint NOT NULL DEFAULT 1,
+  `consecutive_failures` int(10) UNSIGNED NOT NULL DEFAULT 0,
+  `last_error` text DEFAULT NULL,
+  `disabled_at` datetime DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_webhooks_scope` (`scope`, `enabled`),
+  KEY `idx_webhooks_teams_id` (`teams_id`),
+  KEY `idx_webhooks_users_id` (`users_id`),
+  CONSTRAINT `fk_webhooks_teams_id` FOREIGN KEY (`teams_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_webhooks_users_id` FOREIGN KEY (`users_id`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `webhooks_queue` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `webhooks_id` int(10) UNSIGNED NOT NULL,
+  `event_id` char(32) NOT NULL,
+  `event` varchar(64) NOT NULL,
+  `body` json NOT NULL,
+  `state` tinyint NOT NULL DEFAULT 0,
+  `attempts` int(10) UNSIGNED NOT NULL DEFAULT 0,
+  `claim_token` char(32) DEFAULT NULL,
+  `next_attempt_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `delivered_at` datetime DEFAULT NULL,
+  `last_error` text DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_webhooks_queue_drain` (`state`, `next_attempt_at`),
+  KEY `idx_webhooks_queue_claim_token` (`claim_token`),
+  KEY `idx_webhooks_queue_webhooks_id` (`webhooks_id`),
+  CONSTRAINT `fk_webhooks_queue_webhooks_id` FOREIGN KEY (`webhooks_id`) REFERENCES `webhooks` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;

--- a/src/sql/structure.sql
+++ b/src/sql/structure.sql
@@ -2345,6 +2345,55 @@ CREATE TABLE branding (
     PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
+-- schema 225
+-- The pairing of scope with teams_id/users_id is not expressed as a CHECK constraint:
+-- MySQL refuses a CHECK on a column that takes part in a foreign key referential action,
+-- and the cascading deletes matter more. Without them a deleted team or user would leave
+-- webhook rows behind that keep receiving events. The invariant is guaranteed in the model
+-- layer instead, where each scope is its own class and hardcodes both values.
+CREATE TABLE `webhooks` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `scope` varchar(8) NOT NULL,
+  `teams_id` int(10) UNSIGNED DEFAULT NULL,
+  `users_id` int(10) UNSIGNED DEFAULT NULL,
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `url` varchar(512) NOT NULL,
+  `secret` varchar(64) NOT NULL,
+  `events` json NOT NULL,
+  `enabled` tinyint NOT NULL DEFAULT 1,
+  `consecutive_failures` int(10) UNSIGNED NOT NULL DEFAULT 0,
+  `last_error` text DEFAULT NULL,
+  `disabled_at` datetime DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_webhooks_scope` (`scope`, `enabled`),
+  KEY `idx_webhooks_teams_id` (`teams_id`),
+  KEY `idx_webhooks_users_id` (`users_id`),
+  CONSTRAINT `fk_webhooks_teams_id` FOREIGN KEY (`teams_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_webhooks_users_id` FOREIGN KEY (`users_id`) REFERENCES `users` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+CREATE TABLE `webhooks_queue` (
+  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `webhooks_id` int(10) UNSIGNED NOT NULL,
+  `event_id` char(32) NOT NULL,
+  `event` varchar(64) NOT NULL,
+  `body` json NOT NULL,
+  `state` tinyint NOT NULL DEFAULT 0,
+  `attempts` int(10) UNSIGNED NOT NULL DEFAULT 0,
+  `claim_token` char(32) DEFAULT NULL,
+  `next_attempt_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `delivered_at` datetime DEFAULT NULL,
+  `last_error` text DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_webhooks_queue_drain` (`state`, `next_attempt_at`),
+  KEY `idx_webhooks_queue_claim_token` (`claim_token`),
+  KEY `idx_webhooks_queue_webhooks_id` (`webhooks_id`),
+  CONSTRAINT `fk_webhooks_queue_webhooks_id` FOREIGN KEY (`webhooks_id`) REFERENCES `webhooks` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
 --
 -- Indexes and Constraints for table `experiments_templates_edit_mode`
 --

--- a/tests/unit/models/InstanceWebhooksTest.php
+++ b/tests/unit/models/InstanceWebhooksTest.php
@@ -57,14 +57,28 @@ class InstanceWebhooksTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($initialCount, count($this->InstanceWebhooks->readAll()));
     }
 
-    public function testSecretIsHiddenWithoutWriteAccess(): void
+    /**
+     * A webhook target is an outbound data flow, so its url, its events and its failure
+     * history are not public: reading takes the same authority as writing.
+     */
+    public function testReadingWithoutPermissionIsRefused(): void
     {
         $id = $this->InstanceWebhooks->postAction(Action::Create, array(
             'url' => 'https://192.0.2.11/hook',
             'events' => array(WebhookEvent::ItemCreated->value),
         ));
-        $webhook = new InstanceWebhooks(false, $id)->readOne();
-        $this->assertArrayNotHasKey('secret', $webhook);
+        try {
+            new InstanceWebhooks(false, $id)->readOne();
+            $this->fail('reading a webhook without permission should have been refused');
+        } catch (IllegalActionException) {
+            $this->addToAssertionCount(1);
+        }
+        try {
+            new InstanceWebhooks(false)->readAll();
+            $this->fail('listing webhooks without permission should have been refused');
+        } catch (IllegalActionException) {
+            $this->addToAssertionCount(1);
+        }
         new InstanceWebhooks(true, $id)->destroy();
     }
 

--- a/tests/unit/models/InstanceWebhooksTest.php
+++ b/tests/unit/models/InstanceWebhooksTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Models;
+
+use Elabftw\Enums\Action;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Exceptions\IllegalActionException;
+use Elabftw\Exceptions\ImproperActionException;
+
+use function count;
+
+class InstanceWebhooksTest extends \PHPUnit\Framework\TestCase
+{
+    private InstanceWebhooks $InstanceWebhooks;
+
+    protected function setUp(): void
+    {
+        $this->InstanceWebhooks = new InstanceWebhooks(true);
+    }
+
+    public function testGetApiPath(): void
+    {
+        $this->assertStringEndsWith('webhooks/', $this->InstanceWebhooks->getApiPath());
+    }
+
+    public function testCreateReadUpdateDestroy(): void
+    {
+        $initialCount = count($this->InstanceWebhooks->readAll());
+        $id = $this->InstanceWebhooks->postAction(Action::Create, array(
+            'name' => 'test webhook',
+            'url' => 'https://192.0.2.10/hook',
+            'events' => array(WebhookEvent::ExperimentUpdated->value),
+        ));
+        $this->assertEquals($initialCount + 1, count($this->InstanceWebhooks->readAll()));
+
+        $Webhook = new InstanceWebhooks(true, $id);
+        $webhook = $Webhook->readOne();
+        $this->assertEquals('https://192.0.2.10/hook', $webhook['url']);
+        $this->assertEquals(1, $webhook['enabled']);
+        // the secret is readable by someone who may write the webhook, they need it to verify
+        $this->assertNotEmpty($webhook['secret']);
+
+        $updated = $Webhook->patch(Action::Update, array('enabled' => 0));
+        $this->assertEquals(0, $updated['enabled']);
+
+        $this->assertTrue($Webhook->destroy());
+        $this->assertEquals($initialCount, count($this->InstanceWebhooks->readAll()));
+    }
+
+    public function testSecretIsHiddenWithoutWriteAccess(): void
+    {
+        $id = $this->InstanceWebhooks->postAction(Action::Create, array(
+            'url' => 'https://192.0.2.11/hook',
+            'events' => array(WebhookEvent::ItemCreated->value),
+        ));
+        $webhook = new InstanceWebhooks(false, $id)->readOne();
+        $this->assertArrayNotHasKey('secret', $webhook);
+        new InstanceWebhooks(true, $id)->destroy();
+    }
+
+    public function testNotSysadmin(): void
+    {
+        $this->expectException(IllegalActionException::class);
+        new InstanceWebhooks(false)->postAction(Action::Create, array(
+            'url' => 'https://192.0.2.12/hook',
+            'events' => array(WebhookEvent::ExperimentCreated->value),
+        ));
+    }
+
+    public function testCreateWithoutEvents(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->InstanceWebhooks->postAction(Action::Create, array(
+            'url' => 'https://192.0.2.13/hook',
+            'events' => array(),
+        ));
+    }
+
+    public function testCreateWithUnknownEvent(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->InstanceWebhooks->postAction(Action::Create, array(
+            'url' => 'https://192.0.2.14/hook',
+            'events' => array('experiment.exploded'),
+        ));
+    }
+
+    public function testUpdateWithUnknownParameter(): void
+    {
+        $id = $this->InstanceWebhooks->postAction(Action::Create, array(
+            'url' => 'https://192.0.2.15/hook',
+            'events' => array(WebhookEvent::ExperimentUpdated->value),
+        ));
+        $Webhook = new InstanceWebhooks(true, $id);
+        try {
+            $Webhook->patch(Action::Update, array('secret' => 'let me pick my own'));
+            $this->fail('an unknown parameter should have been refused');
+        } catch (ImproperActionException) {
+            $this->addToAssertionCount(1);
+        }
+        $Webhook->destroy();
+    }
+}

--- a/tests/unit/services/WebhookDispatcherTest.php
+++ b/tests/unit/services/WebhookDispatcherTest.php
@@ -149,6 +149,28 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(WebhookState::Sending->value, (int) $this->getRow()['state']);
     }
 
+    /**
+     * When the drain runs out of time it hands back what it has not started, rather than
+     * leaving those rows in Sending until the stale window expires. The attempt is given
+     * back with them, since nothing was sent.
+     */
+    public function testReleasedRowsAreDueAgainWithoutBurningAnAttempt(): void
+    {
+        $Queue = new WebhooksQueue();
+        $claimed = $this->claimOurs($Queue);
+        $this->assertNotNull($claimed);
+        $this->assertEquals(1, (int) $this->getRow()['attempts']);
+
+        $this->assertEquals(1, $Queue->release(array($claimed)));
+
+        $row = $this->getRow();
+        $this->assertEquals(WebhookState::Queued->value, (int) $row['state']);
+        $this->assertEquals(0, (int) $row['attempts']);
+        $this->assertNull($row['claim_token']);
+        // due right away, it was never tried
+        $this->assertLessThanOrEqual(0, (int) $row['due_in_seconds']);
+    }
+
     private function claimOurs(WebhooksQueue $Queue): ?array
     {
         foreach ($Queue->claim(20) as $row) {

--- a/tests/unit/services/WebhookDispatcherTest.php
+++ b/tests/unit/services/WebhookDispatcherTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Console\Output\NullOutput;
 
 use function hash_hmac;
 
+use const CURLOPT_RESOLVE;
+
 class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
 {
     use TestsUtilsTrait;
@@ -68,9 +70,8 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
     {
         $this->send(new Response(200, array(), '{"ok":true}'));
 
-        $this->assertCount(1, $this->captured);
-        [$url, $options] = $this->captured[0];
-        $this->assertEquals('https://192.0.2.30/hook', $url);
+        $options = $this->capturedFor('https://192.0.2.30/hook');
+        $this->assertNotNull($options);
 
         $expected = 'sha256=' . hash_hmac('sha256', $options['body'], $this->secret);
         $this->assertEquals($expected, $options['headers'][WebhookDispatcher::SIGNATURE_HEADER]);
@@ -113,7 +114,7 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
 
         $this->send(new Response(200, array(), '{"ok":true}'));
 
-        $this->assertCount(0, $this->captured);
+        $this->assertNull($this->capturedFor('https://192.0.2.30/hook'));
         $this->assertEquals(WebhookState::Queued->value, (int) $this->getRow()['state']);
     }
 
@@ -150,6 +151,48 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * The pinning is the defence against a second dns answer, so the entry has to be in the
+     * shape curl actually reads: one entry per host and port, addresses comma separated,
+     * ipv6 in brackets. Get it wrong and curl falls back to resolving on its own, silently.
+     */
+    public function testResolveEntryIsInCurlsFormat(): void
+    {
+        $webhookId = new InstanceWebhooks(true)->postAction(Action::Create, array(
+            'name' => 'named target',
+            'url' => 'https://hook.example.test:8443/hook',
+            'events' => array(WebhookEvent::ExperimentCreated->value),
+        ));
+        WebhookEmitter::reset();
+        $this->getFreshExperiment();
+
+        // a stub, because the test environment has no dns and the point here is the format
+        $validatorStub = $this->createStub(WebhookUrlValidator::class);
+        $validatorStub->method('resolve')->willReturn(array('198.51.100.7', '2001:db8::1'));
+        $this->sendWith($validatorStub, new Response(200, array(), '{"ok":true}'));
+
+        $options = $this->capturedFor('https://hook.example.test:8443/hook');
+        $this->assertNotNull($options);
+        $this->assertEquals(
+            array('hook.example.test:8443:198.51.100.7,[2001:db8::1]'),
+            $options['curl'][CURLOPT_RESOLVE],
+        );
+
+        new InstanceWebhooks(true, $webhookId)->destroy();
+    }
+
+    /**
+     * An address literal has no name to rebind, so there is nothing to pin.
+     */
+    public function testAddressLiteralGetsNoResolveEntry(): void
+    {
+        $this->send(new Response(200, array(), '{"ok":true}'));
+
+        $options = $this->capturedFor('https://192.0.2.30/hook');
+        $this->assertNotNull($options);
+        $this->assertEquals(array(), $options['curl'][CURLOPT_RESOLVE]);
+    }
+
+    /**
      * When the drain runs out of time it hands back what it has not started, rather than
      * leaving those rows in Sending until the stale window expires. The attempt is given
      * back with them, since nothing was sent.
@@ -171,6 +214,22 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertLessThanOrEqual(0, (int) $row['due_in_seconds']);
     }
 
+    /**
+     * The queue is shared, so a test looks at its own delivery rather than at the first one
+     * that happened to go out.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function capturedFor(string $url): ?array
+    {
+        foreach ($this->captured as [$captureUrl, $options]) {
+            if ($captureUrl === $url) {
+                return $options;
+            }
+        }
+        return null;
+    }
+
     private function claimOurs(WebhooksQueue $Queue): ?array
     {
         foreach ($Queue->claim(20) as $row) {
@@ -183,6 +242,11 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
 
     private function send(Response $response): void
     {
+        $this->sendWith(new WebhookUrlValidator(false), $response);
+    }
+
+    private function sendWith(WebhookUrlValidator $validator, Response $response): void
+    {
         $getterStub = $this->createStub(HttpGetter::class);
         $getterStub->method('post')->willReturnCallback(
             function (string $url, array $options) use ($response): Response {
@@ -190,8 +254,7 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
                 return $response;
             }
         );
-        // not strict: the target is a documentation address, there is nothing to resolve
-        new WebhookDispatcher($getterStub, new WebhookUrlValidator(false))->send(new NullOutput());
+        new WebhookDispatcher($getterStub, $validator)->send(new NullOutput());
     }
 
     private function getRow(): array

--- a/tests/unit/services/WebhookDispatcherTest.php
+++ b/tests/unit/services/WebhookDispatcherTest.php
@@ -17,6 +17,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\WebhookEvent;
 use Elabftw\Enums\WebhookState;
 use Elabftw\Models\InstanceWebhooks;
+use Elabftw\Models\WebhooksQueue;
 use Elabftw\Traits\TestsUtilsTrait;
 use GuzzleHttp\Psr7\Response;
 use PDO;
@@ -100,6 +101,62 @@ class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(0, $this->captured);
         $this->assertEquals(1, (int) $this->getRow()['attempts']);
+    }
+
+    /**
+     * Turning a webhook off has to stop what is already queued for it, otherwise disabling
+     * a misbehaving target still lets the backlog through.
+     */
+    public function testDisabledWebhookIsNotDelivered(): void
+    {
+        new InstanceWebhooks(true, $this->webhookId)->patch(Action::Update, array('enabled' => 0));
+
+        $this->send(new Response(200, array(), '{"ok":true}'));
+
+        $this->assertCount(0, $this->captured);
+        $this->assertEquals(WebhookState::Queued->value, (int) $this->getRow()['state']);
+    }
+
+    /**
+     * A drain that hangs past the stale window loses its row to the next one. When it
+     * finally returns it must not overwrite the newer result, or a delivered row could be
+     * put back in the queue and sent twice.
+     */
+    public function testLostClaimCannotOverwriteTheNewerOne(): void
+    {
+        $Queue = new WebhooksQueue();
+        $first = $this->claimOurs($Queue);
+        $this->assertNotNull($first);
+        $staleToken = (string) $first['claim_token'];
+
+        // pretend the claim has been sitting there longer than the stale window
+        $Db = Db::getConnection();
+        $req = $Db->prepare('UPDATE webhooks_queue SET next_attempt_at = DATE_SUB(NOW(), INTERVAL 11 MINUTE) WHERE id = :id');
+        $req->bindValue(':id', (int) $first['id'], PDO::PARAM_INT);
+        $Db->execute($req);
+
+        $Queue->releaseStaleClaims();
+        $second = $this->claimOurs($Queue);
+        $this->assertNotNull($second);
+        $this->assertNotEquals($staleToken, (string) $second['claim_token']);
+
+        // the first drain returns from the dead and tries to finish its work
+        $this->assertFalse($Queue->markDelivered((int) $first['id'], $staleToken));
+        $this->assertFalse($Queue->markFailed((int) $first['id'], $staleToken, 'too late'));
+        $this->assertFalse($Queue->markRetry((int) $first['id'], $staleToken, 'too late', 60));
+
+        // the row still belongs to the second drain
+        $this->assertEquals(WebhookState::Sending->value, (int) $this->getRow()['state']);
+    }
+
+    private function claimOurs(WebhooksQueue $Queue): ?array
+    {
+        foreach ($Queue->claim(20) as $row) {
+            if ((int) $row['webhook_id'] === $this->webhookId) {
+                return $row;
+            }
+        }
+        return null;
     }
 
     private function send(Response $response): void

--- a/tests/unit/services/WebhookDispatcherTest.php
+++ b/tests/unit/services/WebhookDispatcherTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Enums\Action;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Enums\WebhookState;
+use Elabftw\Models\InstanceWebhooks;
+use Elabftw\Traits\TestsUtilsTrait;
+use GuzzleHttp\Psr7\Response;
+use PDO;
+use Symfony\Component\Console\Output\NullOutput;
+
+use function hash_hmac;
+
+class WebhookDispatcherTest extends \PHPUnit\Framework\TestCase
+{
+    use TestsUtilsTrait;
+
+    private int $webhookId;
+
+    private string $secret;
+
+    /** @var array<int, array{0: string, 1: array}> */
+    private array $captured = array();
+
+    protected function setUp(): void
+    {
+        $this->captured = array();
+        $this->webhookId = new InstanceWebhooks(true)->postAction(Action::Create, array(
+            'name' => 'dispatcher test',
+            'url' => 'https://192.0.2.30/hook',
+            'events' => array(WebhookEvent::ExperimentCreated->value),
+        ));
+        $this->secret = new InstanceWebhooks(true, $this->webhookId)->readOne()['secret'];
+        WebhookEmitter::reset();
+        $this->getFreshExperiment();
+    }
+
+    protected function tearDown(): void
+    {
+        new InstanceWebhooks(true, $this->webhookId)->destroy();
+    }
+
+    public function testSuccessfulDeliveryIsMarkedDelivered(): void
+    {
+        $this->send(new Response(200, array(), '{"ok":true}'));
+
+        $row = $this->getRow();
+        $this->assertEquals(WebhookState::Delivered->value, (int) $row['state']);
+        $this->assertNotNull($row['delivered_at']);
+        $this->assertNull($row['claim_token']);
+    }
+
+    public function testBodyIsSignedWithTheWebhookSecret(): void
+    {
+        $this->send(new Response(200, array(), '{"ok":true}'));
+
+        $this->assertCount(1, $this->captured);
+        [$url, $options] = $this->captured[0];
+        $this->assertEquals('https://192.0.2.30/hook', $url);
+
+        $expected = 'sha256=' . hash_hmac('sha256', $options['body'], $this->secret);
+        $this->assertEquals($expected, $options['headers'][WebhookDispatcher::SIGNATURE_HEADER]);
+        $this->assertEquals(WebhookEvent::ExperimentCreated->value, $options['headers'][WebhookDispatcher::EVENT_HEADER]);
+        $this->assertNotEmpty($options['headers'][WebhookDispatcher::DELIVERY_HEADER]);
+        // a redirect would lead to a host that never passed the address checks
+        $this->assertFalse($options['allow_redirects']);
+    }
+
+    public function testFailedDeliveryIsRequeuedForLater(): void
+    {
+        $this->send(new Response(500, array(), 'nope'));
+
+        $row = $this->getRow();
+        $this->assertEquals(WebhookState::Queued->value, (int) $row['state']);
+        $this->assertEquals(1, (int) $row['attempts']);
+        $this->assertNull($row['claim_token']);
+        $this->assertStringContainsString('500', (string) $row['last_error']);
+        // it must not be picked up again immediately, or a dead target is hammered every minute
+        $this->assertGreaterThan(0, (int) $row['due_in_seconds']);
+    }
+
+    public function testRequeuedRowIsNotClaimedAgainInTheSameRun(): void
+    {
+        $this->send(new Response(500, array(), 'nope'));
+        $this->captured = array();
+        $this->send(new Response(200, array(), '{"ok":true}'));
+
+        $this->assertCount(0, $this->captured);
+        $this->assertEquals(1, (int) $this->getRow()['attempts']);
+    }
+
+    private function send(Response $response): void
+    {
+        $getterStub = $this->createStub(HttpGetter::class);
+        $getterStub->method('post')->willReturnCallback(
+            function (string $url, array $options) use ($response): Response {
+                $this->captured[] = array($url, $options);
+                return $response;
+            }
+        );
+        // not strict: the target is a documentation address, there is nothing to resolve
+        new WebhookDispatcher($getterStub, new WebhookUrlValidator(false))->send(new NullOutput());
+    }
+
+    private function getRow(): array
+    {
+        $Db = Db::getConnection();
+        $sql = 'SELECT state, attempts, claim_token, delivered_at, last_error,
+                TIMESTAMPDIFF(SECOND, NOW(), next_attempt_at) AS due_in_seconds
+            FROM webhooks_queue WHERE webhooks_id = :id';
+        $req = $Db->prepare($sql);
+        $req->bindValue(':id', $this->webhookId, PDO::PARAM_INT);
+        $Db->execute($req);
+        return $Db->fetch($req);
+    }
+}

--- a/tests/unit/services/WebhookEmitterTest.php
+++ b/tests/unit/services/WebhookEmitterTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Elabftw\Db;
+use Elabftw\Enums\Action;
+use Elabftw\Enums\WebhookEvent;
+use Elabftw\Models\InstanceWebhooks;
+use Elabftw\Params\EntityParams;
+use Elabftw\Traits\TestsUtilsTrait;
+use PDO;
+
+use function json_decode;
+
+class WebhookEmitterTest extends \PHPUnit\Framework\TestCase
+{
+    use TestsUtilsTrait;
+
+    private InstanceWebhooks $Webhooks;
+
+    private int $webhookId;
+
+    protected function setUp(): void
+    {
+        $this->Webhooks = new InstanceWebhooks(true);
+        $this->webhookId = $this->Webhooks->postAction(Action::Create, array(
+            'name' => 'emitter test',
+            'url' => 'https://192.0.2.20/hook',
+            'events' => array(
+                WebhookEvent::ExperimentCreated->value,
+                WebhookEvent::ExperimentUpdated->value,
+            ),
+        ));
+        // the dedup cache is per request, and a test process is one long request
+        WebhookEmitter::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        // queue rows go with it, the foreign key cascades
+        new InstanceWebhooks(true, $this->webhookId)->destroy();
+    }
+
+    public function testCreatingAnExperimentQueuesAnEvent(): void
+    {
+        $Experiment = $this->getFreshExperiment();
+        $queued = $this->getQueued(WebhookEvent::ExperimentCreated);
+        $this->assertCount(1, $queued);
+
+        $body = json_decode($queued[0]['body'], true);
+        $this->assertEquals(WebhookEvent::ExperimentCreated->value, $body['event']);
+        $this->assertEquals($Experiment->id, $body['id']);
+        $this->assertNotEmpty($body['event_id']);
+        $this->assertNotEmpty($body['at']);
+        $this->assertStringEndsWith('/api/v2/experiments/' . $Experiment->id, $body['url']);
+        // no api key was used, this is a plain call
+        $this->assertNull($body['actor']['apikey_id']);
+        $this->assertNotNull($body['actor']['userid']);
+        // the payload must not carry the entity itself
+        $this->assertArrayNotHasKey('title', $body);
+        $this->assertArrayNotHasKey('body', $body);
+    }
+
+    public function testUpdatingAnExperimentQueuesOneEventOnly(): void
+    {
+        $Experiment = $this->getFreshExperiment();
+        WebhookEmitter::reset();
+
+        $Experiment->update(new EntityParams('title', 'a new title'));
+        $Experiment->update(new EntityParams('rating', '3'));
+
+        // two writes, two changelog rows, but one change as far as a subscriber cares
+        $this->assertCount(1, $this->getQueued(WebhookEvent::ExperimentUpdated));
+    }
+
+    public function testUnsubscribedEventIsNotQueued(): void
+    {
+        // this webhook only listens for experiments
+        $this->getFreshItem();
+        $this->assertCount(0, $this->getQueued(WebhookEvent::ItemCreated));
+    }
+
+    public function testDisabledWebhookGetsNothing(): void
+    {
+        new InstanceWebhooks(true, $this->webhookId)->patch(Action::Update, array('enabled' => 0));
+        WebhookEmitter::reset();
+
+        $this->getFreshExperiment();
+        $this->assertCount(0, $this->getQueued(WebhookEvent::ExperimentCreated));
+    }
+
+    /**
+     * A status change is its own event, for experiments and resources alike: reacting to
+     * one is the whole point for a subscriber, and it should not have to diff an update
+     * against the previous state to notice.
+     */
+    public function testStatusChangeIsItsOwnEvent(): void
+    {
+        $probeId = new InstanceWebhooks(true)->postAction(Action::Create, array(
+            'name' => 'status probe',
+            'url' => 'https://192.0.2.21/hook',
+            'events' => array(
+                WebhookEvent::ExperimentStatusChanged->value,
+                WebhookEvent::ItemStatusChanged->value,
+            ),
+        ));
+        WebhookEmitter::reset();
+
+        $Experiment = $this->getFreshExperiment();
+        $Experiment->update(new EntityParams('status', (string) $this->getStatusId('experiments_status')));
+        $Item = $this->getFreshItem();
+        $Item->update(new EntityParams('status', (string) $this->getStatusId('items_status')));
+
+        $events = $this->getEventsFor($probeId);
+        $this->assertContains(WebhookEvent::ExperimentStatusChanged->value, $events);
+        $this->assertContains(WebhookEvent::ItemStatusChanged->value, $events);
+
+        new InstanceWebhooks(true, $probeId)->destroy();
+    }
+
+    private function getStatusId(string $table): int
+    {
+        $Db = Db::getConnection();
+        // the table name is a literal from the caller, never user input
+        $req = $Db->prepare('SELECT id FROM ' . $table . ' WHERE team = 1 ORDER BY id ASC LIMIT 1');
+        $Db->execute($req);
+        return (int) $Db->fetch($req)['id'];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getEventsFor(int $webhookId): array
+    {
+        $Db = Db::getConnection();
+        $req = $Db->prepare('SELECT event FROM webhooks_queue WHERE webhooks_id = :id');
+        $req->bindValue(':id', $webhookId, PDO::PARAM_INT);
+        $Db->execute($req);
+        return $req->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getQueued(WebhookEvent $event): array
+    {
+        $Db = Db::getConnection();
+        $sql = 'SELECT event, event_id, body FROM webhooks_queue WHERE webhooks_id = :id AND event = :event';
+        $req = $Db->prepare($sql);
+        $req->bindValue(':id', $this->webhookId, PDO::PARAM_INT);
+        $req->bindValue(':event', $event->value);
+        $Db->execute($req);
+        return $req->fetchAll();
+    }
+}

--- a/tests/unit/services/WebhookEmitterTest.php
+++ b/tests/unit/services/WebhookEmitterTest.php
@@ -128,6 +128,22 @@ class WebhookEmitterTest extends \PHPUnit\Framework\TestCase
         new InstanceWebhooks(true, $probeId)->destroy();
     }
 
+    /**
+     * Entity writes happen inside a transaction in places (storage units, container links),
+     * and pdo has no nested transactions, so the fanout must ride along rather than open
+     * its own.
+     */
+    public function testFanoutJoinsAnExistingTransaction(): void
+    {
+        $Db = Db::getConnection();
+        $Db->beginTransaction();
+        $Experiment = $this->getFreshExperiment();
+        $Db->commit();
+
+        $this->assertCount(1, $this->getQueued(WebhookEvent::ExperimentCreated));
+        $this->assertNotNull($Experiment->id);
+    }
+
     private function getStatusId(string $table): int
     {
         $Db = Db::getConnection();

--- a/tests/unit/services/WebhookUrlValidatorTest.php
+++ b/tests/unit/services/WebhookUrlValidatorTest.php
@@ -88,6 +88,13 @@ class WebhookUrlValidatorTest extends \PHPUnit\Framework\TestCase
             'https://[::1]/hook',
             'https://[fe80::1]/hook',
             'https://[fc00::1]/hook',
+            // these are v6 addresses whose last 32 bits happen to be written with dots.
+            // Treating them as v4 because of the dots walks them past every v6 rule.
+            'https://[fc00::1.2.3.4]/hook',
+            'https://[fe80::1.2.3.4]/hook',
+            // a real v4-mapped address has to be judged by the v4 rules
+            'https://[::ffff:10.0.0.1]/hook',
+            'https://[::ffff:127.0.0.1]/hook',
         );
         foreach ($blocked as $url) {
             try {
@@ -107,6 +114,12 @@ class WebhookUrlValidatorTest extends \PHPUnit\Framework\TestCase
     {
         $url = 'http://127.0.0.1:9099/hook';
         $this->assertEquals($url, $this->relaxed->validate($url));
+    }
+
+    public function testMappedPublicAddressIsAccepted(): void
+    {
+        $url = 'https://[::ffff:93.184.216.34]/hook';
+        $this->assertEquals($url, $this->strict->validate($url));
     }
 
     public function testAddressLiteralIsReturnedAsIs(): void

--- a/tests/unit/services/WebhookUrlValidatorTest.php
+++ b/tests/unit/services/WebhookUrlValidatorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Moritz IHLER
+ * @copyright 2026 Moritz IHLER
+ * @see https://www.elabftw.net Official website
+ * @license AGPL-3.0
+ * @package elabftw
+ */
+
+namespace Elabftw\Services;
+
+use Elabftw\Exceptions\ImproperActionException;
+
+use function sprintf;
+use function str_repeat;
+
+class WebhookUrlValidatorTest extends \PHPUnit\Framework\TestCase
+{
+    private WebhookUrlValidator $strict;
+
+    private WebhookUrlValidator $relaxed;
+
+    protected function setUp(): void
+    {
+        $this->strict = new WebhookUrlValidator(true);
+        $this->relaxed = new WebhookUrlValidator(false);
+    }
+
+    public function testPublicAddressIsAccepted(): void
+    {
+        // an address literal so the test does not depend on dns
+        $url = 'https://93.184.216.34/hook';
+        $this->assertEquals($url, $this->strict->validate($url));
+    }
+
+    public function testHttpIsRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('http://93.184.216.34/hook');
+    }
+
+    public function testCredentialsAreRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('https://user:pass@93.184.216.34/hook');
+    }
+
+    public function testFragmentIsRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('https://93.184.216.34/hook#nope');
+    }
+
+    public function testEmptyIsRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('');
+    }
+
+    public function testTooLongIsRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('https://93.184.216.34/' . str_repeat('a', WebhookUrlValidator::MAX_URL_LENGTH));
+    }
+
+    public function testGarbageIsRefused(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->strict->validate('not a url at all');
+    }
+
+    /**
+     * These are the addresses that make an admin supplied url an ssrf primitive.
+     */
+    public function testReservedAddressesAreRefused(): void
+    {
+        $blocked = array(
+            'https://127.0.0.1/hook',
+            'https://10.1.2.3/hook',
+            'https://172.16.0.1/hook',
+            'https://192.168.1.1/hook',
+            'https://169.254.169.254/hook',
+            'https://100.64.0.1/hook',
+            'https://0.0.0.0/hook',
+            'https://[::1]/hook',
+            'https://[fe80::1]/hook',
+            'https://[fc00::1]/hook',
+        );
+        foreach ($blocked as $url) {
+            try {
+                $this->strict->validate($url);
+                $this->fail(sprintf('%s should have been refused', $url));
+            } catch (ImproperActionException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    /**
+     * A development instance talks to a receiver on a private address by definition, exactly
+     * like it skips tls verification.
+     */
+    public function testDevModeAllowsPrivateTargets(): void
+    {
+        $url = 'http://127.0.0.1:9099/hook';
+        $this->assertEquals($url, $this->relaxed->validate($url));
+    }
+
+    public function testAddressLiteralIsReturnedAsIs(): void
+    {
+        $this->assertEquals(array('93.184.216.34'), $this->strict->resolve('93.184.216.34'));
+    }
+}

--- a/web/app/controllers/ApiController.php
+++ b/web/app/controllers/ApiController.php
@@ -47,6 +47,8 @@ try {
         $key = $ApiKeys->readFromApiKey($App->Request->server->get('HTTP_AUTHORIZATION') ?? '');
         // replace the Users in App
         $App->Users = new AuthenticatedUser($key['userid'], $key['team']);
+        // carry the (non secret) api key id so outgoing webhook events can name the actual actor
+        $App->Users->apiKeyId = (int) $key['id'];
         $canWrite = (bool) $key['can_write'];
     } else {
         if (!$isPublicBrandingBinaryRequest && $App->Session->get('is_auth') !== 1) {


### PR DESCRIPTION
Part of #3767.

Implements the notification-only webhook mechanism discussed in #3767, following the
delivery model you chose (chronos, every minute) and the actor model you asked for
(unique event id + real actor instead of `origin: web|api`).

The three-level Svelte UI is deliberately not in this PR, the decisions worth arguing
about are the table shape, the retry semantics and the signature format, and those should
be settled before UI work hangs off them. Configuration is fully usable over the API in
the meantime.

## What it does

An entity change queues one row per subscribed webhook; a console command run every minute
POSTs each row, signed, and marks it delivered or failed.

Payload carries identifiers only, never the entity body:

```json
{
  "event": "experiment.updated",
  "event_id": "9f2c…",
  "id": 42,
  "team": 3,
  "url": "https://elab.example.org/api/v2/experiments/42",
  "at": "2026-08-21T10:15:00+02:00",
  "actor": {"userid": 7, "apikey_id": 12}
}
```

`apikey_id` is the non-secret primary key of the `api_keys` row, present when the change
came through the API. An integration can compare it against its own key and skip the
changes it caused itself. A correlation/causation id can be added later without changing
this shape.

Events in this version: `experiment.created`, `experiment.updated`,
`experiment.status_changed`, `item.created`, `item.updated`, `item.status_changed`.

A status change is its own event rather than a plain update, for both entity types: a
subscriber reacting to a status transition should not have to diff against the previous
state to notice one.

## Where events come from

`Changelog::create()`. That is the one place that already records "something changed on this
entity", so all three write paths (`update()`, `patch()`, `addCreationToChangelog()`) are
covered by a single hook and no models grow webhook code. Templates and items types emit
nothing.

An update touching five columns writes five changelog rows but is one change to a
subscriber, so events are deduplicated per entity per request.

## Three levels

Same layering as ROR: an abstract model, three concrete subclasses, one `ApiSubModels` case
registered in the teams/users/instance lists, authority injected by the controller
(`isSysadmin()` / `Model->canWrite()` / `isAdminOf()`).

Unlike ROR the three levels share one table, because a webhook is a dozen columns and
triplicating that DDL buys nothing. What differs per level is who may write it and which
events it sees, and both live outside the table.

**Visibility is restrictive by design**: an instance webhook sees the whole instance, a team
webhook its own team, and a user webhook only entries owned by that user. The payload
protects the entity *content* (the subscriber fetches the URL with their own key), but the
event itself still discloses that entry X changed, so entitlement has to be decided when the
row is queued. Widening this later is harmless; narrowing it would break integrations.

## Delivery

`webhooks:send`, one line in `chronos.go` next to `notifications:send`.

Deviations from the `notifications` drain, both deliberate:

- **Claim step.** `EmailNotifications` selects and sends without locking, which is safe
  because an SMTP send is quick. A webhook drain hangs on other people's HTTP endpoints, so
  overlapping runs are realistic and a row would be delivered twice. Rows are claimed with a
  random token (`UPDATE … SET state = sending, claim_token = …` then `SELECT … WHERE
  claim_token = …`), and claims left behind by a crashed run are released after 10 minutes.
- **Time budget.** `time.Ticker` in chronos drops ticks but starts the next run immediately
  after a long one, so an unbounded drain turns "every minute" into a continuous loop. The
  command stops starting new rounds after 45 seconds.

Retries are exponential (60s, doubling, capped at an hour), five attempts, then the delivery
is marked failed. Ten consecutive failures disable the webhook and notify whoever owns it —
the user, the team admins, or the sysadmins. Re-enabling clears the counter.

## Security

- HMAC-SHA256 over the raw body in `X-Elabftw-Signature: sha256=…`, secret per webhook.
- SSRF guard: https only, no credentials in the URL, no fragment, and every address the host
  resolves to is checked against the reserved ranges (loopback, private, link-local, CGNAT,
  documentation, multicast, and the IPv6 equivalents).
- The check is redone at delivery time, not only when the webhook is configured, and the
  connection is **pinned** to the addresses that were just checked via `CURLOPT_RESOLVE`, so
  a second DNS answer cannot redirect the request. Redirects are not followed.
- In `DEV_MODE` the address checks are relaxed, exactly as TLS verification already is
  (`AbstractEntity.php:1260`) — a dev instance talks to a receiver on a private address by
  definition.

## Schema

`schema225.sql` / `schema225-down.sql`, `REQUIRED_SCHEMA` bumped, DDL mirrored into
`structure.sql`. Two tables: `webhooks` (config, all three scopes) and `webhooks_queue`
(one row per delivery).

The pairing of `scope` with `teams_id`/`users_id` is deliberately *not* a CHECK constraint.
MySQL refuses a CHECK on a column that takes part in a foreign key referential action, and
the cascading deletes are worth more: without them a deleted team or user leaves webhook
rows behind that keep receiving events. The invariant holds by construction in the model
layer, where each scope is its own class and hardcodes both values.

## Tests

33 unit tests, 91 assertions, all passing:

- `WebhookUrlValidatorTest`: scheme, credentials, fragment, length, and each reserved
  address range refused individually, including v6 addresses that write their last 32 bits
  with dots (`fc00::1.2.3.4`) and v4-mapped addresses; DEV_MODE relaxation.
- `InstanceWebhooksTest`: CRUD, reads refused without write authority, unknown events and
  unknown patch parameters refused.
- `WebhookEmitterTest`: creating an experiment queues an event with the right payload and
  no entity body; two writes in one request produce one event; a status change on an
  experiment and on a resource is its own event; the fanout joins a transaction that is
  already open instead of nesting; unsubscribed and disabled webhooks receive nothing.
- `WebhookDispatcherTest`: successful delivery marked delivered, HMAC signature verified
  against the stored secret, `allow_redirects` off, failed delivery requeued with a future
  due time and not re-claimed in the same run, a disabled webhook receiving nothing, a
  claim lost to the stale sweep unable to overwrite the newer one, rows handed back without
  burning an attempt when the time budget runs out, and the `CURLOPT_RESOLVE` entry in the
  shape curl reads (one entry per host and port, addresses comma separated, IPv6
  bracketed, none at all for an address literal).

psalm, phpstan and php-cs-fixer are clean.

## Known gaps

- No Svelte UI yet (PR 2).
- The new endpoints are not in `apidoc/v2/openapi.yaml`, the ROR endpoints are not either,
  so I followed that; happy to add both.
- No `deleted` event: a soft delete currently arrives as `updated`.
- Delivery is covered with a stubbed `HttpGetter`. The `CURLOPT_RESOLVE` entry format is
  unit tested, but whether libcurl honours it is not: that was verified by hand against a
  real receiver on a dev instance, see below.
- Disabling a webhook cannot stop a delivery that is already in flight. Claiming rechecks
  the enabled flag, which narrows the window, but a request that has left the process
  cannot be recalled.

## Verified by hand

On a dev instance, against a receiver that checks the signature:

- creating and updating an experiment produced `experiment.created` and `experiment.updated`
  with distinct event ids, both delivered, both signatures valid
- the same update made through the API with a key produced `"apikey_id": 7`, the key that
  made the change, which is what makes self-caused changes skippable
- changing the status of an experiment and of a resource produced
  `experiment.status_changed` and `item.status_changed`, both delivered and verified
- the SSRF guard accepted a private target (plain http, private address) only because the
  instance runs in DEV_MODE; the same URL is refused otherwise


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configurable webhooks for instances, teams, and users.
- Added subscriptions for experiment and item creation, updates, and status changes.
- Added API management, enable/disable controls, and signed webhook requests.
- Webhook deliveries are queued, retried automatically, and securely sent to validated endpoints.
- Webhooks are disabled after repeated failures, with owner notifications.
- Added automatic delivery processing, cleanup, and delivery status tracking.

## Chores
- Updated the database schema for webhook configuration and delivery queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->