### PR TITLE
bug/medium: admin: restore removing user from team

### DIFF
--- a/src/templates/destroy-user2team-modal.html
+++ b/src/templates/destroy-user2team-modal.html
@@ -1,0 +1,40 @@
+{# Confirmation modal for removing a user from a team #}
+<div class='modal fade' id='destroyUser2teamModal' tabindex='-1' role='dialog' aria-labelledby='destroyUser2teamModalLabel'>
+  <div class='modal-dialog' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title' id='destroyUser2teamModalLabel'>{{ 'Remove user from team'|trans }}</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body'>
+        <dl class='row mb-3'>
+          <dt class='col-sm-3'>{{ 'User'|trans }}</dt>
+          <dd class='col-sm-9' id='destroyUser2teamUser'></dd>
+          <dt class='col-sm-3'>{{ 'Team'|trans }}</dt>
+          <dd class='col-sm-9' id='destroyUser2teamTeam'></dd>
+        </dl>
+        <p>{{ 'This action removes the association between the user and the team and deletes their API keys for that team. It does not delete the user or their entries.'|trans }}</p>
+        <div class='alert alert-warning' role='alert'>
+          <p class='font-weight-bold'>{{ 'Removing a user from a team is not recommended.'|trans }}</p>
+          <p>{{ "Existing entries owned by this user may disappear from this team's listings while remaining accessible through direct links or the API."|trans }}</p>
+          <p class='mb-0'>{{ 'Archive the user in this team instead unless you specifically need to remove the association.'|trans }}</p>
+        </div>
+        <p class='mb-0'>{{ 'Are you sure you want to continue?'|trans }}</p>
+      </div>
+      <div class='modal-footer'>
+        <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
+        <button
+          type='button'
+          class='btn btn-danger'
+          id='destroyUser2teamButton'
+          data-action='destroy-user2team'
+          disabled
+        >
+          {{ 'Remove user from team'|trans }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/templates/destroy-user2team-modal.html
+++ b/src/templates/destroy-user2team-modal.html
@@ -1,6 +1,6 @@
 {# Confirmation modal for removing a user from a team #}
 <div class='modal fade' id='destroyUser2teamModal' tabindex='-1' role='dialog' aria-labelledby='destroyUser2teamModalLabel'>
-  <div class='modal-dialog' role='document'>
+  <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>
         <h5 class='modal-title' id='destroyUser2teamModalLabel'>{{ 'Remove user from team'|trans }}</h5>
@@ -19,19 +19,13 @@
         <div class='alert alert-warning' role='alert'>
           <p class='font-weight-bold'>{{ 'Removing a user from a team is not recommended.'|trans }}</p>
           <p>{{ "Existing entries owned by this user may disappear from this team's listings while remaining accessible through direct links or the API."|trans }}</p>
-          <p class='mb-0'>{{ 'Archive the user in this team instead unless you specifically need to remove the association.'|trans }}</p>
+          <span>{{ 'Archive the user in this team instead unless you specifically need to remove the association.'|trans }}</span>
         </div>
-        <p class='mb-0'>{{ 'Are you sure you want to continue?'|trans }}</p>
+        <span>{{ 'Are you sure you want to continue?'|trans }}</span>
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Cancel'|trans }}</button>
-        <button
-          type='button'
-          class='btn btn-danger'
-          id='destroyUser2teamButton'
-          data-action='destroy-user2team'
-          disabled
-        >
+        <button type='button' class='btn btn-danger' id='destroyUser2teamButton' data-action='destroy-user2team' disabled>
           {{ 'Remove user from team'|trans }}
         </button>
       </div>

--- a/src/templates/editusers.html
+++ b/src/templates/editusers.html
@@ -1,4 +1,5 @@
 {% include 'edit-user-modal.html' %}
+{% include 'destroy-user2team-modal.html' %}
 <div>
   <h2 class='mb-3 p-2 pl-3 section-title'>{{ 'Users list'|trans }}</h2>
   <div class='pl-3'>

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -40,6 +40,7 @@ import {
   updateCatStat,
   makeMalleableColumnsGreatAgain, rebuildTomSelectOptions,
   mountRors,
+  delayConfirmation,
   initPermissionsTomSelects,
   PERMISSION_SELECT_IDS,
   reloadEntitiesShow,
@@ -143,9 +144,8 @@ on('toggle-modal', (el: HTMLElement) => {
       deleteMsg.textContent = i18next.t('info-deleted-entries', {count: count, entity: entityName});
     }
 
-    deleteButton.disabled = true;
+    delayConfirmation(deleteButton);
     showModalAndFocusFirstInput(modalSelector);
-    setTimeout(() => deleteButton.disabled = false, 2000);
   }
 });
 

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import i18next from './i18n';
-import { clearForm, collectForm, delayConfirmation, populateUserModal, reloadElements } from './misc';
+import { clearForm, collectForm, delayConfirmation, getInput, populateUserModal, reloadElements } from './misc';
 import { ApiC } from './api';
 import { Action, Model } from './interfaces';
 import $ from 'jquery';
@@ -180,9 +180,9 @@ document.getElementById('container')?.addEventListener('click', async (event) =>
   } else if (el.matches('[data-action="open-destroy-user2team-modal"]')) {
     const destroyButton = document.getElementById('destroyUser2teamButton') as HTMLButtonElement;
     destroyButton.dataset.teamid = el.dataset.teamid ?? '';
-    const firstname = (document.getElementById('userInput-firstname') as HTMLInputElement).value;
-    const lastname = (document.getElementById('userInput-lastname') as HTMLInputElement).value;
-    const email = (document.getElementById('userInput-email') as HTMLInputElement).value;
+    const firstname = getInput('userInput-firstname').value;
+    const lastname = getInput('userInput-lastname').value;
+    const email = getInput('userInput-email').value;
     document.getElementById('destroyUser2teamUser').textContent = `${firstname} ${lastname}`.trim() || email;
     document.getElementById('destroyUser2teamTeam').textContent = el.dataset.teamname ?? '';
 

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -6,7 +6,7 @@
  * @package elabftw
  */
 import i18next from './i18n';
-import { clearForm, collectForm, populateUserModal, reloadElements } from './misc';
+import { clearForm, collectForm, delayConfirmation, populateUserModal, reloadElements } from './misc';
 import { ApiC } from './api';
 import { Action, Model } from './interfaces';
 import $ from 'jquery';
@@ -15,7 +15,10 @@ import { core } from './core';
 import './users-table';
 
 document.getElementById('container')?.addEventListener('click', async (event) => {
-  const el = (event.target as HTMLElement);
+  const el = (event.target as HTMLElement).closest<HTMLElement>('[data-action]');
+  if (!el) {
+    return;
+  }
   let userid = document.getElementById('editUserModal')?.dataset.userid;
   if (!userid) {
     userid = el.dataset.userid;
@@ -175,14 +178,39 @@ document.getElementById('container')?.addEventListener('click', async (event) =>
     const requests = idList.map(userid => ApiC.patch(`${Model.User}/${userid}`, {action: Action.Add, team: core.currentTeam}));
     await Promise.all(requests);
     document.dispatchEvent(new CustomEvent('dataReload'));
+  // OPEN REMOVE USER FROM TEAM CONFIRMATION
+  } else if (el.matches('[data-action="open-destroy-user2team-modal"]')) {
+    const destroyButton = document.getElementById('destroyUser2teamButton') as HTMLButtonElement;
+    destroyButton.dataset.teamid = el.dataset.teamid ?? '';
+    const firstname = (document.getElementById('userInput-firstname') as HTMLInputElement).value;
+    const lastname = (document.getElementById('userInput-lastname') as HTMLInputElement).value;
+    const email = (document.getElementById('userInput-email') as HTMLInputElement).value;
+    document.getElementById('destroyUser2teamUser').textContent = `${firstname} ${lastname}`.trim() || email;
+    document.getElementById('destroyUser2teamTeam').textContent = el.dataset.teamname ?? '';
+
+    const editUserModal = $('#editUserModal');
+    const destroyUser2teamModal = $('#destroyUser2teamModal');
+    editUserModal.one('hidden.bs.modal', () => {
+      delayConfirmation(destroyButton);
+      destroyUser2teamModal.modal('show');
+    });
+    destroyUser2teamModal.one('hidden.bs.modal', () => editUserModal.modal('show'));
+    editUserModal.modal('hide');
   // REMOVE USER FROM TEAM
   } else if (el.matches('[data-action="destroy-user2team"]')) {
-    alert('It is currently not recommended to remove a user from a team. Use the "Is Archived" property instead to mark them as inactive.');
-    /*
-      const team = parseInt(el.dataset.teamid, 10);
-      ApiC.patch(`${Model.User}/${userid}`, {action: Action.Unreference, team: team})
-        .then(response => response.json()).then(user => populateUserModal(user));
+    const team = parseInt(el.dataset.teamid ?? '', 10);
+    if (!userid || Number.isNaN(team)) {
+      return;
     }
-   */
+    el.setAttribute('disabled', 'disabled');
+    try {
+      const response = await ApiC.patch(`${Model.User}/${userid}`, {action: Action.Unreference, team});
+      await populateUserModal(await response.json());
+      document.dispatchEvent(new CustomEvent('dataReload'));
+      $('#destroyUser2teamModal').modal('hide');
+    } catch (error) {
+      el.removeAttribute('disabled');
+      notify.error(error);
+    }
   }
 });

--- a/src/ts/editusers.ts
+++ b/src/ts/editusers.ts
@@ -16,9 +16,7 @@ import './users-table';
 
 document.getElementById('container')?.addEventListener('click', async (event) => {
   const el = (event.target as HTMLElement).closest<HTMLElement>('[data-action]');
-  if (!el) {
-    return;
-  }
+  if (!el) return;
   let userid = document.getElementById('editUserModal')?.dataset.userid;
   if (!userid) {
     userid = el.dataset.userid;

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -1008,6 +1008,8 @@ export function mkSpinStop(el: HTMLElement, oldHTML: string): void {
   el.removeAttribute('disabled');
 }
 
+// store the active timeout for each confirmation button without preventing
+// the button element from being garbage-collected when removed from DOM
 const confirmationTimeouts = new WeakMap<HTMLButtonElement, number>();
 
 export function delayConfirmation(button: HTMLButtonElement, delay = 2000): void {

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -1007,6 +1007,21 @@ export function mkSpinStop(el: HTMLElement, oldHTML: string): void {
   el.innerHTML = oldHTML;
   el.removeAttribute('disabled');
 }
+
+const confirmationTimeouts = new WeakMap<HTMLButtonElement, number>();
+
+export function delayConfirmation(button: HTMLButtonElement, delay = 2000): void {
+  const timeoutId = confirmationTimeouts.get(button);
+  if (timeoutId !== undefined) {
+    window.clearTimeout(timeoutId);
+  }
+  button.disabled = true;
+  confirmationTimeouts.set(button, window.setTimeout(() => {
+    button.disabled = false;
+    confirmationTimeouts.delete(button);
+  }, delay));
+}
+
 export async function populateUserModal(user: Record<string, string|number>) {
   const manageTeamsDiv = document.getElementById('manageTeamsDiv');
   if (!manageTeamsDiv) {
@@ -1025,15 +1040,19 @@ export async function populateUserModal(user: Record<string, string|number>) {
     teamBadge.classList.add('user-badge', 'm-1');
     teamBadge.innerText = team.name;
     // REMOVE TEAM BUTTON
-    // prevent deleting association of the team we are currently logged in, allow it for other users
-    if (team.id !== requester.team || user.userid !== requester.userid) {
-      const removeTeamBtn = document.createElement('span');
+    // users must keep one team; requester cannot remove themselves from their current team
+    if (userTeams.length > 1 && (team.id !== requester.team || user.userid !== requester.userid)) {
+      const removeTeamBtn = document.createElement('button');
+      removeTeamBtn.type = 'button';
       removeTeamBtn.classList.add('btn', 'btn-danger-ghost', 'btn-sm', 'ml-2');
       removeTeamBtn.title = i18next.t('delete');
-      removeTeamBtn.dataset.action = 'destroy-user2team';
-      removeTeamBtn.dataset.teamid = team.id;
+      removeTeamBtn.setAttribute('aria-label', i18next.t('delete'));
+      removeTeamBtn.dataset.action = 'open-destroy-user2team-modal';
+      removeTeamBtn.dataset.teamid = String(team.id);
+      removeTeamBtn.dataset.teamname = String(team.name);
       const removeTeamIcon = document.createElement('i');
       removeTeamIcon.classList.add('fas', 'fa-xmark');
+      removeTeamIcon.setAttribute('aria-hidden', 'true');
       removeTeamBtn.appendChild(removeTeamIcon);
       teamBadge.appendChild(removeTeamBtn);
     }

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -73,6 +73,7 @@ describe('Experiments', () => {
     cy.get('button[title="More options"]').click();
     cy.get('button[data-action="toggle-modal"][data-target="deleteSelectedEntitiesModal"]').click();
     cy.get('button[data-action="delete-selected-entities"]').should('be.disabled');
+    // the delete button for some use-cases is voluntarily delayed for 2.5s
     cy.wait(2500);
     cy.get('button[data-action="delete-selected-entities"]').should('not.be.disabled').click();
   };

--- a/tests/cypress/integration/entity.cy.ts
+++ b/tests/cypress/integration/entity.cy.ts
@@ -72,7 +72,9 @@ describe('Experiments', () => {
   const entityDestroy = () => {
     cy.get('button[title="More options"]').click();
     cy.get('button[data-action="toggle-modal"][data-target="deleteSelectedEntitiesModal"]').click();
-    cy.get('button[data-action="delete-selected-entities"]').wait(2500).click();
+    cy.get('button[data-action="delete-selected-entities"]').should('be.disabled');
+    cy.wait(2500);
+    cy.get('button[data-action="delete-selected-entities"]').should('not.be.disabled').click();
   };
 
   const entityCatStat = (category: string, categoryTarget: string, statusTarget: string) => {


### PR DESCRIPTION
fix #5864 - restore removing user from team

This PR restores the ability to remove a user from a team while making the consequences of this action explicit.

Removing a user from a team can affect the visibility of their existing entries, so a confirmation modal is now displayed before proceeding. The destructive action is disabled for a short delay to prevent accidental confirmation.

The delayed confirmation mechanism introduced in #7158 (thanks for the work Elsa :p ) for entry deletion has also been made reusable and is now shared by both deletion workflows

Archiving a user remains the recommended option when they should simply become inactive in a team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation dialog for removing a user from a team.
  - Shows the selected user and team, explains consequences such as deleted team API keys, and recommends archiving when appropriate.
  - Prevents removing a user’s final team and provides clearer removal progress and error handling.

- **Bug Fixes**
  - Improved click handling for controls containing nested elements.
  - Prevented accidental repeated deletion actions with delayed confirmation controls.
  - Improved deletion test reliability by waiting for controls to become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->