### PR TITLE
bug/medium: fix archived team memberships granting entity access

### DIFF
--- a/src/Elabftw/CanSqlBuilder.php
+++ b/src/Elabftw/CanSqlBuilder.php
@@ -104,6 +104,7 @@ final class CanSqlBuilder
                         WHERE u2t.users_id = :userid
                           AND u2t.teams_id = entity.team
                           AND u2t.is_admin = 1
+                          AND u2t.is_archived = 0
                       )
                 )
             )',

--- a/src/Elabftw/CanSqlBuilder.php
+++ b/src/Elabftw/CanSqlBuilder.php
@@ -132,13 +132,14 @@ final class CanSqlBuilder
      */
     protected function canTeams(): string
     {
-        if (!empty($this->requester->userData['teams'])) {
-            // JSON_OVERLAPS checks for the intersection of two arrays
-            // for instance [4,5,6] vs [2,6] has 6 in common -> 1 (true)
+        $teamsOfUser = $this->requester->getActiveTeamIds();
+        if (!empty($teamsOfUser)) {
+            // grant access when the entity is explicitly shared with at least
+            // one team in which the requester still has an active membership
             return sprintf(
                 "JSON_OVERLAPS(entity.%s->'$.teams', CAST('[%s]' AS JSON))",
                 $this->accessType->value,
-                implode(', ', array_column($this->requester->userData['teams'], 'id')),
+                implode(', ', $teamsOfUser),
             );
         }
         return '1=2';

--- a/src/Elabftw/EntitySqlBuilder.php
+++ b/src/Elabftw/EntitySqlBuilder.php
@@ -405,11 +405,12 @@ final class EntitySqlBuilder implements SqlBuilderInterface
      */
     protected function canTeams(string $can): string
     {
-        // ultra admin has userid=null during cli eln export so we use the team id
-        $teamsOfUser = array($this->entity->Users->userData['team']);
-
-        if (!empty($this->entity->Users->userData['teams'])) {
-            $teamsOfUser = array_column($this->entity->Users->userData['teams'], 'id');
+        // cross-team permissions must only consider active memberships
+        $teamsOfUser = $this->entity->Users->getActiveTeamIds();
+        // UltraAdmin used by cli exports has no regular team membership data
+        // so preserve the current team as a fallback for that special case
+        if ($this->entity->Users->userid === null && $this->entity->Users->team !== null) {
+            $teamsOfUser = array($this->entity->Users->team);
         }
 
         if (!empty($teamsOfUser)) {
@@ -421,6 +422,7 @@ final class EntitySqlBuilder implements SqlBuilderInterface
                 implode(', ', $teamsOfUser),
             );
         }
+        // no active team membership = no explicit cross-team permission
         return '0';
     }
 

--- a/src/Elabftw/Permissions.php
+++ b/src/Elabftw/Permissions.php
@@ -20,7 +20,6 @@ use Elabftw\Models\Users\Users;
 use Elabftw\Services\TeamsHelper;
 
 use function json_decode;
-use function array_column;
 use function in_array;
 
 /**
@@ -102,8 +101,9 @@ final class Permissions
         }
 
         // check for teams
+        // only active memberships count: an archived team must no longer grant access
         if (!empty($can['teams'])) {
-            $teamsOfUser = array_column($this->Users->userData['teams'], 'id');
+            $teamsOfUser = $this->Users->getActiveTeamIds();
             foreach ($can['teams'] as $team) {
                 if (in_array($team, $teamsOfUser, true)) {
                     return true;

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -815,6 +815,18 @@ class Users extends AbstractRest
         }
     }
 
+    // Return IDs of teams where the user has an active membership
+    public function getActiveTeamIds(): array
+    {
+        $teamIds = array();
+        foreach ($this->userData['teams'] ?? array() as $team) {
+            if ((int) $team['is_archived'] === 0) {
+                $teamIds[] = (int) $team['id'];
+            }
+        }
+        return $teamIds;
+    }
+
     protected static function search(UsersColumn $column, string $term, bool $filterValidated = false): self
     {
         $Db = Db::getConnection();

--- a/tests/unit/models/PermissionsTest.php
+++ b/tests/unit/models/PermissionsTest.php
@@ -63,4 +63,35 @@ class PermissionsTest extends \PHPUnit\Framework\TestCase
         $this->expectException(ForbiddenException::class);
         $bravoExp->readOne();
     }
+
+    public function testArchivedTeamDoesNotGrantReadAccess(): void
+    {
+        // viewer logged into team 1
+        $viewer = new AuthenticatedUser(2, 1);
+        // create exp as another user from team 2
+        $owner = $this->getUserInTeam(2);
+
+        // Viewer is active in team 1 but archived from team 2
+        $viewer->userData['teams'] = array(
+            array('id' => 1, 'is_archived' => 0),
+            array('id' => 2, 'is_archived' => 1),
+        );
+
+        $experiment = new Experiments($owner);
+        $experimentId = $experiment->postAction(Action::Create, array());
+        $experiment->setId($experimentId);
+
+        // share the experiment with team 2. before fix, archived team 2 membership
+        // was still considered and incorrectly had access
+        $canread = json_decode(AbstractEntity::EMPTY_CAN_JSON, true);
+        $canread['teams'] = array(2);
+        $experiment->patch(Action::Update, array(
+            'canread' => json_encode($canread),
+        ));
+
+        $viewerExperiment = new Experiments($viewer);
+
+        $this->expectException(ForbiddenException::class);
+        $viewerExperiment->setId($experimentId);
+    }
 }


### PR DESCRIPTION
fix #6446

Archived team memberships must not grant access through explicit cross-team permissions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Archived team memberships no longer grant access to experiments or other team-restricted content.
  - Team-based permissions now reflect users’ active team memberships.
  - Command-line exports correctly use the current team when no user ID is available.
  - Users without active team memberships no longer receive unintended cross-team access.

- **Tests**
  - Added coverage confirming archived team members are denied access to shared experiments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->