### PR TITLE
bug/major: auth: fix email comparison

### DIFF
--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -820,7 +820,8 @@ class Users extends AbstractRest
         $Db = Db::getConnection();
         // Prefer an active account, but return an archived account if it is the only match.
         $sql = sprintf(
-            'SELECT userid FROM users WHERE %s = :term AND CAST(%s AS BINARY) = CAST(:exact_term AS BINARY) %s
+            'SELECT userid FROM users WHERE %s = :term
+             AND CAST(LOWER(%s) AS BINARY) = CAST(LOWER(:exact_term) AS BINARY) %s
              ORDER BY EXISTS (
               SELECT 1
               FROM users2teams AS ut

--- a/tests/unit/Auth/LocalTest.php
+++ b/tests/unit/Auth/LocalTest.php
@@ -56,6 +56,23 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(1, $authResponse->userid);
     }
 
+    public function testTryAuthWithDifferentStoredEmailCase(): void
+    {
+        $Db = Db::getConnection();
+        $email = 'ToTo@YopMail.Com';
+        $update = $Db->prepare('UPDATE users SET email = :email WHERE userid = 1');
+        $update->bindParam(':email', $email);
+        $Db->execute($update);
+
+        try {
+            $authentication = new Local('toto@yopmail.com', 'totototototo')->authenticate();
+            self::assertSame(1, $authentication->userid);
+        } finally {
+            $email = 'toto@yopmail.com';
+            $Db->execute($update);
+        }
+    }
+
     public function testTryAuthWithInvalidEmail(): void
     {
         $this->expectException(InvalidCredentialsException::class);


### PR DESCRIPTION
an email with capital letters would not match during auth, now the mixed case matches correctly as we do the binary comparison on lowercase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - User search now matches email addresses regardless of letter casing.
  - Authentication succeeds when the email’s capitalization differs from the stored account value.

- **Tests**
  - Added coverage for authentication with differently cased email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->