### PR TITLE
bug/minor: tinymce: ctrl + s shortcut doesnt trigger 'Saved' notif

### DIFF
--- a/src/ts/edit.ts
+++ b/src/ts/edit.ts
@@ -29,6 +29,16 @@ window.onbeforeunload = function() {
 // Which editor are we using? md or tiny
 const editor = getEditor();
 editor.init('edit');
+
+if (editor.type === 'md') {
+  document.getElementById('body_area')?.addEventListener('keydown', event => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+      event.preventDefault();
+      updateEntityBody(false);
+    }
+  });
+}
+
 // initialize the file uploader
 (new Uploader()).init();
 

--- a/src/ts/tinymce.ts
+++ b/src/ts/tinymce.ts
@@ -344,7 +344,7 @@ export function getTinymceBaseConfig(page: string): object {
       plugins: [ 'autolink', 'image', 'link', 'lists', 'save', 'table', 'mention' ],
     },
     // use a custom function for the save button in toolbar
-    save_onsavecallback: (): Promise<void> => updateEntityBody(),
+    save_onsavecallback: (): Promise<void> => updateEntityBody(false),
     // keyboard shortcut to insert today's date at cursor in editor
     menu: {
       file: { title: 'File', items: fileMenuItems },


### PR DESCRIPTION
fix #7075

- `Ctrl+S` in TinyMCE was still saving the entity, but no longer displayed the "Saved" notification or refreshed the "Last saved" timestamp

This was a regression (and it's an indicator we can indeed leave the page after doing ctrl+s). Introduced in a recent change, where `updateEntityBody()` gained a `redirect = true` default parameter -> calling `updateEntityBody()` without arguments therefore disabled the saved notification (`notifOnSaved: 0`) and skipped the timestamp refresh.

This changes it to `updateEntityBody(false)` so `Ctrl+S` behaves like the regular Save button, while autosave remains silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving content in the TinyMCE editor now correctly updates the associated entity without triggering unintended behavior.
  * Added reliable Ctrl/Cmd+S handling for Markdown editing, preventing the browser’s default save action and updating content as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->