### PR TITLE
bug/minor: editor: fix initial TinyMCE height

### DIFF
--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -373,6 +373,10 @@ export function getTinymceBaseConfig(page: string): object {
         if (page !== 'admin' && page !== 'sysconfig') {
           editor.execCommand('lineheight', false, '1');
         }
+        // recalculate after the initial layout to avoid an oversized editor. See #7301.
+        if (page === 'edit' && editor.plugins.autoresize) {
+          window.requestAnimationFrame(() => editor.execCommand('mceAutoResize'));
+        }
       });
       // Hook into the blur event - Finalize potential changes to images if user clicks outside of editor
       editor.on('blur', () => {

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -225,6 +225,10 @@ export function getTinymceBaseConfig(page: string): object {
     isToolbarSticky = true;
   }
 
+  // prevent autoresize from collapsing an empty editor while allowing editors with content to shrink
+  const bodyArea = document.getElementById('body_area') as HTMLTextAreaElement | null;
+  const minHeight = page === 'edit' && !bodyArea?.value.trim() ? 500 : 100;
+
   return {
     selector: '.mceditable',
     table_default_styles: {
@@ -243,6 +247,7 @@ export function getTinymceBaseConfig(page: string): object {
     // remove the "Upgrade" button
     promotion: false,
     autoresize_bottom_margin: 50,
+    min_height: minHeight,
     // autoresize plugin will disallow manually resizing, but setting resize to true will make the scrollbar disappear
     //resize: true,
     plugins: plugins,


### PR DESCRIPTION
fix #7301

Recalculate the editor height after the initial layout so it no longer remains oversized until the first click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TinyMCE editor sizing across pages.
  * Empty edit pages now provide a larger editing area, while populated editors and other pages use a more compact height.
  * Editor content is automatically resized after loading when autoresize support is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->