### PR TITLE
bug/minor: api: restrict anonymous access to team metadata

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -501,7 +501,9 @@ final class Apiv2Controller extends AbstractApiController
 
     private function applyAnonymousRestrictions(): void
     {
-        if (!($this->requester instanceof AnonymousUser)) return;
+        if (!($this->requester instanceof AnonymousUser)) {
+            return;
+        }
         // anon users cannot enumerate another user's endpoint
         if (
             $this->endpoint === ApiEndpoint::Users

--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -32,6 +32,7 @@ use Elabftw\Interfaces\RestInterface;
 use Elabftw\Make\ReportsHandler;
 use Elabftw\Make\Exports;
 use Elabftw\Models\AbstractEntity;
+use Elabftw\Models\AbstractStatus;
 use Elabftw\Models\ApiKeys;
 use Elabftw\Models\Batch;
 use Elabftw\Models\Branding;
@@ -470,6 +471,8 @@ final class Apiv2Controller extends AbstractApiController
 
     private function applyRestrictions(): void
     {
+        $this->applyAnonymousRestrictions();
+
         if (($this->Model instanceof Config) && $this->requester->userData['is_sysadmin'] !== 1) {
             throw new ForbiddenException('Non sysadmin user tried to use a restricted api endpoint.');
         }
@@ -493,6 +496,23 @@ final class Apiv2Controller extends AbstractApiController
         // only accept json content-type unless it's GET or DELETE (also prevents csrf!)
         if (!in_array($this->Request->getMethod(), array(Request::METHOD_GET, Request::METHOD_DELETE), true) && $contentType !== 'application/json') {
             throw new ImproperActionException('Incorrect content-type header.');
+        }
+    }
+
+    private function applyAnonymousRestrictions(): void
+    {
+        if (!($this->requester instanceof AnonymousUser)) return;
+        // anon users cannot enumerate another user's endpoint
+        if (
+            $this->endpoint === ApiEndpoint::Users
+            && $this->id !== null
+            && $this->id !== $this->requester->userData['userid']
+        ) {
+            throw new ForbiddenException();
+        }
+        // these team submodels contain internal organizational metadata
+        if ($this->Model instanceof AbstractStatus || $this->Model instanceof TeamGroups) {
+            throw new ForbiddenException();
         }
     }
 }

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -66,6 +66,17 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         self::assertSame('[]', $res->getContent());
     }
 
+    // the restriction does not accidentally block an anonymous user from accessing /api/v2/users/me
+    public function testAnonymousUserCanReadOwnProfile(): void
+    {
+        $Controller = new Apiv2Controller(new AnonymousUser(1), Request::create('/api/v2/users/me'));
+        $res = $Controller->getResponse();
+        self::assertSame(Response::HTTP_OK, $res->getStatusCode());
+        $content = $res->getContent();
+        self::assertIsString($content);
+        self::assertSame(0, json_decode($content, true)['userid']);
+    }
+
     public function testAnonymousUserCannotWriteEvenWhenCanWriteIsTrue(): void
     {
         $Controller = new Apiv2Controller(
@@ -142,15 +153,30 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
         self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode());
     }
 
-    public function testAnonymousUserCanReadCurrentTeamsSubmodel(): void
+    public function testAnonymousUserCannotReadSensitiveEndpoints(): void
     {
-        $Controller = new Apiv2Controller(
-            new AnonymousUser(1),
-            Request::create('/api/v2/teams/1/status', 'GET'),
+        $uris = array(
+            '/api/v2/users/1',
+            '/api/v2/teams/1/teamgroups',
+            '/api/v2/teams/1/teamgroups/1',
+            '/api/v2/teams/1/status',
+            '/api/v2/teams/1/status/1',
+            '/api/v2/teams/1/experiments_status',
+            '/api/v2/teams/1/experiments_categories',
+            '/api/v2/teams/1/resources_categories',
+            '/api/v2/teams/1/items_status',
         );
 
-        $res = $Controller->getResponse();
-        self::assertSame(Response::HTTP_OK, $res->getStatusCode());
+        foreach ($uris as $uri) {
+            $Controller = new Apiv2Controller(
+                new AnonymousUser(1),
+                Request::create($uri, 'GET'),
+            );
+
+            $res = $Controller->getResponse();
+
+            self::assertSame(Response::HTTP_FORBIDDEN, $res->getStatusCode(), $uri);
+        }
     }
 
     public function testCanReadCurrentTeamsSubmodel(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anonymous access is now limited to the signed-in user’s own profile endpoint.
  - Anonymous users are prevented from accessing other users’ data and sensitive team or status information.

- **Bug Fixes**
  - Anonymous profile requests now correctly identify the requester and return the appropriate personal profile.
  - Restricted requests consistently return a forbidden response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->