### PR TITLE
doc: make it clear quadlets are different than docker compose

### DIFF
--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -157,6 +157,7 @@ Make sure the `elabftw-worker` user can write to these folders.
 This is a Quadlets example, ignore this section if you use Docker Compose.
 
 ~~~yaml
+[Container]
 Volume=/var/cache/elabftw:/var/cache/elabftw:Z
 Volume=/var/elabftw/uploads:/var/lib/elabftw/uploads:Z
 Volume=/var/elabftw/exports:/var/lib/elabftw/exports:Z

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -156,10 +156,10 @@ Make sure the `elabftw-worker` user can write to these folders.
 
 This is a Quadlets example, ignore this section if you use Docker Compose.
 
-~~~yaml
+~~~conf
 [Container]
 Volume=/var/cache/elabftw:/var/cache/elabftw:Z
-Volume=/var/elabftw/uploads:/var/lib/elabftw/uploads:Z
+Volume=/var/elabftw/web:/var/lib/elabftw/uploads:Z
 Volume=/var/elabftw/exports:/var/lib/elabftw/exports:Z
 ~~~
 

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -16,7 +16,7 @@ Here are the main changes:
 - container user configuration change
 - container certificates paths
 
-Note: this guide assumes usage of `docker compose`, with hints related to `podman quadlets` (which is another container engine). For other deployments, you will need to adapt the changes to your context.
+Note: this guide assumes usage of `docker compose`, with hints related to `podman/quadlets` (podman is another container engine and quadlets are systemd-managed container unit files). For other deployments, you will need to adapt the changes to your context.
 
 ## Making backups
 
@@ -97,10 +97,8 @@ chown elabftw-worker:elabftw-worker /var/cache/elabftw
 Then in the configuration file, under `volumes:` section:
 
 ~~~yaml
-# docker
+volumes:
   - /var/cache/elabftw:/var/cache/elabftw
-# quadlets example (only add this line if you use quadlets, not in a docker compose file)
-Volume=/var/cache/elabftw:/var/cache/elabftw:Z
 ~~~
 
 #### Uploads folder
@@ -141,6 +139,29 @@ Adjust the ownership with our new user:
 chown -R elabftw-worker:elabftw-worker /var/elabftw/exports
 ~~~
 
+#### Summary for volumes
+
+The whole `volumes` section should then look like:
+
+~~~yaml
+volumes:
+  - /var/cache/elabftw:/var/cache/elabftw
+  - /var/elabftw/web:/var/lib/elabftw/uploads
+  - /var/elabftw/exports:/var/lib/elabftw/exports
+~~~
+
+Make sure the `elabftw-worker` user can write to these folders.
+
+##### Same thing for Quadlets
+
+This is a Quadlets example, ignore this section if you use Docker Compose.
+
+~~~yaml
+Volume=/var/cache/elabftw:/var/cache/elabftw:Z
+Volume=/var/elabftw/uploads:/var/lib/elabftw/uploads:Z
+Volume=/var/elabftw/exports:/var/lib/elabftw/exports:Z
+~~~
+
 ### TLS Certificates
 
 If you are running the container in HTTPS mode (meaning `DISABLE_HTTPS` is `false`, the default), then you need to modify env and volumes. The cert and key are now indicated by `TLS_CERT_PATH` and `TLS_KEY_PATH` env vars.
@@ -167,7 +188,7 @@ ports:
 
 It is the right-hand side that needs to be modified: the listening port in the container.
 
-For quadlets/podman, adjust PublishPort if you're using this, or adjust your reverse proxy to use port 8080.
+For Quadlets, adjust PublishPort if you're using this, or adjust your reverse proxy to use port 8080.
 
 ### Environment
 

--- a/documentation/docs/install/upgrade/update-6.md
+++ b/documentation/docs/install/upgrade/update-6.md
@@ -16,7 +16,7 @@ Here are the main changes:
 - container user configuration change
 - container certificates paths
 
-Note: this guide assumes usage of `docker compose`, with hints related to `podman quadlets`. For other deployments, you will need to adapt the changes to your context.
+Note: this guide assumes usage of `docker compose`, with hints related to `podman quadlets` (which is another container engine). For other deployments, you will need to adapt the changes to your context.
 
 ## Making backups
 
@@ -62,7 +62,9 @@ tmpfs:
 
 This will make the container start and run with `elabftw-worker` user, and a read-only filesystem.
 
-### Quadlet
+### Quadlets
+
+Ignore this section if you use `docker compose`.
 
 Only changed/added lines are shown:
 
@@ -97,7 +99,7 @@ Then in the configuration file, under `volumes:` section:
 ~~~yaml
 # docker
   - /var/cache/elabftw:/var/cache/elabftw
-# quadlet
+# quadlets example (only add this line if you use quadlets, not in a docker compose file)
 Volume=/var/cache/elabftw:/var/cache/elabftw:Z
 ~~~
 
@@ -165,7 +167,7 @@ ports:
 
 It is the right-hand side that needs to be modified: the listening port in the container.
 
-For quadlets, adjust PublishPort if you're using this, or adjust your reverse proxy to use port 8080.
+For quadlets/podman, adjust PublishPort if you're using this, or adjust your reverse proxy to use port 8080.
 
 ### Environment
 
@@ -200,7 +202,7 @@ The `chem-plugin` addon can now be completely removed! It is not useful anymore:
 
 It is then safe to remove the whole `chem-plugin` block in your docker compose file.
 
-### OpenCloning in Quadlet
+### OpenCloning in Quadlets
 
 If you are running OpenCloning as a user with Quadlets, make sure to add:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Docker Compose and Podman Quadlet terminology in the v5-to-v6 upgrade guide.
  - Explained that Quadlets are systemd-managed container units.
  - Separated Docker Compose YAML from Quadlet directives in volume examples.
  - Added consolidated cache, uploads, and exports volume examples for both formats.
  - Updated uploads path guidance for Quadlets.
  - Revised port and OpenCloning guidance to refer explicitly to Quadlets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->