### PR TITLE
cleanup: remove initial-scale=1

### DIFF
--- a/containers/elabimg/nginx/error-pages/404.html
+++ b/containers/elabimg/nginx/error-pages/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv='Content-type' content='text/html;charset=UTF-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name='viewport' content='width=device-width'>
     <meta name='description' content='Page not found - 404 - eLabFTW'>
     <title>Error | 404 - Page not found</title>
   </head>

--- a/src/templates/eln-preview.html
+++ b/src/templates/eln-preview.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
   <meta http-equiv='Content-type' content='text/html;charset=UTF-8' />
-  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <meta name='viewport' content='width=device-width'>
   <meta name='description' content='This is a .eln export from eLabFTW'>
   <title>ELN archive HTML preview - eLabFTW</title>
   <script type='application/ld+json'>{{ jsonLd|raw }}</script>

--- a/src/templates/head.html
+++ b/src/templates/head.html
@@ -17,7 +17,7 @@
 
 <head>
   <meta http-equiv='Content-type' content='text/html;charset=UTF-8' />
-  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <meta name='viewport' content='width=device-width'>
   <meta name='description' content='Electronic lab notebook - eLabFTW'>
   {% if sessionExpiresAt %}
     <meta name='session-expires-at' content='{{ sessionExpiresAt }}'>

--- a/src/templates/invalid-schema.html
+++ b/src/templates/invalid-schema.html
@@ -9,7 +9,7 @@
 <html lang='en'>
   <head>
     <meta http-equiv='Content-type' content='text/html;charset=UTF-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name='viewport' content='width=device-width'>
     <meta name='description' content='Electronic lab notebook - eLabFTW'>
     <link rel='icon' type='image/ico' href='app/img/favicon.ico' />
     <title>Database update required!</title>

--- a/web/maintenance/index.html
+++ b/web/maintenance/index.html
@@ -9,7 +9,7 @@
 <html lang='en'>
   <head>
     <meta http-equiv='Content-type' content='text/html;charset=UTF-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name='viewport' content='width=device-width'>
     <meta name='description' content='Maintenance mode'>
     <link rel='icon' type='image/ico' href='/favicon.ico' />
     <title>Maintenance | eLabFTW</title>

--- a/web/spreadsheet.html
+++ b/web/spreadsheet.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset='utf-8'>
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <meta name='viewport' content='width=device-width'>
     <title>eLabFTW Spreadsheet Editor</title>
     <script defer src='/assets/spreadsheet.bundle.js?v=%REPLACED_AT_BUILD_TIME%'></script>
     <link rel='stylesheet' media='all' href='/assets/main.min.css?v=%REPLACED_AT_BUILD_TIME%' />


### PR DESCRIPTION
no longer necessary.
https://quirksmode.org/quirksblog/2026/0902-initial.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated viewport settings across application, preview, error, maintenance, and spreadsheet pages.
  - Removed the explicit initial zoom setting while retaining device-width configuration.
  - Pages now rely on the browser’s default initial scaling behavior for responsive display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->