### PR TITLE
bug/minor: fix anon user could read ror and tags

### DIFF
--- a/src/Controllers/Apiv2Controller.php
+++ b/src/Controllers/Apiv2Controller.php
@@ -518,7 +518,12 @@ final class Apiv2Controller extends AbstractApiController
             throw new ForbiddenException();
         }
         // these team submodels contain internal organizational metadata
-        if ($this->Model instanceof AbstractStatus || $this->Model instanceof TeamGroups) {
+        if (
+            $this->Model instanceof AbstractStatus
+            || $this->Model instanceof TeamGroups
+            || $this->Model instanceof TeamTags
+            || $this->Model instanceof Teams2Rors
+        ) {
             throw new ForbiddenException();
         }
     }

--- a/tests/unit/controllers/Apiv2ControllerTest.php
+++ b/tests/unit/controllers/Apiv2ControllerTest.php
@@ -217,6 +217,10 @@ class Apiv2ControllerTest extends \PHPUnit\Framework\TestCase
             '/api/v2/teams/1/experiments_categories',
             '/api/v2/teams/1/resources_categories',
             '/api/v2/teams/1/items_status',
+            '/api/v2/teams/1/tags',
+            '/api/v2/teams/1/tags/1',
+            '/api/v2/teams/1/rors',
+            '/api/v2/teams/1/rors/04vfs2w97',
         );
 
         foreach ($uris as $uri) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anonymous API users are now denied access to additional sensitive team tag and ROR endpoints.
  - Access restrictions now consistently apply to both collections and individual ROR records.

- **Tests**
  - Expanded coverage to verify anonymous access is blocked for team tags, individual tags, ROR endpoints, and specific ROR records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->