### PR TITLE
bug/minor: spreadsheet: save button UI misleading with export functionality

### DIFF
--- a/src/templates/spreadsheet-editor.html
+++ b/src/templates/spreadsheet-editor.html
@@ -1,13 +1,11 @@
-{% set text = 'Beta Notice: The spreadsheet editor is currently in beta (preview release) and should be used with caution. Please avoid storing important data in it. Additionally, files that include styling or advanced features such as graphics may not display as they originally appear. This editor is best suited for simple calculations and handling formulas. We welcome any feedback you may have.'|trans %}
 <section id='spreadsheetEditor' aria-label='{{ 'Spreadsheet Editor'|trans }}'>
   <h3 data-action='toggle-next' data-scroll-btn='fa-file-excel' data-scroll-btn-label='{{ 'Spreadsheet editor'|trans }}' data-toggle-target='spreadsheetEditorDiv' data-opened-icon='fa-caret-down' data-closed-icon='fa-caret-right' class='d-inline togglable-section-title mt-2' tabindex='0' role='button' aria-expanded='false' aria-controls='spreadsheetEditorDiv'>
     <i id='sheetEditorIcon' class='fas fa-caret-right fa-fw mr-2'></i>{{ 'Spreadsheet Editor'|trans }}
   </h3>
-  <span class='beta'>beta</span>
-  {% include 'infotip.html' with {text} %}
+  <div id='spreadsheetEditorDiv' class='m-2' hidden data-save-hidden='spreadsheetEditorDiv'>
   <div class='d-flex justify-content-between align-items-center'>
     <span hidden id='spreadsheetEditorUnsavedChanges'>{{ 'You have unsaved changes'|trans|msg('warning', false) }}</span>
-    <div class='ml-auto'>
+    <div class='ml-auto mb-2'>
       <button type='button' id='spreadsheetSaveAsAttachment' class='btn btn-primary mr-2'>
         <i class='fas fa-paperclip fa-fw mr-1'></i>{{ 'Save as attachment'|trans }}
       </button>
@@ -17,7 +15,6 @@
       <a class='btn btn-ghost external-link' href='https://doc.elabftw.net/docs/usage/user-guide/experiments#spreadsheet-editor' target='_blank' rel='noopener' title='{{ 'Documentation'|trans }}' aria-label='{{ 'Documentation'|trans }}'><i class='fas fa-circle-question fa-fw'></i></a>
     </div>
   </div>
-  <div id='spreadsheetEditorDiv' class='m-2' hidden data-save-hidden='spreadsheetEditorDiv'>
     {% if App.devMode -%}
       <!-- [html-validate-disable-block unique-landmark, no-deprecated-attr, prefer-native-element: suppress errors from spreadsheet editor] -->
     {%- endif %}

--- a/src/templates/spreadsheet-editor.html
+++ b/src/templates/spreadsheet-editor.html
@@ -8,13 +8,13 @@
   <div class='d-flex justify-content-between align-items-center'>
     <span hidden id='spreadsheetEditorUnsavedChanges'>{{ 'You have unsaved changes'|trans|msg('warning', false) }}</span>
     <div class='ml-auto'>
-      <button type='button' id='spreadsheetSaveAsAttachment' class='btn btn-primary'>
-        <i class='fas fa-floppy-disk fa-fw mr-1'></i>{{ 'Save as attachment'|trans }}
+      <button type='button' id='spreadsheetSaveAsAttachment' class='btn btn-primary mr-2'>
+        <i class='fas fa-paperclip fa-fw mr-1'></i>{{ 'Save as attachment'|trans }}
       </button>
-      <button type='button' id='spreadsheetReplaceAttachment' class='btn btn-secondary' disabled>
+      <button type='button' id='spreadsheetReplaceAttachment' class='btn btn-secondary mr-2' title='{{ 'Replace attachment'|trans }}' aria-label='{{ 'Replace attachment'|trans }}' disabled>
         <i class='fas fa-rotate fa-fw mr-1'></i>{{ 'Replace attachment'|trans }}
       </button>
-      <a class='btn btn-ghost mr-2 external-link' href='https://doc.elabftw.net/docs/usage/user-guide/experiments#spreadsheet-editor' target='_blank' rel='noopener'>{{ 'Documentation'|trans }}</a>
+      <a class='btn btn-ghost external-link' href='https://doc.elabftw.net/docs/usage/user-guide/experiments#spreadsheet-editor' target='_blank' rel='noopener' title='{{ 'Documentation'|trans }}' aria-label='{{ 'Documentation'|trans }}'><i class='fas fa-circle-question fa-fw'></i></a>
     </div>
   </div>
   <div id='spreadsheetEditorDiv' class='m-2' hidden data-save-hidden='spreadsheetEditorDiv'>

--- a/src/templates/uploads.html
+++ b/src/templates/uploads.html
@@ -32,8 +32,10 @@
         {% endtrans %} (<span id='uploadsCount'>{{ Entity.entityData.uploads|length }}</span>)
       </h3>
     </div>
+  </div>
 
-    <div id='uploadsViewToggler'>
+  <div class='row mt-2 mx-0' id='uploadsDiv' data-count-for='uploadsCount' data-save-hidden='uploadsDiv'>
+    <div id='uploadsViewToggler' class='w-100 text-right'>
       <button type='button' title='{{ 'Switch layout'|trans }}' aria-label='{{ 'Switch layout'|trans }}' class='btn btn-transparent' data-action='toggle-uploads-layout' data-target-layout='{{ App.Users.userData.uploads_layout ? 0 : 1 }}'>
         <i class='fas fa-fw fa-list fa-flip-horizontal'></i>
         <i class='fas fa-fw fa-table-cells'></i>
@@ -42,9 +44,6 @@
         <i class='fas fa-fw fa-box-archive'></i>
       </button>
     </div>
-  </div>
-
-  <div class='row mt-2 mx-0' id='uploadsDiv' data-count-for='uploadsCount' data-save-hidden='uploadsDiv'>
     {# ADD NEW FILE #}
     {% if mode == 'edit' %}
       <div class='col-md-4 col-sm-6'>

--- a/src/ts/spreadsheet-editor.jsx
+++ b/src/ts/spreadsheet-editor.jsx
@@ -148,12 +148,16 @@ function SpreadsheetEditor() {
       return !unsupportedControls.has(item.content) && !isVerticalAlignment;
     });
 
-    if (saveBtn) saveBtn.tooltip = i18next.t('export');
+    if (saveBtn) {
+        saveBtn.content = 'file_download';
+        saveBtn.tooltip = i18next.t('export');
+    }
     // we render the spreadsheet in an iframe, so we'll also use a custom fullscreen button
     const fullscreenBtn = { type: 'icon', class: 'mx-2 fas fa-expand', tooltip: i18next.t('fullscreen'), onclick: () => toggleFullscreen()};
-    const clearBtn = { type: 'icon', class: 'ml-2 fas fa-trash', tooltip: i18next.t('clear'), onclick: clearSpreadsheet };
+    const clearBtn = { type: 'icon', class: 'fas fa-trash', tooltip: i18next.t('clear'), onclick: clearSpreadsheet };
     const importBtn = { type: 'icon', class: 'fas fa-upload', tooltip: i18next.t('import'), onclick: () => document.getElementById('importFileInput').click() };
-    tb.items.push(fullscreenBtn, importBtn, clearBtn);
+    tb.items.splice(tb.items.indexOf(saveBtn), 0, importBtn);
+    tb.items.push(fullscreenBtn, clearBtn);
     return tb;
   };
   return (


### PR DESCRIPTION
Replace the "save" icon with a download icon, since this button is for exporting to the computer.
Different from "Save as attachment" and "Replace attachment"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added import, export/download, fullscreen, and clear controls to the spreadsheet editor toolbar.

- **Improvements**
  - Updated toolbar icons, placement, and spacing for clearer actions.
  - Added accessible labels and titles to editor actions.
  - Improved the documentation link with a question-circle icon.
  - Improved uploads page layout and right-aligned view controls.

- **Updates**
  - Removed the spreadsheet editor’s beta notice and infotip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->