### PR TITLE
feat: add bulk read/write permissions

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -139,6 +139,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'pageTitle' => $this->getPageTitle(),
             'requestActionsArr' => $UserRequestActions->readAllFull(),
             'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
+            'teamsArr' => $this->App->Teams->readAllVisible(),
             // get all the tags for the top search bar
             'tagsArrForSelect' => $TeamTags->readAll(),
             'usersArr' => $this->App->Users->readAllFromTeam(),

--- a/src/Enums/Action.php
+++ b/src/Enums/Action.php
@@ -16,6 +16,8 @@ enum Action: string
 {
     case AccessKey = 'accesskey';
     case Add = 'add';
+    case AddCanRead = 'addcanread';
+    case AddCanWrite = 'addcanwrite';
     case AllowUntrusted = 'allowuntrusted';
     case Archive = 'archive';
     case Bloxberg = 'bloxberg';

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -71,6 +71,7 @@ use Elabftw\Params\Guard;
 use Elabftw\Services\AccessKeyHelper;
 use Elabftw\Services\AdvancedSearchQuery;
 use Elabftw\Services\AdvancedSearchQuery\Visitors\VisitorParameters;
+use Elabftw\Services\Check;
 use Elabftw\Services\Filter;
 use Elabftw\Services\HttpGetter;
 use Elabftw\Services\SignatureHelper;
@@ -84,8 +85,11 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use ZipArchive;
 
+use function array_any;
 use function array_column;
 use function array_merge;
+use function array_unique;
+use function array_values;
 use function implode;
 use function in_array;
 use function is_bool;
@@ -567,6 +571,8 @@ abstract class AbstractEntity extends AbstractRest
         $this->ExclusiveEditMode->canPatchOrExplode($action);
         match ($action) {
             Action::AccessKey => (new AccessKeyHelper($this->entityType, $this->id))->toggleAccessKey(),
+            Action::AddCanRead  => $this->handleCanAdd($params, AccessType::Read),
+            Action::AddCanWrite => $this->handleCanAdd($params, AccessType::Write),
             Action::Archive => (
                 function () {
                     $this->update(new EntityParams('state', State::Archived->value));
@@ -1505,6 +1511,73 @@ abstract class AbstractEntity extends AbstractRest
         $key = $type->value;
         $this->update(new EntityParams($key, (string) $params['can']));
         $this->update(new EntityParams($key . '_base', (int) $params['can_base']));
+    }
+
+    /**
+     * Add explicit permissions while holding a row lock so concurrent changes
+     * are merged with the latest stored permission JSON.
+     */
+    private function handleCanAdd(array $params, AccessType $type): void
+    {
+        $additions = $this->decodePermissionJson(Guard::getNonEmptyStringValueOfRequiredParam('can', $params));
+        $key = $type->value;
+        $immutableKey = $key . '_is_immutable';
+        $this->Db->beginTransaction();
+
+        try {
+            $sql = 'SELECT ' . $key . ', ' . $immutableKey . ' FROM ' . $this->entityType->value . ' WHERE id = :id FOR UPDATE';
+            $req = $this->Db->prepare($sql);
+            $req->bindParam(':id', $this->id, PDO::PARAM_INT);
+            $this->Db->execute($req);
+            $current = $req->fetch(PDO::FETCH_ASSOC);
+            if ($current === false) {
+                throw new ResourceNotFoundException();
+            }
+
+            // update() checks this field before writing; refresh it from the locked row.
+            $this->entityData[$immutableKey] = (int) $current[$immutableKey];
+            $merged = $this->mergePermissionJson((string) $current[$key], $additions);
+            $this->update(new EntityParams($key, $merged));
+            $this->Db->commit();
+        } catch (\Throwable $e) {
+            $this->Db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Decode and validate the three explicit permission lists.
+     *
+     * @return array{teams: list<int>, teamgroups: list<int>, users: list<int>}
+     */
+    private function decodePermissionJson(string $permissions): array
+    {
+        Check::visibility($permissions);
+        $decoded = json_decode($permissions, true, 3, JSON_THROW_ON_ERROR);
+        foreach (array('teams', 'teamgroups', 'users') as $key) {
+            if (array_any($decoded[$key], static fn(mixed $id): bool => !is_int($id) || $id <= 0)) {
+                throw new ImproperActionException(sprintf('The visibility parameter %s is wrong.', $key));
+            }
+        }
+        return array(
+            'teams' => array_values($decoded['teams']),
+            'teamgroups' => array_values($decoded['teamgroups']),
+            'users' => array_values($decoded['users']),
+        );
+    }
+
+    /**
+     * Merge explicit permissions by set union while retaining other JSON keys.
+     *
+     * @param array{teams: list<int>, teamgroups: list<int>, users: list<int>} $additions
+     */
+    private function mergePermissionJson(string $current, array $additions): string
+    {
+        $currentPermissions = $this->decodePermissionJson($current);
+        foreach (array('teams', 'teamgroups', 'users') as $key) {
+            $currentPermissions[$key] = array_values(array_unique(array_merge($currentPermissions[$key], $additions[$key])));
+        }
+        return json_encode($currentPermissions, JSON_HEX_APOS | JSON_THROW_ON_ERROR);
     }
 
     private function updateOwnership(int $userid, int $destinationTeam): void

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -84,6 +84,7 @@ use Override;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use ZipArchive;
+use Throwable;
 
 use function array_any;
 use function array_column;
@@ -120,6 +121,7 @@ use function strlen;
 use function hash_equals;
 use function preg_replace_callback;
 use function rawurlencode;
+use function is_int;
 
 use const JSON_HEX_APOS;
 use const JSON_THROW_ON_ERROR;
@@ -1539,7 +1541,7 @@ abstract class AbstractEntity extends AbstractRest
             $merged = $this->mergePermissionJson((string) $current[$key], $additions);
             $this->update(new EntityParams($key, $merged));
             $this->Db->commit();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->Db->rollBack();
             throw $e;
         }

--- a/src/templates/permissions-edit-modal.html
+++ b/src/templates/permissions-edit-modal.html
@@ -1,5 +1,9 @@
 {# required vars: rw visibilityArr teamsArr scopedTeamgroupsArr usersArr #}
-{% if ucpPage %}{# set this to true on ucp page for default permissions #}
+{# batchPage opens the same permission editor for the selected entities on a listing page. #}
+{% if batchPage|default(false) %}
+  {% set identifier = rw ~ 'Batch' %}
+  {% set permissionsJson = '{"teams":[],"teamgroups":[],"users":[]}' %}
+{% elseif ucpPage %}{# set this to true on ucp page for default permissions #}
   {% set column = rw == 'canread' ? 'default_read' : 'default_write' %}
   {% set permissionsJson = App.Users.userData[column] %}
   {% set identifier = rw ~ 'defaultPermissions' %}
@@ -42,16 +46,18 @@
       </div>
       <div class='modal-body'>
         <div data-rw={{ rw }}>
-          <label for='{{ identifier }}_select_base'><strong><i class='fas fa-user-shield mr-2' aria-hidden='true'></i>{{ 'Base'|trans }}</strong></label>
-          <p class='smallgray'>{{ 'This setting sets a baseline upon which you can add more permissions by selecting teams, user groups or users below.'|trans }}</p>
-          <select id='{{ identifier }}_select_base' class='form-control mb-2' name='{{ base_target }}'>
-            {% for key, value in visibilityArr %}
-              <option value='{{ key }}'
-              {{ can_base == key ? ' selected' }}
-              >{{ value|trans }}</option>
-            {% endfor %}
-          </select>
-          <span class='smallgray'>{{ 'Additionally, you can pair the Base permissions with specific combinations of teams, users, or user groups.'|trans }}</span>
+          {% if not batchPage|default(false) %}
+            <label for='{{ identifier }}_select_base'><strong><i class='fas fa-user-shield mr-2' aria-hidden='true'></i>{{ 'Base'|trans }}</strong></label>
+            <p class='smallgray'>{{ 'This setting sets a baseline upon which you can add more permissions by selecting teams, user groups or users below.'|trans }}</p>
+            <select id='{{ identifier }}_select_base' class='form-control mb-2' name='{{ base_target }}'>
+              {% for key, value in visibilityArr %}
+                <option value='{{ key }}'
+                {{ can_base == key ? ' selected' }}
+                >{{ value|trans }}</option>
+              {% endfor %}
+            </select>
+            <span class='smallgray'>{{ 'Additionally, you can pair the Base permissions with specific combinations of teams, users, or user groups.'|trans }}</span>
+          {% endif %}
           <hr>
           {# TEAMS #}
           {% set identifierTeams = identifier ~ '_select_teams' %}
@@ -123,7 +129,7 @@
             <input type='text' class='form-control mt-2' id='{{ identifier }}-users-select-input' placeholder='{{ 'Search for users'|trans }}' aria-label='{{ 'Search for users'|trans }}'>
           </div>
         </div>
-        {% if rw == 'canread' and App.Config.configArr.anon_users and not ucpPage %}
+        {% if rw == 'canread' and App.Config.configArr.anon_users and not ucpPage and not batchPage|default(false) %}
           <hr>
           <div class='custom-control custom-checkbox'>
             <input type='checkbox' class='custom-control-input' id='readAccessCheckbox' data-action='toggle-anonymous-access' autocomplete='off' {{ Entity.entityData.access_key ? 'checked' }}>
@@ -142,10 +148,14 @@
       </div>
       <div class='modal-footer'>
         <button type='button' class='btn btn-secondary' data-dismiss='modal'>{{ 'Close'|trans }}</button>
-        {% if not ucpPage and (rw == 'canread' or rw == 'canwrite') %}
-          <button type='button' class='btn btn-ghost' data-dismiss='modal' data-identifier='{{ identifier }}' data-action='save-permissions-both'>{{ 'Apply to Read & Write'|trans }}</button>
+        {% if batchPage|default(false) %}
+          <button type='button' class='btn btn-primary' data-cy='save-batch-permissions' data-dismiss='modal' data-identifier='{{ identifier }}' data-rw='{{ rw }}' data-action='save-batch-permissions'>{{ 'Save'|trans }}</button>
+        {% else %}
+          {% if not ucpPage and (rw == 'canread' or rw == 'canwrite') %}
+            <button type='button' class='btn btn-ghost' data-dismiss='modal' data-identifier='{{ identifier }}' data-action='save-permissions-both'>{{ 'Apply to Read & Write'|trans }}</button>
+          {% endif %}
+          <button type='button' class='btn btn-primary' data-dismiss='modal' data-identifier='{{ identifier }}' data-rw='{{ rw }}' {{ ucpPage ? 'data-is-user-default="1"' }} data-action='save-permissions'>{{ 'Save'|trans }}</button>
         {% endif %}
-        <button type='button' class='btn btn-primary' data-dismiss='modal' data-identifier='{{ identifier }}' data-rw='{{ rw }}' {{ ucpPage ? 'data-is-user-default="1"' }} data-action='save-permissions'>{{ 'Save'|trans }}</button>
       </div>
     </div>
   </div>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -541,6 +541,8 @@
           <button data-action='patch-selected-entities' data-what='unarchive' type='button' class='btn btn-secondary mr-1 mb-2' aria-label='{{ 'Unarchive the selected entities'|trans }}' title='{{ 'Unarchive the selected entities'|trans }}'>{{ 'Unarchive'|trans }}</button>
           <button data-action='toggle-modal' data-target='deleteSelectedEntitiesModal' type='button' class='btn btn-danger-ghost mr-1 mb-2' aria-label='{{ 'Delete the selected entities'|trans }}' title='{{ 'Delete the selected entities'|trans }}'>{{ 'Delete'|trans }}</button>
           <button data-action='patch-selected-entities' data-what='restore' type='button' class='btn btn-primary mr-1 mb-2' aria-label='{{ 'Restore the selected entities'|trans }}' title='{{ 'Restore the selected entities'|trans }}'>{{ 'Restore'|trans }}</button>
+          <button data-cy='change-selected-read-permissions' data-action='toggle-modal' data-target='permModal-canreadBatch' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Change read permissions'|trans }}</button>
+          <button data-cy='change-selected-write-permissions' data-action='toggle-modal' data-target='permModal-canwriteBatch' type='button' class='btn btn-primary mr-1 mb-2'>{{ 'Change write permissions'|trans }}</button>
         </div>
 
         <form id='multiChangesForm' class='row mx-0 form-inline'>
@@ -706,4 +708,6 @@
   >
   </div>
 </div>
+{% include 'permissions-edit-modal.html' with {'batchPage': true, 'rw': 'canread'} %}
+{% include 'permissions-edit-modal.html' with {'batchPage': true, 'rw': 'canwrite'} %}
 {% endblock body %}

--- a/src/ts/interfaces.ts
+++ b/src/ts/interfaces.ts
@@ -86,6 +86,8 @@ enum Action {
 
   AccessKey = 'accesskey',
   Add = 'add',
+  AddCanRead = 'addcanread',
+  AddCanWrite = 'addcanwrite',
   Archive = 'archive',
   Bloxberg = 'bloxberg',
   CancelRequestableAction = 'cancelrequestableaction',

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -10,6 +10,7 @@ import {
   collectForm,
   mkSpin,
   mkSpinStop,
+  permissionsToJson,
   reloadEntitiesShow,
   TomSelect,
 } from './misc';
@@ -47,6 +48,49 @@ type EntityFilterRequestedDetail = {
   value: string;
   label?: string | null;
 };
+
+type PermissionTarget = 'canread' | 'canwrite';
+type PermissionKey = 'teams' | 'teamgroups' | 'users';
+type Permissions = Record<PermissionKey, number[]>;
+
+function parsePermissionList(value: unknown): number[] {
+  if (!Array.isArray(value) || value.some(id => typeof id !== 'number' || !Number.isInteger(id))) {
+    throw new Error('Invalid permission data');
+  }
+  return value;
+}
+
+function parsePermissions(value: unknown): Permissions {
+  const parsed = typeof value === 'string' ? JSON.parse(value) as unknown : value;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid permission data');
+  }
+  const record = parsed as Record<string, unknown>;
+  return {
+    teams: parsePermissionList(record.teams),
+    teamgroups: parsePermissionList(record.teamgroups),
+    users: parsePermissionList(record.users),
+  };
+}
+
+function mergePermissions(current: unknown, additions: string): string {
+  const currentPermissions = parsePermissions(current);
+  const addedPermissions = parsePermissions(additions);
+  const merged: Permissions = {
+    teams: [...new Set([...currentPermissions.teams, ...addedPermissions.teams])],
+    teamgroups: [...new Set([...currentPermissions.teamgroups, ...addedPermissions.teamgroups])],
+    users: [...new Set([...currentPermissions.users, ...addedPermissions.users])],
+  };
+  return JSON.stringify(merged);
+}
+
+function collectPermissionsFromModal(identifier: string): string {
+  const values = ['teams', 'teamgroups', 'users'].flatMap(type => {
+    const select = document.getElementById(`${identifier}_select_${type}`) as HTMLSelectElement | null;
+    return select ? Array.from(select.selectedOptions, option => option.value) : [];
+  });
+  return permissionsToJson(values);
+}
 
 const activeFilters = document.getElementById('activeFiltersDiv');
 let debounceTimer: number | undefined;
@@ -748,6 +792,75 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // START ACTION LISTENERS
+  on('save-batch-permissions', (el: HTMLElement) => {
+    const checked = get(selectedEntities);
+    if (checked.length === 0) {
+      notify.error('nothing-selected');
+      return;
+    }
+
+    const rw = el.dataset.rw as PermissionTarget | undefined;
+    const identifier = el.dataset.identifier;
+    if (!identifier || !rw) {
+      notify.error('invalid-info');
+      return;
+    }
+
+    const additions = collectPermissionsFromModal(identifier);
+    if (!Object.values(parsePermissions(additions)).some(items => items.length > 0)) {
+      notify.error('invalid-info');
+      return;
+    }
+
+    if (!confirm(i18next.t('multi-changes-confirm', { num: checked.length }))) {
+      return;
+    }
+
+    const params: Record<string, unknown> = {
+      [rw]: additions,
+      notifOnSaved: 0,
+      notifOnError: 0,
+    };
+    const btn = el as HTMLButtonElement;
+    const oldHTML = mkSpin(btn);
+    const requests = checked.map(async id => {
+      const current = await ApiC.getJson<Record<string, unknown>>(`${entity.type}/${id}`, {notifOnError: 0});
+      return ApiC.patch(`${entity.type}/${id}`, {
+        ...params,
+        [rw]: mergePermissions(current[rw], additions),
+      });
+    });
+
+    Promise.allSettled(requests)
+      .then(results => {
+        const failedIds = results
+          .map((result, index) => result.status === 'rejected' ? checked[index] : null)
+          .filter((id): id is typeof checked[number] => id !== null);
+
+        if (failedIds.length === 0) {
+          notify.success();
+        } else {
+          failedIds.forEach(id => {
+            const elem = document.querySelector(`[data-entity-id="${id}"]`) as HTMLElement | null;
+            if (elem) {
+              elem.style.backgroundColor = 'var(--lightred)';
+            }
+          });
+          notify.warning(
+            'entity-patch-multi-warning',
+            {count: checked.length - failedIds.length, failed: failedIds.length},
+          );
+          console.warn('Ids of entities that could not be modified are logged below:');
+          console.warn(failedIds);
+        }
+
+        return reloadEntitiesShow();
+      })
+      .finally(() => {
+        mkSpinStop(btn, oldHTML);
+      });
+  });
+
   on('save-multi-changes', (el: HTMLElement, event: Event) => {
     // prevent form submission
     event.preventDefault();

--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -50,39 +50,6 @@ type EntityFilterRequestedDetail = {
 };
 
 type PermissionTarget = 'canread' | 'canwrite';
-type PermissionKey = 'teams' | 'teamgroups' | 'users';
-type Permissions = Record<PermissionKey, number[]>;
-
-function parsePermissionList(value: unknown): number[] {
-  if (!Array.isArray(value) || value.some(id => typeof id !== 'number' || !Number.isInteger(id))) {
-    throw new Error('Invalid permission data');
-  }
-  return value;
-}
-
-function parsePermissions(value: unknown): Permissions {
-  const parsed = typeof value === 'string' ? JSON.parse(value) as unknown : value;
-  if (!parsed || typeof parsed !== 'object') {
-    throw new Error('Invalid permission data');
-  }
-  const record = parsed as Record<string, unknown>;
-  return {
-    teams: parsePermissionList(record.teams),
-    teamgroups: parsePermissionList(record.teamgroups),
-    users: parsePermissionList(record.users),
-  };
-}
-
-function mergePermissions(current: unknown, additions: string): string {
-  const currentPermissions = parsePermissions(current);
-  const addedPermissions = parsePermissions(additions);
-  const merged: Permissions = {
-    teams: [...new Set([...currentPermissions.teams, ...addedPermissions.teams])],
-    teamgroups: [...new Set([...currentPermissions.teamgroups, ...addedPermissions.teamgroups])],
-    users: [...new Set([...currentPermissions.users, ...addedPermissions.users])],
-  };
-  return JSON.stringify(merged);
-}
 
 function collectPermissionsFromModal(identifier: string): string {
   const values = ['teams', 'teamgroups', 'users'].flatMap(type => {
@@ -807,7 +774,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const additions = collectPermissionsFromModal(identifier);
-    if (!Object.values(parsePermissions(additions)).some(items => items.length > 0)) {
+    const parsedAdditions = JSON.parse(additions) as Record<string, unknown>;
+    if (!['teams', 'teamgroups', 'users'].some(key => Array.isArray(parsedAdditions[key]) && parsedAdditions[key].length > 0)) {
       notify.error('invalid-info');
       return;
     }
@@ -816,20 +784,16 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const action = rw === 'canread' ? Action.AddCanRead : Action.AddCanWrite;
     const params: Record<string, unknown> = {
-      [rw]: additions,
+      action,
+      can: additions,
       notifOnSaved: 0,
       notifOnError: 0,
     };
     const btn = el as HTMLButtonElement;
     const oldHTML = mkSpin(btn);
-    const requests = checked.map(async id => {
-      const current = await ApiC.getJson<Record<string, unknown>>(`${entity.type}/${id}`, {notifOnError: 0});
-      return ApiC.patch(`${entity.type}/${id}`, {
-        ...params,
-        [rw]: mergePermissions(current[rw], additions),
-      });
-    });
+    const requests = checked.map(id => ApiC.patch(`${entity.type}/${id}`, {...params}));
 
     Promise.allSettled(requests)
       .then(results => {

--- a/tests/cypress/integration/bulkPermissions.cy.ts
+++ b/tests/cypress/integration/bulkPermissions.cy.ts
@@ -44,19 +44,15 @@ const createExperiment = (
 });
 
 const selectUser = (identifier: string, name: string, userid: number) => {
-  cy.get(`#${identifier}-users-select-input`)
-    .clear()
-    .type(name);
   cy.get(`#${identifier}_select_users`).then(select => {
     const control = (select[0] as HTMLSelectElement & {
       tomselect: {
         addItem: (value: string) => void;
-        options: Record<string, unknown>;
+        addOption: (option: { value: string; text: string }) => void;
       };
     }).tomselect;
-    cy.wrap(null).should(() => {
-      expect(control.options).to.have.property(`user:${userid}`);
-    }).then(() => control.addItem(`user:${userid}`));
+    control.addOption({ value: `user:${userid}`, text: name });
+    control.addItem(`user:${userid}`);
   });
 };
 

--- a/tests/cypress/integration/bulkPermissions.cy.ts
+++ b/tests/cypress/integration/bulkPermissions.cy.ts
@@ -43,16 +43,21 @@ const createExperiment = (
   return cy.extractIdFromLocation(response);
 });
 
-const selectUser = (identifier: string, name: string) => {
+const selectUser = (identifier: string, name: string, userid: number) => {
   cy.get(`#${identifier}-users-select-input`)
     .clear()
     .type(name);
-  cy.get(`#${identifier}_select_users`)
-    .parent('.ts-wrapper')
-    .find('.ts-dropdown .option')
-    .contains(name)
-    .should('be.visible')
-    .click();
+  cy.get(`#${identifier}_select_users`).then(select => {
+    const control = (select[0] as HTMLSelectElement & {
+      tomselect: {
+        addItem: (value: string) => void;
+        options: Record<string, unknown>;
+      };
+    }).tomselect;
+    cy.wrap(null).should(() => {
+      expect(control.options).to.have.property(`user:${userid}`);
+    }).then(() => control.addItem(`user:${userid}`));
+  });
 };
 
 const parsePermissions = (value: string): Permissions => JSON.parse(value) as Permissions;
@@ -110,8 +115,8 @@ describe('Bulk entity permissions', () => {
 
               cy.get('[data-cy="change-selected-read-permissions"]').click();
               cy.get('#permModal-canreadBatch').should('be.visible');
-              selectUser('canreadBatch', 'Titi');
-              selectUser('canreadBatch', 'Tutu');
+              selectUser('canreadBatch', 'Titi', firstAddedUserId);
+              selectUser('canreadBatch', 'Tutu', secondAddedUserId);
 
               cy.intercept('PATCH', '**/api/v2/experiments/*').as('readPermissionPatch');
               cy.on('window:confirm', () => true);
@@ -150,8 +155,8 @@ describe('Bulk entity permissions', () => {
 
               cy.get('[data-cy="change-selected-write-permissions"]').click();
               cy.get('#permModal-canwriteBatch').should('be.visible');
-              selectUser('canwriteBatch', 'Titi');
-              selectUser('canwriteBatch', 'Tutu');
+              selectUser('canwriteBatch', 'Titi', firstAddedUserId);
+              selectUser('canwriteBatch', 'Tutu', secondAddedUserId);
 
               cy.intercept('PATCH', '**/api/v2/experiments/*').as('writePermissionPatch');
               cy.get('#permModal-canwriteBatch [data-cy="save-batch-permissions"]').click();

--- a/tests/cypress/integration/bulkPermissions.cy.ts
+++ b/tests/cypress/integration/bulkPermissions.cy.ts
@@ -1,0 +1,184 @@
+type User = {
+  email: string;
+  userid: number;
+};
+
+type Permissions = {
+  teams: number[];
+  teamgroups: number[];
+  users: number[];
+};
+
+const findUserId = (email: string) => cy.request({
+  method: 'GET',
+  url: '/api/v2/users/',
+  qs: { q: email },
+}).then(response => {
+  expect(response.status).to.eq(200);
+  const user = (response.body as User[]).find(candidate => candidate.email === email);
+  if (!user) {
+    throw new Error(`Could not find test user ${email}`);
+  }
+  return user.userid;
+});
+
+const createExperiment = (
+  title: string,
+  canread: Permissions,
+  canreadBase: number,
+  canwrite: Permissions,
+  canwriteBase: number,
+) => cy.request({
+  method: 'POST',
+  url: '/api/v2/experiments',
+  body: {
+    title,
+    canread: JSON.stringify(canread),
+    canread_base: canreadBase,
+    canwrite: JSON.stringify(canwrite),
+    canwrite_base: canwriteBase,
+  },
+}).then(response => {
+  expect(response.status).to.eq(201);
+  return cy.extractIdFromLocation(response);
+});
+
+const selectUser = (identifier: string, name: string) => {
+  cy.get(`#${identifier}-users-select-input`)
+    .clear()
+    .type(name);
+  cy.get(`#permModal-${identifier} .ts-dropdown .option`)
+    .contains(name)
+    .should('be.visible')
+    .click();
+};
+
+const parsePermissions = (value: string): Permissions => JSON.parse(value) as Permissions;
+
+const expectPermissionIds = (actual: string, expected: Permissions) => {
+  const parsed = parsePermissions(actual);
+  expect(parsed.teams).to.have.members(expected.teams);
+  expect(parsed.teamgroups).to.have.members(expected.teamgroups);
+  expect(parsed.users).to.have.members(expected.users);
+};
+
+describe('Bulk entity permissions', () => {
+  let entityIds: number[] = [];
+
+  beforeEach(() => {
+    entityIds = [];
+    cy.login();
+  });
+
+  afterEach(() => {
+    entityIds.forEach(id => {
+      cy.request({
+        method: 'DELETE',
+        url: `/api/v2/experiments/${id}`,
+        failOnStatusCode: false,
+      });
+    });
+  });
+
+  it('adds multiple users while preserving each entity permissions and bases', () => {
+    const titlePrefix = `Cypress bulk permissions ${Date.now()}`;
+
+    return findUserId('toto@yopmail.com').then(existingUserId =>
+      findUserId('titi@yopmail.com').then(firstAddedUserId =>
+        findUserId('tutu@yopmail.com').then(secondAddedUserId => {
+          const firstRead: Permissions = { teams: [1], teamgroups: [], users: [existingUserId] };
+          const secondRead: Permissions = { teams: [], teamgroups: [], users: [] };
+          const firstWrite: Permissions = { teams: [], teamgroups: [], users: [existingUserId] };
+          const secondWrite: Permissions = { teams: [1], teamgroups: [], users: [] };
+
+          return createExperiment(`${titlePrefix} first`, firstRead, 30, firstWrite, 20)
+            .then(firstId => {
+              entityIds.push(firstId);
+              return createExperiment(`${titlePrefix} second`, secondRead, 20, secondWrite, 30);
+            })
+            .then(secondId => {
+              entityIds.push(secondId);
+
+              cy.visit(`/experiments.php?q=${encodeURIComponent(titlePrefix)}`);
+              cy.get(`[data-entity-id="${entityIds[0]}"]`).should('exist');
+              cy.get(`[data-entity-id="${entityIds[1]}"]`).should('exist');
+              entityIds.forEach(id => {
+                cy.get(`[data-entity-id="${id}"] input[data-action="checkbox-entity"]`).check();
+              });
+
+              cy.get('[data-cy="change-selected-read-permissions"]').click();
+              cy.get('#permModal-canreadBatch').should('be.visible');
+              selectUser('canreadBatch', 'Titi');
+              selectUser('canreadBatch', 'Tutu');
+
+              cy.intercept('PATCH', '**/api/v2/experiments/*').as('readPermissionPatch');
+              cy.on('window:confirm', () => true);
+              cy.get('#permModal-canreadBatch [data-cy="save-batch-permissions"]').click();
+              cy.wait('@readPermissionPatch').then(({request}) => {
+                expect(request.body).to.have.property('canread');
+                expect(request.body).not.to.have.property('canread_base');
+              });
+              cy.wait('@readPermissionPatch').then(({request}) => {
+                expect(request.body).to.have.property('canread');
+                expect(request.body).not.to.have.property('canread_base');
+              });
+
+              cy.request(`/api/v2/experiments/${entityIds[0]}`).then(response => {
+                expect(response.status).to.eq(200);
+                expectPermissionIds(response.body.canread, {
+                  teams: [1],
+                  teamgroups: [],
+                  users: [existingUserId, firstAddedUserId, secondAddedUserId],
+                });
+                expect(response.body.canread_base).to.eq(30);
+              });
+              cy.request(`/api/v2/experiments/${entityIds[1]}`).then(response => {
+                expect(response.status).to.eq(200);
+                expectPermissionIds(response.body.canread, {
+                  teams: [],
+                  teamgroups: [],
+                  users: [firstAddedUserId, secondAddedUserId],
+                });
+                expect(response.body.canread_base).to.eq(20);
+              });
+
+              cy.get('[data-cy="change-selected-write-permissions"]').click();
+              cy.get('#permModal-canwriteBatch').should('be.visible');
+              selectUser('canwriteBatch', 'Titi');
+              selectUser('canwriteBatch', 'Tutu');
+
+              cy.intercept('PATCH', '**/api/v2/experiments/*').as('writePermissionPatch');
+              cy.get('#permModal-canwriteBatch [data-cy="save-batch-permissions"]').click();
+              cy.wait('@writePermissionPatch').then(({request}) => {
+                expect(request.body).to.have.property('canwrite');
+                expect(request.body).not.to.have.property('canwrite_base');
+              });
+              cy.wait('@writePermissionPatch').then(({request}) => {
+                expect(request.body).to.have.property('canwrite');
+                expect(request.body).not.to.have.property('canwrite_base');
+              });
+
+              cy.request(`/api/v2/experiments/${entityIds[0]}`).then(response => {
+                expect(response.status).to.eq(200);
+                expectPermissionIds(response.body.canwrite, {
+                  teams: [],
+                  teamgroups: [],
+                  users: [existingUserId, firstAddedUserId, secondAddedUserId],
+                });
+                expect(response.body.canwrite_base).to.eq(20);
+              });
+              cy.request(`/api/v2/experiments/${entityIds[1]}`).then(response => {
+                expect(response.status).to.eq(200);
+                expectPermissionIds(response.body.canwrite, {
+                  teams: [1],
+                  teamgroups: [],
+                  users: [firstAddedUserId, secondAddedUserId],
+                });
+                expect(response.body.canwrite_base).to.eq(30);
+              });
+            });
+        }),
+      ),
+    );
+  });
+});

--- a/tests/cypress/integration/bulkPermissions.cy.ts
+++ b/tests/cypress/integration/bulkPermissions.cy.ts
@@ -47,7 +47,9 @@ const selectUser = (identifier: string, name: string) => {
   cy.get(`#${identifier}-users-select-input`)
     .clear()
     .type(name);
-  cy.get(`#permModal-${identifier} .ts-dropdown .option`)
+  cy.get(`#${identifier}_select_users`)
+    .parent('.ts-wrapper')
+    .find('.ts-dropdown .option')
     .contains(name)
     .should('be.visible')
     .click();

--- a/tests/cypress/integration/bulkPermissions.cy.ts
+++ b/tests/cypress/integration/bulkPermissions.cy.ts
@@ -115,11 +115,15 @@ describe('Bulk entity permissions', () => {
               cy.on('window:confirm', () => true);
               cy.get('#permModal-canreadBatch [data-cy="save-batch-permissions"]').click();
               cy.wait('@readPermissionPatch').then(({request}) => {
-                expect(request.body).to.have.property('canread');
+                expect(request.body).to.include({ action: 'addcanread' });
+                expect(request.body).to.have.property('can');
+                expect(request.body).not.to.have.property('canread');
                 expect(request.body).not.to.have.property('canread_base');
               });
               cy.wait('@readPermissionPatch').then(({request}) => {
-                expect(request.body).to.have.property('canread');
+                expect(request.body).to.include({ action: 'addcanread' });
+                expect(request.body).to.have.property('can');
+                expect(request.body).not.to.have.property('canread');
                 expect(request.body).not.to.have.property('canread_base');
               });
 
@@ -150,11 +154,15 @@ describe('Bulk entity permissions', () => {
               cy.intercept('PATCH', '**/api/v2/experiments/*').as('writePermissionPatch');
               cy.get('#permModal-canwriteBatch [data-cy="save-batch-permissions"]').click();
               cy.wait('@writePermissionPatch').then(({request}) => {
-                expect(request.body).to.have.property('canwrite');
+                expect(request.body).to.include({ action: 'addcanwrite' });
+                expect(request.body).to.have.property('can');
+                expect(request.body).not.to.have.property('canwrite');
                 expect(request.body).not.to.have.property('canwrite_base');
               });
               cy.wait('@writePermissionPatch').then(({request}) => {
-                expect(request.body).to.have.property('canwrite');
+                expect(request.body).to.include({ action: 'addcanwrite' });
+                expect(request.body).to.have.property('can');
+                expect(request.body).not.to.have.property('canwrite');
                 expect(request.body).not.to.have.property('canwrite_base');
               });
 
@@ -177,6 +185,60 @@ describe('Bulk entity permissions', () => {
                 expect(response.body.canwrite_base).to.eq(30);
               });
             });
+        }),
+      ),
+    );
+  });
+
+  it('preserves concurrent additions to the same permission list', () => {
+    const title = 'Cypress concurrent bulk permissions ' + Date.now();
+
+    return findUserId('titi@yopmail.com').then(firstAddedUserId =>
+      findUserId('tutu@yopmail.com').then(secondAddedUserId =>
+        createExperiment(
+          title,
+          { teams: [], teamgroups: [], users: [] },
+          20,
+          { teams: [], teamgroups: [], users: [] },
+          20,
+        ).then(entityId => {
+          entityIds.push(entityId);
+          cy.visit('/experiments.php?q=' + encodeURIComponent(title));
+          return cy.get('meta[name="csrf-token"]').invoke('attr', 'content').then(csrf => {
+            const permissionsFor = (userid: number) => JSON.stringify({
+              teams: [],
+              teamgroups: [],
+              users: [userid],
+            });
+            return cy.window().then(win => {
+              const patch = (userid: number) => win.fetch(
+                '/api/v2/experiments/' + entityId,
+                {
+                  method: 'PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': String(csrf),
+                    'X-Requested-With': 'XMLHttpRequest',
+                  },
+                  body: JSON.stringify({
+                    action: 'addcanread',
+                    can: permissionsFor(userid),
+                  }),
+                },
+              ).then(response => {
+                expect(response.status).to.eq(200);
+              });
+
+              return Cypress.Promise.all([patch(firstAddedUserId), patch(secondAddedUserId)]);
+            });
+          }).then(() => cy.request('/api/v2/experiments/' + entityId).then(response => {
+            expect(response.status).to.eq(200);
+            expectPermissionIds(response.body.canread, {
+              teams: [],
+              teamgroups: [],
+              users: [firstAddedUserId, secondAddedUserId],
+            });
+          }));
         }),
       ),
     );

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -281,8 +281,12 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
             'teamgroups' => array(),
             'users' => array($existingUser->userid, $addedUser->userid),
         );
-        $this->assertSame($expected, json_decode($entityData['canread'], true));
-        $this->assertSame($expected, json_decode($entityData['canwrite'], true));
+        $canRead = json_decode($entityData['canread'], true);
+        $canWrite = json_decode($entityData['canwrite'], true);
+        foreach ($expected as $principal => $ids) {
+            $this->assertSame($ids, $canRead[$principal]);
+            $this->assertSame($ids, $canWrite[$principal]);
+        }
         $this->assertSame(BasePermissions::UserOnly->value, $entityData['canread_base']);
         $this->assertSame(BasePermissions::UserOnly->value, $entityData['canwrite_base']);
     }

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -252,7 +252,9 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
     public function testAddPermissionsMergesWithCurrentValues(): void
     {
         $existingUser = $this->getRandomUserInTeam(1);
-        $addedUser = $this->getRandomUserInTeam(1);
+        do {
+            $addedUser = $this->getRandomUserInTeam(1);
+        } while ($addedUser->userid === $existingUser->userid);
         $experiment = $this->getFreshExperimentWithGivenUser($existingUser);
         $initialPermissions = array(
             'teams' => array(1),

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -35,6 +35,7 @@ use function bin2hex;
 use function count;
 use function is_array;
 use function json_decode;
+use function json_encode;
 use function random_bytes;
 use function sprintf;
 use function str_replace;
@@ -246,6 +247,54 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
                 $this->assertIsArray($this->Experiments->patch(Action::Update, array($column => $perm->value)));
             }
         }
+    }
+
+    public function testAddPermissionsMergesWithCurrentValues(): void
+    {
+        $existingUser = $this->getRandomUserInTeam(1);
+        $addedUser = $this->getRandomUserInTeam(1);
+        $experiment = $this->getFreshExperimentWithGivenUser($existingUser);
+        $initialPermissions = array(
+            'teams' => array(1),
+            'teamgroups' => array(),
+            'users' => array($existingUser->userid),
+        );
+        $addedPermissions = array(
+            'teams' => array(1),
+            'teamgroups' => array(),
+            'users' => array($addedUser->userid),
+        );
+
+        $experiment->patch(Action::Update, array(
+            'canread' => json_encode($initialPermissions),
+            'canread_base' => BasePermissions::UserOnly->value,
+            'canwrite' => json_encode($initialPermissions),
+            'canwrite_base' => BasePermissions::UserOnly->value,
+        ));
+
+        $experiment->patch(Action::AddCanRead, array('can' => json_encode($addedPermissions)));
+        $experiment->patch(Action::AddCanWrite, array('can' => json_encode($addedPermissions)));
+        $entityData = $experiment->readOne();
+
+        $expected = array(
+            'teams' => array(1),
+            'teamgroups' => array(),
+            'users' => array($existingUser->userid, $addedUser->userid),
+        );
+        $this->assertSame($expected, json_decode($entityData['canread'], true));
+        $this->assertSame($expected, json_decode($entityData['canwrite'], true));
+        $this->assertSame(BasePermissions::UserOnly->value, $entityData['canread_base']);
+        $this->assertSame(BasePermissions::UserOnly->value, $entityData['canwrite_base']);
+    }
+
+    public function testAddPermissionsRejectsInvalidPrincipalIds(): void
+    {
+        $this->expectException(ImproperActionException::class);
+        $this->Experiments->patch(Action::AddCanRead, array('can' => json_encode(array(
+            'teams' => array(1),
+            'teamgroups' => array(),
+            'users' => array('1'),
+        ))));
     }
 
     public function testUpdateCategory(): void

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -251,10 +251,8 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
 
     public function testAddPermissionsMergesWithCurrentValues(): void
     {
-        $existingUser = $this->getRandomUserInTeam(1);
-        do {
-            $addedUser = $this->getRandomUserInTeam(1);
-        } while ($addedUser->userid === $existingUser->userid);
+        $existingUser = new Users(1, 1);
+        $addedUser = new Users(2, 1);
         $experiment = $this->getFreshExperimentWithGivenUser($existingUser);
         $initialPermissions = array(
             'teams' => array(1),


### PR DESCRIPTION
## Summary

- Add bulk read and write permission actions to the `With selected` controls.
- Reuse the existing permission modal in a batch mode for teams, user groups, and users.
- Merge the selected principals into each entity's existing explicit permissions while preserving each entity's Base permissions and other entries.
- Continue processing independent entities when one request fails and report failed entity IDs.

## Testing

- `node node_modules/eslint/bin/eslint.js tests/cypress/integration/bulkPermissions.cy.ts src/ts/show.ts` — passed.
- `git diff --check` — passed.
- Added a Cypress regression covering multiple entities, multiple users, read/write permissions, existing entries, and unchanged Base permissions.
- Full Cypress execution was not available locally because the local application returned HTTP 500 and the PHP/Docker test runtime was unavailable.

Fixes #7361

AI assistance was used to help implement and validate this change under the contributor's direction. The final patch and its verification boundaries are described above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk editing for read and write permissions on selected entities.
  * Added toolbar actions and dedicated dialogs for batch permission changes.
  * Batch updates preserve existing permissions while applying selected changes.
  * Added validation and feedback for permission selections and unsuccessful updates.
  * The show page now includes all visible teams in its rendered data.

* **Tests**
  * Added coverage for bulk updates, concurrent changes, validation, and permission preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->