### PR TITLE
bug/minor: listing: fix always show owned not working in different teams

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -107,12 +107,6 @@ abstract class AbstractEntityController implements ControllerInterface
     {
         // used to get all tags for top page tag filter
         $TeamTags = new TeamTags($this->App->Users, $this->App->Users->userData['team']);
-
-        // must be before the call to readShow
-        if (($this->App->Users->userData['always_show_owned'] ?? null) === 1) {
-            $this->Entity->alwaysShowOwned = true;
-        }
-
         // read all based on query parameters or user defaults
         $orderBy = Orderby::tryFrom($this->App->Users->userData['orderby']) ?? Orderby::Lastchange;
         $skipOrderPinned = $this->App->Request->query->getBoolean('skip_pinned');

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -376,6 +376,8 @@ abstract class AbstractEntity extends AbstractRest
      */
     public function readShow(QueryParamsInterface $displayParams, bool $extended = false, string $can = 'canread'): array
     {
+        // Allow owned entries to pass the permission filter regardless of their team
+        $this->alwaysShowOwned = ($this->Users->userData['always_show_owned'] ?? 0) === 1;
         if ($displayParams->isFast()) {
             return $this->readAllSimple($displayParams);
         }

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -168,8 +168,8 @@ final class DisplayParams extends BaseQueryParams
         if ($scope === Scope::User && empty($query->get('owner')) && empty($query->get('extended'))) {
             $this->appendFilterSql(FilterableColumn::Owner, $this->requester->userData['userid']);
         }
-        // add filter on team only if scope is not set to everything
-        if ($this->requester->userData['scope_' . $this->entityType->value] === Scope::Team->value && $scope !== Scope::Everything) {
+        // filter by the current team only when the effective scope is Team
+        if ($scope === Scope::Team) {
             $this->appendFilterSql(FilterableColumn::Team, $this->requester->team ?? 0);
         }
         // TAGS SEARCH


### PR DESCRIPTION
fix #7120

- allow the "self" scope to display entries owned by the current user across all teams he's part of (**only when "always display your own entries" is enabled via ucp**)
- fix showing own entries when in other teams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for team-scoped views.
  * Entries marked as owned are now correctly displayed according to the user’s “always show owned” preference.
  * Ensured display filters consistently respect the selected scope, including when it differs from the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->