### PR TITLE
bug/minor: ui: unreadable notifs because missing primary color

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -480,7 +480,7 @@ button:disabled {
 .beta {
   background: var(--primary);
   border-radius: 5px;
-  color: var(--strongest);
+  color: var(--primary-fg);
   display: inline-block;
   font-family: sans-serif;
   font-size: 10px;
@@ -1641,7 +1641,7 @@ input[type='color'] {
     background-color: var(--primary);
 
     span {
-      color: var(--chrome-fg);
+      color: var(--primary-fg);
     }
   }
 }


### PR DESCRIPTION
<img width="497" height="198" alt="Capture d’écran du 2026-09-01 16-20-25" src="https://github.com/user-attachments/assets/d71d32a1-6dca-4429-b8f6-cea7d0641749" />

and spreadsheet /proc request Beta tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated beta ribbon and unread notification text colors for improved visual consistency and theme support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->