### PR TITLE
bug/minor: metadata: preserve apostrophes in custom field names

### DIFF
--- a/src/Models/Links/AbstractContainersLinks.php
+++ b/src/Models/Links/AbstractContainersLinks.php
@@ -277,14 +277,14 @@ abstract class AbstractContainersLinks extends AbstractLinks
         $jsonPath = sprintf(
             '$.%s.%s.type',
             MetadataEnum::ExtraFields->value,
-            json_encode($extraFieldKey, JSON_HEX_APOS | JSON_THROW_ON_ERROR)
+            json_encode($extraFieldKey, JSON_THROW_ON_ERROR)
         );
         $sql = sprintf(
-            "SELECT metadata->>'%s' FROM %s WHERE id = :id",
-            $jsonPath,
+            'SELECT JSON_UNQUOTE(JSON_EXTRACT(metadata, :json_path)) FROM %s WHERE id = :id',
             $this->Entity->entityType->value,
         );
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':json_path', $jsonPath);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         $extraFieldType = $req->fetchColumn();

--- a/src/Models/Links/AbstractLinks.php
+++ b/src/Models/Links/AbstractLinks.php
@@ -129,14 +129,14 @@ abstract class AbstractLinks extends AbstractRest
         $jsonPath = sprintf(
             '$.%s.%s.type',
             MetadataEnum::ExtraFields->value,
-            json_encode($extraFieldKey, JSON_HEX_APOS | JSON_THROW_ON_ERROR)
+            json_encode($extraFieldKey, JSON_THROW_ON_ERROR)
         );
         $sql = sprintf(
-            "SELECT metadata->>'%s' FROM %s WHERE id = :id",
-            $jsonPath,
+            'SELECT JSON_UNQUOTE(JSON_EXTRACT(metadata, :json_path)) FROM %s WHERE id = :id',
             $this->Entity->entityType->value,
         );
         $req = $this->Db->prepare($sql);
+        $req->bindValue(':json_path', $jsonPath);
         $req->bindParam(':id', $this->Entity->id, PDO::PARAM_INT);
         $this->Db->execute($req);
         $extraFieldType = $req->fetchColumn();

--- a/src/ts/misc.ts
+++ b/src/ts/misc.ts
@@ -705,9 +705,9 @@ export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// used in metadata.ts to normalize field names only by trimming out double and simple quotes, causing to SQL issues
+// used in metadata.ts to normalize field names by removing double quotes and normalizing whitespace
 export function normalizeFieldName(input: string): string {
-  return input.replace(/['"]/g, '').trim().replace(/\s+/g, ' ');
+  return input.replace(/"/g, '').trim().replace(/\s+/g, ' ');
 }
 
 export function askFileName(extension: FileType): string | undefined {

--- a/tests/cypress/integration/metadata.cy.ts
+++ b/tests/cypress/integration/metadata.cy.ts
@@ -9,4 +9,9 @@ describe('Metadata Extra fields', () => {
     cy.removeMetadataField();
     cy.addUserMetadataField('Owner', 'Titi');
   });
+
+  it('Preserves apostrophes in custom field names', () => {
+    cy.createEntity();
+    cy.addTextMetadataField('l\'appartement');
+  });
 });

--- a/tests/unit/models/ContainersLinksTest.php
+++ b/tests/unit/models/ContainersLinksTest.php
@@ -25,6 +25,7 @@ use PDO;
 
 use function sprintf;
 use function str_repeat;
+use function json_encode;
 
 class ContainersLinksTest extends \PHPUnit\Framework\TestCase
 {
@@ -648,6 +649,21 @@ class ContainersLinksTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($entry);
         // no reason suffix: the line stops at the container id
         $this->assertStringEndsWith(sprintf('(container #%d)', $rowId), $entry['content']);
+    }
+
+    public function testDetectsSelfLinkViaMetadataWithApostrophe(): void
+    {
+        $Item = $this->getFreshItem();
+        $fieldName = "aujourd'hui";
+        $Item->patch(Action::Update, array(
+            'metadata' => json_encode(array(
+                'extra_fields' => array($fieldName => array('type' => $Item->entityType->value, 'value' => array())),
+            ), JSON_THROW_ON_ERROR),
+        ));
+        // calling through Containers2ItemsLinks specifically covers AbstractContainersLinks::isSelfLinkViaMetadata()
+        $Links = new Containers2ItemsLinks($Item);
+        $this->assertTrue($Links->isSelfLinkViaMetadata($fieldName, (string) $Item->id));
+        $this->assertFalse($Links->isSelfLinkViaMetadata($fieldName, (string) ($Item->id + 1)));
     }
 
     private function setCapacity(int $storageId, int $capacity): void

--- a/tests/unit/models/ExperimentsTest.php
+++ b/tests/unit/models/ExperimentsTest.php
@@ -38,6 +38,7 @@ use function json_decode;
 use function random_bytes;
 use function sprintf;
 use function str_replace;
+use function json_encode;
 
 class ExperimentsTest extends \PHPUnit\Framework\TestCase
 {
@@ -450,6 +451,19 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array('first', 'second'), $decoded['extra_fields']['multitext']['value']);
     }
 
+    public function testUpdateJsonFieldWithApostropheInName(): void
+    {
+        $metadata = '{"extra_fields": {"l\'appartement": {"type": "text", "value": "old"}}}';
+        $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
+
+        $res = $this->Experiments->patch(Action::UpdateMetadataField, array(
+            'action' => Action::UpdateMetadataField->value,
+            "l'appartement" => 'new',
+        ));
+        $decoded = json_decode($res['metadata'], true);
+        $this->assertSame('new', $decoded['extra_fields']["l'appartement"]['value']);
+    }
+
     public function testUpdateJsonFieldWithMultipleCompoundValues(): void
     {
         $metadata = '{"extra_fields": {"components": {"type": "compounds", "value": [], "allow_multi_values": true}}}';
@@ -524,13 +538,22 @@ class ExperimentsTest extends \PHPUnit\Framework\TestCase
 
     public function testUpdateJsonFieldRejectsSelfLinkInMultipleValues(): void
     {
-        $metadata = '{"extra_fields": {"related": {"type": "experiments", "value": [], "allow_multi_values": true}}}';
+        $fieldName = "l'expérience associée";
+        $metadata = json_encode(array(
+            'extra_fields' => array(
+                $fieldName => array(
+                    'type' => 'experiments',
+                    'value' => array(),
+                    'allow_multi_values' => true,
+                ),
+            ),
+        ), JSON_THROW_ON_ERROR);
         $this->Experiments->patch(Action::Update, array('metadata' => $metadata));
 
         $this->expectException(ImproperActionException::class);
         $this->Experiments->patch(Action::UpdateMetadataField, array(
             'action' => Action::UpdateMetadataField->value,
-            'related' => array(0, $this->Experiments->id),
+            $fieldName => array(0, $this->Experiments->id),
         ));
     }
 


### PR DESCRIPTION
fix #6795

Keep apostrophes in custom field names and bind metadata JSON paths as SQL parameters to prevent potential quoting issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of custom metadata field names containing apostrophes.
  - Improved metadata-based link validation for field names with special characters.
  - Preserved apostrophes during field-name normalization while continuing to clean up surrounding and repeated whitespace.
  - Improved compatibility when reading metadata across supported database configurations.

- **Tests**
  - Added regression coverage to verify apostrophes remain intact and invalid self-references continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->