### PR TITLE
bug/minor: team sync: make first user in team admin

### DIFF
--- a/src/Models/Teams.php
+++ b/src/Models/Teams.php
@@ -109,7 +109,13 @@ final class Teams extends AbstractRest
         $currentTeams = $UsersHelper->getTeamsIdFromUserid();
 
         $addToTeams = array_diff($teamIdArr, $currentTeams);
-        $Users2Teams->addUserToTeams($userid, $addToTeams, isValidated: $this->Users->userData['validated'] === 1);
+        $isValidated = $this->Users->userData['validated'] === 1;
+        foreach ($addToTeams as $teamId) {
+            $isAdmin = (new TeamsHelper($teamId))->isFirstUserInTeam()
+                ? BinaryValue::True
+                : BinaryValue::False;
+            $Users2Teams->create($userid, $teamId, $isAdmin, $isValidated);
+        }
         $currentTeams = $UsersHelper->getTeamsIdFromUserid();
 
         $rmFromTeams = array_diff($currentTeams, $teamIdArr);

--- a/tests/unit/models/TeamsTest.php
+++ b/tests/unit/models/TeamsTest.php
@@ -15,6 +15,8 @@ use Elabftw\Enums\Action;
 use Elabftw\Exceptions\ForbiddenException;
 use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Models\Users\Users;
+use Elabftw\Services\TeamsHelper;
+use Elabftw\Services\UsersHelper;
 use Elabftw\Traits\TestsUtilsTrait;
 
 use function array_column;
@@ -132,6 +134,25 @@ class TeamsTest extends \PHPUnit\Framework\TestCase
         $this->Teams->setId(1);
         $this->expectException(ImproperActionException::class);
         $this->Teams->destroy();
+    }
+
+    public function testSynchronizeMakesFirstUserInTeamAdmin(): void
+    {
+        $user = $this->getUserInTeam(1);
+        $userid = $user->getUserid();
+        $originalTeams = (new UsersHelper($userid))->getTeamsFromUserid();
+        $teamId = $this->Teams->postAction(Action::Create, array('name' => 'Empty synchronized team'));
+        $teams = $originalTeams;
+        $teams[] = array('id' => $teamId);
+
+        try {
+            $this->Teams->synchronize($userid, $teams);
+
+            $this->assertTrue((new TeamsHelper($teamId))->isAdminInTeam($userid));
+        } finally {
+            $this->Teams->synchronize($userid, $originalTeams);
+            $this->Teams->destroy();
+        }
     }
 
     public function testSendOnboardingEmails(): void


### PR DESCRIPTION
fix #7403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Team synchronization now adds missing memberships individually and correctly assigns administrator status to the first user in an empty team.
  - User validation status is preserved when memberships are synchronized.

- **Tests**
  - Added coverage confirming that the first synchronized user in a team receives administrator access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->