### PR TITLE
bug/medium: server: fix timezone issue

### DIFF
--- a/src/Elabftw/TwigFunctions.php
+++ b/src/Elabftw/TwigFunctions.php
@@ -24,6 +24,7 @@ use function round;
 use function array_rand;
 use function array_splice;
 use function count;
+use function date_default_timezone_get;
 use function in_array;
 use function json_decode;
 
@@ -88,6 +89,11 @@ final class TwigFunctions
     {
         $Db = Db::getConnection();
         return $Db->getNumberOfQueries();
+    }
+
+    public static function getServerTimezone(): string
+    {
+        return date_default_timezone_get();
     }
 
     /**

--- a/src/Traits/TwigTrait.php
+++ b/src/Traits/TwigTrait.php
@@ -81,6 +81,7 @@ trait TwigTrait
         $memoryUsage = new TwigFunction('memoryUsage', '\Elabftw\Elabftw\TwigFunctions::getMemoryUsage');
         $envAsBool = new TwigFunction('envAsBool', '\Elabftw\Elabftw\TwigFunctions::envAsBool');
         $numberOfQueries = new TwigFunction('numberOfQueries', '\Elabftw\Elabftw\TwigFunctions::getNumberOfQueries');
+        $serverTimezone = new TwigFunction('serverTimezone', '\Elabftw\Elabftw\TwigFunctions::getServerTimezone');
         $ext2icon = new TwigFunction('ext2icon', '\Elabftw\Elabftw\Extensions::getIconFromExtension');
         $getExtendedSearchExample = new TwigFunction('getExtendedSearchExample', '\Elabftw\Elabftw\TwigFunctions::getExtendedSearchExample');
 
@@ -116,6 +117,7 @@ trait TwigTrait
         $TwigEnvironment->addFunction($memoryUsage);
         $TwigEnvironment->addFunction($envAsBool);
         $TwigEnvironment->addFunction($numberOfQueries);
+        $TwigEnvironment->addFunction($serverTimezone);
         $TwigEnvironment->addFunction($ext2icon);
         $TwigEnvironment->addFunction($getExtendedSearchExample);
 

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -83,6 +83,7 @@
 <div id='user-prefs'
   data-lang='{{ App.getLang }}'
   data-jslang='{{ App.getJsLang }}'
+  data-timezone='{{ serverTimezone() }}'
   data-isodate='{{ App.Session.has('is_auth') ? App.Users.userData.use_isodate : '0' }}'
   data-sc-search='{{ App.Users.userData.sc_search|default('s') }}'
   data-sc-todolist='{{ App.Users.userData.sc_todo|default('t') }}'

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -65,21 +65,23 @@ export const getInput = (id: string): HTMLInputElement => {
 // DISPLAY TIME RELATIVE TO NOW
 // the datetime is taken from the title of the element so mouse hover will show raw datetime
 export function relativeMoment(): void {
-  const locale = document.getElementById('user-prefs')?.dataset.jslang ?? 'en';
+  const userPrefs = document.getElementById('user-prefs')?.dataset;
+  const locale = userPrefs?.jslang ?? 'en';
+  const timezone = userPrefs?.timezone ?? 'system';
   document.querySelectorAll('.relative-moment').forEach(el => {
     const span = el as HTMLElement;
     // do nothing if it's already loaded, prevent infinite loop with mutation observer
     if (span.innerText) {
       return;
     }
-    span.innerText = toRelative(span.title, locale);
+    span.innerText = toRelative(span.title, locale, timezone);
   });
 }
 
-export function toRelative(title: string, locale: string): string {
+export function toRelative(title: string, locale: string, timezone = document.getElementById('user-prefs')?.dataset.timezone ?? 'system'): string {
   return (
     DateTime
-      .fromFormat(title, 'yyyy-MM-dd HH:mm:ss', {'locale': locale})
+      .fromFormat(title, 'yyyy-MM-dd HH:mm:ss', {'locale': locale, 'zone': timezone})
       .toRelative() ?? ''
   );
 }

--- a/tests/unit/classes/TwigFunctionsTest.php
+++ b/tests/unit/classes/TwigFunctionsTest.php
@@ -13,6 +13,8 @@ namespace Elabftw\Elabftw;
 
 use Elabftw\Models\AbstractEntity;
 
+use function date_default_timezone_get;
+
 class TwigFunctionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetLimitOptions(): void

--- a/tests/unit/classes/TwigFunctionsTest.php
+++ b/tests/unit/classes/TwigFunctionsTest.php
@@ -43,6 +43,11 @@ class TwigFunctionsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt(TwigFunctions::getNumberOfQueries());
     }
 
+    public function testGetServerTimezone(): void
+    {
+        $this->assertSame(date_default_timezone_get(), TwigFunctions::getServerTimezone());
+    }
+
     public function testToDatetime(): void
     {
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', TwigFunctions::toDatetime('2023-02-01'));


### PR DESCRIPTION
fix #4598

Interpret relative timestamps using the server timezone before comparing them with the client time. Fixes issues like "Commented in 10 minutes"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Relative timestamps now use the server’s configured timezone, improving date and time accuracy across localized views.
  - Time displays continue to respect the selected locale while applying the appropriate timezone.
  - Timestamp calculations now fall back to the system timezone when no server timezone is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->