### PR TITLE
bug/minor: fix issue for a completely teamless user

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -55,7 +55,6 @@ use Elabftw\Models\Config;
 use Elabftw\Models\Users\ExistingUser;
 use Elabftw\Models\Idps;
 use Elabftw\Models\Users\Users;
-use Elabftw\Models\Users2Teams;
 use Elabftw\Services\Filter;
 use Elabftw\Services\TeamsHelper;
 use Elabftw\Services\ResetPasswordKey;
@@ -80,6 +79,7 @@ use function rawurldecode;
 use function str_contains;
 use function str_starts_with;
 use function str_replace;
+use function _;
 
 /**
  * For all your authentication/login needs
@@ -478,14 +478,19 @@ final class LoginController implements ControllerInterface
         $authentication = $this->getPendingAuthentication();
         $teamId = $this->Request->request->getInt('team_id');
 
-        // Users may only request a visible team.
-        new TeamsHelper($teamId)->teamIsVisibleOrExplode();
+        $requiresValidation = new Users($authentication->userid)
+            ->requestTeamAccess($teamId);
 
-        new Users2Teams(new Users($authentication->userid))
-            ->create($authentication->userid, $teamId);
-
-        $this->Session->remove('team_request_selection_required');
-
+        // Never leave an authenticated continuation behind after submitting a
+        // request. A validated request can continue with the local value below.
+        $this->clearPendingLoginState();
+        if ($requiresValidation) {
+            $this->Session->getFlashBag()->add(
+                'ok',
+                _('Your team access request has been submitted. An admin must approve it before you can log in.'),
+            );
+            return new RedirectResponse('/login.php');
+        }
         return $this->handleLoginStep(
             $this->loginFlow->afterPasswordRenewal($authentication),
         );

--- a/src/Models/Users/Users.php
+++ b/src/Models/Users/Users.php
@@ -57,6 +57,7 @@ use PDO;
 use Symfony\Component\HttpFoundation\Request;
 use Override;
 use RuntimeException;
+use Throwable;
 
 use function _;
 use function array_column;
@@ -222,6 +223,77 @@ class Users extends AbstractRest
         // it's okay to not have requester for this (register page)
         AuditLogs::create(new UserRegister($this->requester->userid ?? 0, $this->userid));
         return $this->userid;
+    }
+
+    /**
+     * Associate a teamless user with a visible team through the access-request flow.
+     *
+     * @return bool Whether an admin must validate the request before login
+     */
+    public function requestTeamAccess(int $teamId): bool
+    {
+        $TeamsHelper = new TeamsHelper($teamId);
+        $TeamsHelper->teamIsVisibleOrExplode();
+        $requiresValidation = $this->userData['validated'] === 0
+            || (bool) Config::getConfig()->configArr['admin_validate'];
+        $userid = $this->getUserid();
+
+        $this->Db->beginTransaction();
+        try {
+            // Serialize requests for this user so concurrent submissions cannot
+            // associate the same account with several teams.
+            $lockReq = $this->Db->prepare(
+                'SELECT userid FROM users WHERE userid = :userid FOR UPDATE',
+            );
+            $lockReq->bindValue(':userid', $userid, PDO::PARAM_INT);
+            $this->Db->execute($lockReq);
+            if ($lockReq->fetchColumn() === false) {
+                throw new ResourceNotFoundException();
+            }
+
+            $membershipReq = $this->Db->prepare(
+                'SELECT 1 FROM users2teams
+                    WHERE users_id = :userid AND is_archived = 0
+                    LIMIT 1',
+            );
+            $membershipReq->bindValue(':userid', $userid, PDO::PARAM_INT);
+            $this->Db->execute($membershipReq);
+            if ($membershipReq->fetchColumn() !== false) {
+                throw new ImproperActionException(
+                    'Cannot request team access: the user already has an active team.',
+                );
+            }
+
+            $wasInserted = new Users2Teams($this)->create(
+                $userid,
+                $teamId,
+                isValidated: !$requiresValidation,
+            );
+            if (!$wasInserted) {
+                throw new ImproperActionException(
+                    'Cannot request team access: this team is already associated with the user.',
+                );
+            }
+
+            if ($requiresValidation) {
+                $this->rawUpdate(UsersColumn::Validated, 0);
+            }
+            $this->Db->commit();
+        } catch (Throwable $e) {
+            $this->Db->rollBack();
+            throw $e;
+        }
+
+        $this->notifyAdmins(
+            $TeamsHelper->getAllAdminsUserid(),
+            $userid,
+            !$requiresValidation,
+            new Teams($this, $teamId)->teamArr['name'],
+        );
+        if ($requiresValidation) {
+            new SelfNeedValidation($this)->create();
+        }
+        return $requiresValidation;
     }
 
     /**

--- a/tests/unit/models/UsersTest.php
+++ b/tests/unit/models/UsersTest.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace Elabftw\Models;
 
 use DateTimeImmutable;
+use Elabftw\Elabftw\Db;
 use Elabftw\Elabftw\NullLocalPassword;
 use Elabftw\Enums\Action;
+use Elabftw\Enums\Notifications;
 use Elabftw\Enums\Scope;
 use Elabftw\Enums\Usergroup;
 use Elabftw\Enums\Users2TeamsTargets;
@@ -23,10 +25,14 @@ use Elabftw\Exceptions\ImproperActionException;
 use Elabftw\Exceptions\ResourceNotFoundException;
 use Elabftw\Models\Users\Users;
 use Elabftw\Params\UserParams;
+use Elabftw\Services\TeamsHelper;
 use Elabftw\Traits\TestsUtilsTrait;
+use PDO;
 
+use function bin2hex;
 use function count;
 use function is_array;
+use function random_bytes;
 use function strtoupper;
 
 class UsersTest extends \PHPUnit\Framework\TestCase
@@ -338,6 +344,61 @@ class UsersTest extends \PHPUnit\Framework\TestCase
         $this->assertIsInt($this->Users->createOne('blahblah2@yop.fr', array('Bravo'), new NullLocalPassword(), 'yep', 'yop', Usergroup::Admin, true, false));
     }
 
+    public function testRequestTeamAccessHonorsAdminValidationPolicy(): void
+    {
+        $originalAdminValidate = $this->Config->configArr['admin_validate'];
+        try {
+            $this->Config->patch(Action::Update, array('admin_validate' => 1));
+            $pendingUserid = $this->createTeamlessValidatedUser();
+            $validationNotifications = $this->countNotifications(
+                Notifications::UserNeedValidation,
+            );
+
+            $requiresValidation = (new Users($pendingUserid))
+                ->requestTeamAccess(2);
+
+            self::assertTrue($requiresValidation);
+            self::assertSame(
+                0,
+                (new Users($pendingUserid))->userData['validated'],
+            );
+            self::assertTrue(
+                (new TeamsHelper(2))->isUserInTeam($pendingUserid),
+            );
+            self::assertGreaterThan(
+                $validationNotifications,
+                $this->countNotifications(Notifications::UserNeedValidation),
+            );
+
+            $this->Config->patch(Action::Update, array('admin_validate' => 0));
+            $validatedUserid = $this->createTeamlessValidatedUser();
+            $creationNotifications = $this->countNotifications(
+                Notifications::UserCreated,
+            );
+
+            $requiresValidation = (new Users($validatedUserid))
+                ->requestTeamAccess(2);
+
+            self::assertFalse($requiresValidation);
+            self::assertSame(
+                1,
+                (new Users($validatedUserid))->userData['validated'],
+            );
+            self::assertTrue(
+                (new TeamsHelper(2))->isUserInTeam($validatedUserid),
+            );
+            self::assertGreaterThan(
+                $creationNotifications,
+                $this->countNotifications(Notifications::UserCreated),
+            );
+        } finally {
+            $this->Config->patch(
+                Action::Update,
+                array('admin_validate' => $originalAdminValidate),
+            );
+        }
+    }
+
     public function testArchiveWithoutPermission(): void
     {
         $Admin = $this->getUserInTeam(team: 2, admin: 1);
@@ -377,5 +438,39 @@ class UsersTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(ImproperActionException::class);
         $this->Users->destroy();
+    }
+
+    private function createTeamlessValidatedUser(): int
+    {
+        $userid = $this->Users->createOne(
+            'team-access-' . bin2hex(random_bytes(8)) . '@example.com',
+            array(3),
+            new NullLocalPassword(),
+            usergroup: Usergroup::User,
+            automaticValidationEnabled: true,
+            alertAdmin: false,
+        );
+
+        // The public model intentionally prevents removing a user's last team;
+        // reproduce the legacy teamless-account state directly.
+        $Db = Db::getConnection();
+        $req = $Db->prepare(
+            'DELETE FROM users2teams WHERE users_id = :userid',
+        );
+        $req->bindValue(':userid', $userid, PDO::PARAM_INT);
+        $Db->execute($req);
+
+        return $userid;
+    }
+
+    private function countNotifications(Notifications $category): int
+    {
+        $Db = Db::getConnection();
+        $req = $Db->prepare(
+            'SELECT COUNT(*) FROM notifications WHERE category = :category',
+        );
+        $req->bindValue(':category', $category->value, PDO::PARAM_INT);
+        $Db->execute($req);
+        return (int) $req->fetchColumn();
     }
 }


### PR DESCRIPTION
user must be validated and have no active team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can request team access during login.
  - Teams requiring approval display a clear message and return users to the login flow.
  - Approved requests continue the login process, with administrators notified.
  - Archived team memberships are restored when access is requested again.

- **Bug Fixes**
  - Unvalidated users can no longer request team access.
  - Pending authentication state is cleared promptly.
  - Access updates and notifications now remain consistent if an operation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->