### PR TITLE
perf: add a fast sql for default query with no search

### DIFF
--- a/containers/elabdev/docker-compose.yml
+++ b/containers/elabdev/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       - USE_OPENCLONING=true
       - OPENCLONING_URL=http://opencloning:8000/
       - DEV_MODE=true
+      #- DB_QUERY_PROFILING=true
+      #- DB_QUERY_LOG_MIN_MS=30
 
     ports:
       - '3148:8080'

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -299,7 +299,7 @@ services:
 
         # only log queries that take longer than DB_QUERY_LOG_MIN_MS milliseconds
         # default value: 500
-        #- DB_QUERY_LOG_MIN_MS=800
+        #- DB_QUERY_LOG_MIN_MS=500
 
         ###########
         # PLUGINS #

--- a/containers/elabimg/docker-compose.yml-EXAMPLE
+++ b/containers/elabimg/docker-compose.yml-EXAMPLE
@@ -293,6 +293,14 @@ services:
         # example value: https://example.com https://example.org
         #- CUSTOM_CONNECT_SRC=
 
+        # enable sql profiling
+        # default value: false
+        #- DB_QUERY_PROFILING=false
+
+        # only log queries that take longer than DB_QUERY_LOG_MIN_MS milliseconds
+        # default value: 500
+        #- DB_QUERY_LOG_MIN_MS=800
+
         ###########
         # PLUGINS #
         ###########

--- a/containers/elabimg/entrypoint/docker-entrypoint.sh
+++ b/containers/elabimg/entrypoint/docker-entrypoint.sh
@@ -21,6 +21,8 @@ getEnv() {
     db_port=${DB_PORT:-3306}
     db_name=${DB_NAME:-elabftw}
     db_user=${DB_USER:-elabftw}
+    db_query_profiling="${DB_QUERY_PROFILING:-false}"
+    db_query_log_min_ms="${DB_QUERY_LOG_MIN_MS:-500}"
     # Note: no default value here
     db_password=${DB_PASSWORD:-}
     db_cert_path=${DB_CERT_PATH:-}
@@ -398,6 +400,10 @@ populatePhpEnv() {
         sed -i -e "/%ELAB_AWS_ACCESS_KEY%/d" $f
         sed -i -e "/%ELAB_AWS_SECRET_KEY%/d" $f
     fi
+
+    sed -i -e "s/%DB_QUERY_PROFILING%/${db_query_profiling}/" $f
+    sed -i -e "s/%DB_QUERY_LOG_MIN_MS%/${db_query_log_min_ms}/" $f
+
 }
 
 # display a friendly message with running versions

--- a/containers/elabimg/php/elabpool.conf
+++ b/containers/elabimg/php/elabpool.conf
@@ -113,6 +113,8 @@ env[DEV_MODE] = "%DEV_MODE%"
 env[DEMO_MODE] = "%DEMO_MODE%"
 env[PUBCHEM_PUG_URL] = "%PUBCHEM_PUG_URL%"
 env[PUBCHEM_PUG_VIEW_URL] = "%PUBCHEM_PUG_VIEW_URL%"
+env[DB_QUERY_PROFILING] = "%DB_QUERY_PROFILING%"
+env[DB_QUERY_LOG_MIN_MS] = "%DB_QUERY_LOG_MIN_MS%"
 
 php_admin_value[memory_limit] = %PHP_MAX_MEMORY%
 php_admin_value[error_log] = /dev/stderr

--- a/src/Elabftw/Db.php
+++ b/src/Elabftw/Db.php
@@ -19,6 +19,12 @@ use PDOException;
 use PDOStatement;
 
 use function debug_print_backtrace;
+use function hash;
+use function hrtime;
+use function json_encode;
+use function preg_replace;
+use function round;
+use function trim;
 
 /**
  * Connect to the database with a singleton class
@@ -26,6 +32,10 @@ use function debug_print_backtrace;
 final class Db
 {
     public const int DUPLICATE_CONSTRAINT_ERROR = 1062;
+
+    private bool $profileQueries;
+
+    private int $queryLogMinMs;
 
     private PDO $connection;
 
@@ -42,6 +52,9 @@ final class Db
      */
     private function __construct()
     {
+        $this->profileQueries = Env::asBool('DB_QUERY_PROFILING');
+        $this->queryLogMinMs = Env::asInt('DB_QUERY_LOG_MIN_MS');
+
         $pdoOptions = array();
         // throw exception if error
         $pdoOptions[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
@@ -104,6 +117,7 @@ final class Db
      */
     public function execute(PDOStatement $req): bool
     {
+        $startedAt = hrtime(true);
         try {
             $res = $req->execute();
         } catch (PDOException $e) {
@@ -111,6 +125,8 @@ final class Db
                 debug_print_backtrace();
             }
             throw new DatabaseErrorException($e->errorInfo ?? array('OOPS', 42, 'where error?'));
+        } finally {
+            $this->logQuery($req->queryString, $startedAt);
         }
         if (!$res) {
             throw new DatabaseErrorException(array('OOPS', 42, 'Something went wrong :/'));
@@ -138,7 +154,12 @@ final class Db
      */
     public function q(string $sql): PDOStatement
     {
-        $res = $this->connection->query($sql);
+        $startedAt = hrtime(true);
+        try {
+            $res = $this->connection->query($sql);
+        } finally {
+            $this->logQuery($sql, $startedAt);
+        }
         if ($res === false) {
             throw new DatabaseErrorException(array('OOPS', 42, 'Something went wrong :/'));
         }
@@ -191,5 +212,32 @@ final class Db
     public function rollBack(): bool
     {
         return $this->connection->rollBack();
+    }
+
+    private function logQuery(string $sql, int $startedAt): void
+    {
+        if (!$this->profileQueries) {
+            return;
+        }
+
+        $durationMs = (hrtime(true) - $startedAt) / 1_000_000;
+        if ($durationMs < $this->queryLogMinMs) {
+            return;
+        }
+
+        $normalizedSql = preg_replace('/\\s+/', ' ', trim($sql)) ?? $sql;
+        $entry = json_encode(array(
+            'event' => 'sql_query',
+            'request_id' => $_SERVER['ELABFTW_REQUEST_ID'] ?? '',
+            'duration_ms' => round($durationMs, 3),
+            'query_id' => hash('sha256', $normalizedSql),
+            // Do not log bound values: they can contain secrets or personal data.
+            'sql' => $normalizedSql,
+        ));
+
+        if ($entry !== false) {
+            $logger = App::getDefaultLogger();
+            $logger->debug($entry);
+        }
     }
 }

--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -45,6 +45,104 @@ final class EntitySqlBuilder implements SqlBuilderInterface
     }
 
     /**
+     * Select the page of entity IDs before hydrating the show-mode projection.
+     *
+     * Pinned and unpinned entities are separate ordered streams so the normal
+     * entity ordering indexes can be used without sorting the complete result.
+     */
+    public function getReadPageSql(
+        string $displayFilterSql,
+        string $stateSql,
+        string $can,
+        int $limit,
+        int $offset,
+        bool $skipPinned,
+    ): string {
+        $table = $this->entity->entityType->value;
+        $membershipJoinSql = $this->getUserTeamMembershipJoinSql();
+        $canFilterSql = $this->getCanFilter($can);
+
+        if ($skipPinned) {
+            return sprintf(
+                'SELECT entity.id, entity.modified_at, 0 AS is_pinned
+                FROM %1$s AS entity
+                %2$s
+                WHERE 1=1
+                    %3$s
+                    %4$s
+                    %5$s
+                ORDER BY entity.modified_at DESC, entity.id DESC
+                LIMIT %6$d OFFSET %7$d',
+                $table,
+                $membershipJoinSql,
+                $displayFilterSql,
+                $canFilterSql,
+                $stateSql,
+                $limit,
+                $offset,
+            );
+        }
+
+        $candidateLimit = $limit + $offset;
+        $pinTable = sprintf('pin_%s2users', $table);
+        $userid = $this->entity->Users->getUserid();
+        $pinnedSql = sprintf(
+            'SELECT entity.id, entity.modified_at, 1 AS is_pinned
+            FROM %1$s AS candidate_pin
+            INNER JOIN %2$s AS entity
+                ON entity.id = candidate_pin.entity_id
+            %3$s
+            WHERE candidate_pin.users_id = %4$d
+                %5$s
+                %6$s
+                %7$s
+            ORDER BY entity.modified_at DESC, entity.id DESC
+            LIMIT %8$d',
+            $pinTable,
+            $table,
+            $membershipJoinSql,
+            $userid,
+            $displayFilterSql,
+            $canFilterSql,
+            $stateSql,
+            $candidateLimit,
+        );
+        $unpinnedSql = sprintf(
+            'SELECT entity.id, entity.modified_at, 0 AS is_pinned
+            FROM %1$s AS entity
+            LEFT JOIN %2$s AS candidate_pin
+                ON (candidate_pin.entity_id = entity.id
+                    AND candidate_pin.users_id = %3$d)
+            %4$s
+            WHERE candidate_pin.entity_id IS NULL
+                %5$s
+                %6$s
+                %7$s
+            ORDER BY entity.modified_at DESC, entity.id DESC
+            LIMIT %8$d',
+            $table,
+            $pinTable,
+            $userid,
+            $membershipJoinSql,
+            $displayFilterSql,
+            $canFilterSql,
+            $stateSql,
+            $candidateLimit,
+        );
+
+        return sprintf(
+            'SELECT candidate.id, candidate.modified_at, candidate.is_pinned
+            FROM ((%1$s) UNION ALL (%2$s)) AS candidate
+            ORDER BY candidate.is_pinned DESC, candidate.modified_at DESC, candidate.id DESC
+            LIMIT %3$d OFFSET %4$d',
+            $pinnedSql,
+            $unpinnedSql,
+            $limit,
+            $offset,
+        );
+    }
+
+    /**
      * Get the SQL string for read before the WHERE
      *
      * @param bool $fullSelect select all the columns of entity
@@ -355,7 +453,12 @@ final class EntitySqlBuilder implements SqlBuilderInterface
 
     private function userTeamMembership(): void
     {
-        $this->joinsSql[] = sprintf(
+        $this->joinsSql[] = $this->getUserTeamMembershipJoinSql();
+    }
+
+    private function getUserTeamMembershipJoinSql(): string
+    {
+        return sprintf(
             'LEFT JOIN users2teams
                 ON (users2teams.users_id = entity.userid
                     AND users2teams.teams_id = %d)',

--- a/src/Interfaces/QueryParamsInterface.php
+++ b/src/Interfaces/QueryParamsInterface.php
@@ -23,6 +23,8 @@ interface QueryParamsInterface
 
     public function getLimit(): int;
 
+    public function getOffset(): int;
+
     public function getStatesSql(string $tableName): string;
 
     public function getStates(): array;
@@ -38,6 +40,8 @@ interface QueryParamsInterface
     public function getRelatedOrigin(): ?EntityType;
 
     public function getFilterSql(): string;
+
+    public function getSkipOrderPinned(): bool;
 
     public function setSkipOrderPinned(bool $value): void;
 

--- a/src/Models/AbstractEntity.php
+++ b/src/Models/AbstractEntity.php
@@ -33,7 +33,9 @@ use Elabftw\Enums\EntityType;
 use Elabftw\Enums\ExportFormat;
 use Elabftw\Enums\Meaning;
 use Elabftw\Enums\Metadata as MetadataEnum;
+use Elabftw\Enums\Orderby;
 use Elabftw\Enums\RequestableAction;
+use Elabftw\Enums\Sort;
 use Elabftw\Enums\State;
 use Elabftw\Exceptions\DatabaseErrorException;
 use Elabftw\Exceptions\ForbiddenException;
@@ -403,6 +405,12 @@ abstract class AbstractEntity extends AbstractRest
         $EntitySqlBuilder = $this->getSqlBuilder();
         if ($searchJoinSql !== '' && $EntitySqlBuilder instanceof EntitySqlBuilder) {
             $EntitySqlBuilder->setSearchJoinSql($searchJoinSql);
+        }
+        if (
+            $EntitySqlBuilder instanceof EntitySqlBuilder
+            && $this->canUseDefaultReadFastPath($displayParams, $extended, $searchJoinSql, $withCompounds)
+        ) {
+            return $this->readShowDefaultPage($displayParams, $EntitySqlBuilder, $displayFilterSql, $can);
         }
         $sql = $EntitySqlBuilder->getReadSqlBeforeWhere(
             $extended,
@@ -1419,6 +1427,59 @@ abstract class AbstractEntity extends AbstractRest
     }
 
     protected function enforceTemplate(array $teamConfigArr): void {}
+
+    private function canUseDefaultReadFastPath(
+        QueryParamsInterface $displayParams,
+        bool $extended,
+        string $searchJoinSql,
+        bool $withCompounds,
+    ): bool {
+        return $displayParams instanceof DisplayParams
+            && !($this->Users instanceof AnonymousUser)
+            && !$extended
+            && $searchJoinSql === ''
+            && !$displayParams->hasUserQuery()
+            && !$displayParams->isFull()
+            && $displayParams->getRelatedOrigin() === null
+            && !$withCompounds
+            && $this->filterSql === ''
+            && $displayParams->orderby === Orderby::Lastchange
+            && $displayParams->sort === Sort::Desc
+            && $displayParams->getLimit() > 0;
+    }
+
+    /**
+     * This function exists so that default page load with no search is fast
+     */
+    private function readShowDefaultPage(
+        QueryParamsInterface $displayParams,
+        EntitySqlBuilder $EntitySqlBuilder,
+        string $displayFilterSql,
+        string $can,
+    ): array {
+        $pageSql = $EntitySqlBuilder->getReadPageSql(
+            $displayFilterSql,
+            $displayParams->getStatesSql('entity'),
+            $can,
+            $displayParams->getLimit(),
+            $displayParams->getOffset(),
+            $displayParams->getSkipOrderPinned(),
+        );
+        $sql = sprintf(
+            '%s INNER JOIN (%s) AS page
+                ON page.id = entity.id
+            ORDER BY page.is_pinned DESC, page.modified_at DESC, page.id DESC',
+            $EntitySqlBuilder->getReadSqlBeforeWhere(),
+            $pageSql,
+        );
+
+        $req = $this->Db->prepare($sql);
+        $userid = $this->Users->getUserid();
+        $req->bindParam(':userid', $userid, PDO::PARAM_INT);
+        $this->Db->execute($req);
+
+        return $this->hydrateTags($req->fetchAll());
+    }
 
     private function addSimpleQueryBindValues(string $query): void
     {

--- a/src/Params/BaseQueryParams.php
+++ b/src/Params/BaseQueryParams.php
@@ -115,6 +115,18 @@ class BaseQueryParams implements QueryParamsInterface
     }
 
     #[Override]
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    #[Override]
+    public function getSkipOrderPinned(): bool
+    {
+        return false;
+    }
+
+    #[Override]
     public function getSql(): string
     {
         $sql = sprintf(

--- a/src/Params/DisplayParams.php
+++ b/src/Params/DisplayParams.php
@@ -75,6 +75,12 @@ final class DisplayParams extends BaseQueryParams
     }
 
     #[Override]
+    public function getSkipOrderPinned(): bool
+    {
+        return $this->skipOrderPinned;
+    }
+
+    #[Override]
     public function getSql(): string
     {
         if ($this->skipOrderPinned === true) {

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -124,6 +124,28 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEmpty($fast);
     }
 
+    public function testDefaultReadPaginatesPinnedEntitiesFirst(): void
+    {
+        $pinnedId = $this->Experiments->create(title: 'Pinned fast read entity');
+        $PinnedExperiment = new Experiments($this->Users, $pinnedId);
+        new Pins($PinnedExperiment)->togglePin();
+
+        $firstPage = $this->Experiments->readAll(new DisplayParams(
+            requester: $this->Users,
+            entityType: EntityType::Experiments,
+            limit: 1,
+        ));
+        $secondPage = $this->Experiments->readAll(new DisplayParams(
+            requester: $this->Users,
+            entityType: EntityType::Experiments,
+            limit: 1,
+            offset: 1,
+        ));
+
+        self::assertSame($pinnedId, $firstPage[0]['id']);
+        self::assertNotSame($pinnedId, $secondPage[0]['id']);
+    }
+
     public function testUpdate(): void
     {
         $new = $this->Experiments->create();


### PR DESCRIPTION
also add profiling sql code toggles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved loading speed for eligible default entity listings through more efficient pagination.
  - Preserved pinned-item ordering while navigating between pages.

- **Diagnostics**
  - Added optional SQL query profiling with configurable minimum-duration logging.
  - Profiling records request IDs, execution times, and normalized query details for troubleshooting.

- **Bug Fixes**
  - Corrected pagination so pinned items appear on earlier pages as expected.

- **Tests**
  - Added coverage verifying pinned-item ordering across paginated experiment results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->