### PR TITLE
bug/minor: scheduler: force global scope for selected items

### DIFF
--- a/src/Models/Items.php
+++ b/src/Models/Items.php
@@ -22,6 +22,7 @@ use Elabftw\Enums\BodyContentType;
 use Elabftw\Enums\EntityType;
 use Elabftw\Enums\FilterableColumn;
 use Elabftw\Enums\AccessType;
+use Elabftw\Enums\Scope;
 use Elabftw\Models\Links\Items2ItemsLinks;
 use Elabftw\Params\DisplayParams;
 use Elabftw\Services\Filter;
@@ -119,9 +120,12 @@ final class Items extends AbstractConcreteEntity
     /**
      * Get all items with is_bookable that we can read
      */
-    public function readBookable(): array
+    public function readBookable(?Scope $scope = null): array
     {
         $Request = Request::createFromGlobals();
+        if ($scope !== null) {
+            $Request->query->set('scope', $scope->value);
+        }
         $DisplayParams = new DisplayParams($this->Users, EntityType::Items, $Request->query);
         // we only want the bookable type of items
         $DisplayParams->appendFilterSql(FilterableColumn::Bookable, 1);

--- a/src/templates/scheduler.html
+++ b/src/templates/scheduler.html
@@ -15,6 +15,10 @@
       <div class='d-flex flex-row'>
         {#  TODO: make scopeBtn work without full page reload #}
         {# RESOURCES SCOPE #}
+        {# If an item is selected, it's forced to 'Everything' and disabled #}
+        <div id='scopeItemsLocked' class='btn-group' hidden>
+          <button disabled class='btn dropdown-toggle' type='button' aria-label='Scope' title='Scope'><i class='fas fa-globe fa-fw mr-1'></i></button>
+        </div>
         {% include 'scope-button.html' with {'reload': 'page', 'target': 'scope_items'} %}
         {# FILTERS GROUP CATEGORY AND RESOURCE #}
         {% include 'scheduler-filter-items.html' %}

--- a/src/ts/scheduler.ts
+++ b/src/ts/scheduler.ts
@@ -105,12 +105,14 @@ function toggleBindState(entity: 'experiment' | 'item', bound: boolean) {
   document.getElementById(`bindInputs${suffix}`)?.classList.toggle('d-none', bound);
 }
 
-function lockScopeButton(selectedItems: string[]): void {
-  const scopeBtn = document.getElementById('scopeEventBtn');
-  const lockedBtn = document.getElementById('scopeLocked');
+function lockScopeButtons(selectedItems: string[]): void {
   const showLocked = selectedItems.length > 0;
-  scopeBtn?.toggleAttribute('hidden', showLocked);
-  lockedBtn?.toggleAttribute('hidden', !showLocked);
+  ['scopeBtn', 'scopeEventBtn'].forEach(id => {
+    document.getElementById(id)?.toggleAttribute('hidden', showLocked);
+  });
+  ['scopeItemsLocked', 'scopeLocked'].forEach(id => {
+    document.getElementById(id)?.toggleAttribute('hidden', !showLocked);
+  });
 }
 
 document.getElementById('loading-spinner')?.remove();
@@ -171,7 +173,7 @@ if (calendarEl) {
     const ownerInput = document.getElementById('eventOwnerSelect') as HTMLInputElement;
 
     if (itemSelect?.tomselect?.items?.length) {
-      lockScopeButton(itemSelect.tomselect.items);
+      lockScopeButtons(itemSelect.tomselect.items);
       itemSelect.tomselect.items.forEach(id => {
         params.append('items[]', id);
       });
@@ -680,7 +682,7 @@ if (calendarEl) {
       controlInput: '#itemSelectInput',
       dropdownParent: '#itemSelectWrapper',
       onChange: (selectedItems: string[]) => {
-        lockScopeButton(selectedItems);
+        lockScopeButtons(selectedItems);
         const container = document.getElementById('selectedItemsContainer')!;
         const display = document.getElementById('selectedItemsDisplay')!;
         display.innerHTML = '';
@@ -709,7 +711,7 @@ if (calendarEl) {
 
     if (selectedItems.length > 0) {
       itemTs.setValue(selectedItems);
-      lockScopeButton(selectedItems);
+      lockScopeButtons(selectedItems);
     }
 
     categorySelect.addEventListener('change', () => {

--- a/tests/cypress/integration/scheduler.cy.ts
+++ b/tests/cypress/integration/scheduler.cy.ts
@@ -13,9 +13,14 @@ describe('Scheduler', () => {
 
   it('Display Scheduler with selected item', () => {
     // TODO: itemId currently has no real active use
+    cy.request('PATCH', '/api/v2/users/me', { scope_items: 2 });
     cy.createBooking().then(itemId => {
       cy.visit(`/scheduler.php?items[]=${itemId}`);
       cy.get('#loading-spinner').should('not.exist');
+      cy.get('#scopeBtn').should('not.be.visible');
+      cy.get('#scopeItemsLocked').should('be.visible')
+        .find('button').should('be.disabled')
+        .find('i').should('have.class', 'fa-globe');
       cy.get('[data-cy="selectedItemsDisplay"]').should('contain', 'Cypress booked resource');
     });
   });

--- a/tests/unit/models/ItemsTest.php
+++ b/tests/unit/models/ItemsTest.php
@@ -13,8 +13,10 @@ namespace Elabftw\Models;
 
 use Elabftw\Enums\Action;
 use Elabftw\Enums\BasePermissions;
+use Elabftw\Enums\BinaryValue;
 use Elabftw\Enums\FileFromString;
 use Elabftw\Enums\AccessType;
+use Elabftw\Enums\Scope;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\IllegalActionException;
 use Elabftw\Exceptions\ImproperActionException;
@@ -150,7 +152,17 @@ class ItemsTest extends \PHPUnit\Framework\TestCase
 
     public function testReadBookable(): void
     {
-        $this->assertIsArray($this->Items->readBookable());
+        $otherTeamItems = new Items($this->getRandomUserInTeam(2));
+        $otherTeamItemId = $otherTeamItems->create(
+            title: 'Bookable resource from another team',
+            canreadBase: BasePermissions::Organization,
+            isBookable: BinaryValue::True,
+        );
+        $teamItemIds = array_column($this->Items->readBookable(Scope::Team), 'id');
+        $everythingItemIds = array_column($this->Items->readBookable(Scope::Everything), 'id');
+
+        $this->assertNotContains($otherTeamItemId, $teamItemIds);
+        $this->assertContains($otherTeamItemId, $everythingItemIds);
     }
 
     public function testCanBookInPast(): void

--- a/web/scheduler.php
+++ b/web/scheduler.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Elabftw\Elabftw;
 
+use Elabftw\Enums\Scope;
 use Elabftw\Exceptions\AppException;
 use Elabftw\Models\Items;
 use Elabftw\Models\ResourcesCategories;
@@ -34,8 +35,14 @@ try {
     $Response->prepare($Request);
     $Items = new Items($App->Users);
     $ResourcesCategories = new ResourcesCategories($App->Teams);
+    $scope = null;
+    if ($Request->query->has('items')) {
+        $scope = Scope::Everything;
+        // keep the displayed scope in sync with the scope used to find the selected resources. See #6990
+        $Request->query->set('scope', $scope->value);
+    }
     // only the bookable categories
-    $bookableItemsArr = $Items->readBookable();
+    $bookableItemsArr = $Items->readBookable($scope);
     $categoriesOfBookableItems = array_column($bookableItemsArr, 'category');
     $allCategories = $ResourcesCategories->readAll();
     $bookableCategories = array_filter(


### PR DESCRIPTION
fix #6990

force the resource and event scopes to Everything when opening the scheduler with a preselected item


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler behavior when an item is selected by consistently displaying all applicable bookable resources.
  * Scope controls now clearly indicate when filtering is locked and unavailable in the selected-item view.
  * Updated scope button visibility and disabled-state handling for a more consistent scheduling experience.
  * Corrected scope-based resource filtering to ensure results match the selected scope.
* **Tests**
  * Added coverage for locked scope controls and team-specific resource filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->