### PR TITLE
nginx: remove gzip_ratio

### DIFF
--- a/containers/elabimg/nginx/nginx.conf
+++ b/containers/elabimg/nginx/nginx.conf
@@ -53,7 +53,6 @@ http {
         '"upstream_header_time":"$upstream_header_time",'
         '"upstream_response_time":"$upstream_response_time",'
         '"upstream_response_length":"$upstream_response_length",'
-        '"gzip_ratio":"$gzip_ratio",'
         '"brotli_ratio":"$brotli_ratio",'
         '"http_referer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'


### PR DESCRIPTION
no gzip here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `gzip_ratio` field from JSON-formatted access logs for cleaner, more consistent log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->