### PR TITLE
docs: document opencloning quadlets env

### DIFF
--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -200,6 +200,14 @@ The `chem-plugin` addon can now be completely removed! It is not useful anymore:
 
 It is then safe to remove the whole `chem-plugin` block in your docker compose file.
 
+### OpenCloning in Quadlet
+
+If you are running OpenCloning as user with Quadlets, make sure to to add:
+
+`Environment=GUNICORN_CMD_ARGS=--worker-tmp-dir=/dev/shm --no-control-socket
+`
+Or the worker will die when a request arrives.
+
 ### MySQL Persistent connection mode
 
 The environment variable `USE_PERSISTENT_MYSQL_CONN` now defaults to `false`. It used to be `true` by default but that caused more issues than it solved, so now it's set to `false`. This will have an impact if you did not set that value but expected it to be `true` for some reason. If that's the case, then add it explicitly.

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -202,10 +202,10 @@ It is then safe to remove the whole `chem-plugin` block in your docker compose f
 
 ### OpenCloning in Quadlet
 
-If you are running OpenCloning as user with Quadlets, make sure to to add:
+If you are running OpenCloning as a user with Quadlets, make sure to add:
 
-`Environment=GUNICORN_CMD_ARGS=--worker-tmp-dir=/dev/shm --no-control-socket
-`
+`Environment=GUNICORN_CMD_ARGS=--worker-tmp-dir=/dev/shm --no-control-socket`
+
 Or the worker will die when a request arrives.
 
 ### MySQL Persistent connection mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the Quadlet OpenCloning upgrade guidance.
  - Reformatted the `GUNICORN_CMD_ARGS` command onto a single properly formatted line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->