### PR TITLE
docs: add 6.0

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -47,8 +47,8 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-           // Use current while creating the version, then make 5.6 the default.
-          lastVersion: versioningReady ? '5.6' : 'current',
+           // Use current while creating the versions, then make 6.0 the default.
+          lastVersion: versioningReady ? '6.0' : 'current',
 
           versions: {
             current: {
@@ -57,6 +57,10 @@ const config: Config = {
               banner: 'unreleased',
             },
             ...(versioningReady && {
+              '6.0': {
+                label: '6.0',
+                banner: 'none',
+              },
               '5.6': {
                 label: '5.6',
                 banner: 'none',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation versioning to default to version 6.0 when versioning is enabled.
  - Added documentation for version 6.0 without a version banner.
  - Existing versioned documentation behavior remains available alongside the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->