### PR TITLE
bug/minor: notifications:prevent account notifications from blocking the email queue

### DIFF
--- a/src/Factories/NotificationsFactory.php
+++ b/src/Factories/NotificationsFactory.php
@@ -48,8 +48,8 @@ final class NotificationsFactory
     {
         return match (Notifications::from($this->category)) {
             Notifications::CommentCreated => new CommentCreated($this->targetUser, $this->body['page'], $this->body['entity_id'], $this->body['commenter_userid']),
-            Notifications::UserCreated => new UserCreated($this->targetUser, $this->body['userid'], $this->body['team']),
-            Notifications::UserNeedValidation => new UserNeedValidation($this->targetUser, $this->body['userid'], $this->body['team']),
+            Notifications::UserCreated => new UserCreated($this->targetUser, $this->body['userid'], $this->body['team'] ?? ''),
+            Notifications::UserNeedValidation => new UserNeedValidation($this->targetUser, $this->body['userid'], $this->body['team'] ?? ''),
             Notifications::StepDeadline => new StepDeadline($this->targetUser, $this->body['step_id'], $this->body['entity_id'], $this->body['entity_page'], $this->body['deadline']),
             Notifications::EventDeleted => new EventDeleted($this->targetUser, $this->body['event'], $this->body['actor'], $this->body['msg'], EmailTarget::from($this->body['target'])),
             Notifications::SelfNeedValidation => new SelfNeedValidation($this->targetUser),

--- a/src/Services/EmailNotifications.php
+++ b/src/Services/EmailNotifications.php
@@ -19,10 +19,10 @@ use Elabftw\Factories\NotificationsFactory;
 use Elabftw\Models\Notifications\StepDeadline;
 use Elabftw\Models\AuditLogs;
 use Elabftw\Models\Users\Users;
-use Exception;
 use PDO;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Mime\Address;
+use Throwable;
 
 use function bindtextdomain;
 use function dirname;
@@ -78,7 +78,7 @@ class EmailNotifications
                     }
                 }
                 $count++;
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $output->writeln(sprintf('Error sending notification: %s', $e->getMessage()));
             }
         }

--- a/tests/unit/services/EmailNotificationsTest.php
+++ b/tests/unit/services/EmailNotificationsTest.php
@@ -15,6 +15,8 @@ use DateTime;
 use Elabftw\Elabftw\Db;
 use Elabftw\Enums\Action;
 use Elabftw\Enums\EntityType;
+use Elabftw\Enums\Notifications;
+use Elabftw\Factories\NotificationsFactory;
 use Elabftw\Models\Notifications\CommentCreated;
 use Elabftw\Models\Notifications\EventDeleted;
 use Elabftw\Models\Notifications\MathjaxFailed;
@@ -26,8 +28,10 @@ use Elabftw\Models\Notifications\UserCreated;
 use Elabftw\Models\Notifications\UserNeedValidation;
 use Elabftw\Models\Users\Users;
 use Elabftw\Traits\TestsUtilsTrait;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use PDO;
+use TypeError;
 
 class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
 {
@@ -116,6 +120,43 @@ class EmailNotificationsTest extends \PHPUnit\Framework\TestCase
 
         // Restore user archive status
         $this->updateArchiveStatus($targetUser->userid, 0);
+    }
+
+    public function testAccountNotificationsWithoutTeam(): void
+    {
+        $targetUser = new Users(1);
+        foreach (array(Notifications::UserCreated, Notifications::UserNeedValidation) as $category) {
+            foreach (array(
+                array('{"userid":3}', ''),
+                array('{"userid":3,"team":null}', ''),
+                array('{"userid":3,"team":"Some team name"}', 'Some team name'),
+            ) as [$body, $team]) {
+                $Factory = new NotificationsFactory($targetUser, $category->value, $body);
+                $expected = $category === Notifications::UserCreated
+                    ? new UserCreated($targetUser, 3, $team)
+                    : new UserNeedValidation($targetUser, 3, $team);
+                $this->assertSame($expected->getEmail(), $Factory->getMailable()->getEmail());
+            }
+        }
+    }
+
+    public function testSendEmailsContinuesAfterTypeError(): void
+    {
+        // send existing notifications before testing two new ones
+        $this->stubEmail();
+        $targetUser = new Users(1);
+        new SelfIsValidated($targetUser)->create();
+        new SelfIsValidated($targetUser)->create();
+
+        $email = $this->createMock(Email::class);
+        $email->expects($this->exactly(2))
+            ->method('sendEmail')
+            ->willThrowException(new TypeError('Invalid notification payload'));
+        $output = new BufferedOutput();
+        $EmailNotifications = new EmailNotifications($email);
+        $EmailNotifications->sendEmails($output);
+
+        $this->assertStringContainsString('Error sending notification: Invalid notification payload', $output->fetch());
     }
 
     private function stubEmail(): void


### PR DESCRIPTION
fix #7417

Handle missing team names in account notifications also catch Throwable instead of an exception so one failing notification cannot block the queue. Regression tests for missing team names and error handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Account notifications now process correctly when team information is missing or empty.
  - Email notification processing continues when an unexpected sending error occurs, allowing other notifications to be handled.
  - Notification errors are reported more reliably instead of interrupting the overall email process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->