### PR TITLE
bug/minor: anon: prevent anon from reading procurement requests

### DIFF
--- a/src/Models/ProcurementRequests.php
+++ b/src/Models/ProcurementRequests.php
@@ -15,8 +15,10 @@ namespace Elabftw\Models;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\Currency;
 use Elabftw\Enums\ProcurementState;
+use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Interfaces\QueryParamsInterface;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Params\ProcurementRequestParams;
 use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\SetIdTrait;
@@ -42,6 +44,9 @@ final class ProcurementRequests extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
+        if ($this->Teams->Users instanceof AnonymousUser) {
+            throw new ForbiddenException();
+        }
         $sql = "SELECT
             CONCAT(users.firstname, ' ', users.lastname) AS requester_fullname,
             pr.id, pr.created_at, pr.team, pr.requester_userid, pr.entity_id, pr.qty_ordered, pr.qty_received,

--- a/src/Models/ProcurementRequests.php
+++ b/src/Models/ProcurementRequests.php
@@ -44,9 +44,7 @@ final class ProcurementRequests extends AbstractRest
     #[Override]
     public function readAll(?QueryParamsInterface $queryParams = null): array
     {
-        if ($this->Teams->Users instanceof AnonymousUser) {
-            throw new ForbiddenException();
-        }
+        $this->isAuthOrExplode();
         $sql = "SELECT
             CONCAT(users.firstname, ' ', users.lastname) AS requester_fullname,
             pr.id, pr.created_at, pr.team, pr.requester_userid, pr.entity_id, pr.qty_ordered, pr.qty_received,
@@ -74,9 +72,7 @@ final class ProcurementRequests extends AbstractRest
     #[Override]
     public function readOne(): array
     {
-        if ($this->Teams->Users instanceof AnonymousUser) {
-            throw new ForbiddenException();
-        }
+        $this->isAuthOrExplode();
         $sql = 'SELECT id, created_at, team, requester_userid, entity_id, qty_ordered, qty_received, body, quote, email_sent, state
             FROM procurement_requests WHERE id = :id AND team = :team';
         $req = $this->Db->prepare($sql);
@@ -167,8 +163,16 @@ final class ProcurementRequests extends AbstractRest
         }
     }
 
+    private function isAuthOrExplode(): void
+    {
+        if ($this->Teams->Users instanceof AnonymousUser) {
+            throw new ForbiddenException();
+        }
+    }
+
     private function canReadOrExplode(int $entityId): void
     {
+        $this->isAuthOrExplode();
         // A user can only create a procurement request for a resource they can read.
         // setId() calls readOne(), which checks read permissions with canOrExplode().
         new Items($this->Teams->Users, $entityId);

--- a/src/Models/ProcurementRequests.php
+++ b/src/Models/ProcurementRequests.php
@@ -74,6 +74,9 @@ final class ProcurementRequests extends AbstractRest
     #[Override]
     public function readOne(): array
     {
+        if ($this->Teams->Users instanceof AnonymousUser) {
+            throw new ForbiddenException();
+        }
         $sql = 'SELECT id, created_at, team, requester_userid, entity_id, qty_ordered, qty_received, body, quote, email_sent, state
             FROM procurement_requests WHERE id = :id AND team = :team';
         $req = $this->Db->prepare($sql);

--- a/tests/unit/models/ProcurementRequestsTest.php
+++ b/tests/unit/models/ProcurementRequestsTest.php
@@ -15,6 +15,7 @@ use Elabftw\Enums\Action;
 use Elabftw\Enums\ProcurementState;
 use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\ResourceNotFoundException;
+use Elabftw\Models\Users\AnonymousUser;
 use Elabftw\Traits\TestsUtilsTrait;
 
 class ProcurementRequestsTest extends \PHPUnit\Framework\TestCase
@@ -59,6 +60,14 @@ class ProcurementRequestsTest extends \PHPUnit\Framework\TestCase
         $this->assertIsArray($res);
         $this->assertNotEmpty($res);
         $this->assertIsString($res[0]['state_human']);
+    }
+
+    public function testAnonymousUserCannotRead(): void
+    {
+        $ProcurementRequests = new ProcurementRequests(new Teams(new AnonymousUser(1), 1));
+
+        $this->expectException(ForbiddenException::class);
+        $ProcurementRequests->readAll();
     }
 
     public function testReadRecordNotFound(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Anonymous team users are denied access when attempting to view procurement requests.

* **Tests**
  * Added coverage verifying that anonymous users receive a forbidden-access error when attempting to read procurement requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->