### PR TITLE
Add batch container add to lists/table multi-select

### DIFF
--- a/src/Controllers/AbstractEntityController.php
+++ b/src/Controllers/AbstractEntityController.php
@@ -139,6 +139,7 @@ abstract class AbstractEntityController implements ControllerInterface
             'pageTitle' => $this->getPageTitle(),
             'requestActionsArr' => $UserRequestActions->readAllFull(),
             'scopedTeamgroupsArr' => $this->scopedTeamgroupsArr,
+            'storageUnitsArr' => new StorageUnits($this->App->Users, Config::getConfig()->configArr['inventory_require_edit_rights'] === '1')->readAllRecursive(),
             'teamsArr' => $this->App->Teams->readAllVisible(),
             // get all the tags for the top search bar
             'tagsArrForSelect' => $TeamTags->readAll(),

--- a/src/Elabftw/i18n4Js.php
+++ b/src/Elabftw/i18n4Js.php
@@ -70,6 +70,7 @@ final class i18n4Js
             'clear' => _('Clear'),
             'click-to-edit' => _('Click to edit'),
             'check-required' => _('Please check required fields.'),
+            'container-batch-summary' => _('{{entries, number}} entries × {{perEntry, number}} containers = {{total, number}} containers total'),
             'copied' => _('Copied to clipboard.'),
             'comment-add' => _('Add a comment'),
             'confirm-clear-spreadsheet' => _('Discard current spreadsheet? All unsaved changes will be lost.'),

--- a/src/templates/add-container-modal.html
+++ b/src/templates/add-container-modal.html
@@ -1,9 +1,11 @@
 {# Add a container modal #}
-<div class='modal fade' id='storageModal' tabindex='-1' role='dialog' aria-labelledby='storageModalLabel'>
+{# var: withSelected bool — when true, the distribution is applied to every entity selected on the show page #}
+{% set withSelected = withSelected|default(false) %}
+<div class='modal fade' id='storageModal' tabindex='-1' role='dialog' aria-labelledby='storageModalLabel' {{ withSelected ? 'data-with-selected="1"' }}>
   <div class='modal-dialog modal-lg' role='document'>
     <div class='modal-content'>
       <div class='modal-header'>
-        <h4 class='modal-title' id='storageModalLabel'><i class='fas fa-fw fa-warehouse'></i> {{ 'Add container'|trans }}</h4>
+        <h4 class='modal-title' id='storageModalLabel'><i class='fas fa-fw fa-warehouse'></i> {{ withSelected ? 'Add container to selected entries'|trans : 'Add container'|trans }}</h4>
         <button type='button' class='close' data-dismiss='modal' aria-label='{{ 'Close'|trans }}'>
           <span aria-hidden='true'>&times;</span>
         </button>
@@ -23,9 +25,13 @@
               </select>
             </div>
           </div>
-          <h5><label for='containerMultiplierInput'>{{ 'Total number of containers to distribute'|trans }}</label></h5>
+          <h5><label for='containerMultiplierInput'>{{ withSelected ? 'Number of containers to distribute per selected entry'|trans : 'Total number of containers to distribute'|trans }}</label></h5>
           <input type='number' value='1' min='1' step='1' id='containerMultiplierInput' autocomplete='off' class='form-control' />
           <div class='sticky-top py-2 mb-2 mt-2' style='top:0; z-index:1'>
+            {% if withSelected %}
+              {# filled by the js, as the entry count is only known client side #}
+              <p class='smallgray mb-1' id='containerBatchSummary'></p>
+            {% endif %}
             {# shown when the target can never be assigned because the locations are too full #}
             <p class='smallgray' id='containerCapacityNotice' hidden>{{ 'There is not enough room left in these locations for that many containers.'|trans }}</p>
             <div class='d-flex align-items-center'>

--- a/src/templates/show.html
+++ b/src/templates/show.html
@@ -539,6 +539,9 @@
           <button data-action='patch-selected-entities' data-what='timestamp' type='button' class='btn btn-primary mr-1 mb-2' aria-label='{{ 'Timestamp the selected entities'|trans }}' title='{{ 'Timestamp the selected entities'|trans }}'>{{ 'Timestamp'|trans }}</button>
           <button data-action='patch-selected-entities' data-what='archive' type='button' class='btn btn-secondary mr-1 mb-2' aria-label='{{ 'Archive the selected entities'|trans }}' title='{{ 'Archive the selected entities'|trans }}'>{{ 'Archive'|trans }}</button>
           <button data-action='patch-selected-entities' data-what='unarchive' type='button' class='btn btn-secondary mr-1 mb-2' aria-label='{{ 'Unarchive the selected entities'|trans }}' title='{{ 'Unarchive the selected entities'|trans }}'>{{ 'Unarchive'|trans }}</button>
+          {% if storageUnitsArr[null] is defined %}
+            <button data-action='toggle-modal' data-target='storageModal' type='button' class='btn btn-primary mr-1 mb-2' aria-label='{{ 'Add container to selected entries'|trans }}' title='{{ 'Add container to selected entries'|trans }}'>{{ 'Add container'|trans }}</button>
+          {% endif %}
           <button data-action='toggle-modal' data-target='deleteSelectedEntitiesModal' type='button' class='btn btn-danger-ghost mr-1 mb-2' aria-label='{{ 'Delete the selected entities'|trans }}' title='{{ 'Delete the selected entities'|trans }}'>{{ 'Delete'|trans }}</button>
           <button data-action='patch-selected-entities' data-what='restore' type='button' class='btn btn-primary mr-1 mb-2' aria-label='{{ 'Restore the selected entities'|trans }}' title='{{ 'Restore the selected entities'|trans }}'>{{ 'Restore'|trans }}</button>
         </div>
@@ -699,5 +702,8 @@
 {% if not App.isAnonymous() %}
 {% include 'permissions-edit-modal.html' with {'withSelected': true, 'rw': 'canread'} %}
 {% include 'permissions-edit-modal.html' with {'withSelected': true, 'rw': 'canwrite'} %}
+{% if storageUnitsArr[null] is defined %}
+  {% include 'add-container-modal.html' with {'withSelected': true} %}
+{% endif %}
 {% endif %}
 {% endblock body %}

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -35,8 +35,10 @@
         <div class='input-group-prepend'>
           <button type='button' class='btn btn-secondary' data-action='container-qty-minus' data-storage-id='{{ unit.id }}' aria-label='{{ 'Decrease containers for %s'|trans|format(unit.name) }}'><i class='fas fa-minus'></i></button>
         </div>
-        {# max is the room left here, so the browser's own spinner and the js clamp alike #}
-        <input type='number' class='form-control text-center' min='0' step='1' value='0' {% if unit.capacity is not null %}max='{{ unit.capacity - unit.occupancy }}'{% endif %} inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ unit.id }}' aria-label='{{ 'Number of containers for %s'|trans|format(unit.name) }}' />
+        {# max is the room left here, so the browser's own spinner and the js clamp alike. When the
+           same distribution is applied to several entries at once, the js narrows max to what one
+           entry may claim; data-slots-left keeps the unnarrowed count a re-render can restore from #}
+        <input type='number' class='form-control text-center' min='0' step='1' value='0' {% if unit.capacity is not null %}max='{{ unit.capacity - unit.occupancy }}' data-slots-left='{{ unit.capacity - unit.occupancy }}'{% endif %} inputmode='numeric' autocomplete='off' data-action='container-qty-input' data-storage-id='{{ unit.id }}' aria-label='{{ 'Number of containers for %s'|trans|format(unit.name) }}' />
         <div class='input-group-append'>
           <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ unit.id }}' aria-label='{{ 'Increase containers for %s'|trans|format(unit.name) }}'><i class='fas fa-plus'></i></button>
         </div>

--- a/src/templates/storage-list.html
+++ b/src/templates/storage-list.html
@@ -43,6 +43,9 @@
           <button type='button' class='btn btn-secondary' data-action='container-qty-plus' data-storage-id='{{ unit.id }}' aria-label='{{ 'Increase containers for %s'|trans|format(unit.name) }}'><i class='fas fa-plus'></i></button>
         </div>
       </div>
+      {# revealed by the js when the room left cannot be split across every selected entry:
+         the occupancy badge still shows free slots, so the dead stepper needs a reason #}
+      <span class='smallgray' hidden data-batch-full-notice='1' data-storage-id='{{ unit.id }}'><i class='fas fa-ban mr-1'></i>{{ 'Not enough room here for every selected entry'|trans }}</span>
     {% endif %}
   {% endmacro %}
   {# the declared limit, editable on the inventory page only; elsewhere the badge carries it #}

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1011,6 +1011,10 @@ function applyPerEntryCeilings(): void {
     input.closest('.input-group')?.querySelectorAll('button').forEach((btn: HTMLButtonElement) => {
       btn.disabled = perEntry === 0;
     });
+    // the aggregate notice cannot be relied on here: it stays silent as soon as one location
+    // declares no capacity, so each refused location says so for itself
+    document.querySelector(`[data-batch-full-notice][data-storage-id="${input.dataset.storageId}"]`)
+      ?.toggleAttribute('hidden', perEntry !== 0);
   });
 }
 

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -899,11 +899,14 @@ on('toggle-next', (el: HTMLElement) => {
 const storageTreeIds = (): string[] =>
   Array.from(document.querySelectorAll('[data-storage-tree]')).map(el => el.id);
 
-const reloadStorageTrees = (): Promise<void> => reloadElements(storageTreeIds());
+// a re-render restores each stepper's max to the raw free-slot count, so the per-entry
+// ceilings are re-applied here rather than at every call site
+const reloadStorageTrees = (): Promise<void> =>
+  reloadElements(storageTreeIds()).then(() => applyPerEntryCeilings());
 
 /** Refresh the trees along with the entity's own container list: both show occupancy. */
 const reloadStorageAndContainers = (): Promise<void> =>
-  reloadElements(['storageDivContent', ...storageTreeIds()]);
+  reloadElements(['storageDivContent', ...storageTreeIds()]).then(() => applyPerEntryCeilings());
 
 /** Re-open a unit and its ancestors, in every tree that renders it. */
 function revealStorageUnit(storageId: string): void {
@@ -974,9 +977,47 @@ const containerAssigned = (): number =>
   containerStepperInputs().reduce((sum, input) => sum + intFromInput(input), 0);
 
 /**
- * Room left in a location, read from the max the server rendered for it. An unlimited
- * location has no max, hence Infinity. Full locations render no stepper at all, so they
- * never reach here.
+ * The same distribution is applied to every entity, so all the counts in this modal are
+ * per entry: on the show page that is one per selected entry, elsewhere a single entity.
+ */
+const containerEntryCount = (): number => {
+  const modal = document.getElementById('storageModal');
+  if (!modal?.dataset.withSelected) {
+    return 1;
+  }
+  return getFromSvelte(selectedEntities).length;
+};
+
+/**
+ * Narrow every stepper's max from the free slots a location has to what a single entry may
+ * claim, so a distribution can never overbook a location once multiplied by the selection.
+ * A location without room for the whole selection is refused outright, as a full one is.
+ * Runs in both directions, as the selection can shrink between two openings of the modal.
+ */
+function applyPerEntryCeilings(): void {
+  const entries = Math.max(1, containerEntryCount());
+  containerStepperInputs().forEach(input => {
+    // unlimited locations render no slot count and keep their absent max
+    if (input.dataset.slotsLeft === undefined) {
+      return;
+    }
+    // the remainder is unusable: a slot left over cannot be given to every entry
+    const perEntry = Math.floor(Math.max(0, Number(input.dataset.slotsLeft)) / entries);
+    input.max = String(perEntry);
+    input.disabled = perEntry === 0;
+    if (perEntry === 0) {
+      input.value = '0';
+    }
+    input.closest('.input-group')?.querySelectorAll('button').forEach((btn: HTMLButtonElement) => {
+      btn.disabled = perEntry === 0;
+    });
+  });
+}
+
+/**
+ * Room left in a location for one entry, read from its max. An unlimited location has no
+ * max, hence Infinity. Full locations render no stepper at all, so they never reach here.
+ * See applyPerEntryCeilings: max counts what a single entry may claim, not the raw slots.
  */
 const slotsLeft = (input: HTMLInputElement): number =>
   input.max === '' ? Infinity : Math.max(0, Number(input.max));
@@ -999,6 +1040,12 @@ function refreshContainerDistribution(): void {
   if (notice) notice.toggleAttribute('hidden', target <= totalSlotsLeft());
   const submitBtn = document.getElementById('storeContainersBtn') as HTMLButtonElement | null;
   if (submitBtn) submitBtn.disabled = target === 0 || assigned !== target;
+  // only rendered by the batch modal, where the total is not simply the target
+  const summary = document.getElementById('containerBatchSummary');
+  if (summary) {
+    const entries = containerEntryCount();
+    summary.textContent = i18next.t('container-batch-summary', {entries: entries, perEntry: target, total: entries * target});
+  }
 }
 
 /**
@@ -1045,6 +1092,79 @@ on('container-qty-minus', (el: HTMLElement) => {
   if (input) setStepperValue(input, intFromInput(input) - 1);
 });
 
+/** The distribution to create, once per entity: one entry per location that was given containers. */
+const containerPlan = (): {storageId: string, count: number}[] =>
+  containerStepperInputs()
+    .map(input => ({storageId: input.dataset.storageId, count: intFromInput(input)}))
+    .filter(item => item.count > 0);
+
+/**
+ * Run a task over a list with a bounded number in flight. A batch reaches one request per
+ * container per entity, and every one of them row locks its destination location to check
+ * capacity, so firing them all at once only trades browser queueing for database contention.
+ */
+async function runWithConcurrency<T>(items: T[], limit: number, task: (item: T) => Promise<void>): Promise<void> {
+  const queue = items.slice();
+  await Promise.all(Array.from({ length: Math.min(limit, queue.length) }, async () => {
+    for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
+      await task(next);
+    }
+  }));
+}
+
+/**
+ * Apply the distribution to every entity selected on the show page. The steppers are already
+ * capped so that no location can be overbooked, but each container is still created under the
+ * entity's own write permission, so an entity can be refused and is reported as such.
+ */
+async function storeContainersForSelection(
+  plan: {storageId: string, count: number}[],
+  qtyStored: string,
+  qtyUnit: string,
+): Promise<void> {
+  const checked = getFromSvelte(selectedEntities);
+  if (checked.length === 0) {
+    notify.error('nothing-selected');
+    return;
+  }
+  if (!confirm(i18next.t('multi-changes-confirm', { num: checked.length }))) {
+    return;
+  }
+  const failedIds: string[] = [];
+  await runWithConcurrency(checked, 4, async id => {
+    // sequential within an entity: the first refusal condemns the rest of its distribution too
+    try {
+      for (const item of plan) {
+        for (let i = 0; i < item.count; i++) {
+          await ApiC.post(`${entity.type}/${id}/containers/${item.storageId}`, {
+            qty_stored: qtyStored,
+            qty_unit: qtyUnit,
+            notifOnSaved: 0,
+            notifOnError: 0,
+          });
+        }
+      }
+    } catch {
+      failedIds.push(id);
+    }
+  });
+  // the tree lives inside this modal, so reloading it resets the steppers to fresh counts.
+  // The entity list is deliberately left alone: reloading it would drop the selection and the
+  // red marks below, and nothing it displays has changed
+  await reloadStorageTrees();
+  if (failedIds.length === 0) {
+    notify.success();
+    $('#storageModal').modal('hide');
+    return;
+  }
+  for (const id of failedIds) {
+    const elem = document.querySelector(`[data-entity-id="${id}"]`) as HTMLElement;
+    if (elem) { elem.style.backgroundColor = 'var(--lightred)'; }
+  }
+  // stay open on a partial failure, so what was refused can be redistributed
+  notify.warning('entity-patch-multi-warning', {count: checked.length - failedIds.length, failed: failedIds.length});
+}
+
 on('store-containers-distributed', () => {
   const submitBtn = document.getElementById('storeContainersBtn') as HTMLButtonElement | null;
   // guard against double submit: a disabled button means a batch is already in flight
@@ -1053,20 +1173,31 @@ on('store-containers-distributed', () => {
   }
   const qty_stored = (document.getElementById('containerQtyStoredInput') as HTMLInputElement).value;
   const qty_unit = (document.getElementById('containerQtyUnitSelect') as HTMLSelectElement).value;
-  const postCalls = containerStepperInputs().flatMap(input => {
-    const count = intFromInput(input);
-    return Array.from({ length: count }, () =>
-      ApiC.post(`${entity.type}/${entity.id}/containers/${input.dataset.storageId}`, {
+  const plan = containerPlan();
+  if (plan.length === 0) {
+    return;
+  }
+  if (document.getElementById('storageModal')?.dataset.withSelected) {
+    // a batch can be hundreds of requests, so spin the button as the other batch actions do
+    const oldHTML = submitBtn ? mkSpin(submitBtn) : '';
+    storeContainersForSelection(plan, qty_stored, qty_unit).finally(() => {
+      if (submitBtn) mkSpinStop(submitBtn, oldHTML);
+      // after mkSpinStop, which re-enables the button unconditionally
+      refreshContainerDistribution();
+    });
+    return;
+  }
+
+  // lock the button while the batch runs so a second click cannot create a duplicate distribution
+  if (submitBtn) submitBtn.disabled = true;
+  const postCalls = plan.flatMap(item =>
+    Array.from({ length: item.count }, () =>
+      ApiC.post(`${entity.type}/${entity.id}/containers/${item.storageId}`, {
         qty_stored: qty_stored,
         qty_unit: qty_unit,
       }),
-    );
-  });
-  if (postCalls.length === 0) {
-    return;
-  }
-  // lock the button while the batch runs so a second click cannot create a duplicate distribution
-  if (submitBtn) submitBtn.disabled = true;
+    ),
+  );
   // allSettled, not all: one location refusing on capacity must not hide the containers that
   // did land elsewhere. Each request reports its own error, so nothing is notified here.
   Promise.allSettled(postCalls)
@@ -1101,6 +1232,9 @@ if (storageModalEl) {
   // reset all steppers each time the modal opens so a reopened modal starts clean
   $('#storageModal').on('show.bs.modal', () => {
     containerStepperInputs().forEach(input => { input.value = '0'; });
+    // the ceilings depend on how many entities are selected, and the selection cannot change
+    // while the modal is open, so opening it is the moment to recompute them
+    applyPerEntryCeilings();
     refreshContainerDistribution();
   });
 }

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1152,10 +1152,8 @@ async function storeContainersForSelection(
       failedIds.push(id);
     }
   });
-  // the tree lives inside this modal, so reloading it resets the steppers to fresh counts.
-  // The entity list is deliberately left alone: reloading it would drop the selection and the
-  // red marks below, and nothing it displays has changed
-  await reloadStorageTrees();
+  containerStepperInputs().forEach(input => { input.value = '0'; });
+  await reloadStorageTrees().catch(() => undefined);
   if (failedIds.length === 0) {
     notify.success();
     $('#storageModal').modal('hide');

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -18,6 +18,39 @@ describe('Containers', () => {
         return parseInt(resp.headers['location'].toString().split('/').pop(), 10);
       });
 
+  // occupy a location, so that a ceiling computed from it proves occupancy was subtracted
+  const createContainer = (itemId: number, storageId: number): Cypress.Chainable =>
+    cy.request({ method: 'POST', url: `/api/v2/items/${itemId}/containers/${storageId}`, body: { qty_stored: 1 } })
+      .then(resp => {
+        expect(resp.status).to.eq(201);
+      });
+
+  const stepperInput = (storageId: number): string =>
+    `[data-storage-id="${storageId}"] input[data-action="container-qty-input"]`;
+
+  // the per-row checkboxes only exist in item mode; table mode has its own
+  const visitShowPageInItemMode = (): void => {
+    cy.request({ method: 'PATCH', url: '/api/v2/users/me', body: { display_mode: 'it' } });
+    cy.visit('/database.php');
+  };
+
+  const selectEntities = (ids: number[]): void => {
+    ids.forEach(id => {
+      cy.get(`[data-action="checkbox-entity"][data-id="${id}"]`).check();
+    });
+    cy.get('#withSelected').should('be.visible');
+  };
+
+  const openBatchContainerModal = (): void => {
+    cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
+    cy.get('#storageModal').should('be.visible');
+  };
+
+  const closeBatchContainerModal = (): void => {
+    cy.get('#storageModal .modal-footer button[data-dismiss="modal"]').click();
+    cy.get('#storageModal').should('not.be.visible');
+  };
+
   it('distributes containers across multiple storage locations', () => {
     // set up two storage locations and a resource to store them in
     createStorageUnit(`Freezer A ${Date.now()}`).then(storageA => {
@@ -113,22 +146,12 @@ describe('Containers', () => {
         createItem().then(second => {
           createItem().then(third => {
             const ids = [first, second, third];
-            // the per-row checkboxes below only exist in item mode; table mode has its own
-            cy.request({ method: 'PATCH', url: '/api/v2/users/me', body: { display_mode: 'it' } });
-            cy.visit('/database.php');
+            visitShowPageInItemMode();
+            selectEntities(ids);
+            openBatchContainerModal();
 
-            // select the three items we just made, whatever else the team already holds
-            ids.forEach(id => {
-              cy.get(`[data-action="checkbox-entity"][data-id="${id}"]`).check();
-            });
-            cy.get('#withSelected').should('be.visible');
-
-            cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
-            cy.get('#storageModal').should('be.visible');
-
-            const stepper = `[data-storage-id="${storageId}"]`;
             // the ceiling is per entry: floor(7 / 3), not the 7 free slots the server rendered
-            cy.get(`${stepper} input[data-action="container-qty-input"]`)
+            cy.get(stepperInput(storageId))
               .should('have.attr', 'max', '2')
               .and('have.attr', 'data-slots-left', '7');
 
@@ -138,7 +161,7 @@ describe('Containers', () => {
             cy.get('#containerBatchSummary').should('not.have.text', '');
             cy.get('#storeContainersBtn').should('be.disabled');
 
-            cy.get(`${stepper} input[data-action="container-qty-input"]`).invoke('val', '2').trigger('input');
+            cy.get(stepperInput(storageId)).invoke('val', '2').trigger('input');
             cy.get('#containerAssignedCount').should('have.text', '2');
             cy.get('#storeContainersBtn').should('be.enabled').click();
 
@@ -153,6 +176,119 @@ describe('Containers', () => {
                 expect(containers.every(c => c.storage_id === storageId)).to.eq(true);
               });
             });
+
+            // reopening recomputes from fresh occupancy: 7 - 6 = 1 free slot, so no entry
+            // can be given a container any more and the location is refused
+            openBatchContainerModal();
+            cy.get(stepperInput(storageId))
+              .should('have.attr', 'data-slots-left', '1')
+              .and('have.attr', 'max', '0')
+              .and('be.disabled');
+          });
+        });
+      });
+    });
+  });
+
+  it('caps each location by what one selected entry may claim', () => {
+    const stamp = Date.now();
+    // unlimited, too small for the selection, exactly the selection, and partly occupied
+    createStorageUnit(`Unlimited ${stamp}`).then(unlimited => {
+      createStorageUnit(`Too small ${stamp}`, 2).then(tooSmall => {
+        createStorageUnit(`Exactly three ${stamp}`, 3).then(exactly => {
+          createStorageUnit(`Partly occupied ${stamp}`, 9).then(occupied => {
+            createItem().then(holder => {
+              // 3 of the 9 slots taken, so 6 remain and the ceiling must be floor(6 / 3)
+              createContainer(holder, occupied);
+              createContainer(holder, occupied);
+              createContainer(holder, occupied);
+              createItem().then(first => {
+                createItem().then(second => {
+                  createItem().then(third => {
+                    visitShowPageInItemMode();
+                    selectEntities([first, second, third]);
+                    openBatchContainerModal();
+
+                    // no capacity declared, so no ceiling to narrow and no slot count to read
+                    cy.get(stepperInput(unlimited))
+                      .should('not.have.attr', 'max')
+                      .and('not.have.attr', 'data-slots-left')
+                      .and('be.enabled');
+
+                    // floor(2 / 3) is 0: room for some entries is room for none of them
+                    cy.get(stepperInput(tooSmall))
+                      .should('have.attr', 'max', '0')
+                      .and('be.disabled');
+                    cy.get(`[data-storage-id="${tooSmall}"] [data-action="container-qty-plus"]`)
+                      .should('be.disabled');
+
+                    // floor(3 / 3) is exactly 1
+                    cy.get(stepperInput(exactly)).should('have.attr', 'max', '1').and('be.enabled');
+
+                    // occupancy is subtracted before the division: floor((9 - 3) / 3)
+                    cy.get(stepperInput(occupied))
+                      .should('have.attr', 'data-slots-left', '6')
+                      .and('have.attr', 'max', '2');
+
+                    // the plus button clamps to the per-entry ceiling, not to the free slots
+                    cy.get('#containerMultiplierInput').invoke('val', '3').trigger('input');
+                    cy.get(`[data-storage-id="${exactly}"] [data-action="container-qty-plus"]`).click();
+                    cy.get(`[data-storage-id="${exactly}"] [data-action="container-qty-plus"]`).click();
+                    cy.get(stepperInput(exactly)).should('have.value', '1');
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('widens the ceilings again when the selection shrinks', () => {
+    // 4 free slots gives 1 per entry for 3 entries, but 2 per entry once one is unselected
+    createStorageUnit(`Freezer D ${Date.now()}`, 4).then(storageId => {
+      createItem().then(first => {
+        createItem().then(second => {
+          createItem().then(third => {
+            visitShowPageInItemMode();
+            selectEntities([first, second, third]);
+
+            openBatchContainerModal();
+            cy.get(stepperInput(storageId)).should('have.attr', 'max', '1');
+            closeBatchContainerModal();
+
+            cy.get(`[data-action="checkbox-entity"][data-id="${third}"]`).uncheck();
+            openBatchContainerModal();
+            cy.get(stepperInput(storageId)).should('have.attr', 'max', '2');
+          });
+        });
+      });
+    });
+  });
+
+  it('refuses a target that no location has room for across the selection', () => {
+    // 3 free slots is 1 per entry, so a target of 2 per entry cannot be distributed at all
+    createStorageUnit(`Freezer E ${Date.now()}`, 3).then(storageId => {
+      createItem().then(first => {
+        createItem().then(second => {
+          createItem().then(third => {
+            visitShowPageInItemMode();
+            selectEntities([first, second, third]);
+            openBatchContainerModal();
+
+            cy.get(stepperInput(storageId)).should('have.attr', 'max', '1');
+            // submit stays out of reach: the steppers cannot sum to the target.
+            // #containerCapacityNotice is deliberately not asserted here, as totalSlotsLeft()
+            // is Infinity as soon as the team owns one location with no declared capacity
+            cy.get('#containerMultiplierInput').invoke('val', '2').trigger('input');
+            cy.get('#containerAssignedCount').should('have.text', '0');
+            cy.get('#storeContainersBtn').should('be.disabled');
+
+            cy.get(`[data-storage-id="${storageId}"] [data-action="container-qty-plus"]`).click();
+            cy.get(`[data-storage-id="${storageId}"] [data-action="container-qty-plus"]`).click();
+            cy.get('#containerAssignedCount').should('have.text', '1');
+            cy.get('#storeContainersBtn').should('be.disabled');
           });
         });
       });

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -28,6 +28,9 @@ describe('Containers', () => {
   const stepperInput = (storageId: number): string =>
     `[data-storage-id="${storageId}"] input[data-action="container-qty-input"]`;
 
+  const fullNotice = (storageId: number): string =>
+    `[data-batch-full-notice][data-storage-id="${storageId}"]`;
+
   // the per-row checkboxes only exist in item mode; table mode has its own
   const visitShowPageInItemMode = (): void => {
     cy.request({ method: 'PATCH', url: '/api/v2/users/me', body: { display_mode: 'it' } });
@@ -184,6 +187,8 @@ describe('Containers', () => {
               .should('have.attr', 'data-slots-left', '1')
               .and('have.attr', 'max', '0')
               .and('be.disabled');
+            // reached through occupancy rather than a small capacity, but refused all the same
+            cy.get(fullNotice(storageId)).should('be.visible');
           });
         });
       });
@@ -214,6 +219,7 @@ describe('Containers', () => {
                       .should('not.have.attr', 'max')
                       .and('not.have.attr', 'data-slots-left')
                       .and('be.enabled');
+                    cy.get(fullNotice(unlimited)).should('not.be.visible');
 
                     // floor(2 / 3) is 0: room for some entries is room for none of them
                     cy.get(stepperInput(tooSmall))
@@ -221,9 +227,12 @@ describe('Containers', () => {
                       .and('be.disabled');
                     cy.get(`[data-storage-id="${tooSmall}"] [data-action="container-qty-plus"]`)
                       .should('be.disabled');
+                    // the badge still shows 0 / 2, so the reason has to be spelled out
+                    cy.get(fullNotice(tooSmall)).should('be.visible');
 
                     // floor(3 / 3) is exactly 1
                     cy.get(stepperInput(exactly)).should('have.attr', 'max', '1').and('be.enabled');
+                    cy.get(fullNotice(exactly)).should('not.be.visible');
 
                     // occupancy is subtracted before the division: floor((9 - 3) / 3)
                     cy.get(stepperInput(occupied))
@@ -246,21 +255,30 @@ describe('Containers', () => {
   });
 
   it('widens the ceilings again when the selection shrinks', () => {
+    const stamp = Date.now();
     // 4 free slots gives 1 per entry for 3 entries, but 2 per entry once one is unselected
-    createStorageUnit(`Freezer D ${Date.now()}`, 4).then(storageId => {
-      createItem().then(first => {
-        createItem().then(second => {
-          createItem().then(third => {
-            visitShowPageInItemMode();
-            selectEntities([first, second, third]);
+    createStorageUnit(`Freezer D ${stamp}`, 4).then(storageId => {
+      // 2 free slots is nothing per entry for 3 entries, but 1 each for 2 entries
+      createStorageUnit(`Freezer D refused ${stamp}`, 2).then(refusedId => {
+        createItem().then(first => {
+          createItem().then(second => {
+            createItem().then(third => {
+              visitShowPageInItemMode();
+              selectEntities([first, second, third]);
 
-            openBatchContainerModal();
-            cy.get(stepperInput(storageId)).should('have.attr', 'max', '1');
-            closeBatchContainerModal();
+              openBatchContainerModal();
+              cy.get(stepperInput(storageId)).should('have.attr', 'max', '1');
+              cy.get(stepperInput(refusedId)).should('have.attr', 'max', '0').and('be.disabled');
+              cy.get(fullNotice(refusedId)).should('be.visible');
+              closeBatchContainerModal();
 
-            cy.get(`[data-action="checkbox-entity"][data-id="${third}"]`).uncheck();
-            openBatchContainerModal();
-            cy.get(stepperInput(storageId)).should('have.attr', 'max', '2');
+              cy.get(`[data-action="checkbox-entity"][data-id="${third}"]`).uncheck();
+              openBatchContainerModal();
+              cy.get(stepperInput(storageId)).should('have.attr', 'max', '2');
+              // the location is usable again, so its reason has to be taken back down
+              cy.get(stepperInput(refusedId)).should('have.attr', 'max', '1').and('be.enabled');
+              cy.get(fullNotice(refusedId)).should('not.be.visible');
+            });
           });
         });
       });

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -4,8 +4,15 @@ describe('Containers', () => {
   });
 
   // create a storage location via the API and return its id (parsed from the Location header)
-  const createStorageUnit = (name: string): Cypress.Chainable<number> =>
-    cy.request({ method: 'POST', url: '/api/v2/storage_units', body: { name } })
+  const createStorageUnit = (name: string, capacity?: number): Cypress.Chainable<number> =>
+    cy.request({ method: 'POST', url: '/api/v2/storage_units', body: { name, capacity } })
+      .then(resp => {
+        expect(resp.status).to.eq(201);
+        return parseInt(resp.headers['location'].toString().split('/').pop(), 10);
+      });
+
+  const createItem = (): Cypress.Chainable<number> =>
+    cy.request({ method: 'POST', url: '/api/v2/items', body: { title: `Cypress container item ${Date.now()}` } })
       .then(resp => {
         expect(resp.status).to.eq(201);
         return parseInt(resp.headers['location'].toString().split('/').pop(), 10);
@@ -95,6 +102,59 @@ describe('Containers', () => {
               expect(inB).to.eq(2);
             });
           });
+      });
+    });
+  });
+
+  it('applies the distribution to every entity selected on the show page', () => {
+    // capacity 7 with 3 entries selected leaves room for 2 containers per entry, remainder unusable
+    createStorageUnit(`Freezer C ${Date.now()}`, 7).then(storageId => {
+      createItem().then(first => {
+        createItem().then(second => {
+          createItem().then(third => {
+            const ids = [first, second, third];
+            // the per-row checkboxes below only exist in item mode; table mode has its own
+            cy.request({ method: 'PATCH', url: '/api/v2/users/me', body: { display_mode: 'it' } });
+            cy.visit('/database.php');
+
+            // select the three items we just made, whatever else the team already holds
+            ids.forEach(id => {
+              cy.get(`[data-action="checkbox-entity"][data-id="${id}"]`).check();
+            });
+            cy.get('#withSelected').should('be.visible');
+
+            cy.get('[data-action="toggle-modal"][data-target="storageModal"]').click();
+            cy.get('#storageModal').should('be.visible');
+
+            const stepper = `[data-storage-id="${storageId}"]`;
+            // the ceiling is per entry: floor(7 / 3), not the 7 free slots the server rendered
+            cy.get(`${stepper} input[data-action="container-qty-input"]`)
+              .should('have.attr', 'max', '2')
+              .and('have.attr', 'data-slots-left', '7');
+
+            // 2 containers per entry across 3 entries
+            cy.get('#containerMultiplierInput').invoke('val', '2').trigger('input');
+            // asserted as non-empty rather than by wording, which is translated
+            cy.get('#containerBatchSummary').should('not.have.text', '');
+            cy.get('#storeContainersBtn').should('be.disabled');
+
+            cy.get(`${stepper} input[data-action="container-qty-input"]`).invoke('val', '2').trigger('input');
+            cy.get('#containerAssignedCount').should('have.text', '2');
+            cy.get('#storeContainersBtn').should('be.enabled').click();
+
+            cy.get('#storageModal').should('not.be.visible');
+
+            // every selected entity got the same distribution
+            ids.forEach(id => {
+              cy.request({ method: 'GET', url: `/api/v2/items/${id}/containers` }).then(resp => {
+                expect(resp.status).to.eq(200);
+                const containers = resp.body as Array<{ storage_id: number }>;
+                expect(containers).to.have.length(2);
+                expect(containers.every(c => c.storage_id === storageId)).to.eq(true);
+              });
+            });
+          });
+        });
       });
     });
   });

--- a/tests/cypress/integration/containers.cy.ts
+++ b/tests/cypress/integration/containers.cy.ts
@@ -31,10 +31,17 @@ describe('Containers', () => {
   const fullNotice = (storageId: number): string =>
     `[data-batch-full-notice][data-storage-id="${storageId}"]`;
 
-  // the per-row checkboxes only exist in item mode; table mode has its own
+  // show() takes orderby, sort and limit_nb from the user record, so all three are pinned
+  // here: the resources each test creates have to reach the first page for the checkbox
+  // lookups below. skip_pinned drops the pinned-first ordering on top of that.
+  // The per-row checkboxes also only exist in item mode; table mode has its own
   const visitShowPageInItemMode = (): void => {
-    cy.request({ method: 'PATCH', url: '/api/v2/users/me', body: { display_mode: 'it' } });
-    cy.visit('/database.php');
+    cy.request({
+      method: 'PATCH',
+      url: '/api/v2/users/me',
+      body: { display_mode: 'it', orderby: 'lastchange', sort: 'desc', limit_nb: 15 },
+    });
+    cy.visit('/database.php?skip_pinned=1');
   };
 
   const selectEntities = (ids: number[]): void => {

--- a/tests/unit/controllers/AbstractEntityControllerTest.php
+++ b/tests/unit/controllers/AbstractEntityControllerTest.php
@@ -7,6 +7,9 @@ namespace Elabftw\Controllers;
 use Elabftw\Elabftw\App;
 use Elabftw\Models\Config;
 use Elabftw\Models\Experiments;
+use Elabftw\Models\Items;
+use Elabftw\Models\Links\Containers2ItemsLinks;
+use Elabftw\Models\StorageUnits;
 use Elabftw\Traits\TestsUtilsTrait;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
@@ -57,5 +60,41 @@ class AbstractEntityControllerTest extends \PHPUnit\Framework\TestCase
             // confirm that the modal contains exactly all visible teams.
             self::assertSame($expected, $actual);
         }
+    }
+
+    public function testShowRendersTheBatchContainerModalWithFreeSlotCounts(): void
+    {
+        $user = $this->getRandomUserInTeam(1);
+        $StorageUnits = new StorageUnits($user, false);
+        $storageId = $StorageUnits->create('Box the batch modal must count correctly', capacity: 9);
+        // occupy some of it, so a count equal to the capacity would not pass by accident
+        $Item = $this->getFreshItem();
+        new Containers2ItemsLinks($Item, $storageId)->createWithQuantity(1.0, 'mL');
+        new Containers2ItemsLinks($Item, $storageId)->createWithQuantity(1.0, 'mL');
+
+        $App = new App(
+            Request::create('/database.php'),
+            new Session(new MockArraySessionStorage()),
+            Config::getConfig(),
+            App::getDefaultLogger(),
+            $user,
+        );
+        $App->boot();
+
+        $response = new DatabaseController($App, new Items($user))->show();
+        $Crawler = new Crawler((string) $response->getContent());
+
+        // the show page has no storage section of its own, so the tree only reaches it
+        // through the batch modal; without it the new button would open an empty dialog
+        self::assertCount(1, $Crawler->filter('#storageModal[data-with-selected] [data-storage-tree]'));
+
+        // the js divides this number by the size of the selection to get each ceiling, so a
+        // count that disagrees with the guard would block or overbook whole batches
+        $stepper = $Crawler->filter(sprintf('input[data-action="container-qty-input"][data-storage-id="%d"]', $storageId));
+        self::assertCount(1, $stepper);
+        // two of the nine slots are taken, so a stepper that echoed the capacity fails here
+        self::assertSame(2, $StorageUnits->countContainers($storageId));
+        self::assertSame('7', $stepper->attr('data-slots-left'));
+        self::assertSame('7', $stepper->attr('max'));
     }
 }


### PR DESCRIPTION
Thank you for your contribution to **eLabFTW**.

To help us review your pull request more efficiently, please go through the list below and check all applicable boxes:

### Pull Request Checklist

- [x] I have added **tests** for any new features.
- [x] I have mentioned the related **issue** (if applicable).
- [ ] I have updated or verified the relevant documentation (in documentation directory)
---

### Pull Request Description

User in #7398 suggested bulk addition of containers via the resource/experiment list. We can simply extend the current container distribution code to apply to N experiments/resources at a time

This implements the feature with a guard to prevent overfilling capacity given we are adding N resources at a time

Not urgent to make it into 6.0.0 I think! So no rush to review.

---

### Contribution Guidelines

Make sure to read [the contributing documentation](https://doc.elabftw.net/docs/contributing/intro).

**IMPORTANT**: All new features **MUST** have tests added.

Please note that working on a PR doesn't automatically mean that your code will be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk container distribution for multiple selected entries.
  * Added per-entry quantity limits based on available container capacity.
  * Added a live summary showing containers per entry and total containers.
  * Added progress and failure feedback during bulk distribution.
  * Added an “Add container” action to the selected-items toolbar.
  * Added notices when a location cannot accommodate every selected entry.

* **Bug Fixes**
  * Container capacity information is now preserved when storage lists refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->