### PR TITLE
bug/minor: mysql minimum version is 8.4, not the only version supported

### DIFF
--- a/src/Elabftw/Update.php
+++ b/src/Elabftw/Update.php
@@ -50,8 +50,8 @@ final class Update
         // make sure we run MySQL version 8.4 at least
         $mysqlVersion = (string) $this->Db->getAttribute(PDO::ATTR_SERVER_VERSION);
         if (preg_match('/^(\d+)\.(\d+)/', $mysqlVersion, $matches) !== 1
-            || (int) $matches[1] !== 8
-            || (int) $matches[2] !== 4
+            || (int) $matches[1] < 8
+            || ((int) $matches[1] === 8 && (int) $matches[2] < 4)
         ) {
             throw new ImproperActionException(sprintf('MySQL 8.4 is required, found %s', $mysqlVersion));
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MySQL version validation now supports MySQL 8.4 and all later versions during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->