### PR TITLE
bug/minor: storage: display children when listing a container

### DIFF
--- a/src/Models/StorageUnits.php
+++ b/src/Models/StorageUnits.php
@@ -145,18 +145,19 @@ final class StorageUnits extends AbstractRest
     }
 
     /**
-     * Get containers from a given storage unit id
+     * Get containers from a given storage unit and its descendants.
      */
     public function readAllFromStorage(int $storageId): array
     {
         $sql = $this->getRecursiveSql(
-            (int) $this->requester->userData['userid'],
-            (int) $this->requester->userData['team'],
-            ' sh.storage_id = :storage_id',
-        );
+            $this->requester->getUserid(),
+            $this->requester->getTeam(),
+            ' sh.storage_id IN (SELECT storage_id FROM selected_storage_hierarchy)',
+            true,
+        ) . ' ORDER BY full_path, entity_title';
         $req = $this->Db->prepare($sql);
         $req->bindParam(':storage_id', $storageId, PDO::PARAM_INT);
-        $req->bindValue(':userid', $this->requester->userid, PDO::PARAM_INT);
+        $req->bindValue(':userid', $this->requester->getUserid(), PDO::PARAM_INT);
         $this->Db->execute($req);
         return $req->fetchAll();
     }
@@ -752,10 +753,28 @@ final class StorageUnits extends AbstractRest
         }
     }
 
-    private function getRecursiveSql(int $userid, int $team, string $discriminator): string
-    {
+    private function getRecursiveSql(
+        int $userid,
+        int $team,
+        string $discriminator,
+        bool $includeStorageDescendants = false,
+    ): string {
         $CanSqlBuilder = new CanSqlBuilder($this->requester, AccessType::Read);
         $canFilter = $CanSqlBuilder->getCanFilter();
+        $selectedStorageHierarchy = $includeStorageDescendants
+            ? ', selected_storage_hierarchy AS (
+                SELECT id AS storage_id
+                FROM storage_units
+                WHERE id = :storage_id
+
+                UNION ALL
+
+                SELECT child.id
+                FROM storage_units AS child
+                INNER JOIN selected_storage_hierarchy AS parent
+                    ON child.parent_id = parent.storage_id
+            )'
+            : '';
         return sprintf(
             "WITH RECURSIVE storage_hierarchy AS (
                 SELECT
@@ -776,6 +795,7 @@ final class StorageUnits extends AbstractRest
                 FROM storage_units AS su
                 INNER JOIN storage_hierarchy AS parent ON su.parent_id = parent.storage_id
             )
+            %s
 
                 SELECT
                     entity.id AS entity_id,
@@ -905,6 +925,7 @@ final class StorageUnits extends AbstractRest
                 WHERE
                     -- can sql AND query or storage_id
                     1=1 AND entity.state IN (1,2) AND %s %s",
+            $selectedStorageHierarchy,
             $userid,
             $team,
             $discriminator,

--- a/tests/unit/models/StorageUnitsTest.php
+++ b/tests/unit/models/StorageUnitsTest.php
@@ -146,6 +146,28 @@ class StorageUnitsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(0, $res);
     }
 
+    public function testReadAllFromStorageIncludesDescendantsInHierarchyOrder(): void
+    {
+        $rootId = $this->StorageUnits->create('Scoped freezer');
+        $boxAId = $this->StorageUnits->create('Box A', $rootId);
+        $positionId = $this->StorageUnits->create('Position 1', $boxAId);
+        $boxBId = $this->StorageUnits->create('Box B', $rootId);
+        $outsideId = $this->StorageUnits->create('Outside freezer');
+
+        $Item = $this->getFreshItem();
+        new Containers2ItemsLinks($Item, $boxBId)->createWithQuantity(1.0, 'mL');
+        new Containers2ItemsLinks($Item, $outsideId)->createWithQuantity(1.0, 'mL');
+        new Containers2ItemsLinks($Item, $positionId)->createWithQuantity(1.0, 'mL');
+        new Containers2ItemsLinks($Item, $boxAId)->createWithQuantity(1.0, 'mL');
+
+        $result = $this->StorageUnits->readAllFromStorage($rootId);
+
+        $this->assertSame(
+            array($boxAId, $positionId, $boxBId),
+            array_column($result, 'storage_id'),
+        );
+    }
+
     public function testGetApiPath(): void
     {
         $this->assertEquals('api/v2/storage_units/', $this->StorageUnits->getApiPath());


### PR DESCRIPTION
Problem: if you had Drawer > Box > Tube. Listing contents of Drawer or Box would not show the Tube. Now it does.

fix #5690



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage searches now include containers in the selected storage unit and its descendants.
  * Results are ordered by hierarchy path and title for easier navigation.

* **Bug Fixes**
  * Containers outside the selected storage hierarchy are excluded from results.

* **Tests**
  * Added coverage for descendant inclusion, hierarchy ordering, and exclusion of unrelated containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->