### PR TITLE
feat: ensure MySQL 8.4 is running

### DIFF
--- a/containers/elabctl/elabctl.sh
+++ b/containers/elabctl/elabctl.sh
@@ -605,8 +605,7 @@ function uninstall
 
     # remove docker images
     docker rmi elabftw/elabimg || true
-    docker rmi mysql:5.7 || true
-    docker rmi mysql:8.0 || true
+    docker rmi mysql:8.4 || true
 
     echo ""
     echo "[✓] Everything has been obliterated. Have a nice day :)"

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -215,3 +215,7 @@ The environment variable `USE_PERSISTENT_MYSQL_CONN` now defaults to `false`. It
 ### NGINX access logs now use structured JSON
 
 The default NGINX access log format has been replaced with a structured JSON format providing significantly more diagnostic information, including request IDs, request and upstream response timings, response sizes, connection information, and compression ratios. Administrators parsing NGINX access logs should update their log-processing configuration accordingly.
+
+### MySQL 8.4 becomes the minimum supported version
+
+MySQL 8.0 reached its official end-of-life (EOL) on April 30, 2026. eLabFTW version 6 requires running MySQL 8.4 as it uses features available only in this version.

--- a/src/Elabftw/Update.php
+++ b/src/Elabftw/Update.php
@@ -21,7 +21,7 @@ use function bin2hex;
 use function random_bytes;
 use function sha1;
 use function sprintf;
-use function mb_substr;
+use function preg_match;
 
 /**
  * Run the update schema script
@@ -47,10 +47,13 @@ final class Update
      */
     public function runUpdateScript(bool $force = false): int
     {
-        // make sure we run MySQL version 8 at least
-        $mysqlVersion = (int) mb_substr($this->Db->getAttribute(PDO::ATTR_SERVER_VERSION) ?? '1', 0, 1);
-        if ($mysqlVersion < 8) {
-            throw new ImproperActionException('It looks like MySQL server version is less than 8. Update your MySQL server!');
+        // make sure we run MySQL version 8.4 at least
+        $mysqlVersion = (string) $this->Db->getAttribute(PDO::ATTR_SERVER_VERSION);
+        if (preg_match('/^(\d+)\.(\d+)/', $mysqlVersion, $matches) !== 1
+            || (int) $matches[1] !== 8
+            || (int) $matches[2] !== 4
+        ) {
+            throw new ImproperActionException(sprintf('MySQL 8.4 is required, found %s', $mysqlVersion));
         }
 
         // old style update functions have been removed, so add a block to prevent upgrade from very very old to newest directly


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - eLabFTW 6 now requires MySQL 8.4 specifically. Earlier MySQL 8.x versions are no longer supported.
  - Upgrade checks clearly report the detected MySQL version when the requirement is not met.

- **Documentation**
  - Updated upgrade guidance to explain the MySQL 8.4 minimum requirement.

- **Maintenance**
  - Uninstallation now removes the MySQL 8.4 Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->