### PR TITLE
bug/minor: fix anonymous user could read unfinished steps

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -517,8 +517,15 @@ final class Apiv2Controller extends AbstractApiController
         ) {
             throw new ForbiddenException();
         }
-        // these team submodels contain internal organizational metadata
-        if ($this->Model instanceof AbstractStatus || $this->Model instanceof TeamGroups) {
+        // these team-scoped models contain data reserved for authenticated members
+        if (
+            $this->Model instanceof AbstractStatus
+            || $this->Model instanceof TeamGroups
+            || (
+                $this->Model instanceof UnfinishedSteps
+                && $this->Request->query->getString('scope') === 'team'
+            )
+        ) {
             throw new ForbiddenException();
         }
     }

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -217,6 +217,7 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
             '/api/v2/teams/1/experiments_categories',
             '/api/v2/teams/1/resources_categories',
             '/api/v2/teams/1/items_status',
+            '/api/v2/unfinished_steps?scope=team',
         );
 
         foreach ($uris as $uri) {


### PR DESCRIPTION
with scope team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Limited anonymous API access to six explicitly allowed endpoints.
  - Anonymous requests to team-scoped unfinished steps now return a 403 Forbidden response.
- **Tests**
  - Expanded coverage to verify that restricted team-scoped unfinished steps requests are denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->