### PR TITLE
feat: ui: show tags filters in active filters list too

### DIFF
--- a/src/ts/show.ts
+++ b/src/ts/show.ts
@@ -1305,6 +1305,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const selectedTags = Array.isArray(value) ? value as string[] : [];
 
         setEntityFilterParamValues('tags[]', selectedTags);
+        renderActiveFilters();
       },
 
       onItemAdd() {
@@ -1319,7 +1320,13 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     }) as TomSelectWithAllOptions;
 
+    filterControls.push({
+      control: tsTagFilter,
+      param: 'tags[]',
+      title: i18next.t('tags'),
+    });
     hydrateTomSelectFromUrl(tsTagFilter, 'tags[]');
+    renderActiveFilters();
 
     if (dropdownRoot) {
       $(dropdownRoot).on('shown.bs.dropdown', function() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Active-filter chips now update immediately when tag selections change.
  * Tag filters are correctly restored from URL parameters and displayed among active filters when the page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->