### PR TITLE
ci: have dependabot update gh actions too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,6 @@ updates:
       interval: monthly
       day: wednesday
       time: "06:12"
-    open-pull-requests-limit: 10
-    cooldown:
-        default-days: 12
-        semver-major-days: 32
-        semver-minor-days: 24
-        semver-patch-days: 3
   - package-ecosystem: composer
     directory: "/"
     schedule:
@@ -27,9 +21,9 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
-  open-pull-requests-limit: 10
-  cooldown:
-      default-days: 12
-      semver-major-days: 32
-      semver-minor-days: 24
-      semver-patch-days: 3
+open-pull-requests-limit: 10
+cooldown:
+    default-days: 12
+    semver-major-days: 32
+    semver-minor-days: 24
+    semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
         default-days: 12
-        semver-major-days: 32
-        semver-minor-days: 24
-        semver-patch-days: 3
     groups:
       github-actions:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,14 +19,14 @@ updates:
       day: wednesday
       time: "06:12"
   - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-        interval: "weekly"
-      groups:
-        github-actions:
-          applies-to: version-updates
-          patterns:
-            - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
   open-pull-requests-limit: 10
   cooldown:
       default-days: 12

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,28 +2,46 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
+    commit-message:
+      prefix: "bump: npm"
     schedule:
       interval: monthly
       day: wednesday
       time: "06:12"
+    open-pull-requests-limit: 10
+    cooldown:
+        default-days: 12
+        semver-major-days: 32
+        semver-minor-days: 24
+        semver-patch-days: 3
   - package-ecosystem: composer
     directory: "/"
+    commit-message:
+      prefix: "bump: composer"
     schedule:
       interval: monthly
       day: wednesday
       time: "06:12"
+    open-pull-requests-limit: 10
+    cooldown:
+        default-days: 12
+        semver-major-days: 32
+        semver-minor-days: 24
+        semver-patch-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: "bump: actions"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+        default-days: 12
+        semver-major-days: 32
+        semver-minor-days: 24
+        semver-patch-days: 3
     groups:
       github-actions:
         applies-to: version-updates
         patterns:
           - "*"
-open-pull-requests-limit: 10
-cooldown:
-    default-days: 12
-    semver-major-days: 32
-    semver-minor-days: 24
-    semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,32 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    day: wednesday
-    time: "06:12"
-  open-pull-requests-limit: 10
-  cooldown:
-      default-days: 12
-      semver-major-days: 32
-      semver-minor-days: 24
-      semver-patch-days: 3
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: monthly
-    day: wednesday
-    time: "06:12"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      day: wednesday
+      time: "06:12"
+    open-pull-requests-limit: 10
+    cooldown:
+        default-days: 12
+        semver-major-days: 32
+        semver-minor-days: 24
+        semver-patch-days: 3
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: monthly
+      day: wednesday
+      time: "06:12"
+  - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      groups:
+        github-actions:
+          applies-to: version-updates
+          patterns:
+            - "*"
   open-pull-requests-limit: 10
   cooldown:
       default-days: 12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates now use ecosystem-specific commit-message prefixes for npm packages, PHP packages, and GitHub Actions.
  * Monthly package update schedules and the weekly GitHub Actions schedule remain in place.
  * Pull-request limits, default cooldown settings, and GitHub Actions grouping continue to apply.
  * GitHub Actions semver-specific cooldown settings have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->